### PR TITLE
feat(terminal): add Unicode 11 widths and WebGL renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.1.21",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.1.21",
+      "version": "0.1.29",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
@@ -33,6 +33,7 @@
         "@tauri-apps/plugin-updater": "^2.10.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-serialize": "^0.14.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "agent-browser": "^0.24.0",
@@ -4956,6 +4957,12 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
       "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-webgl": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "agent-browser": "^0.24.0",

--- a/src/components/terminal/TerminalPane.tsx
+++ b/src/components/terminal/TerminalPane.tsx
@@ -3,6 +3,8 @@ import { Terminal } from "@xterm/xterm";
 import type { ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { isAppShortcut } from "@/lib/app-shortcuts";
 import { matchesKeyCombo } from "@/lib/keybind-utils";
 import {
@@ -300,9 +302,25 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
 
     const fitAddon = new FitAddon();
     const serializeAddon = new SerializeAddon();
+    const unicode11Addon = new Unicode11Addon();
+    term.loadAddon(unicode11Addon);
+    term.unicode.activeVersion = "11";
     term.loadAddon(fitAddon);
     term.loadAddon(serializeAddon);
     term.open(containerEl);
+
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => {
+        webgl.dispose();
+      });
+      term.loadAddon(webgl);
+    } catch (err) {
+      console.warn(
+        "[Codemux] WebGL renderer unavailable, falling back to DOM",
+        err,
+      );
+    }
 
     termRef.current = term;
     fitAddonRef.current = fitAddon;


### PR DESCRIPTION
## Summary

Phase 1 of the terminal-rendering fix — addresses **Bug 2 (table column drift)** from the comparative analysis doc (`/tmp/terminal-rendering-analysis.md`). Phase 2 (workspace-switch corruption / Bug 1) ships separately.

- Loads `@xterm/addon-unicode11@^0.9.0` (matches the rest of the `@xterm/*` family) and sets `term.unicode.activeVersion = "11"` before `FitAddon` is loaded. xterm.js otherwise silently falls back to Unicode 6 width tables, which mis-measure box-drawing chars (`│ ─ ┼ ┌ ┐ └ ┘ ┬ ┴ ├ ┤`), East-Asian wide chars, and modern emoji.
- Loads the already-declared `@xterm/addon-webgl@^0.19.0` (it was in `package.json` but never imported). Wrapped in try/catch with `onContextLoss` disposal so xterm silently falls back to the DOM renderer in headless/GPU-restricted environments.
- `lineHeight: 1.15` left untouched per the plan — toggle to `1.0` deferred until manual verification confirms whether Unicode11+WebGL alone resolves the drift.

Refs: analysis §3 (Bug 2 root cause), §5.6 (Unicode-11 addon), §5.7 (renderer).

## Test plan

Automated (already green locally):

- [x] `npm run check` — tsc clean
- [x] `npm run test` — 351 vitest tests passed
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 680 tests passed (sanity, no Rust changes)

Manual (please run on this branch before merging):

- [ ] Open a TUI table — `gh pr list`, `lazygit status`, `btop` — confirm columns align across all rows
- [ ] Confirm box-drawing chars (`│ ─ ┼`) are visually continuous vertically with no 1px gaps
- [ ] Type/paste an emoji and CJK string and confirm the cursor lands in the correct cell after
- [ ] Briefly add `console.log(term.unicode.activeVersion)` after the new `Terminal({...})` and confirm it reads `"11"` not `"6"` (optional — the import is enough evidence)
- [ ] After confirming the drift is gone, decide whether to also flip `lineHeight: 1.15` → `1.0` (separate PR if so)