### PR TITLE
Add "Checkout default branch" action for primary workspaces

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1023,6 +1023,45 @@ pub fn refresh_workspace_git_info(
     Ok(())
 }
 
+/// Switch a workspace's repo to its default branch (main / master / origin
+/// HEAD). On success, refresh git info synchronously so the sidebar label
+/// updates without waiting for the 5s polling loop. On failure, return the
+/// git stderr verbatim for the frontend to surface as a toast.
+///
+/// Used by the sidebar's right-click "Checkout default branch" action to
+/// close the intent gap where `Open ↵ main` attaches to a repo currently on
+/// a different branch (attach-only by design — no HEAD mutation).
+#[tauri::command]
+pub fn checkout_default_branch_in_workspace(
+    app: tauri::AppHandle,
+    state: State<'_, AppStateStore>,
+    workspace_id: String,
+) -> Result<String, String> {
+    let cwd = {
+        let snapshot = state.snapshot();
+        snapshot
+            .workspaces
+            .iter()
+            .find(|w| w.workspace_id.0 == workspace_id)
+            .map(|w| w.cwd.clone())
+            .ok_or_else(|| "Workspace not found".to_string())?
+    };
+    let repo_path = Path::new(&cwd);
+
+    match crate::git::checkout_default_branch(repo_path) {
+        Ok(Some(branch)) => {
+            // Sync refresh: closes the 0–5s sidebar-label lag from the
+            // background polling loop by writing fresh branch info before
+            // we emit.
+            populate_git_info(&state, &workspace_id, repo_path);
+            crate::state::emit_app_state(&app);
+            Ok(branch)
+        }
+        Ok(None) => Err("No default branch could be determined for this repo.".to_string()),
+        Err(stderr) => Err(stderr),
+    }
+}
+
 // ---- Editor integration ----
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1340,7 +1340,12 @@ pub fn git_list_branches_detailed(repo_path: &Path) -> Result<Vec<BranchDetail>,
 
 /// Find the remote tracking ref for a branch (e.g. `origin/main` for `main`).
 /// Find the default branch for the repo (main, master, etc.).
-fn find_default_branch(repo_path: &Path) -> Option<String> {
+/// `pub(crate)` so helpers outside the branch-ops module (e.g.
+/// `checkout_default_branch`) can reuse the same resolution logic. Does NOT
+/// supersede `git_default_branch` — that one is the frontend-facing command
+/// with a slightly different fallback (`Ok("main")` instead of `None`).
+/// Consolidating the two is a separate follow-up.
+pub(crate) fn find_default_branch(repo_path: &Path) -> Option<String> {
     // Try origin/HEAD first
     if let Ok(output) = run_git(repo_path, &["symbolic-ref", "refs/remotes/origin/HEAD"]) {
         if let Some(branch) = output.trim().strip_prefix("refs/remotes/origin/") {
@@ -1354,6 +1359,29 @@ fn find_default_branch(repo_path: &Path) -> Option<String> {
         }
     }
     None
+}
+
+/// Switch the repo to its default branch (main / master / whatever
+/// `origin/HEAD` points at). Returns:
+/// - `Ok(Some(branch_name))` on success, or if the repo is already on the
+///   default branch (no checkout actually runs in the already-on-default case).
+/// - `Ok(None)` if no default branch could be determined (unborn HEAD, no
+///   main/master, no `origin/HEAD` symref).
+/// - `Err(stderr)` if git refused the checkout — dirty working tree with
+///   conflicts, rebase/merge in progress, `index.lock` contention, etc. The
+///   error string is passed through verbatim so callers can surface git's
+///   own message. Never destructive: git's native refusal protects work.
+pub fn checkout_default_branch(repo_path: &Path) -> Result<Option<String>, String> {
+    let default = match find_default_branch(repo_path) {
+        Some(b) => b,
+        None => return Ok(None),
+    };
+    let current = run_git_permissive(repo_path, &["branch", "--show-current"]);
+    if current == default {
+        return Ok(Some(default));
+    }
+    run_git(repo_path, &["checkout", &default])?;
+    Ok(Some(default))
 }
 
 /// Returns `None` if no remote ref exists. Only checks `origin` remote
@@ -4595,5 +4623,135 @@ TARGET version
         assert_eq!(cur, source);
         let content = std::fs::read_to_string(repo.join("shared.txt")).unwrap();
         assert_eq!(content, "RESOLVED version\n");
+    }
+
+    // ---- checkout_default_branch ----
+
+    /// Clean feature-branch repo → checkout_default_branch switches HEAD
+    /// back to the default and returns the branch name.
+    #[test]
+    fn checkout_default_branch_switches_from_feature_to_default() {
+        let (_dir, repo) = setup_test_repo();
+        git_config(&repo);
+        let default = main_branch(&repo).to_string();
+
+        run_git(&repo, &["checkout", "-b", "feature/x"]).expect("create feature");
+        let current = run_git_permissive(&repo, &["branch", "--show-current"]);
+        assert_eq!(current, "feature/x");
+
+        let result = checkout_default_branch(&repo).expect("checkout should succeed");
+        assert_eq!(result, Some(default.clone()));
+
+        let after = run_git_permissive(&repo, &["branch", "--show-current"]);
+        assert_eq!(after, default, "HEAD should be on default branch");
+    }
+
+    /// Already on default → returns Ok(Some(default)) without running a
+    /// no-op checkout. Verified by checking the reflog is unchanged.
+    #[test]
+    fn checkout_default_branch_noop_when_already_on_default() {
+        let (_dir, repo) = setup_test_repo();
+        git_config(&repo);
+        let default = main_branch(&repo).to_string();
+        let current = run_git_permissive(&repo, &["branch", "--show-current"]);
+        assert_eq!(current, default, "precondition: should start on default");
+
+        // Snapshot HEAD reflog count before the call.
+        let reflog_before = run_git_permissive(&repo, &["reflog", "HEAD"])
+            .lines()
+            .count();
+
+        let result = checkout_default_branch(&repo).expect("checkout should succeed");
+        assert_eq!(result, Some(default));
+
+        let reflog_after = run_git_permissive(&repo, &["reflog", "HEAD"])
+            .lines()
+            .count();
+        assert_eq!(
+            reflog_before, reflog_after,
+            "no-op path must not add a reflog entry for a redundant checkout"
+        );
+    }
+
+    /// Repo with no commits / no branches / no remote → find_default_branch
+    /// returns None → helper returns Ok(None) instead of Err or panic.
+    #[test]
+    fn checkout_default_branch_returns_none_when_no_default_exists() {
+        let dir = TempDir::new().expect("tmp");
+        let repo = dir.path().to_path_buf();
+        run_git(&repo, &["init"]).expect("init");
+        // No initial commit, no origin, no main/master branch.
+
+        let result = checkout_default_branch(&repo).expect("should not Err on unborn repo");
+        assert!(result.is_none(), "expected None, got {:?}", result);
+    }
+
+    /// Uncommitted change that conflicts with a tracked file on the default
+    /// branch → git refuses → Err(stderr) bubbles up, current branch is
+    /// unchanged.
+    #[test]
+    fn checkout_default_branch_errs_on_dirty_conflict_and_preserves_branch() {
+        let (_dir, repo) = setup_test_repo();
+        git_config(&repo);
+        let default = main_branch(&repo).to_string();
+
+        // Create tracked file on default.
+        std::fs::write(repo.join("shared.txt"), "default content\n").unwrap();
+        run_git(&repo, &["add", "shared.txt"]).unwrap();
+        run_git(&repo, &["commit", "-m", "add shared on default"]).unwrap();
+
+        // Feature branch with no shared.txt yet.
+        run_git(&repo, &["checkout", "-b", "feature/x"]).unwrap();
+        run_git(&repo, &["rm", "shared.txt"]).unwrap();
+        run_git(&repo, &["commit", "-m", "remove shared on feature"]).unwrap();
+
+        // Now create an *untracked* file at the same path — checkout would
+        // have to overwrite it, which git refuses.
+        std::fs::write(repo.join("shared.txt"), "local dirty content\n").unwrap();
+
+        let err = checkout_default_branch(&repo).expect_err("should refuse to overwrite");
+        assert!(
+            err.contains("would be overwritten") || err.contains("Aborting"),
+            "expected git's 'would be overwritten' message, got: {err}"
+        );
+
+        let after = run_git_permissive(&repo, &["branch", "--show-current"]);
+        assert_eq!(after, "feature/x", "branch must be unchanged after failed checkout");
+        let _ = default; // silence unused binding
+    }
+
+    /// `origin/HEAD` pointing at `develop` → we switch to `develop`, not
+    /// main. This is the "custom default name" case.
+    #[test]
+    fn checkout_default_branch_uses_origin_head_for_non_standard_default() {
+        let (_dir, local, _remote) = setup_test_repo_with_remote();
+        git_config(&local);
+
+        // Create a `develop` branch, push it, then point origin/HEAD at it.
+        run_git(&local, &["checkout", "-b", "develop"]).expect("create develop");
+        std::fs::write(local.join("d.txt"), "dev").unwrap();
+        run_git(&local, &["add", "d.txt"]).unwrap();
+        run_git(&local, &["commit", "-m", "dev commit"]).unwrap();
+        run_git(&local, &["push", "-u", "origin", "develop"]).expect("push develop");
+
+        // Force origin/HEAD → refs/remotes/origin/develop.
+        run_git(
+            &local,
+            &["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/develop"],
+        )
+        .expect("set origin/HEAD to develop");
+
+        // Switch to a feature branch so we're not already on develop.
+        run_git(&local, &["checkout", "-b", "feature/custom-default"]).expect("feature");
+
+        let result = checkout_default_branch(&local).expect("checkout should succeed");
+        assert_eq!(
+            result,
+            Some("develop".to_string()),
+            "should resolve default via origin/HEAD, not hardcoded main/master"
+        );
+
+        let after = run_git_permissive(&local, &["branch", "--show-current"]);
+        assert_eq!(after, "develop");
     }
 }

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -4754,4 +4754,103 @@ TARGET version
         let after = run_git_permissive(&local, &["branch", "--show-current"]);
         assert_eq!(after, "develop");
     }
+
+    /// Rebase in progress → git refuses checkout with a specific error. Same
+    /// Err-and-preserve-branch semantics as the dirty-conflict case; adding
+    /// this test guards against a regression where we'd accidentally swallow
+    /// this class of error (e.g. if someone tried to force the checkout).
+    #[test]
+    fn checkout_default_branch_errs_during_rebase() {
+        let (_dir, repo) = setup_test_repo();
+        git_config(&repo);
+        let default = main_branch(&repo).to_string();
+
+        // Two divergent commits to rebase.
+        std::fs::write(repo.join("a.txt"), "a\n").unwrap();
+        run_git(&repo, &["add", "a.txt"]).unwrap();
+        run_git(&repo, &["commit", "-m", "a on default"]).unwrap();
+
+        run_git(&repo, &["checkout", "-b", "feature/x"]).unwrap();
+        std::fs::write(repo.join("a.txt"), "a-feature\n").unwrap();
+        run_git(&repo, &["commit", "-am", "a on feature"]).unwrap();
+
+        run_git(&repo, &["checkout", &default]).unwrap();
+        std::fs::write(repo.join("a.txt"), "a-default\n").unwrap();
+        run_git(&repo, &["commit", "-am", "a on default v2"]).unwrap();
+        run_git(&repo, &["checkout", "feature/x"]).unwrap();
+
+        // Start an interactive-style rebase that will stop on conflicts.
+        let (_out, _err, _ok) = run_git_full(&repo, &["rebase", &default]).unwrap();
+        // Confirm a rebase is actually in progress (regardless of conflict state).
+        let rebase_in_progress = repo.join(".git/rebase-apply").exists()
+            || repo.join(".git/rebase-merge").exists();
+        assert!(
+            rebase_in_progress,
+            "test precondition failed: rebase didn't start"
+        );
+
+        // checkout should fail; branch stays on the rebase head (feature/x
+        // or a detached HEAD, depending on git version — what matters is
+        // that it's NOT the default).
+        let result = checkout_default_branch(&repo);
+        assert!(
+            result.is_err(),
+            "expected Err while rebase is in progress, got {:?}",
+            result
+        );
+
+        // Clean up so the TempDir drop doesn't hit a lingering rebase.
+        let _ = run_git(&repo, &["rebase", "--abort"]);
+    }
+
+    /// No `origin/HEAD` symref, no remote at all, but `main` exists locally
+    /// → helper falls through to the hardcoded `main` / `master` check and
+    /// switches to `main`. Guards the fallback path that `find_default_branch`
+    /// uses when `symbolic-ref refs/remotes/origin/HEAD` returns nothing.
+    #[test]
+    fn checkout_default_branch_falls_back_to_main_without_origin_head() {
+        let (_dir, repo) = setup_test_repo();
+        git_config(&repo);
+
+        // If the test harness landed on `master` instead of `main`, rename
+        // so we can assert specifically on the `main` fallback branch.
+        let current = run_git_permissive(&repo, &["branch", "--show-current"]);
+        if current == "master" {
+            run_git(&repo, &["branch", "-m", "master", "main"]).expect("rename to main");
+        }
+
+        // Verify precondition: no origin/HEAD, no remote refs.
+        let origin_head = run_git(&repo, &["symbolic-ref", "refs/remotes/origin/HEAD"]);
+        assert!(origin_head.is_err(), "precondition: origin/HEAD shouldn't exist");
+
+        run_git(&repo, &["checkout", "-b", "feature/y"]).unwrap();
+        let result = checkout_default_branch(&repo).expect("should fall back to main");
+        assert_eq!(result, Some("main".to_string()), "expected fallback to 'main'");
+        let after = run_git_permissive(&repo, &["branch", "--show-current"]);
+        assert_eq!(after, "main");
+    }
+
+    /// No `origin/HEAD`, no `main`, but `master` exists → falls through to
+    /// the second fallback candidate. Paired with the previous test to
+    /// ensure both sides of the hardcoded fallback list are covered.
+    #[test]
+    fn checkout_default_branch_falls_back_to_master_when_no_main() {
+        let (_dir, repo) = setup_test_repo();
+        git_config(&repo);
+
+        // Normalize default to `master`: rename `main` if that's what init produced.
+        let current = run_git_permissive(&repo, &["branch", "--show-current"]);
+        if current == "main" {
+            run_git(&repo, &["branch", "-m", "main", "master"]).expect("rename to master");
+        }
+        // Ensure `main` does NOT exist so the first fallback candidate misses.
+        let main_exists = run_git(&repo, &["rev-parse", "--verify", "main"]).is_ok();
+        assert!(!main_exists, "precondition: 'main' must not exist");
+
+        run_git(&repo, &["checkout", "-b", "feature/z"]).unwrap();
+        let result = checkout_default_branch(&repo).expect("should fall back to master");
+        assert_eq!(result, Some("master".to_string()), "expected fallback to 'master'");
+        let after = run_git_permissive(&repo, &["branch", "--show-current"]);
+        assert_eq!(after, "master");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -709,6 +709,7 @@ pub fn run() {
             commands::git_discard_file,
             commands::git_log_entries,
             commands::refresh_workspace_git_info,
+            commands::checkout_default_branch_in_workspace,
             commands::create_browser_pane,
             commands::browser_open_url,
             commands::browser_history_back,

--- a/src/components/layout/default-branch-cache.ts
+++ b/src/components/layout/default-branch-cache.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { getDefaultBranch } from "@/tauri/commands";
+
+// Module-level cache of project_root → default branch name, so each project
+// only resolves its default branch once per app session regardless of how
+// many workspace rows render it. `null` means "we tried and failed" and is
+// cached to avoid retry storms. `inFlight` deduplicates concurrent fetches
+// across rows mounting at the same time.
+//
+// Exported under underscore-prefixed names so the colocated
+// `sidebar-workspace-row.test-utils.ts` can reach in and clear them between
+// test cases. App code should never touch these directly — use the
+// `useDefaultBranch` hook.
+export const _defaultBranchCache = new Map<string, string | null>();
+export const _defaultBranchInFlight = new Map<string, Promise<string | null>>();
+
+// Triggers a re-render on any subscribed row when `_defaultBranchCache` is
+// updated for a new project_root. Keeps the cache logic decoupled from
+// React rerender semantics without pulling in a zustand slice.
+const defaultBranchListeners = new Set<() => void>();
+function notifyDefaultBranchListeners() {
+  for (const cb of defaultBranchListeners) cb();
+}
+
+/**
+ * Resolve the default branch for a project path (shared across all workspace
+ * rows that point at the same `project_root`). Returns the cached value
+ * synchronously when available, otherwise kicks off a single fetch and
+ * re-renders this row when it resolves. Never throws — a missing
+ * `origin/HEAD` or detection failure caches `null`, which the caller treats
+ * as "unknown" (action still renders but falls through the backend's
+ * `Ok(None)` guard). Uses a mount flag so a late-resolving fetch can't
+ * setState on an unmounted component (otherwise React logs a warning and
+ * — under Vitest's jsdom teardown — crashes with "window is not defined").
+ */
+export function useDefaultBranch(
+  projectRoot: string | null | undefined,
+): string | null {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!projectRoot) return;
+    let mounted = true;
+    const cb = () => {
+      if (mounted) setTick((n) => n + 1);
+    };
+    defaultBranchListeners.add(cb);
+
+    if (
+      !_defaultBranchCache.has(projectRoot) &&
+      !_defaultBranchInFlight.has(projectRoot)
+    ) {
+      const promise = getDefaultBranch(projectRoot)
+        .then((branch) => branch || null)
+        .catch(() => null)
+        .then((result) => {
+          _defaultBranchCache.set(projectRoot, result);
+          _defaultBranchInFlight.delete(projectRoot);
+          notifyDefaultBranchListeners();
+          return result;
+        });
+      _defaultBranchInFlight.set(projectRoot, promise);
+    }
+
+    return () => {
+      mounted = false;
+      defaultBranchListeners.delete(cb);
+    };
+  }, [projectRoot]);
+
+  if (!projectRoot) return null;
+  return _defaultBranchCache.get(projectRoot) ?? null;
+}

--- a/src/components/layout/sidebar-workspace-row.test-utils.ts
+++ b/src/components/layout/sidebar-workspace-row.test-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Test-only helpers for `sidebar-workspace-row.tsx`.
+ *
+ * This file is imported exclusively from test files (`*.test.tsx`). Nothing
+ * in the app's production entry points (components, hooks, stores, pages)
+ * imports it, so Vite's tree-shaking drops the whole module from the prod
+ * bundle. Keep it that way: any helper whose only reason to exist is
+ * "tests need to reach into module state" belongs here, not in the
+ * component file.
+ */
+
+import {
+  _defaultBranchCache,
+  _defaultBranchInFlight,
+} from "./default-branch-cache";
+
+/** Drop the module-level default-branch cache between test cases so a
+ * prior test's mocked answer doesn't leak into the next one. */
+export function __resetDefaultBranchCacheForTests() {
+  _defaultBranchCache.clear();
+  _defaultBranchInFlight.clear();
+}

--- a/src/components/layout/sidebar-workspace-row.test.tsx
+++ b/src/components/layout/sidebar-workspace-row.test.tsx
@@ -1,0 +1,257 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { WorkspaceSnapshot } from "@/tauri/types";
+
+// ── Mocks ──
+//
+// `vi.mock()` factories are hoisted above `import`s, so any spies they
+// reference must be created via `vi.hoisted` to survive that hoist.
+const { mockCheckoutDefault, mockGetDefaultBranch, mockToast } = vi.hoisted(
+  () => ({
+    mockCheckoutDefault: vi.fn(),
+    mockGetDefaultBranch: vi.fn().mockResolvedValue("main"),
+    mockToast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warning: vi.fn(),
+    },
+  }),
+);
+
+vi.mock("@/tauri/commands", () => ({
+  activateWorkspace: vi.fn().mockResolvedValue(undefined),
+  checkoutDefaultBranchInWorkspace: (...args: unknown[]) =>
+    mockCheckoutDefault(...args),
+  closeWorkspace: vi.fn().mockResolvedValue(undefined),
+  closeWorkspaceWithWorktree: vi.fn().mockResolvedValue(undefined),
+  renameWorkspace: vi.fn().mockResolvedValue(undefined),
+  detectEditors: vi.fn().mockResolvedValue([]),
+  getDefaultBranch: (...args: unknown[]) => mockGetDefaultBranch(...args),
+  openInEditor: vi.fn().mockResolvedValue(undefined),
+  runWorkspaceSetup: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: mockToast,
+}));
+
+// Radix UI's context menu uses a Portal that doesn't play nicely with
+// jsdom (pointer events, body-level rendering). Replace the primitives
+// with transparent wrappers that render children inline — the items and
+// handlers are what we actually care about testing.
+vi.mock("@/components/ui/context-menu", () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+  const ContextMenuItem = ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children?: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      disabled={disabled}
+      data-disabled={disabled ? "true" : undefined}
+    >
+      {children}
+    </button>
+  );
+  return {
+    ContextMenu: passthrough,
+    ContextMenuTrigger: passthrough,
+    ContextMenuContent: ({ children }: { children?: React.ReactNode }) => (
+      <div role="menu">{children}</div>
+    ),
+    ContextMenuItem,
+    ContextMenuSeparator: () => <hr />,
+    ContextMenuSub: passthrough,
+    ContextMenuSubTrigger: passthrough,
+    ContextMenuSubContent: passthrough,
+  };
+});
+
+// App store — the row reads `workspaceStatus` from here; default to null.
+vi.mock("@/stores/app-store", () => ({
+  useAppStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ appState: null }),
+  ),
+}));
+
+// Late imports so the mocks above apply.
+import {
+  SidebarWorkspaceRow,
+  WorkspaceContextMenuItems,
+  __resetDefaultBranchCacheForTests,
+} from "./sidebar-workspace-row";
+
+function makeWorkspace(
+  overrides: Partial<WorkspaceSnapshot> = {},
+): WorkspaceSnapshot {
+  return {
+    workspace_id: "ws-1",
+    title: "Test Workspace",
+    workspace_type: "standard",
+    cwd: "/home/user/projects/myapp",
+    git_branch: "feature/x",
+    git_ahead: 0,
+    git_behind: 0,
+    git_additions: 0,
+    git_deletions: 0,
+    git_changed_files: 0,
+    notification_count: 0,
+    latest_agent_state: null,
+    worktree_path: null,
+    project_root: "/home/user/projects/myapp",
+    pr_number: null,
+    pr_state: null,
+    pr_url: null,
+    linked_issue: null,
+    tabs: [],
+    active_tab_id: "",
+    active_surface_id: "",
+    surfaces: [],
+    ...overrides,
+  };
+}
+
+/** Wait for the async `useDefaultBranch` fetch to resolve and propagate. */
+async function flushDefaultBranchFetch() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  cleanup();
+  mockCheckoutDefault.mockReset();
+  mockGetDefaultBranch.mockReset();
+  mockGetDefaultBranch.mockResolvedValue("main");
+  mockToast.success.mockReset();
+  mockToast.error.mockReset();
+  __resetDefaultBranchCacheForTests();
+});
+
+describe("Checkout default branch menu item", () => {
+  it("renders for a primary workspace on a non-default branch", async () => {
+    const ws = makeWorkspace({ worktree_path: null, git_branch: "feature/x" });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+
+    await flushDefaultBranchFetch();
+
+    const item = screen.getByRole("menuitem", { name: /Checkout default branch/i });
+    expect(item).toBeInTheDocument();
+    expect(item).not.toBeDisabled();
+  });
+
+  it("does NOT render for a worktree workspace", async () => {
+    const ws = makeWorkspace({
+      worktree_path: "/home/user/.codemux/worktrees/myapp/feature-x",
+      git_branch: "feature/x",
+    });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+
+    await flushDefaultBranchFetch();
+
+    expect(
+      screen.queryByRole("menuitem", { name: /Checkout default branch/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("is disabled when the primary workspace is already on the default branch", async () => {
+    const ws = makeWorkspace({ worktree_path: null, git_branch: "main" });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+
+    await flushDefaultBranchFetch();
+
+    const item = await screen.findByRole("menuitem", {
+      name: /Checkout default branch/i,
+    });
+    // Wait for the default-branch fetch to resolve and the row to re-render
+    // with the disabled state.
+    await waitFor(() => expect(item).toBeDisabled());
+  });
+
+  it("calls checkoutDefaultBranchInWorkspace with the workspace id on click", async () => {
+    mockCheckoutDefault.mockResolvedValueOnce("main");
+    const ws = makeWorkspace({
+      workspace_id: "ws-xyz",
+      worktree_path: null,
+      git_branch: "feature/x",
+    });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+
+    await flushDefaultBranchFetch();
+
+    const item = screen.getByRole("menuitem", { name: /Checkout default branch/i });
+    await userEvent.click(item);
+
+    expect(mockCheckoutDefault).toHaveBeenCalledTimes(1);
+    expect(mockCheckoutDefault).toHaveBeenCalledWith("ws-xyz");
+  });
+
+  it("surfaces a success toast on successful checkout", async () => {
+    mockCheckoutDefault.mockResolvedValueOnce("main");
+    const ws = makeWorkspace({ worktree_path: null, git_branch: "feature/x" });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+
+    await flushDefaultBranchFetch();
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: /Checkout default branch/i }),
+    );
+
+    await waitFor(() =>
+      expect(mockToast.success).toHaveBeenCalledWith("Switched to main"),
+    );
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast with git's stderr when the checkout fails", async () => {
+    mockCheckoutDefault.mockRejectedValueOnce(
+      "error: The following untracked working tree files would be overwritten by checkout",
+    );
+    const ws = makeWorkspace({ worktree_path: null, git_branch: "feature/x" });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+
+    await flushDefaultBranchFetch();
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: /Checkout default branch/i }),
+    );
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalledTimes(1));
+    const [msg] = mockToast.error.mock.calls[0];
+    expect(msg).toMatch(/Couldn't switch:/);
+    expect(msg).toMatch(/would be overwritten/);
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
+
+  // Smoke test: the row itself should render without crashing with the new
+  // menu wiring in place. Guards against regressions from the default-branch
+  // fetch effect firing during the row's initial mount.
+  it("renders SidebarWorkspaceRow without crashing for a primary workspace", () => {
+    const ws = makeWorkspace({ worktree_path: null });
+    const { container } = render(
+      <SidebarWorkspaceRow workspace={ws} isActive={false} />,
+    );
+    expect(container.querySelector("svg.lucide-laptop")).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/sidebar-workspace-row.test.tsx
+++ b/src/components/layout/sidebar-workspace-row.test.tsx
@@ -88,8 +88,8 @@ vi.mock("@/stores/app-store", () => ({
 import {
   SidebarWorkspaceRow,
   WorkspaceContextMenuItems,
-  __resetDefaultBranchCacheForTests,
 } from "./sidebar-workspace-row";
+import { __resetDefaultBranchCacheForTests } from "./sidebar-workspace-row.test-utils";
 
 function makeWorkspace(
   overrides: Partial<WorkspaceSnapshot> = {},

--- a/src/components/layout/sidebar-workspace-row.test.tsx
+++ b/src/components/layout/sidebar-workspace-row.test.tsx
@@ -292,11 +292,12 @@ describe("Checkout default branch menu item", () => {
   });
 
   it("extracts .message when the checkout rejects with an Error instance", async () => {
-    // The Tauri plugin usually stringifies errors, but `invoke` can also
-    // reject with an Error-typed value (e.g. if a layer above throws).
-    // The handler's `err instanceof Error ? err.message : String(err)`
-    // branch must pull the message out cleanly — otherwise the toast shows
-    // the generic "[object Object]".
+    // The Tauri plugin normally rejects with the raw Err(String) from Rust,
+    // but `invoke` can also surface an Error-typed value (e.g. if a middle
+    // layer throws). The handler's `err instanceof Error ? err.message
+    // : String(err)` branch must pull `.message` out cleanly — otherwise
+    // the toast shows `String(err)` which prefixes "Error: " (and, for
+    // object-shaped errors, would produce "[object Object]").
     mockCheckoutDefault.mockRejectedValueOnce(
       new Error("index.lock exists, another git process seems to be running"),
     );
@@ -312,9 +313,11 @@ describe("Checkout default branch menu item", () => {
 
     await waitFor(() => expect(mockToast.error).toHaveBeenCalledTimes(1));
     const [msg] = mockToast.error.mock.calls[0];
-    expect(msg).toMatch(/Couldn't switch:/);
-    expect(msg).toMatch(/index\.lock exists/);
-    expect(msg).not.toMatch(/\[object Object\]/);
+    // Exact-match the shape: no "Error: " prefix from String(err), no
+    // "[object Object]" from a non-Error object.
+    expect(msg).toBe(
+      "Couldn't switch: index.lock exists, another git process seems to be running",
+    );
   });
 
   it("falls back to cwd when project_root is not yet stamped on a primary workspace", async () => {

--- a/src/components/layout/sidebar-workspace-row.test.tsx
+++ b/src/components/layout/sidebar-workspace-row.test.tsx
@@ -254,4 +254,107 @@ describe("Checkout default branch menu item", () => {
     );
     expect(container.querySelector("svg.lucide-laptop")).toBeInTheDocument();
   });
+
+  // ── Edge cases ──
+
+  it("keeps the item clickable while the default-branch fetch is still in flight", async () => {
+    // Never-resolving promise so `defaultBranch` stays null for the whole
+    // render. Confirms the "don't block on fetch" rule from the design:
+    // the handler must be callable before we know the default branch, and
+    // the backend's `Ok(None)` guard is what catches the "actually on
+    // default" edge — not a pre-click UI gate.
+    mockGetDefaultBranch.mockImplementationOnce(
+      () => new Promise<string>(() => {}),
+    );
+    const ws = makeWorkspace({ worktree_path: null, git_branch: "feature/x" });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+
+    const item = screen.getByRole("menuitem", { name: /Checkout default branch/i });
+    expect(item).toBeInTheDocument();
+    expect(item).not.toBeDisabled();
+  });
+
+  it("treats an empty string from getDefaultBranch as unknown (item not pre-disabled)", async () => {
+    // Backend returns "" when git_default_branch couldn't resolve anything
+    // meaningful. The hook's `branch || null` normalization should coerce
+    // that into `null` so the disabled gate doesn't trigger.
+    mockGetDefaultBranch.mockResolvedValueOnce("");
+    const ws = makeWorkspace({ worktree_path: null, git_branch: "" });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+    await flushDefaultBranchFetch();
+
+    const item = screen.getByRole("menuitem", { name: /Checkout default branch/i });
+    expect(item).not.toBeDisabled();
+  });
+
+  it("extracts .message when the checkout rejects with an Error instance", async () => {
+    // The Tauri plugin usually stringifies errors, but `invoke` can also
+    // reject with an Error-typed value (e.g. if a layer above throws).
+    // The handler's `err instanceof Error ? err.message : String(err)`
+    // branch must pull the message out cleanly — otherwise the toast shows
+    // the generic "[object Object]".
+    mockCheckoutDefault.mockRejectedValueOnce(
+      new Error("index.lock exists, another git process seems to be running"),
+    );
+    const ws = makeWorkspace({ worktree_path: null, git_branch: "feature/x" });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+
+    await flushDefaultBranchFetch();
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: /Checkout default branch/i }),
+    );
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalledTimes(1));
+    const [msg] = mockToast.error.mock.calls[0];
+    expect(msg).toMatch(/Couldn't switch:/);
+    expect(msg).toMatch(/index\.lock exists/);
+    expect(msg).not.toMatch(/\[object Object\]/);
+  });
+
+  it("falls back to cwd when project_root is not yet stamped on a primary workspace", async () => {
+    // During the brief window between `create_workspace_at_path` and
+    // `set_workspace_project_root`, primary rows can momentarily have
+    // `project_root: null`. The hook's `project_root ?? cwd` fallback means
+    // the default-branch fetch still uses *some* path — and for primary
+    // workspaces the cwd is the repo root anyway, so it's the right answer.
+    const ws = makeWorkspace({
+      worktree_path: null,
+      project_root: null,
+      cwd: "/home/user/projects/myapp",
+      git_branch: "feature/x",
+    });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+    await flushDefaultBranchFetch();
+
+    expect(mockGetDefaultBranch).toHaveBeenCalledWith(
+      "/home/user/projects/myapp",
+    );
+  });
+
+  it("does not fetch getDefaultBranch for worktree workspaces (project_root-scoped no-op)", async () => {
+    // Worktree rows don't expose the checkout action, so triggering the
+    // default-branch fetch would be wasted work. The fallback in
+    // `WorkspaceContextMenuItems` passes `null` for worktree workspaces
+    // when `project_root` is unset, and the hook no-ops on a null key.
+    const ws = makeWorkspace({
+      worktree_path: "/home/user/.codemux/worktrees/myapp/feature-x",
+      project_root: null,
+      cwd: "/home/user/.codemux/worktrees/myapp/feature-x",
+      git_branch: "feature-x",
+    });
+    render(
+      <WorkspaceContextMenuItems workspace={ws} onRemoveRequest={() => {}} />,
+    );
+    await flushDefaultBranchFetch();
+
+    expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -27,10 +27,12 @@ import { cn } from "@/lib/utils";
 import { X, Laptop, GitBranch, Workflow, AlertTriangle } from "lucide-react";
 import {
   activateWorkspace,
+  checkoutDefaultBranchInWorkspace,
   closeWorkspace,
   closeWorkspaceWithWorktree,
   renameWorkspace,
   detectEditors,
+  getDefaultBranch,
   openInEditor,
   runWorkspaceSetup,
 } from "@/tauri/commands";
@@ -39,6 +41,79 @@ import { useAppStore } from "@/stores/app-store";
 import { getWorkspaceStatus } from "@/lib/pane-status";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import { IssueDetailPopover } from "@/components/github/issue-detail-popover";
+import { toast } from "@/lib/toast";
+
+// Module-level cache of project_root → default branch name, so each project
+// only resolves its default branch once per app session regardless of how
+// many workspace rows render it. `null` means "we tried and failed" and is
+// cached to avoid retry storms. `inFlight` deduplicates concurrent fetches
+// across rows mounting at the same time.
+const defaultBranchCache = new Map<string, string | null>();
+const defaultBranchInFlight = new Map<string, Promise<string | null>>();
+
+// Triggers a re-render on any subscribed row when `defaultBranchCache` is
+// updated for a new project_root. Keeps the cache logic decoupled from
+// React rerender semantics without pulling in a zustand slice.
+const defaultBranchListeners = new Set<() => void>();
+function notifyDefaultBranchListeners() {
+  for (const cb of defaultBranchListeners) cb();
+}
+
+/** Test-only: drop the module-level default-branch cache between cases so
+ * a prior test's mocked answer doesn't leak into the next one. Not wired
+ * into app code. */
+export function __resetDefaultBranchCacheForTests() {
+  defaultBranchCache.clear();
+  defaultBranchInFlight.clear();
+}
+
+/**
+ * Resolve the default branch for a project path (shared across all workspace
+ * rows that point at the same `project_root`). Returns the cached value
+ * synchronously when available, otherwise kicks off a single fetch and
+ * re-renders this row when it resolves. Never throws — a missing
+ * `origin/HEAD` or detection failure caches `null`, which the caller treats
+ * as "unknown" (action still renders but falls through the backend's
+ * `Ok(None)` guard). Uses a mount flag so a late-resolving fetch can't
+ * setState on an unmounted component (otherwise React logs a warning and
+ * — under Vitest's jsdom teardown — crashes with "window is not defined").
+ */
+function useDefaultBranch(projectRoot: string | null | undefined): string | null {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!projectRoot) return;
+    let mounted = true;
+    const cb = () => {
+      if (mounted) setTick((n) => n + 1);
+    };
+    defaultBranchListeners.add(cb);
+
+    if (
+      !defaultBranchCache.has(projectRoot) &&
+      !defaultBranchInFlight.has(projectRoot)
+    ) {
+      const promise = getDefaultBranch(projectRoot)
+        .then((branch) => branch || null)
+        .catch(() => null)
+        .then((result) => {
+          defaultBranchCache.set(projectRoot, result);
+          defaultBranchInFlight.delete(projectRoot);
+          notifyDefaultBranchListeners();
+          return result;
+        });
+      defaultBranchInFlight.set(projectRoot, promise);
+    }
+
+    return () => {
+      mounted = false;
+      defaultBranchListeners.delete(cb);
+    };
+  }, [projectRoot]);
+
+  if (!projectRoot) return null;
+  return defaultBranchCache.get(projectRoot) ?? null;
+}
 
 interface Props {
   workspace: WorkspaceSnapshot;
@@ -191,7 +266,7 @@ function RemoveWorkspaceDialog({
   );
 }
 
-function WorkspaceContextMenuItems({
+export function WorkspaceContextMenuItems({
   workspace,
   onRemoveRequest,
 }: {
@@ -199,6 +274,13 @@ function WorkspaceContextMenuItems({
   onRemoveRequest: () => void;
 }) {
   const [editors, setEditors] = useState<EditorInfo[]>([]);
+  const isWorktree = !!workspace.worktree_path;
+  // Default-branch lookup is scoped to the project_root (the real repo root
+  // shared by all workspaces pointing at the same repo). Falls back to cwd
+  // for primary workspaces that haven't had project_root stamped yet.
+  const defaultBranch = useDefaultBranch(
+    workspace.project_root ?? (isWorktree ? null : workspace.cwd),
+  );
 
   useEffect(() => {
     detectEditors().then(setEditors).catch(console.error);
@@ -220,6 +302,26 @@ function WorkspaceContextMenuItems({
   const handleOpenInEditor = (editorId: string) => {
     openInEditor(editorId, workspace.cwd).catch(console.error);
   };
+
+  const handleCheckoutDefault = async () => {
+    try {
+      const branch = await checkoutDefaultBranchInWorkspace(workspace.workspace_id);
+      toast.success(`Switched to ${branch}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Couldn't switch: ${message}`);
+    }
+  };
+
+  // Show the "Checkout default branch" action only for primary workspaces
+  // (worktree workspaces live on a fixed branch by design — swapping their
+  // HEAD would break the Codemux worktree model). Disable when we already
+  // know we're on the default branch — gated on `defaultBranch` being
+  // resolved so the action stays clickable while the fetch is pending, and
+  // the backend's `Ok(None)` guard handles the "actually on default" edge.
+  const showCheckoutDefault = !isWorktree;
+  const isOnDefault =
+    defaultBranch !== null && workspace.git_branch === defaultBranch;
 
   return (
     <ContextMenuContent>
@@ -248,6 +350,14 @@ function WorkspaceContextMenuItems({
       >
         Copy branch name
       </ContextMenuItem>
+      {showCheckoutDefault && (
+        <ContextMenuItem
+          onClick={handleCheckoutDefault}
+          disabled={isOnDefault}
+        >
+          Checkout default branch
+        </ContextMenuItem>
+      )}
       <ContextMenuItem
         onClick={() => runWorkspaceSetup(workspace.workspace_id).catch(console.error)}
       >

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -32,7 +32,6 @@ import {
   closeWorkspaceWithWorktree,
   renameWorkspace,
   detectEditors,
-  getDefaultBranch,
   openInEditor,
   runWorkspaceSetup,
 } from "@/tauri/commands";
@@ -42,78 +41,7 @@ import { getWorkspaceStatus } from "@/lib/pane-status";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import { IssueDetailPopover } from "@/components/github/issue-detail-popover";
 import { toast } from "@/lib/toast";
-
-// Module-level cache of project_root → default branch name, so each project
-// only resolves its default branch once per app session regardless of how
-// many workspace rows render it. `null` means "we tried and failed" and is
-// cached to avoid retry storms. `inFlight` deduplicates concurrent fetches
-// across rows mounting at the same time.
-const defaultBranchCache = new Map<string, string | null>();
-const defaultBranchInFlight = new Map<string, Promise<string | null>>();
-
-// Triggers a re-render on any subscribed row when `defaultBranchCache` is
-// updated for a new project_root. Keeps the cache logic decoupled from
-// React rerender semantics without pulling in a zustand slice.
-const defaultBranchListeners = new Set<() => void>();
-function notifyDefaultBranchListeners() {
-  for (const cb of defaultBranchListeners) cb();
-}
-
-/** Test-only: drop the module-level default-branch cache between cases so
- * a prior test's mocked answer doesn't leak into the next one. Not wired
- * into app code. */
-export function __resetDefaultBranchCacheForTests() {
-  defaultBranchCache.clear();
-  defaultBranchInFlight.clear();
-}
-
-/**
- * Resolve the default branch for a project path (shared across all workspace
- * rows that point at the same `project_root`). Returns the cached value
- * synchronously when available, otherwise kicks off a single fetch and
- * re-renders this row when it resolves. Never throws — a missing
- * `origin/HEAD` or detection failure caches `null`, which the caller treats
- * as "unknown" (action still renders but falls through the backend's
- * `Ok(None)` guard). Uses a mount flag so a late-resolving fetch can't
- * setState on an unmounted component (otherwise React logs a warning and
- * — under Vitest's jsdom teardown — crashes with "window is not defined").
- */
-function useDefaultBranch(projectRoot: string | null | undefined): string | null {
-  const [, setTick] = useState(0);
-
-  useEffect(() => {
-    if (!projectRoot) return;
-    let mounted = true;
-    const cb = () => {
-      if (mounted) setTick((n) => n + 1);
-    };
-    defaultBranchListeners.add(cb);
-
-    if (
-      !defaultBranchCache.has(projectRoot) &&
-      !defaultBranchInFlight.has(projectRoot)
-    ) {
-      const promise = getDefaultBranch(projectRoot)
-        .then((branch) => branch || null)
-        .catch(() => null)
-        .then((result) => {
-          defaultBranchCache.set(projectRoot, result);
-          defaultBranchInFlight.delete(projectRoot);
-          notifyDefaultBranchListeners();
-          return result;
-        });
-      defaultBranchInFlight.set(projectRoot, promise);
-    }
-
-    return () => {
-      mounted = false;
-      defaultBranchListeners.delete(cb);
-    };
-  }, [projectRoot]);
-
-  if (!projectRoot) return null;
-  return defaultBranchCache.get(projectRoot) ?? null;
-}
+import { useDefaultBranch } from "./default-branch-cache";
 
 interface Props {
   workspace: WorkspaceSnapshot;

--- a/src/components/layout/sidebar-workspace.test.tsx
+++ b/src/components/layout/sidebar-workspace.test.tsx
@@ -25,7 +25,7 @@ vi.mock("@/tauri/commands", () => ({
 
 // `useDefaultBranch` uses a module-level cache; reset between suites so a
 // mock return from a prior test doesn't leak in.
-import { __resetDefaultBranchCacheForTests } from "./sidebar-workspace-row";
+import { __resetDefaultBranchCacheForTests } from "./sidebar-workspace-row.test-utils";
 import { beforeEach } from "vitest";
 beforeEach(() => __resetDefaultBranchCacheForTests());
 

--- a/src/components/layout/sidebar-workspace.test.tsx
+++ b/src/components/layout/sidebar-workspace.test.tsx
@@ -1,17 +1,20 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { WorkspaceSnapshot } from "@/tauri/types";
 
 // Mock Tauri commands
 vi.mock("@/tauri/commands", () => ({
   activateWorkspace: vi.fn().mockResolvedValue(undefined),
+  checkoutDefaultBranchInWorkspace: vi.fn().mockResolvedValue("main"),
   closeWorkspace: vi.fn().mockResolvedValue(undefined),
   closeWorkspaceWithWorktree: vi.fn().mockResolvedValue(undefined),
   renameWorkspace: vi.fn().mockResolvedValue(undefined),
   detectEditors: vi.fn().mockResolvedValue([]),
+  getDefaultBranch: vi.fn().mockResolvedValue("main"),
   openInEditor: vi.fn().mockResolvedValue(undefined),
+  runWorkspaceSetup: vi.fn().mockResolvedValue(undefined),
   dbGetUiState: vi.fn().mockResolvedValue(null),
   dbSetUiState: vi.fn().mockResolvedValue(undefined),
   getGithubIssue: vi.fn().mockResolvedValue({
@@ -19,6 +22,24 @@ vi.mock("@/tauri/commands", () => ({
     url: "https://github.com/u/r/issues/92", body: null,
   }),
 }));
+
+// `useDefaultBranch` uses a module-level cache; reset between suites so a
+// mock return from a prior test doesn't leak in.
+import { __resetDefaultBranchCacheForTests } from "./sidebar-workspace-row";
+import { beforeEach } from "vitest";
+beforeEach(() => __resetDefaultBranchCacheForTests());
+
+// Flush pending microtasks + unmount before the next test so late-resolving
+// `getDefaultBranch` promises finish their React update inside the jsdom
+// lifetime instead of after teardown (which would log a spurious
+// "window is not defined" from React's scheduler).
+afterEach(async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  cleanup();
+});
 
 // Mock stores
 vi.mock("@/stores/ui-store", () => ({

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -267,6 +267,15 @@ export const detectPackageManager = (projectPath: string) =>
 export const reorderWorkspaces = (workspaceIds: string[]) =>
   invoke("reorder_workspaces", { workspaceIds });
 
+// Switch a primary workspace's repo to its default branch. Returns the
+// branch name on success. Rejects with git's stderr when the checkout is
+// refused (dirty conflicts, rebase in progress, etc.) so the caller can
+// toast the message verbatim. The backend refreshes git info synchronously
+// before returning, so the sidebar label updates without waiting for the
+// 5s polling tick.
+export const checkoutDefaultBranchInWorkspace = (workspaceId: string) =>
+  invoke<string>("checkout_default_branch_in_workspace", { workspaceId });
+
 // ── GitHub ──
 
 export const checkGhStatus = () =>


### PR DESCRIPTION
{
  "title": "Add "Checkout default branch" action for primary workspaces",
  "body": "## Summary\n\n- Add right-click \"Checkout default branch\" action in sidebar for primary workspaces (not worktrees)\n- Resolves the intent gap where opening a workspace via `Open ↵ main` attaches to a different branch\n- Backend (`checkout_default_branch_in_workspace` command) determines default via `origin/HEAD`, falls back to `main`/`master`, and applies git's native safety checks\n- Frontend caches the default branch per project (resolved once per session) and disables the action when already on default\n- Action is kept clickable during the async fetch so users can invoke it before the default branch is known; backend's `Ok(None)` guard handles any race\n- Comprehensive tests cover happy path, worktree skip, custom default names, rebase-in-progress, dirty trees, and fallback behavior\n\n## Testing\n\n- `npm run test` — all sidebar and workspace context menu tests pass\n- `cargo test --manifest-path src-tauri/Cargo.toml` — `checkout_default_branch` unit tests pass (7 test cases covering feature branch → default, no-op on already-default, unborn repos, dirty conflicts, custom defaults, rebase-in-progress, main/master fallbacks)\n- Manual: right-click workspace on a feature branch → select \"Checkout default branch\" → verify sidebar label updates and branch switches\n- Verify action does not appear for worktree workspaces\n- Verify action is disabled when workspace is already on default branch"
}