### PR TITLE
feat(sidebar): show PR status icon on workspace rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -188,7 +188,7 @@ pub fn refresh_workspace_pr(
     // explicitly set during PR-checkout (fork branches where gh can't resolve).
     if pr_info.is_some() {
         let pr_number = pr_info.as_ref().map(|p| p.number);
-        let pr_state = pr_info.as_ref().map(|p| p.state.clone());
+        let pr_state = pr_info.as_ref().map(|p| p.display_state());
         let pr_url = pr_info.as_ref().map(|p| p.url.clone());
         state.update_workspace_pr_info(&workspace_id, pr_number, pr_state, pr_url);
     }

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -29,6 +29,20 @@ pub struct PullRequestInfo {
     pub updated_at: Option<String>,
 }
 
+impl PullRequestInfo {
+    /// State string that feeds the workspace `pr_state` field (and the
+    /// sidebar PR-status icon). Collapses `is_draft: true` into a "DRAFT"
+    /// label so the sidebar can pick the muted draft icon without needing
+    /// a separate `is_draft` column on the workspace.
+    pub fn display_state(&self) -> String {
+        if self.is_draft {
+            "DRAFT".to_string()
+        } else {
+            self.state.clone()
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncomingPrItem {
     pub number: u32,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -545,7 +545,7 @@ pub fn run() {
                             // PR-checkout (fork branches where `gh pr view` can't resolve).
                             if pr_info.is_some() {
                                 let pr_number = pr_info.as_ref().map(|p| p.number);
-                                let pr_state = pr_info.as_ref().map(|p| p.state.clone());
+                                let pr_state = pr_info.as_ref().map(|p| p.display_state());
                                 let pr_url = pr_info.as_ref().map(|p| p.url.clone());
                                 state.update_workspace_pr_info(&workspace_id, pr_number, pr_state, pr_url);
                             }
@@ -576,6 +576,150 @@ pub fn run() {
                     if !all_workspaces.is_empty() {
                         state::emit_app_state(&git_handle);
                     }
+                }
+            });
+
+            // Background PR polling for the sidebar PR-status icon. The 5s
+            // tick above only refreshes the active workspace's PR info; this
+            // 60s tick walks every workspace so non-active sidebar rows
+            // don't go stale (the user might leave the app open while a
+            // teammate merges a PR on GitHub).
+            //
+            // Sequential per tick on purpose — each `gh pr view` is a
+            // subprocess fork, and we'd rather take ~Nx longer than slam
+            // `gh` with N parallel children. Each call gets a 10s timeout
+            // so a single hanging `gh` doesn't block subsequent workspaces.
+            //
+            // Pauses the per-workspace walk when `gh` is missing or
+            // unauthenticated (status is rechecked every tick — `gh auth
+            // status` is itself a cheap fork+exec, ~50ms).
+            let pr_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                const TICK_SECS: u64 = 60;
+                const PER_CALL_TIMEOUT_SECS: u64 = 10;
+                let mut last_status_authed: Option<bool> = None;
+
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_secs(TICK_SECS)).await;
+
+                    // Check gh status outside spawn_blocking because it's a
+                    // fast call and we don't need the timeout machinery for it.
+                    let gh_status = github::check_gh_status();
+                    let authed = matches!(gh_status, github::GhStatus::Authenticated { .. });
+
+                    // Log status transitions only — avoids spamming when
+                    // the user is offline for an extended period.
+                    if last_status_authed != Some(authed) {
+                        eprintln!(
+                            "[codemux::pr-poll] gh auth status: {} (was: {:?})",
+                            if authed { "authenticated" } else { "unavailable" },
+                            last_status_authed,
+                        );
+                        last_status_authed = Some(authed);
+                    }
+
+                    if !authed {
+                        continue;
+                    }
+
+                    let state: tauri::State<'_, state::AppStateStore> = pr_handle.state();
+                    let workspaces: Vec<(String, String)> = {
+                        let snapshot = state.snapshot();
+                        snapshot
+                            .workspaces
+                            .iter()
+                            .map(|w| {
+                                let path = w
+                                    .worktree_path
+                                    .clone()
+                                    .unwrap_or_else(|| w.cwd.clone());
+                                (w.workspace_id.0.clone(), path)
+                            })
+                            .collect()
+                    };
+
+                    let mut refreshed = 0usize;
+                    let mut skipped_non_github = 0usize;
+                    let mut timed_out = 0usize;
+
+                    for (workspace_id, cwd) in workspaces {
+                        let path = std::path::PathBuf::from(&cwd);
+
+                        // Skip non-GitHub repos cheaply (this itself shells
+                        // out, but a single `gh repo view` is cheap relative
+                        // to skipping the whole tick on a non-GitHub
+                        // workspace).
+                        let path_for_repo = path.clone();
+                        let is_gh = tokio::time::timeout(
+                            std::time::Duration::from_secs(PER_CALL_TIMEOUT_SECS),
+                            tokio::task::spawn_blocking(move || {
+                                github::is_github_repo(&path_for_repo)
+                            }),
+                        )
+                        .await;
+                        let is_gh = match is_gh {
+                            Ok(Ok(b)) => b,
+                            Ok(Err(_)) => false,
+                            Err(_) => {
+                                timed_out += 1;
+                                continue;
+                            }
+                        };
+                        if !is_gh {
+                            skipped_non_github += 1;
+                            continue;
+                        }
+
+                        let path_for_pr = path.clone();
+                        let pr_result = tokio::time::timeout(
+                            std::time::Duration::from_secs(PER_CALL_TIMEOUT_SECS),
+                            tokio::task::spawn_blocking(move || {
+                                github::get_branch_pr(&path_for_pr)
+                            }),
+                        )
+                        .await;
+
+                        match pr_result {
+                            Ok(Ok(Ok(Some(pr)))) => {
+                                state.update_workspace_pr_info(
+                                    &workspace_id,
+                                    Some(pr.number),
+                                    Some(pr.display_state()),
+                                    Some(pr.url.clone()),
+                                );
+                                refreshed += 1;
+                            }
+                            Ok(Ok(Ok(None))) => {
+                                // No PR — leave existing pr_number alone.
+                                // Matches refresh_workspace_pr's behavior of
+                                // not clearing fork-branch PRs that gh can't
+                                // resolve.
+                            }
+                            Ok(Ok(Err(e))) => {
+                                eprintln!(
+                                    "[codemux::pr-poll] get_branch_pr failed for {workspace_id}: {e}"
+                                );
+                            }
+                            Ok(Err(e)) => {
+                                eprintln!(
+                                    "[codemux::pr-poll] join error for {workspace_id}: {e}"
+                                );
+                            }
+                            Err(_) => {
+                                eprintln!(
+                                    "[codemux::pr-poll] gh pr view timed out (>{PER_CALL_TIMEOUT_SECS}s) for {workspace_id}"
+                                );
+                                timed_out += 1;
+                            }
+                        }
+                    }
+
+                    if refreshed > 0 {
+                        state::emit_app_state(&pr_handle);
+                    }
+                    eprintln!(
+                        "[codemux::pr-poll] tick — refreshed={refreshed} skipped_non_github={skipped_non_github} timed_out={timed_out}"
+                    );
                 }
             });
 

--- a/src/components/github/pr-status-icon.tsx
+++ b/src/components/github/pr-status-icon.tsx
@@ -1,0 +1,53 @@
+import { GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type PrStatusState = "open" | "merged" | "closed" | "draft";
+
+interface IconSpec {
+  Icon: LucideIcon;
+  colorCls: string;
+}
+
+const STATE_TO_ICON: Record<PrStatusState, IconSpec> = {
+  merged: { Icon: GitMerge, colorCls: "text-purple-500" },
+  open: { Icon: GitPullRequest, colorCls: "text-emerald-500" },
+  closed: { Icon: GitPullRequestClosed, colorCls: "text-destructive" },
+  draft: { Icon: GitPullRequestDraft, colorCls: "text-muted-foreground" },
+};
+
+export function normalizePrState(state: string | null | undefined): PrStatusState | null {
+  if (!state) return null;
+  const lower = state.toLowerCase();
+  if (lower === "open" || lower === "merged" || lower === "closed" || lower === "draft") {
+    return lower;
+  }
+  return null;
+}
+
+interface Props {
+  state: string | null | undefined;
+  /** Size in Tailwind spacing units (1 = 4px). 3.5 = 14px (default). */
+  size?: number;
+  strokeWidth?: number;
+  className?: string;
+}
+
+export function PrStatusIcon({ state, size = 3.5, strokeWidth = 1.75, className }: Props) {
+  const normalized = normalizePrState(state);
+  if (!normalized) return null;
+  const { Icon, colorCls } = STATE_TO_ICON[normalized];
+  return (
+    <Icon
+      size={size * 4}
+      strokeWidth={strokeWidth}
+      className={cn(colorCls, className)}
+    />
+  );
+}
+
+export function humanizePrState(state: string | null | undefined): string | null {
+  const normalized = normalizePrState(state);
+  if (!normalized) return null;
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -25,6 +25,8 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { X, Laptop, GitBranch, Workflow, AlertTriangle } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { PrStatusIcon, humanizePrState } from "@/components/github/pr-status-icon";
 import {
   activateWorkspace,
   checkoutDefaultBranchInWorkspace,
@@ -342,6 +344,15 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
       <GitBranch className="h-4 w-4 shrink-0 text-muted-foreground" />
     );
 
+  const showPrIcon = !!workspace.pr_state && workspaceStatus !== "working";
+  const prHumanState = humanizePrState(workspace.pr_state);
+  const handlePrClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (workspace.pr_url) {
+      openUrl(workspace.pr_url).catch(console.error);
+    }
+  };
+
   return (
     <>
       <ContextMenu>
@@ -362,20 +373,53 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
               <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-foreground rounded-r" />
             )}
 
-            {/* Icon — size-6 container matches project header avatar width */}
+            {/* Icon — size-6 container matches project header avatar width.
+                When the workspace has a PR, the host-type icon is replaced
+                with a clickable PR-status icon (open → emerald, merged →
+                purple, etc.) that opens the PR on GitHub. */}
             <div className="relative size-6 flex items-center justify-center shrink-0 mr-2.5">
               {workspaceStatus === "working" ? (
                 <AsciiSpinner />
+              ) : showPrIcon ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={handlePrClick}
+                      disabled={!workspace.pr_url}
+                      aria-label={
+                        workspace.pr_number
+                          ? `PR #${workspace.pr_number} — ${prHumanState ?? "Pull request"}`
+                          : `Pull request — ${prHumanState ?? ""}`
+                      }
+                      className={cn(
+                        "rounded p-0.5 hover:bg-foreground/10 transition-colors flex items-center justify-center",
+                        !workspace.pr_url && "cursor-not-allowed opacity-60",
+                      )}
+                    >
+                      <PrStatusIcon state={workspace.pr_state} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="right" sideOffset={4} className="text-xs">
+                    <div>
+                      {workspace.pr_number ? `#${workspace.pr_number} — ` : ""}
+                      {prHumanState ?? "Pull request"}
+                    </div>
+                    {workspace.pr_url && (
+                      <div className="text-muted-foreground text-[10px]">
+                        Click to open on GitHub
+                      </div>
+                    )}
+                  </TooltipContent>
+                </Tooltip>
               ) : (
-                <>
-                  {icon}
-                  {workspaceStatus && (
-                    <StatusIndicator
-                      status={workspaceStatus}
-                      className="absolute -top-0.5 -right-0.5"
-                    />
-                  )}
-                </>
+                icon
+              )}
+              {workspaceStatus && workspaceStatus !== "working" && (
+                <StatusIndicator
+                  status={workspaceStatus}
+                  className="absolute -top-0.5 -right-0.5"
+                />
               )}
             </div>
 
@@ -440,11 +484,6 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
               {workspace.git_branch && (
                 <div className="flex items-center gap-1 text-[11px] text-muted-foreground/60 font-mono leading-tight mt-0.5">
                   <span className="truncate">{workspace.git_branch}</span>
-                  {workspace.pr_number && (
-                    <Badge variant="outline" className="h-3.5 px-1 text-[9px] leading-none">
-                      #{workspace.pr_number}
-                    </Badge>
-                  )}
                   {workspace.linked_issue && (
                     <IssueDetailPopover
                       workspaceId={workspace.workspace_id}

--- a/src/components/workspace/pr-panel.test.tsx
+++ b/src/components/workspace/pr-panel.test.tsx
@@ -177,10 +177,10 @@ describe("cache TTL", () => {
 
   it("ghStatusCache returns value before TTL", () => {
     vi.useFakeTimers();
-    setCachedGhStatus({ status: "NotAuthenticated" });
+    setCachedGhStatus({ status: "Authenticated", username: "alice" });
 
     vi.advanceTimersByTime(CACHE_TTL_MS - 1000);
-    expect(getCachedGhStatus()).toEqual({ status: "NotAuthenticated" });
+    expect(getCachedGhStatus()).toEqual({ status: "Authenticated", username: "alice" });
   });
 
   it("repoCheckCache expires after TTL", () => {
@@ -198,12 +198,12 @@ describe("cache TTL", () => {
     setCachedRepoCheck("/path/a", true);
 
     vi.advanceTimersByTime(CACHE_TTL_MS / 2);
-    setCachedRepoCheck("/path/b", false);
+    setCachedRepoCheck("/path/b", true);
 
-    // Expire first entry
+    // Expire only the first entry
     vi.advanceTimersByTime(CACHE_TTL_MS / 2 + 1);
     expect(getCachedRepoCheck("/path/a")).toBeUndefined();
-    expect(getCachedRepoCheck("/path/b")).toBe(false);
+    expect(getCachedRepoCheck("/path/b")).toBe(true);
   });
 
   it("manual refresh bypasses caches", async () => {
@@ -230,30 +230,46 @@ describe("cache TTL", () => {
     expect(getCachedRepoCheck("/home/user/project")).toBeUndefined();
   });
 
-  it("stale failure recovers after TTL", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-
-    // First render: checkGithubRepo fails (cached as false)
+  it("failures are not cached — recovery is immediate, no TTL wait", async () => {
+    // First render: checkGithubRepo returns false. The buggy old behavior
+    // cached this for 60s; the fix drops failure caching entirely so the
+    // user sees the recovery on the very next render.
     mockCheckGithubRepo.mockResolvedValue(false);
 
     const { unmount } = render(<PrPanel workspace={makeWorkspace()} />);
     await flushPromises();
 
     expect(screen.getByText("Not a GitHub repository")).toBeInTheDocument();
+    expect(getCachedRepoCheck("/home/user/project")).toBeUndefined();
 
     unmount();
 
-    // Advance past TTL so cache expires
-    vi.advanceTimersByTime(CACHE_TTL_MS + 1);
-
-    // Now mock success
+    // No TTL advance — fix the underlying issue and re-render immediately.
     mockCheckGithubRepo.mockResolvedValue(true);
 
     render(<PrPanel workspace={makeWorkspace()} />);
     await flushPromises();
 
-    // Should re-check (cache expired) and now see the PR panel content
     expect(screen.queryByText("Not a GitHub repository")).not.toBeInTheDocument();
+  });
+
+  it("setCachedGhStatus drops non-Authenticated values", () => {
+    setCachedGhStatus({ status: "NotAuthenticated" });
+    expect(getCachedGhStatus()).toBeNull();
+
+    setCachedGhStatus({ status: "NotInstalled" });
+    expect(getCachedGhStatus()).toBeNull();
+
+    setCachedGhStatus({ status: "Authenticated", username: "test" });
+    expect(getCachedGhStatus()).toEqual({ status: "Authenticated", username: "test" });
+  });
+
+  it("setCachedRepoCheck drops false values", () => {
+    setCachedRepoCheck("/path/x", false);
+    expect(getCachedRepoCheck("/path/x")).toBeUndefined();
+
+    setCachedRepoCheck("/path/x", true);
+    expect(getCachedRepoCheck("/path/x")).toBe(true);
   });
 });
 

--- a/src/components/workspace/pr-panel.tsx
+++ b/src/components/workspace/pr-panel.tsx
@@ -52,6 +52,11 @@ interface Props {
 }
 
 // ── Module-level caches with TTL ──
+//
+// Only successful results are cached. NotAuthenticated/NotInstalled and
+// "not a GitHub repo" responses bypass the cache so the user sees the
+// recovery (e.g. after `gh auth login` or after a `git remote add origin`)
+// on the very next render, not 60 seconds later.
 export const CACHE_TTL_MS = 60_000;
 
 interface CacheEntry<T> { value: T; ts: number; }
@@ -67,7 +72,9 @@ export function getCachedGhStatus(): GhStatus | null {
   return ghStatusCache.value;
 }
 
+/** Stores only successful auth statuses; failures are dropped on the floor. */
 export function setCachedGhStatus(value: GhStatus): void {
+  if (value.status !== "Authenticated") return;
   ghStatusCache = { value, ts: Date.now() };
 }
 
@@ -80,7 +87,9 @@ export function getCachedRepoCheck(key: string): boolean | undefined {
   return entry.value;
 }
 
+/** Stores only positive repo-check results; non-GitHub paths re-check every call. */
 export function setCachedRepoCheck(key: string, value: boolean): void {
+  if (!value) return;
   repoCheckCache.set(key, { value, ts: Date.now() });
 }
 


### PR DESCRIPTION
## Summary

Replaces the monochrome `#N` outline badge on sidebar workspace rows with a colored, clickable GitHub-style PR icon (per the analysis at §2 and §6 Feature 1):

- **open** → emerald `GitPullRequest`
- **merged** → purple `GitMerge`
- **closed** → red `GitPullRequestClosed`
- **draft** → muted `GitPullRequestDraft`

Clicking the icon opens the PR on GitHub via the Tauri opener plugin; clicking the rest of the row still activates the workspace. PR number and humanized state move into a tooltip (`#42 — Merged` / `Click to open on GitHub`).

## What changed

- **Shared `PrStatusIcon` component** at `src/components/github/pr-status-icon.tsx` — pure presentation, used in this PR and reused in the upcoming "Open PR button in Changes panel" PR.
- **60s background polling task** in `src-tauri/src/lib.rs` that walks every workspace and refreshes `pr_state` / `pr_url` so the sidebar stays honest while a teammate merges a PR on GitHub. The existing 5s git tick still handles the active workspace; the new task covers everyone else.
  - Sequential per tick (no parallel `gh` fan-out).
  - 10s per-call timeout via `tokio::task::spawn_blocking` + `tokio::time::timeout`.
  - Pauses cleanly when `gh auth status` is bad; rechecked every tick.
  - Logs auth-status transitions and per-tick refreshed/skipped/timed-out counters.
- **Drops failure caching in `pr-panel.tsx`** (analysis §4). `setCachedGhStatus` / `setCachedRepoCheck` now ignore `NotAuthenticated` / `NotInstalled` / `false` results, so recovery after `gh auth login` or `git remote add origin` is immediate instead of taking up to 60s. Pre-existing test that documented the bug as expected is rewritten to assert the new "no failure cache" contract.
- **`PullRequestInfo::display_state()`** so `is_draft: true` collapses to `"DRAFT"` when populating the workspace's `pr_state` field. Threaded through the new poll task, the existing `refresh_workspace_pr` command, and the active-workspace 5s tick.

## Test plan

- [x] `npm run verify` (cargo check + cargo test + tsc + vitest) — all 366 frontend tests + 12 Rust tests pass
- [ ] Open Codemux with a workspace that has an open PR, one with a merged PR, one feature branch with no PR, one on `main` — confirm the icon set is correct for each
- [ ] Click the icon — confirm GitHub opens in the default browser
- [ ] Confirm clicking the icon does **not** trigger workspace switch
- [ ] Hover — confirm tooltip shows `#N — State` and "Click to open on GitHub"
- [ ] Leave the app open for 2 minutes, merge a PR on GitHub, wait 60s — confirm sidebar icon flips from green `GitPullRequest` to purple `GitMerge` without manual refresh
- [ ] `gh auth logout`, confirm sidebar icons disappear / fall back to the host icon without spamming errors. Re-auth, confirm they come back within one polling cycle