### PR TITLE
fix(sidebar): place PR icon at bottom-right, restore host icon on left

### DIFF
--- a/src/components/github/pr-status-icon.tsx
+++ b/src/components/github/pr-status-icon.tsx
@@ -16,6 +16,22 @@ const STATE_TO_ICON: Record<PrStatusState, IconSpec> = {
   draft: { Icon: GitPullRequestDraft, colorCls: "text-muted-foreground" },
 };
 
+/** Tinted background + text-color pair for the sidebar PR pill — matches
+ *  the icon color at low opacity so the row reads "this PR is merged/open/…"
+ *  at a glance. Mirrors Superset's color-coded badge style. */
+const STATE_TO_TONE: Record<PrStatusState, string> = {
+  merged: "text-purple-500 bg-purple-500/15",
+  open: "text-emerald-500 bg-emerald-500/15",
+  closed: "text-destructive bg-destructive/15",
+  draft: "text-muted-foreground bg-muted-foreground/15",
+};
+
+export function prStatusToneClass(state: string | null | undefined): string | null {
+  const normalized = normalizePrState(state);
+  if (!normalized) return null;
+  return STATE_TO_TONE[normalized];
+}
+
 export function normalizePrState(state: string | null | undefined): PrStatusState | null {
   if (!state) return null;
   const lower = state.toLowerCase();

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -484,7 +484,7 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                             >
                               <PrStatusIcon state={workspace.pr_state} size={3} />
                               {workspace.pr_number && (
-                                <span className="text-[10px] tabular-nums text-white">
+                                <span className="text-[10px] tabular-nums text-muted-foreground/60">
                                   #{workspace.pr_number}
                                 </span>
                               )}

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -484,7 +484,7 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                             >
                               <PrStatusIcon state={workspace.pr_state} size={3} />
                               {workspace.pr_number && (
-                                <span className="text-[10px] tabular-nums">
+                                <span className="text-[10px] tabular-nums text-white">
                                   #{workspace.pr_number}
                                 </span>
                               )}

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -447,53 +447,61 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                 )}
               </div>
 
-              {/* Branch name row */}
+              {/* Branch name row. Issue + PR badges are grouped into a
+                  single right-aligned cluster so they sit next to each
+                  other at the bottom-right when both are present (no dead
+                  gap), and the branch text is the only element that
+                  truncates when space is tight. */}
               {workspace.git_branch && (
                 <div className="flex items-center gap-1 text-[11px] text-muted-foreground/60 font-mono leading-tight mt-0.5">
                   <span className="truncate">{workspace.git_branch}</span>
-                  {workspace.linked_issue && (
-                    <IssueDetailPopover
-                      workspaceId={workspace.workspace_id}
-                      issue={workspace.linked_issue}
-                    />
-                  )}
-                  {showPrIcon && (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={handlePrClick}
-                          disabled={!workspace.pr_url}
-                          aria-label={
-                            workspace.pr_number
-                              ? `PR #${workspace.pr_number} — ${prHumanState ?? "Pull request"}`
-                              : `Pull request — ${prHumanState ?? ""}`
-                          }
-                          className={cn(
-                            "ml-auto inline-flex items-center gap-0.5 shrink-0 rounded px-0.5 hover:bg-foreground/10 transition-colors",
-                            !workspace.pr_url && "cursor-not-allowed opacity-60",
-                          )}
-                        >
-                          <PrStatusIcon state={workspace.pr_state} size={3} />
-                          {workspace.pr_number && (
-                            <span className="text-[10px] tabular-nums">
-                              #{workspace.pr_number}
-                            </span>
-                          )}
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="right" sideOffset={4} className="text-xs">
-                        <div>
-                          {workspace.pr_number ? `#${workspace.pr_number} — ` : ""}
-                          {prHumanState ?? "Pull request"}
-                        </div>
-                        {workspace.pr_url && (
-                          <div className="text-muted-foreground text-[10px]">
-                            Click to open on GitHub
-                          </div>
-                        )}
-                      </TooltipContent>
-                    </Tooltip>
+                  {(workspace.linked_issue || showPrIcon) && (
+                    <div className="flex items-center gap-1 ml-auto shrink-0">
+                      {workspace.linked_issue && (
+                        <IssueDetailPopover
+                          workspaceId={workspace.workspace_id}
+                          issue={workspace.linked_issue}
+                        />
+                      )}
+                      {showPrIcon && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              onClick={handlePrClick}
+                              disabled={!workspace.pr_url}
+                              aria-label={
+                                workspace.pr_number
+                                  ? `PR #${workspace.pr_number} — ${prHumanState ?? "Pull request"}`
+                                  : `Pull request — ${prHumanState ?? ""}`
+                              }
+                              className={cn(
+                                "inline-flex items-center gap-0.5 rounded px-0.5 hover:bg-foreground/10 transition-colors",
+                                !workspace.pr_url && "cursor-not-allowed opacity-60",
+                              )}
+                            >
+                              <PrStatusIcon state={workspace.pr_state} size={3} />
+                              {workspace.pr_number && (
+                                <span className="text-[10px] tabular-nums">
+                                  #{workspace.pr_number}
+                                </span>
+                              )}
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="right" sideOffset={4} className="text-xs">
+                            <div>
+                              {workspace.pr_number ? `#${workspace.pr_number} — ` : ""}
+                              {prHumanState ?? "Pull request"}
+                            </div>
+                            {workspace.pr_url && (
+                              <div className="text-muted-foreground text-[10px]">
+                                Click to open on GitHub
+                              </div>
+                            )}
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
                   )}
                 </div>
               )}

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -373,53 +373,20 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
               <div className="absolute left-0 top-0 bottom-0 w-0.5 bg-foreground rounded-r" />
             )}
 
-            {/* Icon — size-6 container matches project header avatar width.
-                When the workspace has a PR, the host-type icon is replaced
-                with a clickable PR-status icon (open → emerald, merged →
-                purple, etc.) that opens the PR on GitHub. */}
+            {/* Icon — size-6 container matches project header avatar width */}
             <div className="relative size-6 flex items-center justify-center shrink-0 mr-2.5">
               {workspaceStatus === "working" ? (
                 <AsciiSpinner />
-              ) : showPrIcon ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={handlePrClick}
-                      disabled={!workspace.pr_url}
-                      aria-label={
-                        workspace.pr_number
-                          ? `PR #${workspace.pr_number} — ${prHumanState ?? "Pull request"}`
-                          : `Pull request — ${prHumanState ?? ""}`
-                      }
-                      className={cn(
-                        "rounded p-0.5 hover:bg-foreground/10 transition-colors flex items-center justify-center",
-                        !workspace.pr_url && "cursor-not-allowed opacity-60",
-                      )}
-                    >
-                      <PrStatusIcon state={workspace.pr_state} />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="right" sideOffset={4} className="text-xs">
-                    <div>
-                      {workspace.pr_number ? `#${workspace.pr_number} — ` : ""}
-                      {prHumanState ?? "Pull request"}
-                    </div>
-                    {workspace.pr_url && (
-                      <div className="text-muted-foreground text-[10px]">
-                        Click to open on GitHub
-                      </div>
-                    )}
-                  </TooltipContent>
-                </Tooltip>
               ) : (
-                icon
-              )}
-              {workspaceStatus && workspaceStatus !== "working" && (
-                <StatusIndicator
-                  status={workspaceStatus}
-                  className="absolute -top-0.5 -right-0.5"
-                />
+                <>
+                  {icon}
+                  {workspaceStatus && (
+                    <StatusIndicator
+                      status={workspaceStatus}
+                      className="absolute -top-0.5 -right-0.5"
+                    />
+                  )}
+                </>
               )}
             </div>
 
@@ -489,6 +456,44 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                       workspaceId={workspace.workspace_id}
                       issue={workspace.linked_issue}
                     />
+                  )}
+                  {showPrIcon && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={handlePrClick}
+                          disabled={!workspace.pr_url}
+                          aria-label={
+                            workspace.pr_number
+                              ? `PR #${workspace.pr_number} — ${prHumanState ?? "Pull request"}`
+                              : `Pull request — ${prHumanState ?? ""}`
+                          }
+                          className={cn(
+                            "ml-auto inline-flex items-center gap-0.5 shrink-0 rounded px-0.5 hover:bg-foreground/10 transition-colors",
+                            !workspace.pr_url && "cursor-not-allowed opacity-60",
+                          )}
+                        >
+                          <PrStatusIcon state={workspace.pr_state} size={3} />
+                          {workspace.pr_number && (
+                            <span className="text-[10px] tabular-nums">
+                              #{workspace.pr_number}
+                            </span>
+                          )}
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" sideOffset={4} className="text-xs">
+                        <div>
+                          {workspace.pr_number ? `#${workspace.pr_number} — ` : ""}
+                          {prHumanState ?? "Pull request"}
+                        </div>
+                        {workspace.pr_url && (
+                          <div className="text-muted-foreground text-[10px]">
+                            Click to open on GitHub
+                          </div>
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
               )}

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -477,7 +477,7 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                                   : `Pull request — ${prHumanState ?? ""}`
                               }
                               className={cn(
-                                "inline-flex items-center gap-0.5 rounded px-1 py-px transition-opacity",
+                                "inline-flex items-center gap-0.5 rounded-md px-1.5 py-px transition-opacity",
                                 prToneCls,
                                 workspace.pr_url ? "hover:opacity-80" : "cursor-not-allowed opacity-60",
                               )}

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -477,7 +477,7 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                                   : `Pull request — ${prHumanState ?? ""}`
                               }
                               className={cn(
-                                "inline-flex items-center gap-0.5 rounded-md px-1.5 py-px transition-opacity",
+                                "inline-flex items-center gap-0.5 rounded-full px-1.5 py-px transition-opacity",
                                 prToneCls,
                                 workspace.pr_url ? "hover:opacity-80" : "cursor-not-allowed opacity-60",
                               )}

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -26,7 +26,7 @@ import {
 import { cn } from "@/lib/utils";
 import { X, Laptop, GitBranch, Workflow, AlertTriangle } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { PrStatusIcon, humanizePrState } from "@/components/github/pr-status-icon";
+import { PrStatusIcon, humanizePrState, prStatusToneClass } from "@/components/github/pr-status-icon";
 import {
   activateWorkspace,
   checkoutDefaultBranchInWorkspace,
@@ -346,6 +346,7 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
 
   const showPrIcon = !!workspace.pr_state && workspaceStatus !== "working";
   const prHumanState = humanizePrState(workspace.pr_state);
+  const prToneCls = prStatusToneClass(workspace.pr_state);
   const handlePrClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (workspace.pr_url) {
@@ -476,8 +477,9 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                                   : `Pull request — ${prHumanState ?? ""}`
                               }
                               className={cn(
-                                "inline-flex items-center gap-0.5 rounded px-0.5 hover:bg-foreground/10 transition-colors",
-                                !workspace.pr_url && "cursor-not-allowed opacity-60",
+                                "inline-flex items-center gap-0.5 rounded px-1 py-px transition-opacity",
+                                prToneCls,
+                                workspace.pr_url ? "hover:opacity-80" : "cursor-not-allowed opacity-60",
                               )}
                             >
                               <PrStatusIcon state={workspace.pr_state} size={3} />


### PR DESCRIPTION
## Summary

Phase 1 (#6) read the analysis too literally and put the PR status icon **where the host-type icon used to live** (left of the workspace label). Superset's actual layout — confirmed via screenshot comparison — keeps the host icon on the left and tucks the PR icon + `#N` into the **right side of the branch-name row**, mirroring how diff stats sit at the top-right.

This PR matches Superset's layout:

- Icon column reverts to its pre-#6 state: spinner / host icon (Laptop / GitBranch / Workflow) / status-indicator dot overlay.
- PR icon + `#N` move into the branch-name row, pushed right with `ml-auto`.
- Same click-to-open-GitHub behavior + tooltip (`#N — State` / `Click to open on GitHub`).

## Before / After

**Superset (target):** host icon left; `+308 -33` top-right; PR icon `#6` bottom-right.
**Phase 1 (#6):** PR icon hijacked the host-icon slot on the left.
**This PR:** host icon back on the left; PR icon `#6` at the bottom-right.

## Test plan

- [x] `npm run check` + `npm run test` (all 366 tests pass)
- [ ] Visual confirmation in dev build that the layout matches `side1.png` (Superset reference)
- [ ] Click PR icon — confirm GitHub opens, row click still activates the workspace