### PR TITLE
feat(onboarding): add skip affordance and prevent re-trap

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -674,7 +674,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codemux"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src/components/overlays/new-project-screen.tsx
+++ b/src/components/overlays/new-project-screen.tsx
@@ -110,7 +110,7 @@ export function NewProjectScreen() {
       const hasWorkspaces = (useAppStore.getState().appState?.workspaces.length ?? 0) > 0;
       const wsId = await createEmptyWorkspace(projectPath);
       await activateWorkspace(wsId);
-      if (!hasWorkspaces) {
+      if (!hasWorkspaces && !useUIStore.getState().hasSeenOnboarding) {
         useUIStore.getState().setOnboardingProjectDir(projectPath);
       }
       setShowNewProjectScreen(false);

--- a/src/components/overlays/project-onboarding.test.tsx
+++ b/src/components/overlays/project-onboarding.test.tsx
@@ -1,0 +1,139 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ProjectOnboarding } from "./project-onboarding";
+
+// ── Mock Tauri commands ──
+//
+// The component fires several side-effecting calls on mount (branch list,
+// worktree list, etc.). Resolve them with empty defaults so the component
+// reaches its rendered state. Then we can assert on skip behavior.
+vi.mock("@/tauri/commands", () => ({
+  listBranchesDetailed: vi.fn().mockResolvedValue([]),
+  listWorktrees: vi.fn().mockResolvedValue([]),
+  getDefaultBranch: vi.fn().mockResolvedValue("main"),
+  generateBranchName: vi.fn().mockResolvedValue("some-branch"),
+  generateRandomBranchName: vi.fn().mockResolvedValue("random-branch"),
+  createWorktreeWorkspace: vi.fn().mockResolvedValue("ws-new"),
+  importWorktreeWorkspace: vi.fn().mockResolvedValue("ws-new"),
+  activateWorkspace: vi.fn().mockResolvedValue(undefined),
+  closeWorkspace: vi.fn().mockResolvedValue(undefined),
+  detectPackageManager: vi.fn().mockResolvedValue([]),
+  setProjectScripts: vi.fn().mockResolvedValue(undefined),
+  dbAddRecentProject: vi.fn().mockResolvedValue(undefined),
+  getPresets: vi.fn().mockResolvedValue({
+    presets: [],
+    bar_visible: false,
+    default_preset_id: null,
+  }),
+}));
+
+import { closeWorkspace } from "@/tauri/commands";
+
+const mockCloseWorkspace = vi.mocked(closeWorkspace);
+
+function renderOnboarding(overrides: {
+  onComplete?: () => void;
+  onCancel?: () => void;
+} = {}) {
+  const onComplete = overrides.onComplete ?? vi.fn();
+  const onCancel = overrides.onCancel ?? vi.fn();
+  const utils = render(
+    <TooltipProvider>
+      <ProjectOnboarding
+        projectDir="/home/user/myproj"
+        tempWorkspaceId="ws-temp-1"
+        onComplete={onComplete}
+        onCancel={onCancel}
+      />
+    </TooltipProvider>,
+  );
+  return { ...utils, onComplete, onCancel };
+}
+
+async function flushMountEffects() {
+  // The mount useEffect does Promise.all(...) then setState. Flushing a
+  // microtask tick lets the mocked commands resolve before we click.
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ProjectOnboarding — skip affordance", () => {
+  it("renders a skip button with accessible label", async () => {
+    renderOnboarding();
+    await flushMountEffects();
+
+    const skipBtn = screen.getByRole("button", { name: /skip onboarding/i });
+    expect(skipBtn).toBeInTheDocument();
+  });
+
+  it("clicking skip invokes onCancel", async () => {
+    const { onCancel } = renderOnboarding();
+    await flushMountEffects();
+
+    fireEvent.click(screen.getByRole("button", { name: /skip onboarding/i }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking skip does NOT close the temp workspace", async () => {
+    // This is the deliberate spec: leaving the temp workspace intact lands
+    // the user in the real workspace shell, not <EmptyState />. Closing it
+    // would defeat the purpose of the skip affordance.
+    renderOnboarding();
+    await flushMountEffects();
+
+    fireEvent.click(screen.getByRole("button", { name: /skip onboarding/i }));
+
+    expect(mockCloseWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("clicking skip does not invoke onComplete", async () => {
+    const { onComplete } = renderOnboarding();
+    await flushMountEffects();
+
+    fireEvent.click(screen.getByRole("button", { name: /skip onboarding/i }));
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("unmount does not crash if a debounce timer is outstanding", async () => {
+    // Regression guard for the post-unmount-setState warning. Type into the
+    // task input to schedule a debounce, then unmount before it fires.
+    // Previously the timer would fire after unmount and trigger a React
+    // warning; the new unmount-cleanup effect clears it.
+    vi.useFakeTimers();
+    try {
+      const { unmount } = renderOnboarding();
+      // Advance past the initial mount microtasks without letting the real
+      // event loop race us; the mock resolvers use microtasks so this is OK.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const taskInput = screen.getByPlaceholderText(/add dark mode/i);
+      fireEvent.change(taskInput, { target: { value: "build a rocket" } });
+
+      // The debounce is 500ms in the component. Unmount before it fires.
+      unmount();
+
+      // Now advance past the debounce window. If the cleanup works, no
+      // setState-on-unmounted-component occurs; if it doesn't, React logs
+      // a warning which vitest surfaces as a stderr line.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      // Getting here without throwing is the pass condition.
+      expect(true).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/components/overlays/project-onboarding.tsx
+++ b/src/components/overlays/project-onboarding.tsx
@@ -25,7 +25,13 @@ import {
   ChevronLeft,
   ChevronDown,
   Check,
+  X,
 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { BranchPicker } from "./branch-picker";
 import { useUIStore } from "@/stores/ui-store";
 import {
@@ -55,7 +61,7 @@ interface Props {
   onCancel: () => void;
 }
 
-export function ProjectOnboarding({ projectDir, tempWorkspaceId, onComplete, onCancel: _onCancel }: Props) {
+export function ProjectOnboarding({ projectDir, tempWorkspaceId, onComplete, onCancel }: Props) {
   // ── Step state ──
   const [step, setStep] = useState<Step>("workspace");
 
@@ -135,6 +141,19 @@ export function ProjectOnboarding({ projectDir, tempWorkspaceId, onComplete, onC
       setTimeout(() => taskInputRef.current?.focus(), 100);
     }
   }, [step]);
+
+  // ── Clear debounce timer on unmount to avoid post-unmount setState ──
+  useEffect(() => {
+    return () => {
+      if (branchGenTimeout.current) clearTimeout(branchGenTimeout.current);
+    };
+  }, []);
+
+  // ── Skip onboarding — dismiss wizard, leave temp workspace intact ──
+  const handleSkip = () => {
+    if (branchGenTimeout.current) clearTimeout(branchGenTimeout.current);
+    onCancel();
+  };
 
   // ── Debounced branch name generation (only when not manually edited) ──
   const handleTaskChange = (value: string) => {
@@ -314,7 +333,23 @@ export function ProjectOnboarding({ projectDir, tempWorkspaceId, onComplete, onC
   const projectName = projectDir.split("/").filter(Boolean).pop() || "project";
 
   return (
-    <div className="flex-1 h-full flex flex-col overflow-hidden bg-background">
+    <div className="relative flex-1 h-full flex flex-col overflow-hidden bg-background">
+      {/* ── Skip affordance — top-right, always visible ── */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleSkip}
+            aria-label="Skip onboarding"
+            className="absolute top-4 right-4 z-10 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Skip (Esc)</TooltipContent>
+      </Tooltip>
+
       {/* ── External worktrees banner — outside scroll container ── */}
       {externalWorktrees.length > 0 && (
         <div className="mx-6 mt-6 rounded-lg border border-border/60 bg-card/50 p-4">

--- a/src/hooks/use-keyboard-shortcuts.test.ts
+++ b/src/hooks/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { dispatch } from "./use-keyboard-shortcuts";
+import { useUIStore } from "@/stores/ui-store";
+import { useAppStore } from "@/stores/app-store";
+
+// A fake KeyboardEvent — dispatch only uses the second arg when it needs to
+// call preventDefault via the caller, not inside dispatch itself, so a stub
+// is fine for closeOverlay-path testing.
+const FAKE_EVENT = new KeyboardEvent("keydown", { key: "Escape" });
+
+beforeEach(() => {
+  useAppStore.setState({ appState: null });
+  useUIStore.setState({
+    onboardingProjectDir: null,
+    hasSeenOnboarding: false,
+    showSettings: false,
+    showFileSearch: false,
+    showContentSearch: false,
+    showCommandPalette: false,
+  });
+  window.localStorage.clear();
+});
+
+describe("use-keyboard-shortcuts dispatch — closeOverlay precedence", () => {
+  it("returns false when no overlay is open", () => {
+    const handled = dispatch("closeOverlay", FAKE_EVENT);
+    expect(handled).toBe(false);
+  });
+
+  it("returns false for an unknown actionId", () => {
+    // Sanity check — dispatch should not swallow unrelated actions even when
+    // state that closeOverlay cares about is set.
+    useUIStore.setState({ showSettings: true });
+    const handled = dispatch("someOtherAction", FAKE_EVENT);
+    expect(handled).toBe(false);
+    // And settings stays open.
+    expect(useUIStore.getState().showSettings).toBe(true);
+  });
+
+  describe("onboarding priority", () => {
+    it("clears onboardingProjectDir when it's set (the escape-hatch fix)", () => {
+      useUIStore.setState({ onboardingProjectDir: "/home/user/myproj" });
+
+      const handled = dispatch("closeOverlay", FAKE_EVENT);
+
+      expect(handled).toBe(true);
+      const s = useUIStore.getState();
+      expect(s.onboardingProjectDir).toBeNull();
+      // And Escape counts as "onboarding seen" so Escape-dismissal doesn't
+      // re-arm on the next project open.
+      expect(s.hasSeenOnboarding).toBe(true);
+    });
+
+    it("onboarding takes precedence over settings", () => {
+      useUIStore.setState({
+        onboardingProjectDir: "/home/user/myproj",
+        showSettings: true,
+      });
+
+      dispatch("closeOverlay", FAKE_EVENT);
+
+      const s = useUIStore.getState();
+      expect(s.onboardingProjectDir).toBeNull();
+      // Settings stays open — only one overlay closes per Escape press.
+      expect(s.showSettings).toBe(true);
+    });
+
+    it("onboarding takes precedence over all other overlays simultaneously", () => {
+      useUIStore.setState({
+        onboardingProjectDir: "/home/user/myproj",
+        showSettings: true,
+        showFileSearch: true,
+        showContentSearch: true,
+        showCommandPalette: true,
+      });
+
+      dispatch("closeOverlay", FAKE_EVENT);
+
+      const s = useUIStore.getState();
+      expect(s.onboardingProjectDir).toBeNull();
+      expect(s.showSettings).toBe(true);
+      expect(s.showFileSearch).toBe(true);
+      expect(s.showContentSearch).toBe(true);
+      expect(s.showCommandPalette).toBe(true);
+    });
+  });
+
+  describe("other overlays — ordering preserved", () => {
+    it("closes settings when onboarding is not active", () => {
+      useUIStore.setState({ showSettings: true });
+      const handled = dispatch("closeOverlay", FAKE_EVENT);
+      expect(handled).toBe(true);
+      expect(useUIStore.getState().showSettings).toBe(false);
+    });
+
+    it("closes fileSearch before contentSearch", () => {
+      useUIStore.setState({ showFileSearch: true, showContentSearch: true });
+      dispatch("closeOverlay", FAKE_EVENT);
+      const s = useUIStore.getState();
+      expect(s.showFileSearch).toBe(false);
+      expect(s.showContentSearch).toBe(true);
+    });
+
+    it("closes contentSearch before commandPalette", () => {
+      useUIStore.setState({
+        showContentSearch: true,
+        showCommandPalette: true,
+      });
+      dispatch("closeOverlay", FAKE_EVENT);
+      const s = useUIStore.getState();
+      expect(s.showContentSearch).toBe(false);
+      expect(s.showCommandPalette).toBe(true);
+    });
+
+    it("closes commandPalette when it's the only overlay open", () => {
+      useUIStore.setState({ showCommandPalette: true });
+      const handled = dispatch("closeOverlay", FAKE_EVENT);
+      expect(handled).toBe(true);
+      expect(useUIStore.getState().showCommandPalette).toBe(false);
+    });
+  });
+
+  describe("other dispatch actions still work", () => {
+    it("commandPalette toggles on", () => {
+      expect(useUIStore.getState().showCommandPalette).toBe(false);
+      const handled = dispatch("commandPalette", FAKE_EVENT);
+      expect(handled).toBe(true);
+      expect(useUIStore.getState().showCommandPalette).toBe(true);
+    });
+
+    it("openSettings opens settings", () => {
+      const handled = dispatch("openSettings", FAKE_EVENT);
+      expect(handled).toBe(true);
+      expect(useUIStore.getState().showSettings).toBe(true);
+    });
+  });
+});

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -68,7 +68,7 @@ export function useKeyboardShortcuts() {
   return null;
 }
 
-function dispatch(actionId: string, _e: KeyboardEvent): boolean {
+export function dispatch(actionId: string, _e: KeyboardEvent): boolean {
   const ui = useUIStore.getState();
   const appState = useAppStore.getState().appState;
 

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -74,6 +74,12 @@ function dispatch(actionId: string, _e: KeyboardEvent): boolean {
 
   // ── Close overlay (Escape) — conditional ──
   if (actionId === "closeOverlay") {
+    // Onboarding is a full-view replacement, not a modal — prioritize it over
+    // dismissible overlays so Escape always provides an escape hatch.
+    if (ui.onboardingProjectDir) {
+      ui.setOnboardingProjectDir(null);
+      return true;
+    }
     if (ui.showSettings) {
       ui.setShowSettings(false);
       return true;

--- a/src/hooks/use-project-actions.test.ts
+++ b/src/hooks/use-project-actions.test.ts
@@ -1,0 +1,244 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { AppStateSnapshot, WorkspaceSnapshot } from "@/tauri/types";
+
+// ── Mock Tauri commands ──
+vi.mock("@/tauri/commands", () => ({
+  pickFolderDialog: vi.fn(),
+  checkIsGitRepo: vi.fn().mockResolvedValue(true),
+  initGitRepo: vi.fn().mockResolvedValue(undefined),
+  dbAddRecentProject: vi.fn().mockResolvedValue(undefined),
+  gitCloneRepo: vi.fn(),
+  createEmptyWorkspace: vi.fn().mockResolvedValue("ws-new"),
+  activateWorkspace: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  pickFolderDialog,
+  checkIsGitRepo,
+  gitCloneRepo,
+  createEmptyWorkspace,
+  activateWorkspace,
+} from "@/tauri/commands";
+import { useProjectActions } from "./use-project-actions";
+import { useAppStore } from "@/stores/app-store";
+import { useUIStore } from "@/stores/ui-store";
+
+const mockPickFolderDialog = vi.mocked(pickFolderDialog);
+const mockCheckIsGitRepo = vi.mocked(checkIsGitRepo);
+const mockGitCloneRepo = vi.mocked(gitCloneRepo);
+const mockCreateEmptyWorkspace = vi.mocked(createEmptyWorkspace);
+const mockActivateWorkspace = vi.mocked(activateWorkspace);
+
+function makeWs(id: string): WorkspaceSnapshot {
+  return {
+    workspace_id: id,
+    title: `Workspace ${id}`,
+    workspace_type: "standard",
+    cwd: "/some/path",
+    git_branch: null,
+    git_ahead: 0,
+    git_behind: 0,
+    git_additions: 0,
+    git_deletions: 0,
+    git_changed_files: 0,
+    worktree_path: null,
+    project_root: null,
+    pr_number: null,
+    pr_state: null,
+    pr_url: null,
+    linked_issue: null,
+    notification_count: 0,
+    latest_agent_state: null,
+    tabs: [],
+    active_tab_id: "",
+    active_surface_id: "",
+    surfaces: [],
+  };
+}
+
+function makeAppState(workspaces: WorkspaceSnapshot[]): AppStateSnapshot {
+  // The gate only reads `workspaces.length`. Stub the rest with empty
+  // defaults so the shape satisfies AppStateSnapshot without pulling in
+  // fixtures for fields the gate doesn't care about.
+  return {
+    schema_version: 1,
+    active_workspace_id: workspaces[0]?.workspace_id ?? "",
+    workspaces,
+    terminal_sessions: [],
+    browser_sessions: [],
+    agent_browser_sessions: [],
+    notifications: [],
+    detected_ports: [],
+    pane_statuses: {},
+    persistence: {} as AppStateSnapshot["persistence"],
+    config: {} as AppStateSnapshot["config"],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCheckIsGitRepo.mockResolvedValue(true);
+  mockCreateEmptyWorkspace.mockResolvedValue("ws-new");
+  mockActivateWorkspace.mockResolvedValue(undefined);
+
+  // Reset both stores to a pristine state.
+  useAppStore.setState({ appState: null });
+  useUIStore.setState({
+    onboardingProjectDir: null,
+    hasSeenOnboarding: false,
+  });
+  window.localStorage.clear();
+});
+
+describe("useProjectActions — onboarding trigger gate", () => {
+  describe("openProject", () => {
+    it("fires onboarding when workspaces empty AND hasSeenOnboarding false", async () => {
+      mockPickFolderDialog.mockResolvedValue("/home/user/fresh-project");
+      useAppStore.setState({ appState: makeAppState([]) });
+
+      const { result } = renderHook(() => useProjectActions());
+      await act(async () => {
+        await result.current.openProject();
+      });
+
+      expect(useUIStore.getState().onboardingProjectDir).toBe(
+        "/home/user/fresh-project",
+      );
+    });
+
+    it("does NOT fire onboarding when hasSeenOnboarding true (the re-trap fix)", async () => {
+      mockPickFolderDialog.mockResolvedValue("/home/user/second-project");
+      useAppStore.setState({ appState: makeAppState([]) });
+      useUIStore.setState({ hasSeenOnboarding: true });
+
+      const { result } = renderHook(() => useProjectActions());
+      await act(async () => {
+        await result.current.openProject();
+      });
+
+      expect(useUIStore.getState().onboardingProjectDir).toBeNull();
+      // Temp workspace still created — the fix only suppresses the wizard.
+      expect(mockCreateEmptyWorkspace).toHaveBeenCalledWith(
+        "/home/user/second-project",
+      );
+      expect(mockActivateWorkspace).toHaveBeenCalledWith("ws-new");
+    });
+
+    it("does NOT fire onboarding when workspaces already exist", async () => {
+      mockPickFolderDialog.mockResolvedValue("/home/user/another");
+      useAppStore.setState({ appState: makeAppState([makeWs("ws-existing")]) });
+
+      const { result } = renderHook(() => useProjectActions());
+      await act(async () => {
+        await result.current.openProject();
+      });
+
+      expect(useUIStore.getState().onboardingProjectDir).toBeNull();
+    });
+
+    it("does NOT fire onboarding when both gates fail (workspaces exist AND seen)", async () => {
+      mockPickFolderDialog.mockResolvedValue("/home/user/p");
+      useAppStore.setState({ appState: makeAppState([makeWs("ws-existing")]) });
+      useUIStore.setState({ hasSeenOnboarding: true });
+
+      const { result } = renderHook(() => useProjectActions());
+      await act(async () => {
+        await result.current.openProject();
+      });
+
+      expect(useUIStore.getState().onboardingProjectDir).toBeNull();
+    });
+
+    it("early-returns without effects when folder picker is cancelled", async () => {
+      mockPickFolderDialog.mockResolvedValue(null);
+      useAppStore.setState({ appState: makeAppState([]) });
+
+      const { result } = renderHook(() => useProjectActions());
+      const res = await act(async () => result.current.openProject());
+
+      expect(res).toEqual({ success: false });
+      expect(mockCreateEmptyWorkspace).not.toHaveBeenCalled();
+      expect(useUIStore.getState().onboardingProjectDir).toBeNull();
+    });
+  });
+
+  describe("cloneProject", () => {
+    it("fires onboarding when workspaces empty AND hasSeenOnboarding false", async () => {
+      mockGitCloneRepo.mockResolvedValue("/home/user/cloned");
+      useAppStore.setState({ appState: makeAppState([]) });
+
+      const { result } = renderHook(() => useProjectActions());
+      await act(async () => {
+        await result.current.cloneProject("git@host:u/r.git", "/home/user");
+      });
+
+      expect(useUIStore.getState().onboardingProjectDir).toBe(
+        "/home/user/cloned",
+      );
+    });
+
+    it("does NOT fire onboarding when hasSeenOnboarding true (the re-trap fix)", async () => {
+      mockGitCloneRepo.mockResolvedValue("/home/user/cloned-again");
+      useAppStore.setState({ appState: makeAppState([]) });
+      useUIStore.setState({ hasSeenOnboarding: true });
+
+      const { result } = renderHook(() => useProjectActions());
+      await act(async () => {
+        await result.current.cloneProject("git@host:u/r.git", "/home/user");
+      });
+
+      expect(useUIStore.getState().onboardingProjectDir).toBeNull();
+      // Temp workspace still created — the fix only suppresses the wizard.
+      expect(mockCreateEmptyWorkspace).toHaveBeenCalledWith(
+        "/home/user/cloned-again",
+      );
+    });
+
+    it("does NOT fire onboarding when workspaces already exist", async () => {
+      mockGitCloneRepo.mockResolvedValue("/home/user/cloned-x");
+      useAppStore.setState({ appState: makeAppState([makeWs("ws-existing")]) });
+
+      const { result } = renderHook(() => useProjectActions());
+      await act(async () => {
+        await result.current.cloneProject("git@host:u/r.git", "/home/user");
+      });
+
+      expect(useUIStore.getState().onboardingProjectDir).toBeNull();
+    });
+  });
+
+  describe("integration — the full re-trap scenario", () => {
+    it("second openProject after skip does not re-arm onboarding", async () => {
+      // Scenario: truly first-time user opens project #1, skips onboarding,
+      // closes all workspaces, opens project #2. Onboarding must not re-fire.
+      mockPickFolderDialog.mockResolvedValueOnce("/home/user/p1");
+      useAppStore.setState({ appState: makeAppState([]) });
+
+      const { result } = renderHook(() => useProjectActions());
+
+      // First open triggers onboarding.
+      await act(async () => {
+        await result.current.openProject();
+      });
+      expect(useUIStore.getState().onboardingProjectDir).toBe("/home/user/p1");
+
+      // User clicks skip → setOnboardingProjectDir(null) → flag flips true.
+      act(() => {
+        useUIStore.getState().setOnboardingProjectDir(null);
+      });
+      expect(useUIStore.getState().hasSeenOnboarding).toBe(true);
+
+      // User closes all workspaces (simulate empty list again).
+      useAppStore.setState({ appState: makeAppState([]) });
+
+      // Second openProject MUST NOT re-trigger onboarding.
+      mockPickFolderDialog.mockResolvedValueOnce("/home/user/p2");
+      await act(async () => {
+        await result.current.openProject();
+      });
+      expect(useUIStore.getState().onboardingProjectDir).toBeNull();
+    });
+  });
+});

--- a/src/hooks/use-project-actions.ts
+++ b/src/hooks/use-project-actions.ts
@@ -37,12 +37,14 @@ export function useProjectActions() {
 
     await dbAddRecentProject(folder, name);
 
-    // Only show the onboarding wizard if there are no existing workspaces
-    // across any project. If workspaces already exist, just create and activate.
+    // Only show the onboarding wizard for truly first-time users — no existing
+    // workspaces AND they have never seen/dismissed onboarding before. The
+    // `hasSeenOnboarding` flag persists so that closing all workspaces or
+    // opening a second project doesn't re-arm the wizard.
     const hasWorkspaces = (useAppStore.getState().appState?.workspaces.length ?? 0) > 0;
     const wsId = await createEmptyWorkspace(folder);
     await activateWorkspace(wsId);
-    if (!hasWorkspaces) {
+    if (!hasWorkspaces && !useUIStore.getState().hasSeenOnboarding) {
       useUIStore.getState().setOnboardingProjectDir(folder);
     }
 
@@ -62,7 +64,7 @@ export function useProjectActions() {
       const hasWorkspaces = (useAppStore.getState().appState?.workspaces.length ?? 0) > 0;
       const wsId = await createEmptyWorkspace(clonedPath);
       await activateWorkspace(wsId);
-      if (!hasWorkspaces) {
+      if (!hasWorkspaces && !useUIStore.getState().hasSeenOnboarding) {
         useUIStore.getState().setOnboardingProjectDir(clonedPath);
       }
 

--- a/src/stores/ui-store.test.ts
+++ b/src/stores/ui-store.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useUIStore } from "./ui-store";
+
+const STORAGE_KEY = "codemux-ui";
+
+beforeEach(() => {
+  // Reset volatile state between tests. Zustand's persist middleware writes
+  // to localStorage synchronously on every setState in jsdom, so clearing
+  // localStorage AFTER the reset prevents the reset itself from leaking a
+  // non-default snapshot across tests.
+  useUIStore.setState({
+    rightPanelTabs: {},
+    rightPanelWidth: 320,
+    showNewWorkspaceDialog: false,
+    newWorkspaceProjectDir: null,
+    showSettings: false,
+    settingsSection: null,
+    showFileSearch: false,
+    showContentSearch: false,
+    pendingWorkspaces: [],
+    lastSelectedAgentId: null,
+    showCommandPalette: false,
+    showCloneDialog: false,
+    showNewProjectScreen: false,
+    onboardingProjectDir: null,
+    hasSeenOnboarding: false,
+    sidebarToggleFn: null,
+  });
+  window.localStorage.clear();
+});
+
+describe("ui-store — onboarding state", () => {
+  it("starts with onboardingProjectDir null and hasSeenOnboarding false", () => {
+    const s = useUIStore.getState();
+    expect(s.onboardingProjectDir).toBeNull();
+    expect(s.hasSeenOnboarding).toBe(false);
+  });
+
+  describe("setOnboardingProjectDir", () => {
+    it("with a path sets the dir and leaves hasSeenOnboarding unchanged (false)", () => {
+      useUIStore.getState().setOnboardingProjectDir("/home/user/myproj");
+
+      const s = useUIStore.getState();
+      expect(s.onboardingProjectDir).toBe("/home/user/myproj");
+      expect(s.hasSeenOnboarding).toBe(false);
+    });
+
+    it("with a path leaves hasSeenOnboarding unchanged when already true", () => {
+      // Simulate a returning user who already saw onboarding once.
+      useUIStore.setState({ hasSeenOnboarding: true });
+      useUIStore.getState().setOnboardingProjectDir("/home/user/another");
+
+      const s = useUIStore.getState();
+      expect(s.onboardingProjectDir).toBe("/home/user/another");
+      expect(s.hasSeenOnboarding).toBe(true);
+    });
+
+    it("with null clears the dir and flips hasSeenOnboarding to true", () => {
+      // Seed an active onboarding session.
+      useUIStore.setState({ onboardingProjectDir: "/home/user/myproj" });
+      expect(useUIStore.getState().hasSeenOnboarding).toBe(false);
+
+      useUIStore.getState().setOnboardingProjectDir(null);
+
+      const s = useUIStore.getState();
+      expect(s.onboardingProjectDir).toBeNull();
+      expect(s.hasSeenOnboarding).toBe(true);
+    });
+
+    it("with null is idempotent when hasSeenOnboarding is already true", () => {
+      useUIStore.setState({
+        onboardingProjectDir: "/home/user/myproj",
+        hasSeenOnboarding: true,
+      });
+
+      useUIStore.getState().setOnboardingProjectDir(null);
+
+      const s = useUIStore.getState();
+      expect(s.onboardingProjectDir).toBeNull();
+      expect(s.hasSeenOnboarding).toBe(true);
+    });
+
+    it("with null flips the flag even when dir was already null", () => {
+      // Defensive: a caller that clears onboarding without ever setting a dir
+      // (e.g. an Escape dispatch before onboarding is active) must still
+      // count as "seen" so subsequent flips remain consistent.
+      expect(useUIStore.getState().onboardingProjectDir).toBeNull();
+
+      useUIStore.getState().setOnboardingProjectDir(null);
+
+      expect(useUIStore.getState().hasSeenOnboarding).toBe(true);
+    });
+
+    it("full lifecycle: enter → exit flips hasSeenOnboarding exactly once", () => {
+      // Enter
+      useUIStore.getState().setOnboardingProjectDir("/p1");
+      expect(useUIStore.getState().hasSeenOnboarding).toBe(false);
+
+      // Exit via any path (skip, complete, auto-dismiss — all end up here)
+      useUIStore.getState().setOnboardingProjectDir(null);
+      expect(useUIStore.getState().hasSeenOnboarding).toBe(true);
+
+      // Second open (e.g. user opens another project) must not re-flip or
+      // reset the flag.
+      useUIStore.getState().setOnboardingProjectDir("/p2");
+      expect(useUIStore.getState().hasSeenOnboarding).toBe(true);
+
+      useUIStore.getState().setOnboardingProjectDir(null);
+      expect(useUIStore.getState().hasSeenOnboarding).toBe(true);
+    });
+  });
+
+  describe("persistence", () => {
+    it("persists hasSeenOnboarding to localStorage", () => {
+      useUIStore.getState().setOnboardingProjectDir(null);
+
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const persisted = JSON.parse(raw!);
+      // Zustand persist format: { state: {...}, version: N }
+      expect(persisted.state.hasSeenOnboarding).toBe(true);
+    });
+
+    it("does NOT persist onboardingProjectDir (session-only)", () => {
+      useUIStore.getState().setOnboardingProjectDir("/home/user/myproj");
+
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const persisted = JSON.parse(raw!);
+      // onboardingProjectDir must stay transient so a crash during onboarding
+      // doesn't re-arm the wizard on next launch.
+      expect(persisted.state.onboardingProjectDir).toBeUndefined();
+    });
+
+    it("does NOT persist transient overlay flags", () => {
+      useUIStore.setState({
+        showSettings: true,
+        showFileSearch: true,
+        showContentSearch: true,
+        showCommandPalette: true,
+        showCloneDialog: true,
+        showNewProjectScreen: true,
+        showNewWorkspaceDialog: true,
+      });
+      // Force a persist write.
+      useUIStore.getState().setOnboardingProjectDir(null);
+
+      const persisted = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!);
+      expect(persisted.state.showSettings).toBeUndefined();
+      expect(persisted.state.showFileSearch).toBeUndefined();
+      expect(persisted.state.showContentSearch).toBeUndefined();
+      expect(persisted.state.showCommandPalette).toBeUndefined();
+      expect(persisted.state.showCloneDialog).toBeUndefined();
+      expect(persisted.state.showNewProjectScreen).toBeUndefined();
+      expect(persisted.state.showNewWorkspaceDialog).toBeUndefined();
+    });
+
+    it("persists hasSeenOnboarding alongside existing allowlist fields", () => {
+      useUIStore.setState({
+        rightPanelWidth: 400,
+        lastSelectedAgentId: "builtin-claude",
+      });
+      useUIStore.getState().setOnboardingProjectDir(null);
+
+      const persisted = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!);
+      expect(persisted.state.hasSeenOnboarding).toBe(true);
+      expect(persisted.state.rightPanelWidth).toBe(400);
+      expect(persisted.state.lastSelectedAgentId).toBe("builtin-claude");
+    });
+  });
+});

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -19,6 +19,7 @@ interface UIStore {
   showCloneDialog: boolean;
   showNewProjectScreen: boolean;
   onboardingProjectDir: string | null;
+  hasSeenOnboarding: boolean;
   /** Callback ref set by AppShell after SidebarProvider mounts */
   sidebarToggleFn: (() => void) | null;
 
@@ -59,6 +60,7 @@ export const useUIStore = create<UIStore>()(
       showCloneDialog: false,
       showNewProjectScreen: false,
       onboardingProjectDir: null,
+      hasSeenOnboarding: false,
       sidebarToggleFn: null,
 
       getRightPanelTab: (workspaceId) => get().rightPanelTabs[workspaceId] ?? null,
@@ -113,7 +115,12 @@ export const useUIStore = create<UIStore>()(
 
       setShowNewProjectScreen: (show) => set({ showNewProjectScreen: show }),
 
-      setOnboardingProjectDir: (dir) => set({ onboardingProjectDir: dir }),
+      setOnboardingProjectDir: (dir) =>
+        set((s) =>
+          dir === null
+            ? { onboardingProjectDir: null, hasSeenOnboarding: true }
+            : { onboardingProjectDir: dir, hasSeenOnboarding: s.hasSeenOnboarding },
+        ),
 
       setSidebarToggleFn: (fn) => set({ sidebarToggleFn: fn }),
     }),
@@ -123,6 +130,7 @@ export const useUIStore = create<UIStore>()(
         rightPanelTabs: state.rightPanelTabs,
         rightPanelWidth: state.rightPanelWidth,
         lastSelectedAgentId: state.lastSelectedAgentId,
+        hasSeenOnboarding: state.hasSeenOnboarding,
       }),
     },
   ),


### PR DESCRIPTION
## Summary

- Add skip button (X icon, top-right) to ProjectOnboarding overlay; clicking invokes `onCancel` without closing the temp workspace
- Introduce `hasSeenOnboarding` flag to UIStore that prevents re-triggering the wizard when workspaces are closed and reopened
- Prioritize Escape key for onboarding dismissal over other overlays, providing an escape hatch
- Gate onboarding in `openProject` and `cloneProject` on both `!hasWorkspaces` AND `!hasSeenOnboarding`
- Clear debounce timers on unmount to avoid post-unmount setState warnings
- Persist `hasSeenOnboarding` across sessions; keep `onboardingProjectDir` transient

## Testing

- [x] ProjectOnboarding skip button renders with accessible label
- [x] Clicking skip invokes onCancel and does not close temp workspace
- [x] Unmount clears debounce timers without crashes
- [x] Keyboard shortcut dispatch prioritizes onboarding over other overlays
- [x] Escape dismissal flips `hasSeenOnboarding` to prevent re-trap
- [x] Second `openProject` after skip does not re-arm onboarding
- [x] `cloneProject` respects the same re-trap gate
- [x] `hasSeenOnboarding` persists to localStorage
- [x] `onboardingProjectDir` stays session-only (not persisted)
- [x] Full lifecycle: enter → skip → second open → no re-trigger