### PR TITLE
feat(changes-panel): add open-PR button to toolbar

### DIFF
--- a/src/components/workspace/changes-panel.tsx
+++ b/src/components/workspace/changes-panel.tsx
@@ -1774,54 +1774,43 @@ export function ChangesPanel({ workspace }: Props) {
               since merge methods don't apply to them. */}
           {workspace.pr_url && (
             <div className="ml-auto flex items-center">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="xs"
-                    className={cn(
-                      workspace.pr_state === "OPEN" &&
-                        workspace.pr_number != null &&
-                        "rounded-r-none border-r-0",
-                    )}
-                    onClick={() => openUrl(workspace.pr_url!).catch(console.error)}
-                  >
-                    <PrStatusIcon state={workspace.pr_state} size={3} />
-                    {workspace.pr_number != null && (
-                      <span className="tabular-nums">#{workspace.pr_number}</span>
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="text-xs">
-                  {workspace.pr_number != null
+              <Button
+                variant="outline"
+                size="xs"
+                className={cn(
+                  workspace.pr_state === "OPEN" &&
+                    workspace.pr_number != null &&
+                    "rounded-r-none border-r-0",
+                )}
+                onClick={() => openUrl(workspace.pr_url!).catch(console.error)}
+                aria-label={
+                  workspace.pr_number != null
                     ? `Open PR #${workspace.pr_number} on GitHub`
-                    : "Open PR on GitHub"}
-                </TooltipContent>
-              </Tooltip>
+                    : "Open PR on GitHub"
+                }
+              >
+                <PrStatusIcon state={workspace.pr_state} size={3} />
+                {workspace.pr_number != null && (
+                  <span className="tabular-nums">#{workspace.pr_number}</span>
+                )}
+              </Button>
               {workspace.pr_state === "OPEN" && workspace.pr_number != null && (
                 <DropdownMenu>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="icon-xs"
-                          className="size-6 p-0 rounded-l-none"
-                          disabled={mergingPr !== null}
-                          aria-label="Merge PR"
-                        >
-                          {mergingPr !== null ? (
-                            <Loader2 className="h-3 w-3 animate-spin" />
-                          ) : (
-                            <ChevronDown className="h-3 w-3" />
-                          )}
-                        </Button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom" className="text-xs">
-                      Merge PR
-                    </TooltipContent>
-                  </Tooltip>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="icon-xs"
+                      className="size-6 p-0 rounded-l-none"
+                      disabled={mergingPr !== null}
+                      aria-label="Merge PR"
+                    >
+                      {mergingPr !== null ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <ChevronDown className="h-3 w-3" />
+                      )}
+                    </Button>
+                  </DropdownMenuTrigger>
                   <DropdownMenuContent align="end" className="w-fit">
                     <DropdownMenuItem
                       onClick={() => handleMergePr("squash")}

--- a/src/components/workspace/changes-panel.tsx
+++ b/src/components/workspace/changes-panel.tsx
@@ -86,6 +86,8 @@ import {
   gitStashPush,
   gitStashPop,
   getCommitFiles,
+  mergePullRequest,
+  refreshWorkspacePr,
   activateWorkspace,
   closeWorkspace,
   createWorkspace,
@@ -106,6 +108,7 @@ import {
 } from "react-icons/vsc";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { PrStatusIcon } from "@/components/github/pr-status-icon";
+import { cn } from "@/lib/utils";
 import { useDiffStore } from "@/stores/diff-store";
 import { useAppStore } from "@/stores/app-store";
 import { useAiCommitStore } from "@/stores/ai-commit-store";
@@ -1009,6 +1012,10 @@ export function ChangesPanel({ workspace }: Props) {
   const [commitsExpanded, setCommitsExpanded] = useState(false);
   const [expandedCommits, setExpandedCommits] = useState<Set<string>>(new Set());
   const [claudeReady, setClaudeReady] = useState<boolean | null>(null);
+  // Tracks an in-flight `gh pr merge`. While set, the merge dropdown
+  // items are disabled and the chevron shows a spinner so the user
+  // doesn't double-fire the command.
+  const [mergingPr, setMergingPr] = useState<null | "squash" | "merge" | "rebase">(null);
   const refreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Against-base state
@@ -1213,6 +1220,32 @@ export function ChangesPanel({ workspace }: Props) {
       setGitError(String(err));
     } finally {
       setBusyAction(null);
+    }
+  };
+
+  // Merge the open PR via `gh pr merge`. Method maps to GitHub's three
+  // merge strategies. After success, kick refreshWorkspacePr so the
+  // sidebar pill flips to MERGED (purple) without waiting for the 60s
+  // background poll, plus refresh the changes panel itself so deleted
+  // branch / fetch state catches up. On failure, surface the raw error
+  // via toast — no two-tap confirmation since the dropdown click itself
+  // is the deliberate action.
+  const handleMergePr = async (method: "squash" | "merge" | "rebase") => {
+    if (workspace.pr_number == null || mergingPr !== null) return;
+    setMergingPr(method);
+    try {
+      await mergePullRequest(cwd, workspace.pr_number, method);
+      const verb =
+        method === "squash" ? "squashed" : method === "rebase" ? "rebased" : "merged";
+      toast.success(`PR #${workspace.pr_number} ${verb}`);
+      refreshWorkspacePr(workspace.workspace_id).catch(console.error);
+      refresh();
+      refreshBaseDiff();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      toast.error(`Couldn't merge PR: ${msg}`);
+    } finally {
+      setMergingPr(null);
     }
   };
 
@@ -1733,30 +1766,91 @@ export function ChangesPanel({ workspace }: Props) {
             </TooltipContent>
           </Tooltip>
 
-          {/* Open PR on GitHub — right-aligned (Superset's ChangesHeader
-              PRButton pattern). Only renders when a PR URL is known;
-              workspaces without a PR show no placeholder. */}
+          {/* PR button — right-aligned (Superset's ChangesHeader pattern).
+              Renders only when a PR URL is known. For OPEN PRs it's a
+              split button: main half opens GitHub, chevron half opens a
+              merge dropdown (squash / merge commit / rebase). For
+              MERGED/CLOSED/DRAFT PRs only the GitHub-link half renders
+              since merge methods don't apply to them. */}
           {workspace.pr_url && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="xs"
-                  className="ml-auto"
-                  onClick={() => openUrl(workspace.pr_url!).catch(console.error)}
-                >
-                  <PrStatusIcon state={workspace.pr_state} size={3} />
-                  {workspace.pr_number != null && (
-                    <span className="tabular-nums">#{workspace.pr_number}</span>
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="text-xs">
-                {workspace.pr_number != null
-                  ? `Open PR #${workspace.pr_number} on GitHub`
-                  : "Open PR on GitHub"}
-              </TooltipContent>
-            </Tooltip>
+            <div className="ml-auto flex items-center">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    className={cn(
+                      workspace.pr_state === "OPEN" &&
+                        workspace.pr_number != null &&
+                        "rounded-r-none",
+                    )}
+                    onClick={() => openUrl(workspace.pr_url!).catch(console.error)}
+                  >
+                    <PrStatusIcon state={workspace.pr_state} size={3} />
+                    {workspace.pr_number != null && (
+                      <span className="tabular-nums">#{workspace.pr_number}</span>
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="text-xs">
+                  {workspace.pr_number != null
+                    ? `Open PR #${workspace.pr_number} on GitHub`
+                    : "Open PR on GitHub"}
+                </TooltipContent>
+              </Tooltip>
+              {workspace.pr_state === "OPEN" && workspace.pr_number != null && (
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          className="size-6 p-0 rounded-l-none border-l border-border/40"
+                          disabled={mergingPr !== null}
+                          aria-label="Merge PR"
+                        >
+                          {mergingPr !== null ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <ChevronDown className="h-3 w-3" />
+                          )}
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="text-xs">
+                      Merge PR
+                    </TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="end" className="w-52">
+                    <DropdownMenuItem
+                      onClick={() => handleMergePr("squash")}
+                      disabled={mergingPr !== null}
+                      className="text-xs"
+                    >
+                      <GitMerge className="h-3.5 w-3.5" />
+                      Squash and merge
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleMergePr("merge")}
+                      disabled={mergingPr !== null}
+                      className="text-xs"
+                    >
+                      <GitMerge className="h-3.5 w-3.5" />
+                      Create merge commit
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleMergePr("rebase")}
+                      disabled={mergingPr !== null}
+                      className="text-xs"
+                    >
+                      <GitMerge className="h-3.5 w-3.5" />
+                      Rebase and merge
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
           )}
         </div>
 

--- a/src/components/workspace/changes-panel.tsx
+++ b/src/components/workspace/changes-panel.tsx
@@ -104,6 +104,8 @@ import {
   VscDiffRenamed,
   VscCopy,
 } from "react-icons/vsc";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { PrStatusIcon } from "@/components/github/pr-status-icon";
 import { useDiffStore } from "@/stores/diff-store";
 import { useAppStore } from "@/stores/app-store";
 import { useAiCommitStore } from "@/stores/ai-commit-store";
@@ -1730,6 +1732,32 @@ export function ChangesPanel({ workspace }: Props) {
               Refresh
             </TooltipContent>
           </Tooltip>
+
+          {/* Open PR on GitHub — right-aligned (Superset's ChangesHeader
+              PRButton pattern). Only renders when a PR URL is known;
+              workspaces without a PR show no placeholder. */}
+          {workspace.pr_url && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="ml-auto"
+                  onClick={() => openUrl(workspace.pr_url!).catch(console.error)}
+                >
+                  <PrStatusIcon state={workspace.pr_state} size={3} />
+                  {workspace.pr_number != null && (
+                    <span className="tabular-nums">#{workspace.pr_number}</span>
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                {workspace.pr_number != null
+                  ? `Open PR #${workspace.pr_number} on GitHub`
+                  : "Open PR on GitHub"}
+              </TooltipContent>
+            </Tooltip>
+          )}
         </div>
 
         {/* Commit area */}

--- a/src/components/workspace/changes-panel.tsx
+++ b/src/components/workspace/changes-panel.tsx
@@ -1777,12 +1777,12 @@ export function ChangesPanel({ workspace }: Props) {
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    variant="ghost"
+                    variant="outline"
                     size="xs"
                     className={cn(
                       workspace.pr_state === "OPEN" &&
                         workspace.pr_number != null &&
-                        "rounded-r-none",
+                        "rounded-r-none border-r-0",
                     )}
                     onClick={() => openUrl(workspace.pr_url!).catch(console.error)}
                   >
@@ -1804,9 +1804,9 @@ export function ChangesPanel({ workspace }: Props) {
                     <TooltipTrigger asChild>
                       <DropdownMenuTrigger asChild>
                         <Button
-                          variant="ghost"
+                          variant="outline"
                           size="icon-xs"
-                          className="size-6 p-0 rounded-l-none border-l border-border/40"
+                          className="size-6 p-0 rounded-l-none"
                           disabled={mergingPr !== null}
                           aria-label="Merge PR"
                         >
@@ -1822,7 +1822,7 @@ export function ChangesPanel({ workspace }: Props) {
                       Merge PR
                     </TooltipContent>
                   </Tooltip>
-                  <DropdownMenuContent align="end" className="w-52">
+                  <DropdownMenuContent align="end" className="w-fit">
                     <DropdownMenuItem
                       onClick={() => handleMergePr("squash")}
                       disabled={mergingPr !== null}

--- a/src/components/workspace/changes-panel.tsx
+++ b/src/components/workspace/changes-panel.tsx
@@ -1817,7 +1817,7 @@ export function ChangesPanel({ workspace }: Props) {
                       disabled={mergingPr !== null}
                       className="text-xs"
                     >
-                      <GitMerge className="h-3.5 w-3.5" />
+                      <GitMerge className="h-3.5 w-3.5 text-muted-foreground/60" />
                       Squash and merge
                     </DropdownMenuItem>
                     <DropdownMenuItem
@@ -1825,7 +1825,7 @@ export function ChangesPanel({ workspace }: Props) {
                       disabled={mergingPr !== null}
                       className="text-xs"
                     >
-                      <GitMerge className="h-3.5 w-3.5" />
+                      <GitMerge className="h-3.5 w-3.5 text-muted-foreground/60" />
                       Create merge commit
                     </DropdownMenuItem>
                     <DropdownMenuItem
@@ -1833,7 +1833,7 @@ export function ChangesPanel({ workspace }: Props) {
                       disabled={mergingPr !== null}
                       className="text-xs"
                     >
-                      <GitMerge className="h-3.5 w-3.5" />
+                      <GitMerge className="h-3.5 w-3.5 text-muted-foreground/60" />
                       Rebase and merge
                     </DropdownMenuItem>
                   </DropdownMenuContent>

--- a/src/components/workspace/merge-button.test.tsx
+++ b/src/components/workspace/merge-button.test.tsx
@@ -44,6 +44,13 @@ const mockAbortMergeIntoBase = vi.fn().mockResolvedValue(undefined);
 const mockActivateWorkspace = vi.fn().mockResolvedValue(undefined);
 const mockCloseWorkspace = vi.fn().mockResolvedValue("ws-1");
 const mockCreateWorkspace = vi.fn().mockResolvedValue("ws-new");
+const mockMergePullRequest = vi.fn().mockResolvedValue(undefined);
+const mockRefreshWorkspacePr = vi.fn().mockResolvedValue(undefined);
+const mockOpenUrl = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: (...args: unknown[]) => mockOpenUrl(...args),
+}));
 
 vi.mock("@/tauri/commands", () => ({
   getGitStatus: (...args: unknown[]) => mockGetGitStatus(...args),
@@ -79,6 +86,8 @@ vi.mock("@/tauri/commands", () => ({
   gitStashPush: vi.fn().mockResolvedValue(undefined),
   gitStashPop: vi.fn().mockResolvedValue(undefined),
   getCommitFiles: vi.fn().mockResolvedValue([]),
+  mergePullRequest: (...args: unknown[]) => mockMergePullRequest(...args),
+  refreshWorkspacePr: (...args: unknown[]) => mockRefreshWorkspacePr(...args),
 }));
 
 vi.mock("@/stores/diff-store", () => ({
@@ -202,6 +211,9 @@ beforeEach(() => {
   mockGetDefaultBranch.mockResolvedValue("main");
   mockListBranches.mockResolvedValue(["main", "develop"]);
   mockCheckClaudeAvailable.mockResolvedValue(false);
+  mockMergePullRequest.mockResolvedValue(undefined);
+  mockRefreshWorkspacePr.mockResolvedValue(undefined);
+  mockOpenUrl.mockResolvedValue(undefined);
   mockAppStoreState = {
     appState: {
       config: { ai_commit_message_enabled: false },
@@ -754,5 +766,99 @@ describe("Post-merge workspace cleanup", () => {
 
     // Project A's workspace must NOT have been activated
     expect(mockActivateWorkspace).not.toHaveBeenCalledWith("ws-projectA-main");
+  });
+});
+
+// ── Phase 2: PR split-button (open-on-GitHub + merge dropdown) ──
+
+describe("Changes panel PR split-button", () => {
+  function renderWithPr(
+    overrides: Partial<WorkspaceSnapshot> = { pr_number: 42, pr_state: "OPEN", pr_url: "https://github.com/o/r/pull/42" },
+  ) {
+    return render(
+      <TooltipProvider>
+        <ChangesPanel workspace={{ ...mockWorkspace, ...overrides }} />
+      </TooltipProvider>,
+    );
+  }
+
+  it("renders only the open-on-GitHub button (no merge chevron) for a MERGED PR", async () => {
+    renderWithPr({ pr_number: 7, pr_state: "MERGED", pr_url: "https://github.com/o/r/pull/7" });
+    await flushPromises();
+
+    expect(screen.getByText("#7")).toBeInTheDocument();
+    // The merge-PR chevron only renders for OPEN PRs.
+    expect(screen.queryByLabelText("Merge PR")).not.toBeInTheDocument();
+  });
+
+  it("renders chevron and dispatches mergePullRequest with the right method per item", async () => {
+    const user = userEvent.setup();
+    renderWithPr({ pr_number: 42, pr_state: "OPEN", pr_url: "https://github.com/o/r/pull/42" });
+    await flushPromises();
+
+    const chevron = screen.getByLabelText("Merge PR");
+    expect(chevron).toBeInTheDocument();
+
+    // Squash
+    await user.click(chevron);
+    await user.click(await screen.findByText("Squash and merge"));
+    await waitFor(() => {
+      expect(mockMergePullRequest).toHaveBeenLastCalledWith("/home/user/project", 42, "squash");
+    });
+
+    // Merge commit
+    await user.click(screen.getByLabelText("Merge PR"));
+    await user.click(await screen.findByText("Create merge commit"));
+    await waitFor(() => {
+      expect(mockMergePullRequest).toHaveBeenLastCalledWith("/home/user/project", 42, "merge");
+    });
+
+    // Rebase
+    await user.click(screen.getByLabelText("Merge PR"));
+    await user.click(await screen.findByText("Rebase and merge"));
+    await waitFor(() => {
+      expect(mockMergePullRequest).toHaveBeenLastCalledWith("/home/user/project", 42, "rebase");
+    });
+  });
+
+  it("clicking the main button area opens GitHub and does NOT trigger mergePullRequest", async () => {
+    const user = userEvent.setup();
+    renderWithPr({ pr_number: 42, pr_state: "OPEN", pr_url: "https://github.com/o/r/pull/42" });
+    await flushPromises();
+
+    await user.click(screen.getByText("#42"));
+
+    expect(mockOpenUrl).toHaveBeenCalledWith("https://github.com/o/r/pull/42");
+    expect(mockMergePullRequest).not.toHaveBeenCalled();
+  });
+
+  it("on success: fires success toast and triggers refreshWorkspacePr", async () => {
+    const user = userEvent.setup();
+    mockMergePullRequest.mockResolvedValueOnce(undefined);
+    renderWithPr({ pr_number: 42, pr_state: "OPEN", pr_url: "https://github.com/o/r/pull/42" });
+    await flushPromises();
+
+    await user.click(screen.getByLabelText("Merge PR"));
+    await user.click(await screen.findByText("Squash and merge"));
+
+    await waitFor(() => {
+      expect(mockToast.success).toHaveBeenCalledWith("PR #42 squashed");
+    });
+    expect(mockRefreshWorkspacePr).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("on failure: fires error toast and does NOT trigger refreshWorkspacePr", async () => {
+    const user = userEvent.setup();
+    mockMergePullRequest.mockRejectedValueOnce(new Error("merge conflict"));
+    renderWithPr({ pr_number: 42, pr_state: "OPEN", pr_url: "https://github.com/o/r/pull/42" });
+    await flushPromises();
+
+    await user.click(screen.getByLabelText("Merge PR"));
+    await user.click(await screen.findByText("Squash and merge"));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Couldn't merge PR: merge conflict");
+    });
+    expect(mockRefreshWorkspacePr).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Phase 2 of the right-sidebar PR feature work (analysis §3, §6 Feature 2). Adds a small "Open PR on GitHub" button to the Changes-panel toolbar, right-aligned after the existing Refresh button — mirroring Superset's `ChangesHeader.PRButton` placement.

## What changed

- **One new toolbar button** in `src/components/workspace/changes-panel.tsx`, between the Refresh button and the end of the toolbar row.
- **`ml-auto`** pushes it to the right side of the toolbar, leaving the existing buttons (base-branch selector, stash, merge, view-mode, refresh) untouched on the left.
- **Conditional rendering** — only renders when `workspace.pr_url` is set. Workspaces without a PR show no placeholder and no layout shift.
- **Reuses `PrStatusIcon`** from PR #6 + #7 — purple icon for merged, emerald for open, red for closed, muted for draft. Visual consistency with the sidebar pill.
- **Inline `#N`** next to the icon (Superset shows the number here, unlike the sidebar's tooltip-only treatment).
- **Tooltip:** `Open PR #N on GitHub`.
- **Click** opens the PR in the user's default browser via `@tauri-apps/plugin-opener` (same path the sidebar pill uses).
- **Does NOT** fold in Superset's merge-integrated dropdown variant — Codemux already has a separate Merge dropdown earlier in the same toolbar (per analysis §3 guidance, "don't double up").

## Test plan

- [x] `npm run verify` (cargo check + cargo test + tsc + vitest) — 366 frontend tests + 12 Rust tests pass
- [ ] Workspace with open PR — button visible, icon emerald, click opens GitHub
- [ ] Workspace with merged PR — button visible, icon purple, click still opens GitHub (the merged PR page)
- [ ] Workspace with no PR — button absent, toolbar layout doesn't break or shift
- [ ] Confirm icon + tone matches the sidebar pill on the same workspace