### PR TITLE
fix(sidebar): drop hover tooltip on PR pill

### DIFF
--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -465,43 +465,28 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                         />
                       )}
                       {showPrIcon && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              onClick={handlePrClick}
-                              disabled={!workspace.pr_url}
-                              aria-label={
-                                workspace.pr_number
-                                  ? `PR #${workspace.pr_number} — ${prHumanState ?? "Pull request"}`
-                                  : `Pull request — ${prHumanState ?? ""}`
-                              }
-                              className={cn(
-                                "inline-flex items-center gap-0.5 rounded-full px-1.5 py-px transition-opacity",
-                                prToneCls,
-                                workspace.pr_url ? "hover:opacity-80" : "cursor-not-allowed opacity-60",
-                              )}
-                            >
-                              <PrStatusIcon state={workspace.pr_state} size={3} />
-                              {workspace.pr_number && (
-                                <span className="text-[10px] tabular-nums text-muted-foreground/60">
-                                  #{workspace.pr_number}
-                                </span>
-                              )}
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent side="right" sideOffset={4} className="text-xs">
-                            <div>
-                              {workspace.pr_number ? `#${workspace.pr_number} — ` : ""}
-                              {prHumanState ?? "Pull request"}
-                            </div>
-                            {workspace.pr_url && (
-                              <div className="text-muted-foreground text-[10px]">
-                                Click to open on GitHub
-                              </div>
-                            )}
-                          </TooltipContent>
-                        </Tooltip>
+                        <button
+                          type="button"
+                          onClick={handlePrClick}
+                          disabled={!workspace.pr_url}
+                          aria-label={
+                            workspace.pr_number
+                              ? `Open PR #${workspace.pr_number} on GitHub — ${prHumanState ?? "Pull request"}`
+                              : `Open pull request on GitHub — ${prHumanState ?? ""}`
+                          }
+                          className={cn(
+                            "inline-flex items-center gap-0.5 rounded-full px-1.5 py-px transition-opacity",
+                            prToneCls,
+                            workspace.pr_url ? "hover:opacity-80" : "cursor-not-allowed opacity-60",
+                          )}
+                        >
+                          <PrStatusIcon state={workspace.pr_state} size={3} />
+                          {workspace.pr_number && (
+                            <span className="text-[10px] tabular-nums text-muted-foreground/60">
+                              #{workspace.pr_number}
+                            </span>
+                          )}
+                        </button>
                       )}
                     </div>
                   )}


### PR DESCRIPTION
## Summary

Matches the change just shipped on PR #8 commit 4 for the changes-panel split-button: Superset doesn't show a hover popup on the sidebar PR pill either, so this strips the `<Tooltip>` wrapper around the workspace-row PR icon.

## What changed

- Removed the `<Tooltip>` / `<TooltipTrigger>` / `<TooltipContent>` wrapper around the sidebar PR pill in `src/components/layout/sidebar-workspace-row.tsx`.
- Folded the descriptive text into a richer `aria-label`: `"Open PR #N on GitHub — Merged"` (was a tooltip line + a secondary "Click to open on GitHub" line).
- `Tooltip` imports stay because they're still used elsewhere in the file (Hide/Delete/Close confirmation buttons).

## Test plan

- [x] `npm run check` + `npm run test` (all 366 tests pass)
- [ ] Hover the sidebar PR pill — confirm no popup appears
- [ ] Click the pill — confirm GitHub still opens
- [ ] Tab to the pill — confirm screen reader announces the full aria-label