### PR TITLE
Live branch labels: refresh git state across all workspaces with visibility-based gating

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -531,11 +531,15 @@ pub fn activate_workspace(
     workspace_id: String,
 ) -> Result<(), String> {
     if state.activate_workspace(&workspace_id) {
-        // Refresh git info synchronously before emitting state so the sidebar
-        // sees the current HEAD immediately on click, not up to 5s later when
-        // the background polling loop next ticks. Cheap (~3 git subprocesses,
-        // ~20ms typical); `git_branch_info` handles non-git/detached/corrupted
-        // repos without panicking.
+        // Kick off git refresh in a background thread — don't block the
+        // activate click. `populate_git_info` runs 5-8 git subprocesses
+        // (branch + upstream + ahead/behind + two diff-stat calls + status
+        // with duplicated `diff --numstat`), which can hit 100-300ms on a
+        // cold filesystem cache or a large repo. The 5s polling loop
+        // reconciles, so worst case the sidebar shows slightly stale branch
+        // info for one tick. `git_branch_info` handles non-git / detached /
+        // corrupted repos without panicking, and the spawned thread emits
+        // app state when done so the sidebar picks up the refresh.
         let cwd = {
             let snapshot = state.snapshot();
             snapshot
@@ -545,7 +549,13 @@ pub fn activate_workspace(
                 .map(|w| w.cwd.clone())
         };
         if let Some(cwd) = cwd {
-            populate_git_info(&state, &workspace_id, Path::new(&cwd));
+            let refresh_app = app.clone();
+            let refresh_ws = workspace_id.clone();
+            std::thread::spawn(move || {
+                let state: tauri::State<'_, AppStateStore> = refresh_app.state();
+                populate_git_info(&state, &refresh_ws, Path::new(&cwd));
+                crate::state::emit_app_state(&refresh_app);
+            });
         }
 
         // Lazy PTY hydration: `spawn_missing_ptys` at startup only resumed

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -22,7 +22,13 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use tauri::{Emitter, Manager, State};
 
-fn populate_git_info(state: &AppStateStore, workspace_id: &str, repo_path: &Path) {
+/// Read fresh git branch / ahead-behind / diff-stat / changed-file counts for
+/// `repo_path` and write them into the workspace snapshot. Crash-proof:
+/// `git_branch_info` and friends return defaults for non-git directories,
+/// detached HEAD, and corrupted `.git` directories. `pub(crate)` so the
+/// periodic refresh loop in `lib.rs` can reuse this instead of duplicating
+/// the extraction logic.
+pub(crate) fn populate_git_info(state: &AppStateStore, workspace_id: &str, repo_path: &Path) {
     let branch_info = crate::git::git_branch_info(repo_path).ok();
     let diff_stat = crate::git::git_diff_stat(repo_path).ok();
     let changed_files = crate::git::git_status(repo_path).map(|f| f.len() as u32).unwrap_or(0);
@@ -525,6 +531,23 @@ pub fn activate_workspace(
     workspace_id: String,
 ) -> Result<(), String> {
     if state.activate_workspace(&workspace_id) {
+        // Refresh git info synchronously before emitting state so the sidebar
+        // sees the current HEAD immediately on click, not up to 5s later when
+        // the background polling loop next ticks. Cheap (~3 git subprocesses,
+        // ~20ms typical); `git_branch_info` handles non-git/detached/corrupted
+        // repos without panicking.
+        let cwd = {
+            let snapshot = state.snapshot();
+            snapshot
+                .workspaces
+                .iter()
+                .find(|w| w.workspace_id.0 == workspace_id)
+                .map(|w| w.cwd.clone())
+        };
+        if let Some(cwd) = cwd {
+            populate_git_info(&state, &workspace_id, Path::new(&cwd));
+        }
+
         // Lazy PTY hydration: `spawn_missing_ptys` at startup only resumed
         // sessions for the workspace that was active at last close. Sessions
         // for any other workspace stay on disk-only until the user activates

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -496,14 +496,22 @@ pub fn run() {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-                    // Only poll when the user can see the sidebar. `is_focused`
-                    // returns Err if the window is closing; treat that as
-                    // unfocused and skip.
-                    let window_focused = git_handle
+                    // Pause polling only when the sidebar is genuinely not
+                    // on screen. `is_focused()` would wrongly pause when the
+                    // window is visible on another Hyprland/KDE/Gnome
+                    // workspace — users there still expect the sidebar to
+                    // reflect live branch state. `is_minimized()` returning
+                    // Err defaults to "treat as minimized" so we skip the
+                    // tick rather than busy-loop on a broken window handle.
+                    let window_active = git_handle
                         .get_webview_window("main")
-                        .and_then(|w| w.is_focused().ok())
+                        .map(|w| {
+                            let visible = w.is_visible().unwrap_or(false);
+                            let minimized = w.is_minimized().unwrap_or(true);
+                            visible && !minimized
+                        })
                         .unwrap_or(false);
-                    if !window_focused {
+                    if !window_active {
                         continue;
                     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -480,25 +480,49 @@ pub fn run() {
 
             control::spawn_control_server(app.handle().clone());
 
-            // Periodically refresh git info for the active workspace
+            // Periodically refresh git info for EVERY workspace (so non-active
+            // sidebar rows stay honest when agents switch branches), plus
+            // PR/issue info for the active workspace only (where `gh` CLI
+            // calls are the expensive part and only the visible row benefits
+            // from being up-to-date every 5s).
+            //
+            // Serial iteration on purpose — cost is predictable (~3 git
+            // subprocesses × N workspaces per tick) and easy to throttle
+            // later if needed. Skips the tick entirely when the main window
+            // is unfocused to avoid wasting CPU/battery while the user is
+            // elsewhere.
             let git_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    let state: tauri::State<'_, state::AppStateStore> = git_handle.state();
-                    if let Some((workspace_id, cwd)) = state.active_workspace_cwd() {
-                        let path = std::path::PathBuf::from(&cwd);
-                        let branch_info = git::git_branch_info(&path).ok();
-                        let diff_stat = git::git_diff_stat(&path).ok();
-                        let changed_files = git::git_status(&path).map(|f| f.len() as u32).unwrap_or(0);
-                        let branch = branch_info.as_ref().and_then(|i| i.branch.clone());
-                        let ahead = branch_info.as_ref().map(|i| i.ahead).unwrap_or(0);
-                        let behind = branch_info.as_ref().map(|i| i.behind).unwrap_or(0);
-                        let additions = diff_stat.as_ref().map(|s| s.staged_additions + s.unstaged_additions).unwrap_or(0);
-                        let deletions = diff_stat.as_ref().map(|s| s.staged_deletions + s.unstaged_deletions).unwrap_or(0);
-                        state.update_workspace_git_info(&workspace_id, branch, ahead, behind, additions, deletions, changed_files);
 
-                        // Only fetch PR/issue info if gh CLI is available
+                    // Only poll when the user can see the sidebar. `is_focused`
+                    // returns Err if the window is closing; treat that as
+                    // unfocused and skip.
+                    let window_focused = git_handle
+                        .get_webview_window("main")
+                        .and_then(|w| w.is_focused().ok())
+                        .unwrap_or(false);
+                    if !window_focused {
+                        continue;
+                    }
+
+                    let state: tauri::State<'_, state::AppStateStore> = git_handle.state();
+                    let all_workspaces = state.all_workspace_cwds();
+                    let active = state.active_workspace_cwd();
+
+                    // Refresh git info for every workspace via the shared helper.
+                    for (workspace_id, cwd) in &all_workspaces {
+                        let path = std::path::PathBuf::from(cwd);
+                        commands::workspace::populate_git_info(&state, workspace_id, &path);
+                    }
+
+                    // PR / linked-issue refresh stays scoped to the active
+                    // workspace — each call shells out to `gh`, which is the
+                    // expensive part, and the user can only see one PR panel
+                    // at a time anyway.
+                    if let Some((workspace_id, cwd)) = active {
+                        let path = std::path::PathBuf::from(&cwd);
                         if github::gh_available() {
                             let pr_info = match github::get_branch_pr(&path) {
                                 Ok(info) => info,
@@ -536,8 +560,12 @@ pub fn run() {
                                 }
                             }
                         }
+                    }
 
-                        // Single emit after both git and PR info are updated
+                    // Single emit per tick, regardless of how many workspaces
+                    // were refreshed or whether PR info was updated. The
+                    // frontend dedups on payload equality anyway.
+                    if !all_workspaces.is_empty() {
                         state::emit_app_state(&git_handle);
                     }
                 }

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -18,6 +18,11 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { X, Laptop, GitBranch, Workflow, AlertTriangle } from "lucide-react";
 import {
@@ -87,12 +92,14 @@ function RemoveWorkspaceDialog({
       <DialogContent showCloseButton={false} className="max-w-[340px]">
         <DialogHeader>
           <DialogTitle className="text-sm">
-            Remove workspace &ldquo;{workspace.title}&rdquo;?
+            {isWorktree
+              ? <>Remove workspace &ldquo;{workspace.title}&rdquo;?</>
+              : <>Close workspace &ldquo;{workspace.title}&rdquo;?</>}
           </DialogTitle>
           <DialogDescription>
             {isWorktree
               ? "Deleting will permanently remove the worktree. You can hide instead to keep files on disk."
-              : "This will close the workspace."}
+              : "Removes this workspace from the sidebar. Project files on disk are untouched."}
           </DialogDescription>
         </DialogHeader>
 
@@ -128,23 +135,55 @@ function RemoveWorkspaceDialog({
           >
             Cancel
           </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            className="h-7 px-3 text-xs"
-            onClick={handleHide}
-          >
-            Hide
-          </Button>
-          {isWorktree && (
-            <Button
-              variant="destructive"
-              size="sm"
-              className="h-7 px-3 text-xs"
-              onClick={handleDelete}
-            >
-              Delete
-            </Button>
+          {isWorktree ? (
+            <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="h-7 px-3 text-xs"
+                    onClick={handleHide}
+                  >
+                    Hide
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4} className="text-xs">
+                  Remove from sidebar. Worktree files stay on disk.
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    className="h-7 px-3 text-xs"
+                    onClick={handleDelete}
+                  >
+                    Delete
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4} className="text-xs">
+                  Permanently remove worktree directory from disk.
+                </TooltipContent>
+              </Tooltip>
+            </>
+          ) : (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="h-7 px-3 text-xs"
+                  onClick={handleHide}
+                >
+                  Close
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={4} className="text-xs">
+                Remove from sidebar. Project files on disk are untouched.
+              </TooltipContent>
+            </Tooltip>
           )}
         </div>
       </DialogContent>

--- a/src/components/overlays/new-workspace-dialog.tsx
+++ b/src/components/overlays/new-workspace-dialog.tsx
@@ -264,6 +264,17 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     return map;
   }, [appState, projectDir]);
 
+  // Worktree paths already owned by a Codemux workspace. Used to filter
+  // `git worktree list` so "Open ↵ <branch>" doesn't try to re-import a
+  // worktree that's already attached to another workspace row.
+  const existingWorktreePaths = useMemo(() => {
+    const set = new Set<string>();
+    for (const ws of appState?.workspaces ?? []) {
+      if (ws.worktree_path) set.add(ws.worktree_path);
+    }
+    return set;
+  }, [appState]);
+
   // All branches merged and deduplicated
   const allBranches = useMemo(() => {
     const set = new Set([...localBranches, ...remoteBranches]);
@@ -369,16 +380,26 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
 
         let wsId: string;
         let agentHandled = false;
+        // A real orphan is a worktree on disk whose branch we want, that isn't the
+        // main repo itself and isn't already owned by an existing Codemux workspace.
+        // Both filters are required: the first excludes the primary repo (which appears
+        // in `git worktree list --porcelain`), the second excludes worktrees we already
+        // manage as a workspace.
         const orphan = worktrees.find(
           (wt) =>
-            wt.branch === openExistingBranch ||
-            wt.branch === `refs/heads/${openExistingBranch}`,
+            (wt.branch === openExistingBranch ||
+              wt.branch === `refs/heads/${openExistingBranch}`) &&
+            wt.path !== projectDir &&
+            !existingWorktreePaths.has(wt.path),
         );
 
         const isDefaultOpen = openExistingBranch === "main" || openExistingBranch === "master";
         if (orphan) {
           wsId = await importWorktreeWorkspace(orphan.path, openExistingBranch, "single");
-        } else if (openExistingBranch === currentBranch && isDefaultOpen) {
+        } else if (isDefaultOpen) {
+          // Open on the default branch always attaches to the real repo root.
+          // The sidebar label will reflect actual HEAD via the live refresh loop,
+          // so the user sees reality. No phantom worktree is created.
           wsId = await createWorkspace(projectDir);
         } else {
           wsId = await createWorktreeWorkspace(
@@ -443,18 +464,25 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
       let wsId: string;
       let agentHandled = false;
 
-      // Default branch (main/master): open as workspace directly.
-      // Feature branches always get a proper worktree — even if currently
-      // checked out (git_create_worktree will switch the main repo away).
+      // Existing default branch (main/master): always attach to the real repo
+      // root regardless of what the main repo currently has checked out. The
+      // sidebar branch label reflects actual HEAD via the live refresh loop,
+      // so the user sees reality instead of a phantom worktree at
+      // ~/.codemux/worktrees/<project>/main. Feature branches always get a
+      // proper worktree.
       const isDefault = resolvedBranch === "main" || resolvedBranch === "master";
-      if (resolvedBranch === currentBranch && !isNewBranch && isDefault) {
+      if (isDefault && !isNewBranch) {
         wsId = await createWorkspace(projectDir);
       } else {
-        // Check for orphan worktree
+        // Same orphan filter as the open-existing flow above: skip the main
+        // repo entry (which `git worktree list` includes) and any worktree
+        // already owned by another workspace.
         const orphan = worktrees.find(
           (wt) =>
-            wt.branch === resolvedBranch ||
-            wt.branch === `refs/heads/${resolvedBranch}`,
+            (wt.branch === resolvedBranch ||
+              wt.branch === `refs/heads/${resolvedBranch}`) &&
+            wt.path !== projectDir &&
+            !existingWorktreePaths.has(wt.path),
         );
 
         if (orphan) {
@@ -518,6 +546,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     openExistingBranch,
     branchWorkspaceMap,
     worktrees,
+    existingWorktreePaths,
     currentBranch,
     linkedIssue,
     onOpenChange,


### PR DESCRIPTION
## Summary

- **Git refresh now covers all workspaces**, not just the active one — sidebar branch labels stay accurate when agents switch branches or you navigate between workspaces
- **Non-blocking activation**: workspace selection now triggers git refresh in a background thread instead of blocking the UI click
- **Visibility-based gating**: polling pauses when the window is minimized or hidden to save CPU/battery
- **PR info stays scoped to active workspace** — expensive `gh` CLI calls only refresh where visible
- **Fixed "Open ↵ main" to attach to real repo root** instead of creating a phantom worktree; the live refresh loop reflects actual HEAD
- **Improved button clarity**: Close/Hide/Delete now have tooltips explaining the difference (sidebar removal vs disk deletion)
- **Added onboarding skip affordance** (Esc or X button) and fixed re-trap where skipping the first project would re-show the wizard on the second
- **Comprehensive test coverage** for onboarding escape hatch, keyboard dispatch precedence, and new worktree filtering logic

## Testing

- `npm run verify` passes (tests + type check + build)
- Manual: open a fresh project, verify skip button (X / Esc) dismisses wizard without closing workspace
- Manual: skip first project onboarding, open second project — wizard should not appear (re-trap fix)
- Manual: open two workspaces on different branches, switch between them — sidebar labels update live
- Manual: minimize or move Codemux to another desktop — git polling pauses; bring it back — polling resumes
- Manual: click workspace — no UI lag; git info refreshes in background and sidebar updates within ~1 tick
- Manual: verify Close vs Hide vs Delete tooltips appear on hover in the remove-workspace dialog