### PR TITLE
feat(terminal): persist xterm instances across workspace switches

### DIFF
--- a/docs/core/STATUS.md
+++ b/docs/core/STATUS.md
@@ -46,6 +46,7 @@ The repo structure is clean and domain-split:
 - Built-in file editor with CodeMirror, syntax highlighting, and markdown preview
 - MCP server exposing 29 tools via JSON-RPC 2.0 (browser, workspace, pane, git, notification)
 - Session persistence: terminal scrollback saved/restored across restarts, adapter-based resume for CLI tools (Claude Code)
+- Terminal pane persistence across workspace switch: xterm.js Terminal instance + PTY-output channel survive component unmount via the module-level cache in `src/components/terminal/terminal-cache.ts`. Workspace switches reparent the wrapper into a hidden parking node instead of disposing, so alt-screen TUIs (Claude Code, lazygit, btop, vim) keep rendering correctly on return. Disposal is driven by AppState diffs in `useTerminalCacheGc` so close-pane / close-tab / close-workspace / PTY-exit all reach `disposeTerminal`.
 
 ## Partial / Being Hardened
 

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -14,6 +14,14 @@ The terminal system provides multi-session PTY terminals rendered with xterm.js 
 
 The Rust layer uses `portable-pty` to spawn shells. Each terminal session has a master PTY handle, a read thread, and a write path. The frontend uses xterm.js with the WebGL renderer for GPU-accelerated display. Data flows: PTY read thread -> Tauri channel -> xterm.js write. User input flows: xterm.js onData -> Tauri command `write_to_pty` -> PTY master write.
 
+### Terminal Pane Persistence
+
+The xterm.js `Terminal` instance, its addons, the persistent wrapper `<div>`, and the PTY-output `Channel` all live in a module-level cache (`src/components/terminal/terminal-cache.ts`) keyed by `sessionId`. The cache lifetime equals the PTY session lifetime; `TerminalPane.tsx` is a thin DOM-attach wrapper that reparents the cached wrapper between its layout container and a body-level `#codemux-terminal-parking` node on mount/unmount.
+
+This is the load-bearing invariant: bytes flowing in from a long-running alt-screen TUI (Claude Code's "Simmering…", lazygit, vim, btop) keep being processed by the same xterm even while the React component is unmounted, so its mode flags / cursor / cell grid stay in sync with the PTY producer. Workspace switches no longer cause garbled or misaligned rendering on return.
+
+Disposal is driven by `useTerminalCacheGc` in `src/hooks/use-terminal-cache-gc.ts`: it diffs `AppState.terminal_sessions` and calls `disposeTerminal(sid)` for any session that disappears, covering close-pane / close-tab / close-workspace / PTY-exit. Because the channel stays attached for the session's lifetime, the Rust-side `pending_output` buffer (`src-tauri/src/terminal/mod.rs`) is effectively a cold-start replay window only; the `dropped_chunks` counter on `SessionRuntime` is a regression signal — non-zero means the channel was somehow detached when the buffer overflowed.
+
 ## What Works Today
 
 - multiple concurrent terminal sessions per workspace
@@ -46,8 +54,10 @@ Note: terminal scrollback is saved and restored across app restarts. See `docs/f
 
 ## Important Touch Points
 
-- `src-tauri/src/terminal/mod.rs` — PTY spawning, read/write, session management, comm log locks
+- `src-tauri/src/terminal/mod.rs` — PTY spawning, read/write, session management, comm log locks, dropped-chunk observability counter
 - `src-tauri/src/commands/workspace.rs` — `create_terminal_session`, `write_to_pty`, `resize_pty`, `attach_pty_output`
-- `src/components/terminal/TerminalPane.tsx` — xterm.js rendering, WebGL, input handling
+- `src/components/terminal/TerminalPane.tsx` — DOM-attach wrapper, ResizeObserver, focus, status overlay, custom key handler
+- `src/components/terminal/terminal-cache.ts` — module-level Terminal cache, parking node, attach/detach/dispose API
+- `src/hooks/use-terminal-cache-gc.ts` — disposes cache entries when sessions disappear from AppState
 - `src/lib/app-shortcuts.ts` — terminal-specific keyboard shortcuts
 - `src-tauri/src/agent_context.rs` — environment variable injection for terminal sessions

--- a/docs/reference/ARCHITECTURE.md
+++ b/docs/reference/ARCHITECTURE.md
@@ -20,7 +20,7 @@ The frontend is React + Tailwind v4 + shadcn (preset b3kIbNYVW). State managemen
 
 - shadcn primitives: `src/components/ui/` (button, tabs, sidebar, resizable, badge, tooltip, etc.)
 - app shell layout: `src/components/layout/` (AppSidebar, PaneNode, TabBar, WorkspaceMain, RightPanel)
-- terminal integration: `src/components/terminal/TerminalPane.tsx` (xterm.js + PTY via Tauri Channel)
+- terminal integration: `src/components/terminal/TerminalPane.tsx` (thin DOM-attach wrapper) + `src/components/terminal/terminal-cache.ts` (module-level cache that owns the xterm.js Terminal, addons, wrapper `<div>`, and PTY-output channel for the lifetime of the PTY session). Workspace switches reparent the wrapper into a hidden `#codemux-terminal-parking` node instead of disposing — this is the load-bearing invariant that keeps alt-screen TUIs (Claude Code, lazygit, vim) coherent across switches. Disposal is driven by AppState diffs in `src/hooks/use-terminal-cache-gc.ts`.
 - React hooks: `src/hooks/` (useTauriEvent, useAppStateInit, useKeyboardShortcuts, useThemeColors)
 - zustand stores: `src/stores/` (app-store.ts for AppStateSnapshot, ui-store.ts for local UI state)
 - Tauri bridge: `src/tauri/commands.ts` (120+ typed invoke wrappers), `src/tauri/events.ts` (12 event helpers), `src/tauri/types.ts` (all shared types)

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -115,6 +115,13 @@ pub struct SessionRuntime {
     pub master: Option<Box<dyn MasterPty + Send>>,
     pub output_channel: Option<Channel<Vec<u8>>>,
     pub pending_output: VecDeque<Vec<u8>>,
+    /// Cumulative count of chunks evicted from `pending_output` because the
+    /// buffer hit `OUTPUT_BUFFER_LIMIT` while no consumer was attached. With
+    /// the frontend cache (terminal-cache.ts) the channel stays attached for
+    /// the entire session lifetime, so this should stay at 0 in the steady
+    /// state. A non-zero value indicates either a long startup window or a
+    /// regression where the channel was detached on workspace switch.
+    pub dropped_chunks: u64,
     pub last_status: TerminalStatusPayload,
     pub child_pid: Option<u32>,
     pub skip_preset_launch: bool,
@@ -138,6 +145,7 @@ impl SessionRuntime {
             master: None,
             output_channel: None,
             pending_output: VecDeque::new(),
+            dropped_chunks: 0,
             last_status: TerminalStatusPayload {
                 session_id: session_id.to_string(),
                 state: TerminalLifecycleState::Starting,
@@ -385,6 +393,19 @@ fn queue_or_send_output(
             runtime.pending_output.push_back(chunk.clone());
             while runtime.pending_output.len() > OUTPUT_BUFFER_LIMIT {
                 runtime.pending_output.pop_front();
+                let dropped = runtime.dropped_chunks.saturating_add(1);
+                runtime.dropped_chunks = dropped;
+                // Log on the first drop and then on each power-of-two boundary
+                // so a chatty regression doesn't spam stderr but is still
+                // discoverable. A single line is enough — the count is the
+                // signal; the rest is in the bug.
+                if dropped == 1 || dropped.is_power_of_two() {
+                    eprintln!(
+                        "[codemux::terminal] session={session_id} dropped pending_output \
+                         chunk (cumulative={dropped}). Indicates the frontend was \
+                         detached when the buffer overflowed."
+                    );
+                }
             }
 
             if let Some(channel) = runtime.output_channel.clone() {
@@ -2646,6 +2667,227 @@ mod tests {
         let runtime = guard.get("sess").unwrap();
         assert_eq!(runtime.pending_output.len(), 1);
         assert_eq!(runtime.pending_output[0], vec![1, 2, 3, 4, 5]);
+    }
+
+    /// dropped_chunks is per-session, not global — eviction in session A
+    /// must not increment session B's counter.
+    #[test]
+    fn test_dropped_chunks_isolated_per_session() {
+        let sessions = make_sessions();
+        with_session_runtime(&sessions, "a", || SessionRuntime::new("a"), |_| {});
+        with_session_runtime(&sessions, "b", || SessionRuntime::new("b"), |_| {});
+
+        for i in 0..OUTPUT_BUFFER_LIMIT + 3 {
+            queue_or_send_output(&sessions, "a", vec![i as u8]);
+        }
+        for i in 0..5 {
+            queue_or_send_output(&sessions, "b", vec![i]);
+        }
+
+        let guard = sessions.lock().unwrap();
+        assert_eq!(guard.get("a").unwrap().dropped_chunks, 3);
+        assert_eq!(guard.get("b").unwrap().dropped_chunks, 0);
+    }
+
+    /// dropped_chunks does not reset across attach/detach cycles. A counter
+    /// reset would obscure the cumulative regression signal.
+    #[test]
+    fn test_dropped_chunks_persists_across_attach_detach() {
+        let sessions = make_sessions();
+        with_session_runtime(
+            &sessions,
+            "persist",
+            || SessionRuntime::new("persist"),
+            |_| {},
+        );
+
+        for i in 0..OUTPUT_BUFFER_LIMIT + 7 {
+            queue_or_send_output(&sessions, "persist", vec![i as u8]);
+        }
+        let after_first_overflow = {
+            let guard = sessions.lock().unwrap();
+            guard.get("persist").unwrap().dropped_chunks
+        };
+        assert_eq!(after_first_overflow, 7);
+
+        // Simulate attach (mirrors attach_pty_output body): install a
+        // channel, drain pending_output, then detach again.
+        let channel: Channel<Vec<u8>> = Channel::new(|_| Ok(()));
+        with_session_runtime(
+            &sessions,
+            "persist",
+            || SessionRuntime::new("persist"),
+            |runtime| {
+                runtime.output_channel = Some(channel);
+                runtime.pending_output.clear();
+            },
+        );
+        with_session_runtime(
+            &sessions,
+            "persist",
+            || SessionRuntime::new("persist"),
+            |runtime| {
+                runtime.output_channel = None;
+            },
+        );
+
+        // Counter should still reflect the prior overflow.
+        let guard = sessions.lock().unwrap();
+        assert_eq!(
+            guard.get("persist").unwrap().dropped_chunks,
+            7,
+            "dropped_chunks must NOT reset on attach/detach"
+        );
+    }
+
+    /// `dropped_chunks` increments exactly once per evicted chunk when the
+    /// buffer overflows with no channel attached. This is the observability
+    /// hook the cache architecture uses to detect a regression that would
+    /// silently lose PTY data.
+    #[test]
+    fn test_dropped_chunks_counter_increments_on_overflow() {
+        let sessions = make_sessions();
+        with_session_runtime(&sessions, "drop", || SessionRuntime::new("drop"), |_| {});
+
+        let extra = 5usize;
+        for i in 0..OUTPUT_BUFFER_LIMIT + extra {
+            queue_or_send_output(&sessions, "drop", vec![i as u8]);
+        }
+
+        let guard = sessions.lock().unwrap();
+        let runtime = guard.get("drop").unwrap();
+        assert_eq!(runtime.pending_output.len(), OUTPUT_BUFFER_LIMIT);
+        assert_eq!(
+            runtime.dropped_chunks, extra as u64,
+            "dropped_chunks should record every eviction, not just the first"
+        );
+    }
+
+    /// The flush-on-attach mechanism is the load-bearing claim from the
+    /// terminal-rendering analysis §6 step 2. With the cache architecture the
+    /// channel stays attached for the session lifetime so this path is
+    /// effectively cold-start-only — but the invariant must still hold,
+    /// because cold start IS the only time the channel attaches and the
+    /// pending_output between PTY spawn and first attach must reach the
+    /// frontend in order, with no loss.
+    ///
+    /// Constructs a real `tauri::ipc::Channel` whose handler captures the
+    /// payload bytes, mirrors the body of `attach_pty_output` directly
+    /// (collecting `pending_output` then forwarding through the channel),
+    /// and asserts the consumer received the full stream in order.
+    #[test]
+    fn test_pending_output_replays_on_attach() {
+        use std::sync::Mutex as StdMutex;
+
+        let sessions = make_sessions();
+        with_session_runtime(
+            &sessions,
+            "replay",
+            || SessionRuntime::new("replay"),
+            |_| {},
+        );
+
+        // Queue bytes BEFORE any consumer exists — this is the "PTY ran
+        // ahead of the frontend attach" window.
+        for i in 0..10u8 {
+            queue_or_send_output(&sessions, "replay", vec![i, i + 100]);
+        }
+
+        let captured: Arc<StdMutex<Vec<Vec<u8>>>> = Arc::new(StdMutex::new(Vec::new()));
+        let captured_handler = captured.clone();
+        let channel: Channel<Vec<u8>> = Channel::new(move |body| {
+            let bytes = body.deserialize::<Vec<u8>>().expect("decode body");
+            captured_handler.lock().unwrap().push(bytes);
+            Ok(())
+        });
+
+        // Mirror the attach_pty_output Tauri command body directly: install
+        // the channel, snapshot pending_output, then forward each chunk.
+        let pending_chunks = with_session_runtime(
+            &sessions,
+            "replay",
+            || SessionRuntime::new("replay"),
+            |runtime| {
+                runtime.output_channel = Some(channel.clone());
+                runtime.pending_output.iter().cloned().collect::<Vec<_>>()
+            },
+        );
+        for chunk in pending_chunks {
+            channel.send(chunk).expect("channel send");
+        }
+
+        let received = captured.lock().unwrap().clone();
+        assert_eq!(received.len(), 10, "consumer should see every chunk");
+        for (i, chunk) in received.iter().enumerate() {
+            assert_eq!(
+                chunk,
+                &vec![i as u8, i as u8 + 100],
+                "chunk {i} payload preserved end-to-end"
+            );
+        }
+    }
+
+    /// With the cache architecture, the channel stays attached for the full
+    /// session lifetime. Once attached, every subsequent chunk produced by
+    /// the reader thread (modeled here as direct `queue_or_send_output`
+    /// calls) is forwarded to the consumer immediately. The pending_output
+    /// buffer is the cold-start replay window only — it must not grow once
+    /// a live channel is installed.
+    #[test]
+    fn test_attached_channel_receives_live_writes() {
+        use std::sync::Mutex as StdMutex;
+
+        let sessions = make_sessions();
+        with_session_runtime(
+            &sessions,
+            "live",
+            || SessionRuntime::new("live"),
+            |_| {},
+        );
+
+        let captured: Arc<StdMutex<Vec<Vec<u8>>>> = Arc::new(StdMutex::new(Vec::new()));
+        let captured_handler = captured.clone();
+        let channel: Channel<Vec<u8>> = Channel::new(move |body| {
+            let bytes = body.deserialize::<Vec<u8>>().expect("decode body");
+            captured_handler.lock().unwrap().push(bytes);
+            Ok(())
+        });
+        with_session_runtime(
+            &sessions,
+            "live",
+            || SessionRuntime::new("live"),
+            |runtime| {
+                runtime.output_channel = Some(channel);
+            },
+        );
+
+        // Drive the same path the reader thread uses for each batched flush.
+        for i in 0..20u8 {
+            queue_or_send_output(&sessions, "live", vec![i]);
+        }
+
+        let received = captured.lock().unwrap().clone();
+        assert_eq!(
+            received.len(),
+            20,
+            "channel should receive every chunk synchronously when attached"
+        );
+        for (i, chunk) in received.iter().enumerate() {
+            assert_eq!(chunk, &vec![i as u8]);
+        }
+
+        // pending_output is still appended to (the buffer is the source for
+        // cold-start replay if the consumer ever reattaches), but the
+        // channel-side delivery is the live path and never lossy. Verify
+        // chunks are bounded by OUTPUT_BUFFER_LIMIT and that no drops have
+        // occurred — drops are the regression signal added in 2.6.
+        let guard = sessions.lock().unwrap();
+        let runtime = guard.get("live").unwrap();
+        assert!(runtime.pending_output.len() <= OUTPUT_BUFFER_LIMIT);
+        assert_eq!(
+            runtime.dropped_chunks, 0,
+            "no drops with channel attached and buffer well under limit"
+        );
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { useAppStateInit } from "@/hooks/use-app-state";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { useAuthEvents } from "@/hooks/use-auth-events";
 import { useScrollbackSerializer } from "@/hooks/use-scrollback-serializer";
+import { useTerminalCacheGc } from "@/hooks/use-terminal-cache-gc";
+import { useTerminalThemeSync } from "@/hooks/use-terminal-theme-sync";
 import { AppShell } from "@/components/layout/app-shell";
 import { Toaster } from "@/components/ui/sonner";
 import { UpdateToast } from "@/components/update/update-toast";
@@ -30,6 +32,8 @@ function App() {
   useAppStateInit(!isAuthenticated);
   useKeyboardShortcuts();
   useScrollbackSerializer();
+  useTerminalCacheGc();
+  useTerminalThemeSync();
 
   if (isLoading || !isAuthenticated) {
     return <LoginScreen />;

--- a/src/components/terminal/TerminalPane.tsx
+++ b/src/components/terminal/TerminalPane.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useRef, useCallback } from "react";
-import { Terminal } from "@xterm/xterm";
 import type { ITheme } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import { SerializeAddon } from "@xterm/addon-serialize";
-import { Unicode11Addon } from "@xterm/addon-unicode11";
-import { WebglAddon } from "@xterm/addon-webgl";
 import { isAppShortcut } from "@/lib/app-shortcuts";
 import { matchesKeyCombo } from "@/lib/keybind-utils";
 import {
@@ -12,9 +7,6 @@ import {
   BACKSPACE_CODEPOINT,
   csiUModifier,
   csiUSequence,
-  scanKittySequences,
-  applyKittyStack,
-  kittyFlags,
 } from "@/lib/kitty-keyboard";
 import { resolveKeybinds } from "@/hooks/use-resolved-keybinds";
 import { useSyncedSettingsStore } from "@/stores/synced-settings-store";
@@ -26,17 +18,15 @@ import {
 import {
   writeToPty,
   resizePty,
-  detachPtyOutput,
-  attachPtyOutput,
   getTerminalStatus,
   clearAgentStatus,
-  getTerminalScrollback,
-  cacheTerminalScrollback,
-  uncacheTerminalScrollback,
-  Channel,
-  type ScrollbackPayload,
 } from "@/tauri/commands";
-import { registerTerminalForSerialize } from "@/hooks/use-scrollback-serializer";
+import {
+  getOrCreateTerminal,
+  attachToContainer,
+  detachFromContainer,
+  type CachedTerminal,
+} from "@/components/terminal/terminal-cache";
 import { useAppStore } from "@/stores/app-store";
 import { onTerminalStatus } from "@/tauri/events";
 // TODO: re-enable as "system theme" option in settings
@@ -101,44 +91,13 @@ function buildThemeFromCSS(): ITheme {
   };
 }
 
-// TODO: re-enable as "system theme" option in settings
-// function buildXtermTheme(t: ThemeColors): ITheme {
-//   return {
-//     background: t.background, foreground: t.foreground, cursor: t.cursor,
-//     selectionBackground: t.selection_background, selectionForeground: t.selection_foreground,
-//     black: t.color0, red: t.color1, green: t.color2, yellow: t.color3,
-//     blue: t.color4, magenta: t.color5, cyan: t.color6, white: t.color7,
-//     brightBlack: t.color8, brightRed: t.color9, brightGreen: t.color10, brightYellow: t.color11,
-//     brightBlue: t.color12, brightMagenta: t.color13, brightCyan: t.color14, brightWhite: t.color15,
-//   };
-// }
-
-function extractBytes(payload: unknown): Uint8Array | null {
-  if (payload instanceof Uint8Array) return payload;
-  if (payload instanceof ArrayBuffer) return new Uint8Array(payload);
-  if (Array.isArray(payload)) return new Uint8Array(payload as number[]);
-  if (typeof payload === "string") return new TextEncoder().encode(payload);
-  return null;
-}
-
 export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
-  // TODO: re-enable as "system theme" option in settings
-  // const { theme, shellAppearance } = useThemeColors();
-
-  // Refs for mutable state that persists across renders
+  // Refs for DOM and per-mount state. The xterm Terminal instance, addons,
+  // PTY channel, and serialize registration live in the module-level cache
+  // (see terminal-cache.ts) so they survive workspace switches.
   const shellRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const termRef = useRef<Terminal | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
-  const serializeAddonRef = useRef<SerializeAddon | null>(null);
-  const attachedSessionRef = useRef<string | null>(null);
-  // Adapter captures from the scrollback restore — persists across tab switches
-  // even when the pane state (layout.json) doesn't have them.
-  const restoredCapturesRef = useRef<Record<string, string>>({});
-  const kittyStackRef = useRef<number[]>([]);
-  const kittyLevelRef = useRef(0);
-  const pendingPtyWrites = useRef<Uint8Array[]>([]);
-  const ptyWriteFrameRef = useRef<number | null>(null);
+  const entryRef = useRef<CachedTerminal | null>(null);
   const statusRef = useRef<TerminalStatusPayload>({
     session_id: sessionId,
     state: "starting",
@@ -146,97 +105,35 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
     exit_code: null,
   });
   const statusOverlayRef = useRef<HTMLDivElement>(null);
-  const ptyDecoderRef = useRef(new TextDecoder("utf-8", { fatal: false }));
   const blockNewlineRef = useRef<((e: Event) => void) | null>(null);
-  const dataDisposableRef = useRef<{ dispose: () => void } | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const windowResizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Track latest sessionId for closures
   const sessionIdRef = useRef(sessionId);
   sessionIdRef.current = sessionId;
-  // Track props for closures
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
-
-  // ── Kitty protocol scanning ──
-  const scanKittyProtocol = useCallback((data: Uint8Array | string) => {
-    const str =
-      typeof data === "string"
-        ? data
-        : ptyDecoderRef.current.decode(data);
-
-    const scan = scanKittySequences(str);
-
-    // Respond to Kitty keyboard protocol query (\x1b[?u) with current flags.
-    // Apps (Claude Code, nvim, etc.) send this to check if the terminal
-    // supports enhanced key reporting before pushing Kitty mode.
-    if (scan.hasQuery) {
-      writeToPty(
-        sessionIdRef.current,
-        `\x1b[?${kittyFlags(kittyStackRef.current)}u`,
-      ).catch(console.error);
-    }
-
-    // Apply push/pop/reset. DA query from a new shell resets stale state.
-    kittyStackRef.current = applyKittyStack(
-      kittyStackRef.current,
-      scan.pushValues,
-      scan.popCount,
-      scan.hasDAQuery,
-    );
-    kittyLevelRef.current = kittyFlags(kittyStackRef.current);
-  }, []);
-
-  // ── PTY output batching ──
-  const flushPtyWrites = useCallback(() => {
-    ptyWriteFrameRef.current = null;
-    const term = termRef.current;
-    const pending = pendingPtyWrites.current;
-    if (!term || pending.length === 0) return;
-
-    if (pending.length === 1) {
-      term.write(pending[0]);
-    } else {
-      let totalLen = 0;
-      for (const chunk of pending) totalLen += chunk.length;
-      const combined = new Uint8Array(totalLen);
-      let offset = 0;
-      for (const chunk of pending) {
-        combined.set(chunk, offset);
-        offset += chunk.length;
-      }
-      term.write(combined);
-    }
-    pendingPtyWrites.current = [];
-  }, []);
-
-  const writePtyChunk = useCallback(
-    (payload: unknown) => {
-      if (!termRef.current) return;
-      const bytes = extractBytes(payload);
-      if (!bytes) return;
-
-      scanKittyProtocol(bytes);
-      pendingPtyWrites.current.push(bytes);
-      if (ptyWriteFrameRef.current === null) {
-        ptyWriteFrameRef.current = requestAnimationFrame(flushPtyWrites);
-      }
-    },
-    [scanKittyProtocol, flushPtyWrites],
-  );
+  const paneIdRef = useRef(paneId);
+  paneIdRef.current = paneId;
 
   // ── Resize sync ──
+  // Only emits resizePty when dims actually changed (no-op detection).
+  // No-op when the container has zero dims — the ResizeObserver will fire
+  // again once layout completes.
   const syncTerminalSize = useCallback(async () => {
-    const term = termRef.current;
-    const fitAddon = fitAddonRef.current;
-    if (!term || !fitAddon || !visibleRef.current) return;
+    const entry = entryRef.current;
+    const containerEl = containerRef.current;
+    if (!entry || !containerEl || !visibleRef.current) return;
+    if (containerEl.clientWidth === 0 || containerEl.clientHeight === 0) return;
 
-    fitAddon.fit();
-    if (term.cols === 0 || term.rows === 0) return;
+    entry.fitAddon.fit();
+    const { cols, rows } = entry.terminal;
+    if (cols === 0 || rows === 0) return;
+    if (cols === entry.lastDims.cols && rows === entry.lastDims.rows) return;
 
+    entry.lastDims = { cols, rows };
     try {
-      await resizePty(sessionIdRef.current, term.cols, term.rows);
+      await resizePty(sessionIdRef.current, cols, rows);
     } catch (err) {
       console.error("Failed to resize PTY:", err);
     }
@@ -286,286 +183,156 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
     const containerEl = containerRef.current;
     if (!containerEl) return;
 
-    // ── Create terminal ──
-    const term = new Terminal({
-      fontFamily: getTerminalFontFamily(),
-      theme: buildThemeFromCSS(),
-      convertEol: false,
-      cursorBlink: true,
-      cursorWidth: 2,
-      lineHeight: 1.15,
-      letterSpacing: 0,
-      fontSize: getTerminalFontSize(),
-      cursorStyle: getTerminalCursorStyle() as "bar" | "block" | "underline",
-      altClickMovesCursor: true,
-    });
-
-    const fitAddon = new FitAddon();
-    const serializeAddon = new SerializeAddon();
-    const unicode11Addon = new Unicode11Addon();
-    term.loadAddon(unicode11Addon);
-    term.unicode.activeVersion = "11";
-    term.loadAddon(fitAddon);
-    term.loadAddon(serializeAddon);
-    term.open(containerEl);
-
-    try {
-      const webgl = new WebglAddon();
-      webgl.onContextLoss(() => {
-        webgl.dispose();
-      });
-      term.loadAddon(webgl);
-    } catch (err) {
-      console.warn(
-        "[Codemux] WebGL renderer unavailable, falling back to DOM",
-        err,
-      );
-    }
-
-    termRef.current = term;
-    fitAddonRef.current = fitAddon;
-    serializeAddonRef.current = serializeAddon;
-    kittyStackRef.current = [];
-    kittyLevelRef.current = 0;
-
-    // ── Custom key handler ──
-    term.attachCustomKeyEventHandler((ev) => {
-      // Escape / Ctrl+C — clear this pane's Working/Permission status.
-      // Claude Code's Stop hook does NOT fire on user interrupts (Ctrl+C, Escape).
-      // Check this specific pane's status to avoid false positives (e.g. vim).
-      if (ev.type === "keydown" && paneId) {
-        const isInterrupt =
-          ev.key === "Escape" ||
-          (ev.key === "c" && ev.ctrlKey && !ev.shiftKey && !ev.altKey);
-        if (isInterrupt) {
-          const status =
-            useAppStore.getState().appState?.pane_statuses[paneId];
-          if (status === "working" || status === "permission") {
-            clearAgentStatus(sid).catch(console.error);
-          }
-          return true; // let the key pass through to the terminal
-        }
-      }
-      // App-level shortcuts — must fire BEFORE CSI u encoding so that
-      // Ctrl+K (command palette) etc. are never sent to the terminal.
-      if (isAppShortcut(ev)) return false;
-      // Modern terminals unconditionally send CSI u for modified
-      // functional keys (Enter, Tab, Space). This lets CLI apps like
-      // Claude Code distinguish Shift+Enter from Enter without
-      // requiring Kitty protocol negotiation.
-      // Backspace is only CSI-u-encoded when Kitty mode is active so
-      // that backward-kill-word (Ctrl+Backspace → \x17) still works
-      // in plain shells.
-      {
-        const codepoint = KITTY_FUNCTIONAL_KEYS.get(ev.key);
-        const mod = csiUModifier(ev);
-        if (codepoint !== undefined && mod > 1) {
-          const isBackspace = codepoint === BACKSPACE_CODEPOINT;
-          if (!isBackspace || kittyLevelRef.current > 0) {
-            if (ev.type === "keydown") {
-              writeToPty(sid, csiUSequence(codepoint, mod)).catch(console.error);
-            }
-            ev.preventDefault?.();
-            return false;
-          }
-        }
-      }
-      // Terminal-level shortcuts (resolved from keybind registry)
-      const overrides = useSyncedSettingsStore.getState().settings.keyboard.shortcuts;
-      const resolved = resolveKeybinds(overrides);
-      const killCombo = resolved.getKeysForAction("backwardKillWord");
-      const copyCombo = resolved.getKeysForAction("copySelection");
-      const pasteCombo = resolved.getKeysForAction("pasteTerminal");
-
-      if (killCombo && matchesKeyCombo(ev, killCombo)) {
-        if (ev.type === "keydown") {
-          writeToPty(sid, "\x17").catch(console.error);
-        }
-        ev.preventDefault?.();
-        return false;
-      }
-      if (copyCombo && matchesKeyCombo(ev, copyCombo)) {
-        if (ev.type === "keydown") {
-          const selection = term.getSelection();
-          if (selection) navigator.clipboard.writeText(selection).catch(console.error);
-        }
-        ev.preventDefault?.();
-        return false;
-      }
-      if (pasteCombo && matchesKeyCombo(ev, pasteCombo)) {
-        if (ev.type === "keydown") {
-          navigator.clipboard
-            .readText()
-            .then((text) => { if (text) term.paste(text); })
-            .catch(console.error);
-        }
-        ev.preventDefault?.();
-        return false;
-      }
-      return true;
-    });
-
-    // ── WKWebView newline bug workaround ──
-    const blockNewline = (e: Event) => {
-      if (kittyLevelRef.current <= 0) return;
-      const ie = e as InputEvent;
-      if (
-        ie.inputType === "insertLineBreak" ||
-        ie.inputType === "insertParagraph" ||
-        (ie.inputType === "insertText" && ie.data === "\n")
-      ) {
-        e.stopPropagation();
-        e.preventDefault();
-      }
-    };
-    containerEl.addEventListener("input", blockNewline, true);
-    blockNewlineRef.current = blockNewline;
-
-    // ── User input handler ──
-    let pendingInput = "";
-    let inputQueued = false;
-    const dataDisposable = term.onData((data) => {
-      pendingInput += data;
-      if (!inputQueued) {
-        inputQueued = true;
-        queueMicrotask(() => {
-          const batch = pendingInput;
-          pendingInput = "";
-          inputQueued = false;
-          writeToPty(sid, batch).catch((err) => {
-            console.error(`Failed to write to PTY for ${sid}:`, err);
-          });
-        });
-      }
-    });
-    dataDisposableRef.current = dataDisposable;
-
-    // ── Scrollback serialization helper ──
-    // Shared between the live-serialize registry (on close) and the unmount
-    // cache path (on tab/workspace switch).
-    const buildScrollbackPayload = (): ScrollbackPayload | null => {
-      const t = termRef.current;
-      const sa = serializeAddonRef.current;
-      if (!t || !sa) return null;
-
-      const appState = useAppStore.getState().appState;
-      if (!appState) return null;
-
-      const session = appState.terminal_sessions.find(
-        (s) => s.session_id === sid,
-      );
-      if (!session) return null;
-
-      const workspace = appState.workspaces.find((ws) =>
-        ws.surfaces.some((surf) => {
-          const json = JSON.stringify(surf.root);
-          return json.includes(sid);
-        }),
-      );
-
-      // Detect alternate screen buffer (TUI apps: vim, htop, Claude Code, etc.)
-      const isAlternateBuffer = t.buffer.active.type === "alternate";
-
-      const scrollbackLines = useSyncedSettingsStore.getState().settings.session_restore.scrollback_lines;
-      const data = sa.serialize({ scrollback: scrollbackLines });
-
-      return {
-        pane_id: paneId ?? sid,
-        session_id: sid,
-        workspace_id: workspace?.workspace_id ?? "",
-        working_directory: session.cwd,
-        original_command: session.original_command,
-        cols: session.cols,
-        rows: session.rows,
-        data,
-        adapter_captures: {
-          ...restoredCapturesRef.current,
-          ...(session.adapter_captures ?? {}),
-        },
-        adapter_id: null,
-        alternate_buffer: isAlternateBuffer,
-      };
-    };
-
-    // Register for live serialization on close
-    const unregisterSerialize = registerTerminalForSerialize(sid, buildScrollbackPayload);
-
-    // Clear any stale cached scrollback for this session (we're live now)
-    uncacheTerminalScrollback(sid).catch(() => {});
-
-    // ── Attach PTY session ──
-    //
-    // Restore scrollback, then attach PTY output and fit the pane.
     let cancelled = false;
 
     (async () => {
+      let entry: CachedTerminal;
+      let isNew: boolean;
       try {
-        const appState = useAppStore.getState().appState;
-        const workspace = appState?.workspaces.find((ws) =>
-          ws.surfaces.some((surf) => {
-            const json = JSON.stringify(surf.root);
-            return json.includes(sid);
-          }),
-        );
-        const restoreEnabled = useSyncedSettingsStore.getState().settings.session_restore.enabled;
-
-        if (restoreEnabled && workspace && paneId) {
-          const scrollback = await getTerminalScrollback(workspace.workspace_id, paneId);
-          if (scrollback && !cancelled) {
-            const { meta } = scrollback;
-            // Cache captures from scrollback metadata — these survive tab switches
-            // even when layout.json doesn't persist adapter_captures.
-            if (meta.adapter_captures && Object.keys(meta.adapter_captures).length > 0) {
-              restoredCapturesRef.current = meta.adapter_captures;
-            }
-            if (!meta.alternate_buffer && scrollback.data) {
-              term.write(scrollback.data);
-              term.write("\r\n\x1b[2m── session restored ──\x1b[0m\r\n\r\n");
-            }
-          }
-        }
-      } catch {
-        // Scrollback restore failed — continue with fresh pane
-      }
-
-      // Attach PTY — never blocked by adapter checks
-      try {
-        const status = await getTerminalStatus(sid);
-        if (cancelled) return;
-        updateStatusOverlay(status);
-      } catch {
-        if (cancelled) return;
-        updateStatusOverlay({
-          session_id: sid,
-          state: "failed",
-          message: "Failed to read terminal status",
-          exit_code: null,
+        const result = await getOrCreateTerminal(sid, {
+          paneId: paneIdRef.current ?? null,
+          fontFamily: getTerminalFontFamily(),
+          fontSize: getTerminalFontSize(),
+          cursorStyle: getTerminalCursorStyle() as
+            | "bar"
+            | "block"
+            | "underline",
+          theme: buildThemeFromCSS(),
         });
-      }
-
-      const channel = new Channel<unknown>((payload) => {
-        writePtyChunk(payload);
-      });
-
-      try {
-        await attachPtyOutput(sid, channel);
-        if (cancelled) return;
-        attachedSessionRef.current = sid;
+        entry = result.entry;
+        isNew = result.isNew;
       } catch (err) {
         if (cancelled) return;
         updateStatusOverlay({
           session_id: sid,
           state: "failed",
-          message: `Failed to attach terminal output: ${String(err)}`,
+          message: `Failed to initialize terminal: ${String(err)}`,
           exit_code: null,
         });
         return;
       }
-
-      fitAddon.fit();
-      if (term.cols > 0 && term.rows > 0) {
-        resizePty(sid, term.cols, term.rows).catch(console.error);
+      if (cancelled) {
+        // The component unmounted during async init. Park the wrapper.
+        detachFromContainer(sid);
+        return;
       }
+      // Race: the session may have been GC'd by useTerminalCacheGc while we
+      // were awaiting (PTY exit, close_pane, workspace deletion).
+      // Calling methods on a disposed Terminal throws.
+      if (entry.disposed) return;
+
+      entryRef.current = entry;
+      attachToContainer(sid, containerEl);
+
+      // Custom key handler depends on paneId, which can plausibly differ
+      // between mounts of the same session (it doesn't today, but the cache
+      // shouldn't pin paneId to a single value). Re-register on each mount.
+      entry.terminal.attachCustomKeyEventHandler((ev) => {
+        if (ev.type === "keydown" && paneIdRef.current) {
+          const isInterrupt =
+            ev.key === "Escape" ||
+            (ev.key === "c" && ev.ctrlKey && !ev.shiftKey && !ev.altKey);
+          if (isInterrupt) {
+            const status =
+              useAppStore.getState().appState?.pane_statuses[paneIdRef.current];
+            if (status === "working" || status === "permission") {
+              clearAgentStatus(sid).catch(console.error);
+            }
+            return true;
+          }
+        }
+        if (isAppShortcut(ev)) return false;
+        {
+          const codepoint = KITTY_FUNCTIONAL_KEYS.get(ev.key);
+          const mod = csiUModifier(ev);
+          if (codepoint !== undefined && mod > 1) {
+            const isBackspace = codepoint === BACKSPACE_CODEPOINT;
+            if (!isBackspace || entry.kittyLevel > 0) {
+              if (ev.type === "keydown") {
+                writeToPty(sid, csiUSequence(codepoint, mod)).catch(
+                  console.error,
+                );
+              }
+              ev.preventDefault?.();
+              return false;
+            }
+          }
+        }
+        const overrides =
+          useSyncedSettingsStore.getState().settings.keyboard.shortcuts;
+        const resolved = resolveKeybinds(overrides);
+        const killCombo = resolved.getKeysForAction("backwardKillWord");
+        const copyCombo = resolved.getKeysForAction("copySelection");
+        const pasteCombo = resolved.getKeysForAction("pasteTerminal");
+
+        if (killCombo && matchesKeyCombo(ev, killCombo)) {
+          if (ev.type === "keydown") {
+            writeToPty(sid, "\x17").catch(console.error);
+          }
+          ev.preventDefault?.();
+          return false;
+        }
+        if (copyCombo && matchesKeyCombo(ev, copyCombo)) {
+          if (ev.type === "keydown") {
+            const selection = entry.terminal.getSelection();
+            if (selection)
+              navigator.clipboard.writeText(selection).catch(console.error);
+          }
+          ev.preventDefault?.();
+          return false;
+        }
+        if (pasteCombo && matchesKeyCombo(ev, pasteCombo)) {
+          if (ev.type === "keydown") {
+            navigator.clipboard
+              .readText()
+              .then((text) => {
+                if (text) entry.terminal.paste(text);
+              })
+              .catch(console.error);
+          }
+          ev.preventDefault?.();
+          return false;
+        }
+        return true;
+      });
+
+      // ── WKWebView newline bug workaround ──
+      const blockNewline = (e: Event) => {
+        if (entry.kittyLevel <= 0) return;
+        const ie = e as InputEvent;
+        if (
+          ie.inputType === "insertLineBreak" ||
+          ie.inputType === "insertParagraph" ||
+          (ie.inputType === "insertText" && ie.data === "\n")
+        ) {
+          e.stopPropagation();
+          e.preventDefault();
+        }
+      };
+      containerEl.addEventListener("input", blockNewline, true);
+      blockNewlineRef.current = blockNewline;
+
+      // Refresh status from backend (catches state changes that happened
+      // while this component was unmounted).
+      try {
+        const status = await getTerminalStatus(sid);
+        if (!cancelled) updateStatusOverlay(status);
+      } catch {
+        if (!cancelled && isNew) {
+          updateStatusOverlay({
+            session_id: sid,
+            state: "failed",
+            message: "Failed to read terminal status",
+            exit_code: null,
+          });
+        }
+      }
+
+      // Initial fit + resize. Backend already knows the prior dims; we only
+      // emit resize if the container has actual dims and they differ.
+      syncTerminalSize();
+
+      if (focused) entry.terminal.focus();
     })();
 
     // ── ResizeObserver ──
@@ -588,7 +355,8 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
     // ── Window resize handler ──
     const windowResize = () => {
       if (!visibleRef.current) return;
-      if (windowResizeTimerRef.current) clearTimeout(windowResizeTimerRef.current);
+      if (windowResizeTimerRef.current)
+        clearTimeout(windowResizeTimerRef.current);
       windowResizeTimerRef.current = setTimeout(() => {
         windowResizeTimerRef.current = null;
         syncTerminalSize();
@@ -597,24 +365,20 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
     window.addEventListener("resize", windowResize);
 
     // ── Cleanup ──
+    // IMPORTANT: do NOT term.dispose() and do NOT detachPtyOutput here.
+    // The terminal stays alive in the cache; we only park its wrapper so the
+    // React DOM can be collected. The xterm keeps consuming PTY bytes from
+    // the still-attached channel — this is the whole reason workspace
+    // switches no longer corrupt alt-screen TUIs.
     return () => {
       cancelled = true;
 
-      if (attachedSessionRef.current) {
-        detachPtyOutput(attachedSessionRef.current).catch(console.error);
-        attachedSessionRef.current = null;
+      const containerNow = containerEl;
+      const blockNewline = blockNewlineRef.current;
+      if (blockNewline) {
+        containerNow.removeEventListener("input", blockNewline, true);
+        blockNewlineRef.current = null;
       }
-      dataDisposable.dispose();
-      dataDisposableRef.current = null;
-
-      if (ptyWriteFrameRef.current !== null) {
-        cancelAnimationFrame(ptyWriteFrameRef.current);
-        ptyWriteFrameRef.current = null;
-      }
-      pendingPtyWrites.current = [];
-
-      containerEl.removeEventListener("input", blockNewline, true);
-      blockNewlineRef.current = null;
 
       if (resizeTimerRef.current !== null) {
         clearTimeout(resizeTimerRef.current);
@@ -627,50 +391,20 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
 
       resizeObserverRef.current?.disconnect();
       resizeObserverRef.current = null;
-
       window.removeEventListener("resize", windowResize);
 
-      // Cache scrollback BEFORE disposing xterm — the serialize addon needs
-      // the live terminal buffer. This covers tab switches and workspace switches.
-      const restoreEnabled = useSyncedSettingsStore.getState().settings.session_restore.enabled;
-      if (restoreEnabled) {
-        const payload = buildScrollbackPayload();
-        if (payload && payload.data) {
-          cacheTerminalScrollback(payload).catch(() => {});
-        }
-      }
-
-      unregisterSerialize();
-      serializeAddonRef.current = null;
-      fitAddonRef.current = null;
-      kittyStackRef.current = [];
-      kittyLevelRef.current = 0;
-      term.dispose();
-      termRef.current = null;
+      detachFromContainer(sid);
+      entryRef.current = null;
     };
-    // Intentionally depend only on sessionId — theme updates are handled separately
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
-
-  // TODO: re-enable as "system theme" option in settings
-  // useEffect(() => {
-  //   if (termRef.current) {
-  //     termRef.current.options.theme = buildXtermTheme(theme);
-  //   }
-  // }, [theme]);
-  //
-  // useEffect(() => {
-  //   if (termRef.current) {
-  //     termRef.current.options.fontFamily = shellAppearance.font_family || "monospace";
-  //     fitAddonRef.current?.fit();
-  //   }
-  // }, [shellAppearance]);
 
   // ── Re-read CSS variables when theme class/style changes ──
   useEffect(() => {
     const observer = new MutationObserver(() => {
-      if (termRef.current) {
-        termRef.current.options.theme = buildThemeFromCSS();
+      const entry = entryRef.current;
+      if (entry) {
+        entry.terminal.options.theme = buildThemeFromCSS();
       }
     });
     observer.observe(document.documentElement, {
@@ -682,16 +416,20 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
 
   // ── Focus management ──
   useEffect(() => {
-    if (focused && termRef.current) {
-      termRef.current.focus();
+    const entry = entryRef.current;
+    if (focused && entry) {
+      entry.terminal.focus();
     }
   }, [focused]);
 
   return (
-    <div ref={shellRef} className="relative flex flex-1 w-full h-full min-w-0 min-h-0 bg-background">
+    <div
+      ref={shellRef}
+      className="relative flex flex-1 w-full h-full min-w-0 min-h-0 bg-background"
+    >
       <div
         ref={containerRef}
-        className="block flex-1 w-full h-full min-w-0 min-h-0 overflow-hidden px-2 py-1.5 box-border [&_.xterm]:h-full [&_.xterm]:w-full [&_.xterm-viewport]:!bg-transparent"
+        className="block flex-1 w-full h-full min-w-0 min-h-0 overflow-hidden px-2 py-1.5 box-border [&_.codemux-terminal-wrapper]:h-full [&_.codemux-terminal-wrapper]:w-full [&_.xterm]:h-full [&_.xterm]:w-full [&_.xterm-viewport]:!bg-transparent"
       />
       <div
         ref={statusOverlayRef}

--- a/src/components/terminal/terminal-cache.test.ts
+++ b/src/components/terminal/terminal-cache.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──
+//
+// The cache calls a handful of Tauri commands during cold-start
+// initialization (uncacheTerminalScrollback, getTerminalScrollback,
+// attachPtyOutput, writeToPty). Under jsdom there is no Tauri runtime, so
+// each is stubbed to a resolved promise. We do not assert on their argument
+// shapes here — that's covered by the Rust integration tests. This test's
+// job is the cache-identity invariant: same sessionId → same Terminal
+// instance across mount/unmount cycles.
+
+// Stub out the entire commands module — pulling in actual breaks because
+// @tauri-apps/api/core's Channel constructor reads window.__TAURI_INTERNALS__,
+// which jsdom doesn't have. The factory body runs hoisted, so MockChannel
+// is defined inline to keep the closure self-contained.
+vi.mock("@/tauri/commands", () => {
+  class MockChannel<T> {
+    constructor(_handler?: (payload: T) => void) {}
+    send(_data: T) {
+      return Promise.resolve();
+    }
+  }
+  return {
+    Channel: MockChannel,
+    writeToPty: vi.fn().mockResolvedValue(undefined),
+    attachPtyOutput: vi.fn().mockResolvedValue(undefined),
+    getTerminalScrollback: vi.fn().mockResolvedValue(null),
+    cacheTerminalScrollback: vi.fn().mockResolvedValue(undefined),
+    uncacheTerminalScrollback: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock("@/stores/app-store", () => ({
+  useAppStore: {
+    getState: () => ({ appState: null }),
+  },
+}));
+
+vi.mock("@/stores/synced-settings-store", () => ({
+  useSyncedSettingsStore: {
+    getState: () => ({
+      settings: {
+        session_restore: { enabled: false, scrollback_lines: 1000 },
+      },
+    }),
+  },
+}));
+
+// register/unregister can be no-ops; the test does not exercise the
+// app-close serialization path.
+vi.mock("@/hooks/use-scrollback-serializer", () => ({
+  registerTerminalForSerialize: () => () => {},
+}));
+
+// xterm's WebGL addon throws under jsdom because there's no real canvas
+// context. The cache catches the error and falls back to DOM rendering, so
+// the mock just lets the throw happen naturally — but jsdom canvas APIs
+// vary across versions, so silence the warn.
+vi.spyOn(console, "warn").mockImplementation(() => {});
+
+// xterm's CoreBrowserService calls window.matchMedia during open() to track
+// devicePixelRatio. jsdom does not implement matchMedia by default, so we
+// stub a no-op MediaQueryList — its only consumer here is xterm's DPR sync.
+if (!window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}
+
+import {
+  getOrCreateTerminal,
+  attachToContainer,
+  detachFromContainer,
+  disposeTerminal,
+  hasCachedTerminal,
+  peekCachedTerminal,
+  applyThemeToAllTerminals,
+  _cacheSize,
+} from "./terminal-cache";
+import * as commands from "@/tauri/commands";
+
+const baseOptions = {
+  paneId: "pane-1",
+  fontFamily: "monospace",
+  fontSize: 13,
+  cursorStyle: "block" as const,
+  theme: {},
+};
+
+describe("terminal-cache", () => {
+  beforeEach(() => {
+    // Each test starts from a clean cache and DOM. The cache's parking node
+    // is body-mounted on first use; we wipe the body to drop it.
+    document.body.innerHTML = "";
+  });
+
+  it("getOrCreateTerminal returns the same instance for repeat calls with the same sessionId", async () => {
+    const sid = "session-A";
+    const first = await getOrCreateTerminal(sid, baseOptions);
+    const second = await getOrCreateTerminal(sid, baseOptions);
+
+    expect(first.isNew).toBe(true);
+    expect(second.isNew).toBe(false);
+    expect(second.entry).toBe(first.entry);
+    expect(second.entry.terminal).toBe(first.entry.terminal);
+    expect(second.entry.wrapperEl).toBe(first.entry.wrapperEl);
+
+    disposeTerminal(sid);
+  });
+
+  it("attach/detach reparents the same wrapper across mount cycles", async () => {
+    const sid = "session-B";
+    const containerA = document.createElement("div");
+    const containerB = document.createElement("div");
+    document.body.append(containerA, containerB);
+
+    // Cold start: cache miss creates the terminal and parks the wrapper.
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+
+    // Simulate mount #1
+    attachToContainer(sid, containerA);
+    expect(entry.wrapperEl.parentElement).toBe(containerA);
+
+    // Simulate unmount (workspace switch) — wrapper goes to parking node.
+    detachFromContainer(sid);
+    expect(entry.wrapperEl.parentElement?.id).toBe("codemux-terminal-parking");
+
+    // Simulate remount under a different container (could be a different
+    // workspace returning, or even a different pane in the same layout).
+    // The cached entry still owns the same wrapper.
+    attachToContainer(sid, containerB);
+    expect(entry.wrapperEl.parentElement).toBe(containerB);
+    expect(peekCachedTerminal(sid)).toBe(entry);
+
+    disposeTerminal(sid);
+  });
+
+  it("disposeTerminal removes the cache entry and detaches the wrapper", async () => {
+    const sid = "session-C";
+    await getOrCreateTerminal(sid, baseOptions);
+    expect(hasCachedTerminal(sid)).toBe(true);
+
+    disposeTerminal(sid);
+    expect(hasCachedTerminal(sid)).toBe(false);
+    expect(peekCachedTerminal(sid)).toBeNull();
+
+    // The parking node should be empty after disposal — no leaked wrappers.
+    const parking = document.getElementById("codemux-terminal-parking");
+    expect(parking?.children.length ?? 0).toBe(0);
+  });
+
+  it("disposeTerminal is idempotent", async () => {
+    const sid = "session-D";
+    await getOrCreateTerminal(sid, baseOptions);
+    disposeTerminal(sid);
+    expect(() => disposeTerminal(sid)).not.toThrow();
+  });
+
+  it("different sessionIds get independent terminal instances", async () => {
+    const a = await getOrCreateTerminal("session-X", baseOptions);
+    const b = await getOrCreateTerminal("session-Y", baseOptions);
+    expect(a.entry).not.toBe(b.entry);
+    expect(a.entry.terminal).not.toBe(b.entry.terminal);
+    disposeTerminal("session-X");
+    disposeTerminal("session-Y");
+  });
+
+  it("disposeTerminal on an unknown sessionId is a safe no-op", () => {
+    expect(() => disposeTerminal("never-existed")).not.toThrow();
+    expect(_cacheSize()).toBe(0);
+  });
+
+  it("attachToContainer on an unknown sessionId returns null", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    expect(attachToContainer("phantom", container)).toBeNull();
+  });
+
+  it("detachFromContainer on an unknown sessionId is a safe no-op", () => {
+    expect(() => detachFromContainer("phantom")).not.toThrow();
+  });
+
+  it("getOrCreateTerminal updates the cached entry's paneId on reuse", async () => {
+    const sid = "session-pane-update";
+    const first = await getOrCreateTerminal(sid, {
+      ...baseOptions,
+      paneId: "pane-original",
+    });
+    expect(first.entry.paneId).toBe("pane-original");
+
+    const second = await getOrCreateTerminal(sid, {
+      ...baseOptions,
+      paneId: "pane-renamed",
+    });
+    expect(second.entry).toBe(first.entry);
+    expect(second.entry.paneId).toBe("pane-renamed");
+
+    disposeTerminal(sid);
+  });
+
+  it("getOrCreateTerminal rolls back the cache entry if attach fails", async () => {
+    const attachMock = vi.mocked(commands.attachPtyOutput);
+    attachMock.mockRejectedValueOnce(new Error("simulated backend failure"));
+
+    const sid = "session-fail";
+    await expect(getOrCreateTerminal(sid, baseOptions)).rejects.toThrow(
+      "simulated backend failure",
+    );
+    // The next call should be a cold start again (cache rolled back) — if
+    // the entry stuck, we'd see isNew=false here and a stuck broken xterm.
+    expect(hasCachedTerminal(sid)).toBe(false);
+
+    attachMock.mockResolvedValueOnce(undefined);
+    const retry = await getOrCreateTerminal(sid, baseOptions);
+    expect(retry.isNew).toBe(true);
+    disposeTerminal(sid);
+  });
+
+  it("applyThemeToAllTerminals updates every cached entry's theme", async () => {
+    const a = await getOrCreateTerminal("theme-A", baseOptions);
+    const b = await getOrCreateTerminal("theme-B", baseOptions);
+
+    const updated = { background: "#ff0000", foreground: "#00ff00" };
+    applyThemeToAllTerminals(updated);
+
+    expect(a.entry.terminal.options.theme?.background).toBe("#ff0000");
+    expect(b.entry.terminal.options.theme?.background).toBe("#ff0000");
+
+    disposeTerminal("theme-A");
+    disposeTerminal("theme-B");
+  });
+
+  it("applyThemeToAllTerminals skips disposed entries without throwing", async () => {
+    await getOrCreateTerminal("theme-skip", baseOptions);
+    disposeTerminal("theme-skip");
+    expect(() =>
+      applyThemeToAllTerminals({ background: "#000000" }),
+    ).not.toThrow();
+  });
+
+  it("attachToContainer is idempotent — calling it twice does not duplicate the wrapper", async () => {
+    const sid = "session-idem-attach";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+
+    attachToContainer(sid, container);
+    attachToContainer(sid, container);
+
+    // Wrapper should appear exactly once in containerEl, never duplicated.
+    const matches = container.querySelectorAll(".codemux-terminal-wrapper");
+    expect(matches.length).toBe(1);
+    expect(entry.wrapperEl.parentElement).toBe(container);
+
+    disposeTerminal(sid);
+  });
+});

--- a/src/components/terminal/terminal-cache.ts
+++ b/src/components/terminal/terminal-cache.ts
@@ -1,0 +1,520 @@
+/**
+ * Terminal cache: keeps xterm.js Terminal instances alive across React unmounts.
+ *
+ * The xterm Terminal, its addons, the persistent wrapper <div>, the PTY-output
+ * channel attachment, and the input handlers all live in this module-level
+ * cache keyed by sessionId. React's TerminalPane becomes a thin DOM-attach
+ * wrapper that reparents the cached <div> in and out of its layout container.
+ *
+ * Lifetime invariant: the cache entry exists for the lifetime of the PTY
+ * session. It is created on first mount (cold start) and disposed only when
+ * the session ends (close button, workspace delete, app shutdown). Workspace
+ * switches and tab switches reparent the wrapper into a hidden parking node
+ * but never call term.dispose() — the xterm keeps consuming PTY bytes the
+ * whole time, so its mode flags / cursor / alt-screen state stay in sync
+ * with the agent.
+ *
+ * Design references:
+ * - /tmp/terminal-rendering-analysis.md §5.1 (xterm-instance-lifetime split)
+ * - Superset's apps/desktop/.../v1-terminal-cache.ts: same wrapper-div pattern
+ *   for the same reason. We do not transplant; we reimplement for our React
+ *   + Tauri stack.
+ */
+import { Terminal } from "@xterm/xterm";
+import type { ITheme } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
+import { WebglAddon } from "@xterm/addon-webgl";
+import {
+  writeToPty,
+  attachPtyOutput,
+  getTerminalScrollback,
+  cacheTerminalScrollback,
+  uncacheTerminalScrollback,
+  Channel,
+  type ScrollbackPayload,
+} from "@/tauri/commands";
+import {
+  scanKittySequences,
+  applyKittyStack,
+  kittyFlags,
+} from "@/lib/kitty-keyboard";
+import { useAppStore } from "@/stores/app-store";
+import { useSyncedSettingsStore } from "@/stores/synced-settings-store";
+import { registerTerminalForSerialize } from "@/hooks/use-scrollback-serializer";
+
+const PARKING_NODE_ID = "codemux-terminal-parking";
+
+export interface TerminalCreateOptions {
+  paneId: string | null;
+  fontFamily: string;
+  fontSize: number;
+  cursorStyle: "bar" | "block" | "underline";
+  theme: ITheme;
+}
+
+export interface CachedTerminal {
+  sessionId: string;
+  terminal: Terminal;
+  wrapperEl: HTMLDivElement;
+  fitAddon: FitAddon;
+  serializeAddon: SerializeAddon;
+  unicode11Addon: Unicode11Addon;
+  webglAddon: WebglAddon | null;
+  /** Last cols/rows pushed to the backend; used for resize no-op detection. */
+  lastDims: { cols: number; rows: number };
+  /** Latest pane ID this session is rendered under. Updated on each attach
+   *  because the custom key handler (interrupt-clears) consults pane status. */
+  paneId: string | null;
+  /** Cleared by disposeTerminal so RAFs queued from the channel callback
+   *  short-circuit instead of writing into a disposed Terminal. */
+  disposed: boolean;
+  /** Frame ID for the pending PTY-write batch. */
+  ptyWriteFrame: number | null;
+  pendingPtyWrites: Uint8Array[];
+  /** Kitty keyboard protocol stack (push/pop/reset).
+   *  Stays per-session because the agent-side stack is per-PTY. */
+  kittyStack: number[];
+  kittyLevel: number;
+  /** Disposers for resources the cache owns (input handler, serialize
+   *  registration). Called from disposeTerminal. */
+  cleanups: Array<() => void>;
+}
+
+const cache = new Map<string, CachedTerminal>();
+
+function ensureParkingNode(): HTMLElement {
+  let node = document.getElementById(PARKING_NODE_ID);
+  if (!node) {
+    node = document.createElement("div");
+    node.id = PARKING_NODE_ID;
+    node.style.position = "absolute";
+    node.style.width = "0";
+    node.style.height = "0";
+    node.style.overflow = "hidden";
+    node.style.visibility = "hidden";
+    node.style.pointerEvents = "none";
+    document.body.appendChild(node);
+  }
+  return node;
+}
+
+function extractBytes(payload: unknown): Uint8Array | null {
+  if (payload instanceof Uint8Array) return payload;
+  if (payload instanceof ArrayBuffer) return new Uint8Array(payload);
+  if (Array.isArray(payload)) return new Uint8Array(payload as number[]);
+  if (typeof payload === "string") return new TextEncoder().encode(payload);
+  return null;
+}
+
+function flushPtyWrites(entry: CachedTerminal) {
+  entry.ptyWriteFrame = null;
+  if (entry.disposed) return;
+  const pending = entry.pendingPtyWrites;
+  if (pending.length === 0) return;
+
+  if (pending.length === 1) {
+    entry.terminal.write(pending[0]);
+  } else {
+    let totalLen = 0;
+    for (const chunk of pending) totalLen += chunk.length;
+    const combined = new Uint8Array(totalLen);
+    let offset = 0;
+    for (const chunk of pending) {
+      combined.set(chunk, offset);
+      offset += chunk.length;
+    }
+    entry.terminal.write(combined);
+  }
+  entry.pendingPtyWrites = [];
+}
+
+function scanKittyProtocol(entry: CachedTerminal, data: Uint8Array) {
+  const decoded = new TextDecoder("utf-8", { fatal: false }).decode(data);
+  const scan = scanKittySequences(decoded);
+
+  if (scan.hasQuery) {
+    writeToPty(
+      entry.sessionId,
+      `\x1b[?${kittyFlags(entry.kittyStack)}u`,
+    ).catch(console.error);
+  }
+  entry.kittyStack = applyKittyStack(
+    entry.kittyStack,
+    scan.pushValues,
+    scan.popCount,
+    scan.hasDAQuery,
+  );
+  entry.kittyLevel = kittyFlags(entry.kittyStack);
+}
+
+function buildScrollbackPayload(
+  entry: CachedTerminal,
+): ScrollbackPayload | null {
+  const t = entry.terminal;
+  const sa = entry.serializeAddon;
+  const sid = entry.sessionId;
+
+  const appState = useAppStore.getState().appState;
+  if (!appState) return null;
+
+  const session = appState.terminal_sessions.find(
+    (s) => s.session_id === sid,
+  );
+  if (!session) return null;
+
+  const workspace = appState.workspaces.find((ws) =>
+    ws.surfaces.some((surf) => {
+      const json = JSON.stringify(surf.root);
+      return json.includes(sid);
+    }),
+  );
+
+  const scrollbackLines =
+    useSyncedSettingsStore.getState().settings.session_restore.scrollback_lines;
+  const data = sa.serialize({ scrollback: scrollbackLines });
+
+  return {
+    pane_id: entry.paneId ?? sid,
+    session_id: sid,
+    workspace_id: workspace?.workspace_id ?? "",
+    working_directory: session.cwd,
+    original_command: session.original_command,
+    cols: session.cols,
+    rows: session.rows,
+    data,
+    adapter_captures: session.adapter_captures ?? {},
+    adapter_id: null,
+    alternate_buffer: t.buffer.active.type === "alternate",
+  };
+}
+
+/**
+ * Construct a new xterm Terminal, load addons, and wire up the input handler
+ * + PTY-output channel. Returns a CachedTerminal whose wrapperEl lives in the
+ * parking node until attachToContainer reparents it.
+ */
+function createCachedTerminal(
+  sessionId: string,
+  options: TerminalCreateOptions,
+): CachedTerminal {
+  const wrapperEl = document.createElement("div");
+  wrapperEl.className = "codemux-terminal-wrapper";
+  wrapperEl.style.width = "100%";
+  wrapperEl.style.height = "100%";
+  ensureParkingNode().appendChild(wrapperEl);
+
+  const terminal = new Terminal({
+    fontFamily: options.fontFamily,
+    theme: options.theme,
+    convertEol: false,
+    cursorBlink: true,
+    cursorWidth: 2,
+    lineHeight: 1.15,
+    letterSpacing: 0,
+    fontSize: options.fontSize,
+    cursorStyle: options.cursorStyle,
+    altClickMovesCursor: true,
+    // Required so Unicode11Addon.activate() can call terminal.unicode.register
+    // — `unicode.activeVersion = "11"` is a proposed API in xterm 6.x.
+    allowProposedApi: true,
+  });
+
+  const fitAddon = new FitAddon();
+  const serializeAddon = new SerializeAddon();
+  const unicode11Addon = new Unicode11Addon();
+
+  terminal.loadAddon(unicode11Addon);
+  terminal.unicode.activeVersion = "11";
+  terminal.loadAddon(fitAddon);
+  terminal.loadAddon(serializeAddon);
+
+  // xterm needs to be open()'d into a real DOM element so its renderer can
+  // measure cells. Even while parked the wrapper is in the body, so this
+  // works. WebGL is loaded lazily after open() returns.
+  terminal.open(wrapperEl);
+
+  let webglAddon: WebglAddon | null = null;
+  try {
+    webglAddon = new WebglAddon();
+    webglAddon.onContextLoss(() => {
+      webglAddon?.dispose();
+      webglAddon = null;
+    });
+    terminal.loadAddon(webglAddon);
+  } catch (err) {
+    console.warn(
+      "[Codemux] WebGL renderer unavailable, falling back to DOM",
+      err,
+    );
+    webglAddon = null;
+  }
+
+  const entry: CachedTerminal = {
+    sessionId,
+    terminal,
+    wrapperEl,
+    fitAddon,
+    serializeAddon,
+    unicode11Addon,
+    webglAddon,
+    lastDims: { cols: 0, rows: 0 },
+    paneId: options.paneId,
+    disposed: false,
+    ptyWriteFrame: null,
+    pendingPtyWrites: [],
+    kittyStack: [],
+    kittyLevel: 0,
+    cleanups: [],
+  };
+
+  // ── User input handler ──
+  // Stable: sessionId never changes for a given cache entry.
+  let pendingInput = "";
+  let inputQueued = false;
+  const dataDisposable = terminal.onData((data) => {
+    if (entry.disposed) return;
+    pendingInput += data;
+    if (!inputQueued) {
+      inputQueued = true;
+      queueMicrotask(() => {
+        const batch = pendingInput;
+        pendingInput = "";
+        inputQueued = false;
+        writeToPty(sessionId, batch).catch((err) => {
+          console.error(`Failed to write to PTY for ${sessionId}:`, err);
+        });
+      });
+    }
+  });
+  entry.cleanups.push(() => dataDisposable.dispose());
+
+  // ── Serialization registration ──
+  // Lives for the cache entry's lifetime (not the React mount), so unmounted-
+  // but-cached panes still serialize on app close.
+  const unregisterSerialize = registerTerminalForSerialize(sessionId, () =>
+    buildScrollbackPayload(entry),
+  );
+  entry.cleanups.push(unregisterSerialize);
+
+  return entry;
+}
+
+/**
+ * Wire up the PTY → xterm channel for a freshly-created cache entry. This
+ * runs once per session (cold start). Stays attached for the entire session
+ * lifetime — workspace switches do NOT detach.
+ */
+async function attachPtyChannel(entry: CachedTerminal): Promise<void> {
+  const channel = new Channel<unknown>((payload) => {
+    if (entry.disposed) return;
+    const bytes = extractBytes(payload);
+    if (!bytes) return;
+    scanKittyProtocol(entry, bytes);
+    entry.pendingPtyWrites.push(bytes);
+    if (entry.ptyWriteFrame === null) {
+      entry.ptyWriteFrame = requestAnimationFrame(() => flushPtyWrites(entry));
+    }
+  });
+  await attachPtyOutput(entry.sessionId, channel);
+}
+
+/**
+ * Restore on-disk scrollback into a freshly-created xterm. Skips replay if
+ * the saved buffer was alt-screen (TUI) — fresh shell is more useful than a
+ * frozen frame of vim.
+ */
+async function restoreScrollback(entry: CachedTerminal): Promise<void> {
+  const restoreEnabled =
+    useSyncedSettingsStore.getState().settings.session_restore.enabled;
+  if (!restoreEnabled) return;
+
+  const appState = useAppStore.getState().appState;
+  const workspace = appState?.workspaces.find((ws) =>
+    ws.surfaces.some((surf) => {
+      const json = JSON.stringify(surf.root);
+      return json.includes(entry.sessionId);
+    }),
+  );
+  if (!workspace || !entry.paneId) return;
+
+  try {
+    const scrollback = await getTerminalScrollback(
+      workspace.workspace_id,
+      entry.paneId,
+    );
+    if (!scrollback || entry.disposed) return;
+    if (!scrollback.meta.alternate_buffer && scrollback.data) {
+      entry.terminal.write(scrollback.data);
+      entry.terminal.write(
+        "\r\n\x1b[2m── session restored ──\x1b[0m\r\n\r\n",
+      );
+    }
+  } catch {
+    // Restore failed — fresh shell is still usable
+  }
+}
+
+/**
+ * Get an existing cache entry or create + initialize a new one.
+ *
+ * On cold start (cache miss) this also restores disk scrollback and attaches
+ * the PTY-output channel. On warm reuse, it returns the existing entry —
+ * the caller just needs to attachToContainer.
+ *
+ * `isNew` lets the caller distinguish the two paths so it can show a status
+ * overlay only on cold start.
+ */
+export async function getOrCreateTerminal(
+  sessionId: string,
+  options: TerminalCreateOptions,
+): Promise<{ entry: CachedTerminal; isNew: boolean }> {
+  const existing = cache.get(sessionId);
+  if (existing) {
+    existing.paneId = options.paneId;
+    return { entry: existing, isNew: false };
+  }
+
+  const entry = createCachedTerminal(sessionId, options);
+  cache.set(sessionId, entry);
+
+  // Clear stale on-disk-cached bytes (we are about to attach live)
+  uncacheTerminalScrollback(sessionId).catch(() => {});
+
+  try {
+    await restoreScrollback(entry);
+    if (entry.disposed) return { entry, isNew: true };
+    await attachPtyChannel(entry);
+  } catch (err) {
+    // Init failed partway — tear the half-formed entry down so the next
+    // mount retries cold-start instead of finding a stuck cache hit.
+    if (cache.get(sessionId) === entry) {
+      disposeTerminal(sessionId);
+    }
+    throw err;
+  }
+  return { entry, isNew: true };
+}
+
+/**
+ * Reparent the cached wrapperEl into the live container and fit the terminal
+ * to its new dimensions. No-ops if the container has zero dims (it hasn't
+ * laid out yet) — the caller's ResizeObserver will fit once it does.
+ */
+export function attachToContainer(
+  sessionId: string,
+  containerEl: HTMLElement,
+): CachedTerminal | null {
+  const entry = cache.get(sessionId);
+  if (!entry || entry.disposed) return null;
+
+  if (entry.wrapperEl.parentElement !== containerEl) {
+    containerEl.appendChild(entry.wrapperEl);
+  }
+
+  const { clientWidth, clientHeight } = containerEl;
+  if (clientWidth > 0 && clientHeight > 0) {
+    entry.fitAddon.fit();
+  }
+  return entry;
+}
+
+/**
+ * Reparent the wrapperEl back to the parking node. The xterm and PTY
+ * channel stay alive — bytes keep flowing into the wrapper while it's
+ * parked, so workspace return shows the live frame.
+ *
+ * Idempotent.
+ */
+export function detachFromContainer(sessionId: string): void {
+  const entry = cache.get(sessionId);
+  if (!entry || entry.disposed) return;
+  const parking = ensureParkingNode();
+  if (entry.wrapperEl.parentElement !== parking) {
+    parking.appendChild(entry.wrapperEl);
+  }
+}
+
+/**
+ * Dispose the cache entry. Call this when the session itself ends (close
+ * button, workspace deletion, app shutdown) — NOT on component unmount.
+ *
+ * Caches the final scrollback to the Rust backstop so app-close-while-the-
+ * pane-is-mid-dispose still gets persisted on disk.
+ */
+export function disposeTerminal(sessionId: string): void {
+  const entry = cache.get(sessionId);
+  if (!entry) return;
+
+  // Best-effort persistence of final state. We're not awaiting this — the
+  // session is going away regardless and Rust accepts a fire-and-forget cache.
+  const restoreEnabled =
+    useSyncedSettingsStore.getState().settings.session_restore.enabled;
+  if (restoreEnabled) {
+    const payload = buildScrollbackPayload(entry);
+    if (payload && payload.data) {
+      cacheTerminalScrollback(payload).catch(() => {});
+    }
+  }
+
+  entry.disposed = true;
+  cache.delete(sessionId);
+
+  if (entry.ptyWriteFrame !== null) {
+    cancelAnimationFrame(entry.ptyWriteFrame);
+    entry.ptyWriteFrame = null;
+  }
+  entry.pendingPtyWrites = [];
+
+  for (const cleanup of entry.cleanups) {
+    try {
+      cleanup();
+    } catch (err) {
+      console.error("[Codemux] terminal cache cleanup failed", err);
+    }
+  }
+  entry.cleanups = [];
+
+  try {
+    entry.terminal.dispose();
+  } catch (err) {
+    console.error("[Codemux] terminal.dispose failed", err);
+  }
+
+  if (entry.wrapperEl.parentElement) {
+    entry.wrapperEl.parentElement.removeChild(entry.wrapperEl);
+  }
+}
+
+/**
+ * Apply a fresh theme to every cached terminal. Called by the app-level
+ * theme observer so unmounted-but-cached panes still pick up theme changes
+ * — without this, switching theme while a pane is parked would leave it
+ * stuck on the old palette until the user changed theme a second time.
+ */
+export function applyThemeToAllTerminals(theme: ITheme): void {
+  for (const entry of cache.values()) {
+    if (entry.disposed) continue;
+    try {
+      entry.terminal.options.theme = theme;
+    } catch (err) {
+      console.error("[Codemux] failed to apply theme to cached terminal", err);
+    }
+  }
+}
+
+/** Test/debug helper: peek at the cache without leaking the Map. */
+export function hasCachedTerminal(sessionId: string): boolean {
+  return cache.has(sessionId);
+}
+
+/** Test/debug helper: read cache entry for identity assertions. */
+export function peekCachedTerminal(sessionId: string): CachedTerminal | null {
+  return cache.get(sessionId) ?? null;
+}
+
+/** Test-only helper: count of live cache entries. */
+export function _cacheSize(): number {
+  return cache.size;
+}

--- a/src/hooks/use-terminal-cache-gc.ts
+++ b/src/hooks/use-terminal-cache-gc.ts
@@ -1,0 +1,40 @@
+/**
+ * Garbage-collect the module-level terminal cache.
+ *
+ * The xterm Terminal for a session lives in `terminal-cache.ts` for the
+ * full lifetime of the PTY session — workspace switches keep the cache
+ * entry alive. The only truly session-ending events come from the Rust
+ * backend (close_pane / close_tab / close_workspace, PTY exit, app
+ * shutdown), which all manifest as the session_id disappearing from
+ * AppState.terminal_sessions.
+ *
+ * This hook subscribes to that store and calls disposeTerminal for any
+ * cached entry whose session is no longer tracked.
+ */
+import { useEffect } from "react";
+import { useAppStore } from "@/stores/app-store";
+import { disposeTerminal } from "@/components/terminal/terminal-cache";
+
+const tracked = new Set<string>();
+
+export function useTerminalCacheGc() {
+  useEffect(() => {
+    // Seed from current state so we don't fire spurious disposals if the
+    // cache somehow has stale entries on first mount.
+    const initial = useAppStore.getState().appState?.terminal_sessions ?? [];
+    for (const s of initial) tracked.add(s.session_id);
+
+    return useAppStore.subscribe((state) => {
+      const sessions = state.appState?.terminal_sessions;
+      if (!sessions) return;
+      const live = new Set(sessions.map((s) => s.session_id));
+      for (const sid of tracked) {
+        if (!live.has(sid)) {
+          tracked.delete(sid);
+          disposeTerminal(sid);
+        }
+      }
+      for (const sid of live) tracked.add(sid);
+    });
+  }, []);
+}

--- a/src/hooks/use-terminal-theme-sync.ts
+++ b/src/hooks/use-terminal-theme-sync.ts
@@ -1,0 +1,77 @@
+/**
+ * App-level theme MutationObserver for the terminal cache.
+ *
+ * Theme changes (light/dark, accent updates) are signalled by class/style
+ * mutations on document.documentElement. This hook installs ONE observer
+ * that walks every cached xterm and updates its theme — including panes
+ * that are currently unmounted/parked. Without it, switching theme while
+ * a workspace pane is unmounted leaves it stuck on the old palette.
+ *
+ * The TerminalPane component still has a per-mount observer for the live
+ * theme of the visible pane (cheap belt-and-suspenders), but this hook is
+ * the source of truth for cached-but-unmounted panes.
+ */
+import { useEffect } from "react";
+import type { ITheme } from "@xterm/xterm";
+import { applyThemeToAllTerminals } from "@/components/terminal/terminal-cache";
+
+const ANSI_COLORS = {
+  black: "#151110",
+  red: "#dc6b6b",
+  green: "#7ec699",
+  yellow: "#e5c07b",
+  blue: "#61afef",
+  magenta: "#c678dd",
+  cyan: "#56b6c2",
+  white: "#eae8e6",
+  brightBlack: "#5c5856",
+  brightRed: "#e88888",
+  brightGreen: "#98d1a8",
+  brightYellow: "#ecd08f",
+  brightBlue: "#7ec0f5",
+  brightMagenta: "#d494e6",
+  brightCyan: "#73c7d3",
+  brightWhite: "#ffffff",
+};
+
+function resolveOklch(value: string): string {
+  const el = document.createElement("div");
+  el.style.color = value;
+  document.body.appendChild(el);
+  const rgb = getComputedStyle(el).color;
+  document.body.removeChild(el);
+  return rgb;
+}
+
+function getCSSVar(name: string): string {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  if (!raw) return "";
+  return resolveOklch(raw);
+}
+
+function buildThemeFromCSS(): ITheme {
+  return {
+    background: getCSSVar("--background"),
+    foreground: getCSSVar("--foreground"),
+    cursor: getCSSVar("--sidebar-primary"),
+    cursorAccent: getCSSVar("--background"),
+    selectionBackground: getCSSVar("--accent"),
+    selectionForeground: getCSSVar("--accent-foreground"),
+    ...ANSI_COLORS,
+  };
+}
+
+export function useTerminalThemeSync() {
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      applyThemeToAllTerminals(buildThemeFromCSS());
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style"],
+    });
+    return () => observer.disconnect();
+  }, []);
+}


### PR DESCRIPTION
## Summary

- Move xterm.js Terminal + addons + wrapper `<div>` + PTY-output channel into a module-level cache (`src/components/terminal/terminal-cache.ts`) keyed by sessionId. Workspace switches reparent the wrapper into a hidden `#codemux-terminal-parking` node instead of disposing, so alt-screen TUIs (Claude Code's "Simmering…", lazygit, vim, btop) stay coherent across switches.
- `TerminalPane.tsx` becomes a thin DOM-attach wrapper. Disposal is driven by AppState diffs in a new `useTerminalCacheGc` hook so close-pane / close-tab / close-workspace / PTY exit all reach `disposeTerminal`. App-level `useTerminalThemeSync` walks every cached entry on theme change so parked panes pick up new palettes.
- Backend: per-session `dropped_chunks` counter on `SessionRuntime` surfaces silent `pending_output` evictions in stderr instead of swallowing PTY data unobserved.

## Architecture

The bug being fixed is the architectural one called out in the rendering analysis: `term.dispose()` on every workspace switch meant a fresh Terminal at default 80×24 in normal-screen mode was receiving raw PTY bytes computed for the prior alt-screen + actual-dim state. The fix is to never dispose on unmount — the xterm instance lifetime is now equal to the PTY session lifetime, not the React component lifetime, mirroring Superset's `v1-terminal-cache.ts` pattern (reimplemented for our React + Tauri stack).

## Tests

Backend (Rust, real `tauri::ipc::Channel`):
- `test_pending_output_replays_on_attach` — cold-start replay preserves order
- `test_attached_channel_receives_live_writes` — channel attached → no buffer growth, no drops
- `test_dropped_chunks_counter_increments_on_overflow` — observability counter works
- `test_dropped_chunks_isolated_per_session` — counter is per-session
- `test_dropped_chunks_persists_across_attach_detach` — counter does not reset

Frontend (vitest, jsdom):
- Same `Terminal` instance reused across mount/unmount cycles for the same sessionId
- attach/detach reparents the cached wrapper between containers
- `disposeTerminal` is idempotent and cleans up the parking node
- Different sessionIds get independent instances
- `disposeTerminal` / `attachToContainer` / `detachFromContainer` no-op for unknown sessionId
- `getOrCreateTerminal` updates `paneId` on warm reuse
- Failed init rolls back the cache so the next call retries cold-start
- `applyThemeToAllTerminals` updates every entry; safe on disposed entries
- `attachToContainer` is idempotent (no duplicated wrappers)

`npm run verify` is green: `cargo test` 608 passed, `tsc` clean, vitest 364 tests across 28 files.

## Test plan

- [ ] Open Codemux, create a workspace, start `claude` agent, trigger a long-running task that puts Claude Code into the alt-screen "Simmering…" loop with continuous output
- [ ] Switch to a different workspace, wait 30 seconds, switch back — frame should be live, intact, and updating; no garbled lines, misaligned characters, or overlap
- [ ] Repeat with `lazygit`, `btop`, `htop`, `vim` — any alt-screen TUI
- [ ] Close a workspace while a terminal is running → terminal disposes, no zombie xterm in the cache, parking node empty
- [ ] Open a split pane → second pane does not affect the first pane's cached xterm
- [ ] Switch theme while a workspace pane is unmounted → on switch back, the pane shows the new palette (no stale theme)
- [ ] Open and close 20 workspaces in a row → process memory grows only while sessions are alive, then shrinks as they're disposed; no leaked DOM nodes in `#codemux-terminal-parking`
- [ ] App reload → cache cleared cleanly