### PR TITLE
fix(terminal): pause hidden terminals to kill cross-workspace typing lag

### DIFF
--- a/src/components/terminal/terminal-cache.test.ts
+++ b/src/components/terminal/terminal-cache.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Terminal } from "@xterm/xterm";
 
 // ── Mocks ──
 //
@@ -14,20 +15,47 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // @tauri-apps/api/core's Channel constructor reads window.__TAURI_INTERNALS__,
 // which jsdom doesn't have. The factory body runs hoisted, so MockChannel
 // is defined inline to keep the closure self-contained.
+//
+// `attachPtyOutput` records the channel's handler keyed by sessionId so tests
+// can drive bytes into the cache via `__test_emitChannelBytes(sid, bytes)`.
+// This is the only way to exercise the parked-buffer / drain code paths
+// because the channel object the cache constructs is otherwise opaque to
+// callers.
 vi.mock("@/tauri/commands", () => {
+  type Handler = (payload: unknown) => void;
+  const handlers = new Map<string, Handler>();
+  let lastConstructedHandler: Handler | null = null;
+
   class MockChannel<T> {
-    constructor(_handler?: (payload: T) => void) {}
+    constructor(handler?: (payload: T) => void) {
+      if (handler) lastConstructedHandler = handler as Handler;
+    }
     send(_data: T) {
       return Promise.resolve();
     }
   }
+
   return {
     Channel: MockChannel,
     writeToPty: vi.fn().mockResolvedValue(undefined),
-    attachPtyOutput: vi.fn().mockResolvedValue(undefined),
+    attachPtyOutput: vi.fn().mockImplementation(async (sid: string) => {
+      if (lastConstructedHandler) {
+        handlers.set(sid, lastConstructedHandler);
+        lastConstructedHandler = null;
+      }
+    }),
     getTerminalScrollback: vi.fn().mockResolvedValue(null),
     cacheTerminalScrollback: vi.fn().mockResolvedValue(undefined),
     uncacheTerminalScrollback: vi.fn().mockResolvedValue(undefined),
+    __test_emitChannelBytes: (sid: string, bytes: Uint8Array) => {
+      const h = handlers.get(sid);
+      if (!h) throw new Error(`no channel handler for session ${sid}`);
+      h(bytes);
+    },
+    __test_resetChannels: () => {
+      handlers.clear();
+      lastConstructedHandler = null;
+    },
   };
 });
 
@@ -85,8 +113,17 @@ import {
   peekCachedTerminal,
   applyThemeToAllTerminals,
   _cacheSize,
+  _setParkedBufferCapForTest,
 } from "./terminal-cache";
 import * as commands from "@/tauri/commands";
+
+// Re-typed handles to the test-only escape hatches the mock exposes.
+const emitChannelBytes = (commands as unknown as {
+  __test_emitChannelBytes: (sid: string, bytes: Uint8Array) => void;
+}).__test_emitChannelBytes;
+const resetChannels = (commands as unknown as {
+  __test_resetChannels: () => void;
+}).__test_resetChannels;
 
 const baseOptions = {
   paneId: "pane-1",
@@ -101,6 +138,8 @@ describe("terminal-cache", () => {
     // Each test starts from a clean cache and DOM. The cache's parking node
     // is body-mounted on first use; we wipe the body to drop it.
     document.body.innerHTML = "";
+    resetChannels();
+    _setParkedBufferCapForTest(null);
   });
 
   it("getOrCreateTerminal returns the same instance for repeat calls with the same sessionId", async () => {
@@ -261,6 +300,299 @@ describe("terminal-cache", () => {
     expect(matches.length).toBe(1);
     expect(entry.wrapperEl.parentElement).toBe(container);
 
+    disposeTerminal(sid);
+  });
+
+  // ── Park-mode behavior ──────────────────────────────────────────────
+  // The lag regression fix in this commit gates two things on the `parked`
+  // flag: (a) PTY bytes received while parked accumulate in
+  // `pendingParkedBytes` instead of being written to xterm, and (b) the
+  // WebGL renderer is dropped on park and reloaded on activate. These tests
+  // pin the byte-routing contract — WebGL specifics aren't observable in
+  // jsdom (the addon throws on construct, so webglAddon is always null).
+
+  it("bytes received while parked accumulate in the parked buffer instead of pendingPtyWrites", async () => {
+    const sid = "session-park-buffer";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    // Park the entry — bytes should now route into pendingParkedBytes.
+    detachFromContainer(sid);
+    expect(entry.parked).toBe(true);
+
+    const chunkA = new TextEncoder().encode("hello ");
+    const chunkB = new TextEncoder().encode("world");
+    emitChannelBytes(sid, chunkA);
+    emitChannelBytes(sid, chunkB);
+
+    expect(entry.pendingParkedBytes.length).toBe(2);
+    expect(entry.pendingParkedSize).toBe(chunkA.length + chunkB.length);
+    // Live RAF queue must stay empty so a stale flush can't fire on the
+    // parked terminal between detach and reattach.
+    expect(entry.pendingPtyWrites.length).toBe(0);
+    expect(entry.ptyWriteFrame).toBeNull();
+
+    disposeTerminal(sid);
+  });
+
+  it("attachToContainer drains the parked buffer into a single terminal.write", async () => {
+    const sid = "session-drain";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    detachFromContainer(sid);
+    const writeSpy = vi.spyOn(entry.terminal, "write");
+    emitChannelBytes(sid, new TextEncoder().encode("alpha"));
+    emitChannelBytes(sid, new TextEncoder().encode("beta"));
+    emitChannelBytes(sid, new TextEncoder().encode("gamma"));
+
+    // No write yet — we're parked.
+    expect(writeSpy).not.toHaveBeenCalled();
+
+    attachToContainer(sid, container);
+
+    // Exactly one write — the whole point of the buffer is to coalesce.
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const arg = writeSpy.mock.calls[0]?.[0] as Uint8Array;
+    expect(arg).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(arg)).toBe("alphabetagamma");
+
+    // Buffer state has to reset so the next park cycle starts clean.
+    expect(entry.parked).toBe(false);
+    expect(entry.pendingParkedBytes.length).toBe(0);
+    expect(entry.pendingParkedSize).toBe(0);
+    expect(entry.parkedOverflow).toBe(false);
+
+    disposeTerminal(sid);
+  });
+
+  it("parked-buffer overflow drops the oldest chunk and sets parkedOverflow", async () => {
+    const sid = "session-overflow";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+    detachFromContainer(sid);
+
+    // Tiny cap so we don't have to pump megabytes through the mock.
+    _setParkedBufferCapForTest(8);
+
+    emitChannelBytes(sid, new TextEncoder().encode("AAAA")); // size 4 → total 4
+    emitChannelBytes(sid, new TextEncoder().encode("BBBB")); // size 4 → total 8 (at cap, no drop)
+    emitChannelBytes(sid, new TextEncoder().encode("CCCC")); // size 4 → total 12, drops "AAAA"
+
+    expect(entry.parkedOverflow).toBe(true);
+    expect(entry.pendingParkedSize).toBe(8);
+
+    const concatenated = entry.pendingParkedBytes
+      .map((c) => new TextDecoder().decode(c))
+      .join("");
+    expect(concatenated).toBe("BBBBCCCC");
+
+    disposeTerminal(sid);
+  });
+
+  it("kitty stack still advances on bytes received while parked", async () => {
+    // Kitty CSI-u state has to track the agent even when we're not rendering.
+    // The escape sequence below is `CSI > 1 u` which pushes flag value 1 onto
+    // the stack — picked because scanKittySequences recognizes it without
+    // needing a full DA reply.
+    const sid = "session-kitty-park";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    expect(entry.kittyStack.length).toBe(0);
+    expect(entry.kittyLevel).toBe(0);
+
+    detachFromContainer(sid);
+    emitChannelBytes(sid, new TextEncoder().encode("\x1b[>1u"));
+
+    // Even though we're parked, kitty bookkeeping has run.
+    expect(entry.kittyStack.length).toBeGreaterThan(0);
+    expect(entry.kittyLevel).toBeGreaterThan(0);
+
+    disposeTerminal(sid);
+  });
+
+  it("detachFromContainer is idempotent — second call does not re-process state", async () => {
+    const sid = "session-detach-idem";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+    detachFromContainer(sid);
+    emitChannelBytes(sid, new TextEncoder().encode("x"));
+    expect(entry.pendingParkedBytes.length).toBe(1);
+
+    // Second detach should be a no-op — must not flush, clear, or move
+    // the wrapper since it's already parked.
+    detachFromContainer(sid);
+    expect(entry.parked).toBe(true);
+    expect(entry.pendingParkedBytes.length).toBe(1);
+
+    disposeTerminal(sid);
+  });
+
+  it("disposeTerminal clears any buffered parked bytes", async () => {
+    const sid = "session-park-dispose";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+    detachFromContainer(sid);
+    emitChannelBytes(sid, new TextEncoder().encode("buffered"));
+    expect(entry.pendingParkedBytes.length).toBeGreaterThan(0);
+
+    disposeTerminal(sid);
+
+    expect(entry.disposed).toBe(true);
+    expect(entry.pendingParkedBytes.length).toBe(0);
+    expect(entry.pendingParkedSize).toBe(0);
+  });
+
+  it("detachFromContainer migrates unflushed pendingPtyWrites into the parked queue", async () => {
+    // Cold start has parked=false, so bytes from the channel queue into
+    // pendingPtyWrites + a RAF. If the user switches workspaces before that
+    // RAF fires, detach has to migrate the in-flight bytes — otherwise they
+    // disappear silently and the next reactivate shows a stale frame.
+    const sid = "session-migrate";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    emitChannelBytes(sid, new TextEncoder().encode("preempted"));
+    expect(entry.pendingPtyWrites.length).toBe(1);
+    expect(entry.ptyWriteFrame).not.toBeNull();
+
+    detachFromContainer(sid);
+
+    // RAF cancelled, queue empty, bytes now in the parked queue.
+    expect(entry.ptyWriteFrame).toBeNull();
+    expect(entry.pendingPtyWrites.length).toBe(0);
+    expect(entry.pendingParkedBytes.length).toBe(1);
+    expect(new TextDecoder().decode(entry.pendingParkedBytes[0])).toBe(
+      "preempted",
+    );
+
+    disposeTerminal(sid);
+  });
+
+  it("kitty query while parked still triggers writeToPty (response to agent)", async () => {
+    // The agent issues `\x1b[?u` to ask what kitty level we support. Even
+    // when the workspace isn't visible, we still have to answer or the agent
+    // will hang waiting for the reply. This pins the contract that scanning
+    // happens at receive time, not drain time.
+    const sid = "session-kitty-query";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    const writeMock = vi.mocked(commands.writeToPty);
+    writeMock.mockClear();
+
+    detachFromContainer(sid);
+    emitChannelBytes(sid, new TextEncoder().encode("\x1b[?u"));
+
+    expect(writeMock).toHaveBeenCalledTimes(1);
+    expect(writeMock.mock.calls[0]?.[0]).toBe(sid);
+
+    disposeTerminal(sid);
+  });
+
+  it("warm reattach (not previously parked) does not double-drain", async () => {
+    // attachToContainer can be called when we're already attached (e.g. a
+    // resize observer that re-runs the mount effect). In that case wasParked
+    // is false and we must skip drainParkedBytes — otherwise an empty drain
+    // would still call entry.parkedOverflow=false (harmless) but the more
+    // important guarantee is no spurious WebGL reload churn.
+    const sid = "session-warm-reattach";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+    expect(entry.parked).toBe(false);
+
+    const writeSpy = vi.spyOn(entry.terminal, "write");
+    attachToContainer(sid, container); // re-attach without detach
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(entry.parked).toBe(false);
+
+    disposeTerminal(sid);
+  });
+
+  it("attachToContainer transitioning out of parked invokes loadAddon (WebGL reload)", async () => {
+    // jsdom has no WebGL context so entry.webglAddon is always null after
+    // load — but Terminal.prototype.loadAddon is still called. Spying on it
+    // is the only way to verify the reload path actually runs without
+    // standing up a real GPU.
+    const sid = "session-webgl-reload";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    const loadAddonSpy = vi.spyOn(Terminal.prototype, "loadAddon");
+    detachFromContainer(sid);
+    expect(loadAddonSpy).not.toHaveBeenCalled(); // detach unloads, doesn't load
+
+    attachToContainer(sid, container);
+    // Exactly one loadAddon call on un-park: the WebGL reload.
+    expect(loadAddonSpy).toHaveBeenCalledTimes(1);
+
+    loadAddonSpy.mockRestore();
+    disposeTerminal(sid);
+  });
+
+  it("flushPtyWrites short-circuits if the entry was parked between RAF schedule and fire", async () => {
+    // Defensive contract: if a RAF was scheduled before park (and somehow
+    // survived cancelAnimationFrame — single-threaded JS makes this almost
+    // impossible but we guard anyway), it must not write into a parked
+    // terminal. Instead it migrates its bytes into the parked queue.
+    const sid = "session-flush-park";
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    emitChannelBytes(sid, new TextEncoder().encode("ghost"));
+    expect(entry.pendingPtyWrites.length).toBe(1);
+
+    // Flip park manually without going through detachFromContainer so we can
+    // observe what flushPtyWrites does on its own — modeling the race.
+    entry.parked = true;
+    const writeSpy = vi.spyOn(entry.terminal, "write");
+
+    // Internal flushPtyWrites isn't exported; trigger it via a fresh emit
+    // that schedules a new RAF, then manually invoke through the existing
+    // frame. Easier path: import flushPtyWrites? No — keep it black-box and
+    // rely on the public observable: the parked queue should have absorbed
+    // ghost bytes when we dispatch a fresh emit (the channel callback
+    // already routes parked-state correctly), but the existing pendingPtyWrites
+    // should also drain via flushPtyWrites's parked branch on next RAF.
+    // Simulate the RAF by directly calling a fresh emit (which is parked-
+    // routed) plus a wait for the RAF callback our test environment runs.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+
+    // Either the RAF ran and migrated, or cancelAnimationFrame dropped it —
+    // both outcomes leave no terminal.write call against the parked terminal.
+    expect(writeSpy).not.toHaveBeenCalled();
+    // ghost bytes have to be reachable on next attach: either still in
+    // pendingPtyWrites (RAF cancelled) or in pendingParkedBytes (RAF migrated).
+    const reachable =
+      entry.pendingPtyWrites.length + entry.pendingParkedBytes.length;
+    expect(reachable).toBeGreaterThan(0);
+
+    writeSpy.mockRestore();
     disposeTerminal(sid);
   });
 });

--- a/src/components/terminal/terminal-cache.ts
+++ b/src/components/terminal/terminal-cache.ts
@@ -8,11 +8,28 @@
  *
  * Lifetime invariant: the cache entry exists for the lifetime of the PTY
  * session. It is created on first mount (cold start) and disposed only when
- * the session ends (close button, workspace delete, app shutdown). Workspace
- * switches and tab switches reparent the wrapper into a hidden parking node
- * but never call term.dispose() — the xterm keeps consuming PTY bytes the
- * whole time, so its mode flags / cursor / alt-screen state stay in sync
- * with the agent.
+ * the session ends (close button, workspace delete, app shutdown).
+ *
+ * Park / activate semantics: workspace switches reparent the wrapper into a
+ * hidden parking node but NEVER call term.dispose(). While parked, the PTY
+ * channel keeps streaming bytes from Rust — but instead of writing each chunk
+ * straight into xterm (which would parse ANSI for an invisible buffer and
+ * also drag the WebGL context along), we accumulate bytes in
+ * `pendingParkedBytes`. The kitty keyboard state machine still ticks at
+ * receive time so the per-PTY kitty stack stays in sync with the agent.
+ *
+ * On reactivate (attachToContainer when transitioning out of `parked`), we
+ * concatenate the buffered bytes into a single terminal.write — xterm
+ * processes them in order, so the final visible state is identical to what
+ * you would see if writes had happened live. We also reload the WebGL addon
+ * which we disposed on park (browsers cap concurrent WebGL contexts at ~16;
+ * leaving them alive on every parked terminal is the typing-lag cliff this
+ * caching strategy fell into in 0.1.30).
+ *
+ * Buffer cap: PARKED_BUFFER_CAP guards against pathological agents that
+ * dump megabytes while the workspace sits parked. On overflow we drop the
+ * oldest chunk — xterm's scrollback would discard those lines anyway and a
+ * TUI repaint on next user interaction reconciles any lost frames.
  *
  * Design references:
  * - /tmp/terminal-rendering-analysis.md §5.1 (xterm-instance-lifetime split)
@@ -46,6 +63,17 @@ import { registerTerminalForSerialize } from "@/hooks/use-scrollback-serializer"
 
 const PARKING_NODE_ID = "codemux-terminal-parking";
 
+/**
+ * Cap (in bytes) on how much PTY output we'll buffer for a single parked
+ * terminal before we start dropping the oldest chunk. 16 MB is enormously
+ * larger than any practical TUI redraw cycle yet small enough that a
+ * runaway agent can't OOM the renderer process.
+ *
+ * Tunable via _setParkedBufferCapForTest from tests; runtime callers should
+ * never touch it. Module-level `let` (not const) only for that reason.
+ */
+let PARKED_BUFFER_CAP = 16 * 1024 * 1024;
+
 export interface TerminalCreateOptions {
   paneId: string | null;
   fontFamily: string;
@@ -70,9 +98,22 @@ export interface CachedTerminal {
   /** Cleared by disposeTerminal so RAFs queued from the channel callback
    *  short-circuit instead of writing into a disposed Terminal. */
   disposed: boolean;
-  /** Frame ID for the pending PTY-write batch. */
+  /** True when the wrapper has been moved to the parking node and the entry
+   *  should buffer PTY bytes instead of writing them. Flipped by
+   *  detachFromContainer / attachToContainer. */
+  parked: boolean;
+  /** Frame ID for the pending PTY-write batch (only used while not parked). */
   ptyWriteFrame: number | null;
   pendingPtyWrites: Uint8Array[];
+  /** Bytes received from the PTY while parked, awaiting drain on next
+   *  attachToContainer. Capped at PARKED_BUFFER_CAP bytes total — see the
+   *  module header. */
+  pendingParkedBytes: Uint8Array[];
+  pendingParkedSize: number;
+  /** Set whenever enqueueParkedBytes had to drop a chunk because the cap was
+   *  exceeded. Logged on drain so a regression in the cap surfaces in
+   *  devtools instead of silently shaving lines off scrollback. */
+  parkedOverflow: boolean;
   /** Kitty keyboard protocol stack (push/pop/reset).
    *  Stays per-session because the agent-side stack is per-PTY. */
   kittyStack: number[];
@@ -105,12 +146,136 @@ function extractBytes(payload: unknown): Uint8Array | null {
   if (payload instanceof ArrayBuffer) return new Uint8Array(payload);
   if (Array.isArray(payload)) return new Uint8Array(payload as number[]);
   if (typeof payload === "string") return new TextEncoder().encode(payload);
+  // Cross-realm typed-array fallback. The `instanceof Uint8Array` check above
+  // returns false when payload was constructed in a different module realm
+  // (Vitest's mock isolation hits this; a future Tauri Channel that crossed
+  // a worker boundary could too). ArrayBuffer.isView is realm-agnostic.
+  if (
+    payload &&
+    typeof payload === "object" &&
+    ArrayBuffer.isView(payload as ArrayBufferView)
+  ) {
+    const view = payload as ArrayBufferView;
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  }
   return null;
+}
+
+/**
+ * Load the WebGL renderer onto an open xterm. Safe no-op if it's already
+ * loaded. Failure to load (jsdom, no GPU, blocked context) is swallowed —
+ * xterm falls back to its DOM renderer transparently.
+ */
+function loadWebglAddon(entry: CachedTerminal): void {
+  if (entry.webglAddon || entry.disposed) return;
+  try {
+    const addon = new WebglAddon();
+    addon.onContextLoss(() => {
+      try {
+        addon.dispose();
+      } catch {
+        // ignore — context-loss already torpedoed it
+      }
+      if (entry.webglAddon === addon) entry.webglAddon = null;
+    });
+    entry.terminal.loadAddon(addon);
+    entry.webglAddon = addon;
+  } catch (err) {
+    console.warn(
+      "[Codemux] WebGL renderer unavailable, falling back to DOM",
+      err,
+    );
+    entry.webglAddon = null;
+  }
+}
+
+/**
+ * Tear down the WebGL renderer. Called on park (so the GPU context is freed
+ * for the active workspace's terminals) and on dispose. xterm reverts to its
+ * DOM renderer automatically.
+ */
+function unloadWebglAddon(entry: CachedTerminal): void {
+  if (!entry.webglAddon) return;
+  try {
+    entry.webglAddon.dispose();
+  } catch (err) {
+    console.error("[Codemux] webgl dispose failed", err);
+  }
+  entry.webglAddon = null;
+}
+
+/**
+ * Append a PTY chunk to the parked buffer, dropping the oldest chunks if the
+ * total would exceed PARKED_BUFFER_CAP. Sets parkedOverflow on first drop so
+ * drainParkedBytes can warn.
+ */
+function enqueueParkedBytes(entry: CachedTerminal, bytes: Uint8Array): void {
+  entry.pendingParkedBytes.push(bytes);
+  entry.pendingParkedSize += bytes.length;
+  while (
+    entry.pendingParkedSize > PARKED_BUFFER_CAP &&
+    entry.pendingParkedBytes.length > 1
+  ) {
+    const dropped = entry.pendingParkedBytes.shift();
+    if (!dropped) break;
+    entry.pendingParkedSize -= dropped.length;
+    entry.parkedOverflow = true;
+  }
+}
+
+/**
+ * Concatenate every buffered chunk into one Uint8Array and write it to xterm
+ * in a single call. xterm's parser handles large batched writes far better
+ * than many small ones — this is the whole point of the buffer.
+ *
+ * No-op when the queue is empty.
+ */
+function drainParkedBytes(entry: CachedTerminal): void {
+  // Defensive re-check: disposeTerminal could have been invoked between
+  // attachToContainer's top-of-function disposed guard and now (e.g. the
+  // terminal-cache GC reacting to a session vanishing from app-state). xterm
+  // throws on write-after-dispose, so bail before we do that.
+  if (entry.disposed) return;
+  if (entry.pendingParkedBytes.length === 0) {
+    entry.parkedOverflow = false;
+    return;
+  }
+  const totalLen = entry.pendingParkedSize;
+  const combined = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of entry.pendingParkedBytes) {
+    combined.set(chunk, offset);
+    offset += chunk.length;
+  }
+  const overflowed = entry.parkedOverflow;
+  entry.pendingParkedBytes = [];
+  entry.pendingParkedSize = 0;
+  entry.parkedOverflow = false;
+  entry.terminal.write(combined);
+  if (overflowed) {
+    console.warn(
+      `[Codemux] parked terminal ${entry.sessionId} exceeded buffer cap; oldest scrollback dropped`,
+    );
+  }
 }
 
 function flushPtyWrites(entry: CachedTerminal) {
   entry.ptyWriteFrame = null;
   if (entry.disposed) return;
+  // Defensive: detachFromContainer cancels the queued RAF, but if the cancel
+  // raced with an already-running frame (rare — single-threaded JS makes
+  // this hard) we'd otherwise write into a parked terminal whose WebGL
+  // context has been torn down. Move the bytes into the parked queue so the
+  // next reactivate still drains them.
+  if (entry.parked) {
+    if (entry.pendingPtyWrites.length > 0) {
+      for (const chunk of entry.pendingPtyWrites) {
+        enqueueParkedBytes(entry, chunk);
+      }
+      entry.pendingPtyWrites = [];
+    }
+    return;
+  }
   const pending = entry.pendingPtyWrites;
   if (pending.length === 0) return;
 
@@ -235,22 +400,6 @@ function createCachedTerminal(
   // works. WebGL is loaded lazily after open() returns.
   terminal.open(wrapperEl);
 
-  let webglAddon: WebglAddon | null = null;
-  try {
-    webglAddon = new WebglAddon();
-    webglAddon.onContextLoss(() => {
-      webglAddon?.dispose();
-      webglAddon = null;
-    });
-    terminal.loadAddon(webglAddon);
-  } catch (err) {
-    console.warn(
-      "[Codemux] WebGL renderer unavailable, falling back to DOM",
-      err,
-    );
-    webglAddon = null;
-  }
-
   const entry: CachedTerminal = {
     sessionId,
     terminal,
@@ -258,16 +407,24 @@ function createCachedTerminal(
     fitAddon,
     serializeAddon,
     unicode11Addon,
-    webglAddon,
+    webglAddon: null,
     lastDims: { cols: 0, rows: 0 },
     paneId: options.paneId,
     disposed: false,
+    parked: false,
     ptyWriteFrame: null,
     pendingPtyWrites: [],
+    pendingParkedBytes: [],
+    pendingParkedSize: 0,
+    parkedOverflow: false,
     kittyStack: [],
     kittyLevel: 0,
     cleanups: [],
   };
+
+  // Cold-start WebGL load. Done after the entry exists so the load helper
+  // can store the addon onto entry.webglAddon directly.
+  loadWebglAddon(entry);
 
   // ── User input handler ──
   // Stable: sessionId never changes for a given cache entry.
@@ -311,7 +468,14 @@ async function attachPtyChannel(entry: CachedTerminal): Promise<void> {
     if (entry.disposed) return;
     const bytes = extractBytes(payload);
     if (!bytes) return;
+    // Kitty stack has to advance at receive time regardless of park state —
+    // the input handler reads kittyLevel synchronously on every keystroke and
+    // a stale stack would send the wrong CSI-u sequences.
     scanKittyProtocol(entry, bytes);
+    if (entry.parked) {
+      enqueueParkedBytes(entry, bytes);
+      return;
+    }
     entry.pendingPtyWrites.push(bytes);
     if (entry.ptyWriteFrame === null) {
       entry.ptyWriteFrame = requestAnimationFrame(() => flushPtyWrites(entry));
@@ -413,6 +577,16 @@ export function attachToContainer(
     containerEl.appendChild(entry.wrapperEl);
   }
 
+  // Transitioning out of parked: reload WebGL (we dropped the GPU context on
+  // detach) and drain the buffered PTY bytes into a single xterm.write so the
+  // visible frame catches up to the live stream.
+  const wasParked = entry.parked;
+  entry.parked = false;
+  if (wasParked) {
+    loadWebglAddon(entry);
+    drainParkedBytes(entry);
+  }
+
   const { clientWidth, clientHeight } = containerEl;
   if (clientWidth > 0 && clientHeight > 0) {
     entry.fitAddon.fit();
@@ -421,15 +595,37 @@ export function attachToContainer(
 }
 
 /**
- * Reparent the wrapperEl back to the parking node. The xterm and PTY
- * channel stay alive — bytes keep flowing into the wrapper while it's
- * parked, so workspace return shows the live frame.
+ * Reparent the wrapperEl back to the parking node and put the entry into
+ * parked mode: PTY bytes will be buffered (not written to xterm) and the
+ * WebGL renderer is torn down to free the GPU context.
  *
- * Idempotent.
+ * Any pending RAF batch is canceled and its bytes migrated into the parked
+ * queue so we don't lose output mid-flush.
+ *
+ * Idempotent — calling on an already-parked entry is a no-op.
  */
 export function detachFromContainer(sessionId: string): void {
   const entry = cache.get(sessionId);
   if (!entry || entry.disposed) return;
+  if (entry.parked) return;
+
+  entry.parked = true;
+
+  // Cancel the in-flight RAF; its bytes have to go into the parked queue
+  // because once we unload WebGL we don't want them rendered until reactivate.
+  if (entry.ptyWriteFrame !== null) {
+    cancelAnimationFrame(entry.ptyWriteFrame);
+    entry.ptyWriteFrame = null;
+  }
+  if (entry.pendingPtyWrites.length > 0) {
+    for (const chunk of entry.pendingPtyWrites) {
+      enqueueParkedBytes(entry, chunk);
+    }
+    entry.pendingPtyWrites = [];
+  }
+
+  unloadWebglAddon(entry);
+
   const parking = ensureParkingNode();
   if (entry.wrapperEl.parentElement !== parking) {
     parking.appendChild(entry.wrapperEl);
@@ -466,6 +662,9 @@ export function disposeTerminal(sessionId: string): void {
     entry.ptyWriteFrame = null;
   }
   entry.pendingPtyWrites = [];
+  entry.pendingParkedBytes = [];
+  entry.pendingParkedSize = 0;
+  entry.parkedOverflow = false;
 
   for (const cleanup of entry.cleanups) {
     try {
@@ -475,6 +674,11 @@ export function disposeTerminal(sessionId: string): void {
     }
   }
   entry.cleanups = [];
+
+  // Drop the WebGL context before tearing down the terminal so the GPU
+  // resource is released even if terminal.dispose's internal addon cleanup
+  // misses it.
+  unloadWebglAddon(entry);
 
   try {
     entry.terminal.dispose();
@@ -517,4 +721,13 @@ export function peekCachedTerminal(sessionId: string): CachedTerminal | null {
 /** Test-only helper: count of live cache entries. */
 export function _cacheSize(): number {
   return cache.size;
+}
+
+/**
+ * Test-only helper: override the parked-buffer cap so overflow behavior can
+ * be exercised without pumping 16 MB through a mock channel. Pass null to
+ * restore the production default.
+ */
+export function _setParkedBufferCapForTest(cap: number | null): void {
+  PARKED_BUFFER_CAP = cap ?? 16 * 1024 * 1024;
 }


### PR DESCRIPTION
## Summary

After the v0.1.30 terminal-persistence change (#5 / 14735bf), typing got slow when more than one workspace was open. Hidden terminals were still fully active — every PTY byte ran ANSI parse + xterm.write + WebGL render, so each keystroke paid O(N workspaces) cost. Leaked WebGL contexts also blew past the browser's ~16 cap, triggering slow GPU evictions on every workspace switch.

Fix: park = "buffer, don't render". Hidden terminals queue PTY bytes in a 16 MB buffer instead of writing them. On reactivate, the buffer drains via a single `terminal.write` — xterm parses the same byte stream in the same order, so the visible state is identical to live writes (no scramble regression).

WebGL addon is disposed on park (frees GPU context) and reloaded on activate. Kitty keyboard state still ticks at receive time so the per-PTY stack stays in sync with the agent — including the `\x1b[?u` query response path.

## What changed

- `terminal-cache.ts`: `parked` flag, `pendingParkedBytes` queue (16 MB cap, drop oldest on overflow), `loadWebglAddon` / `unloadWebglAddon` helpers, channel callback routes by parked state, `attachToContainer` drains + reloads, `detachFromContainer` migrates pending writes + tears down WebGL.
- Defensive guards: `flushPtyWrites` short-circuits if parked (RAF cancel race), `drainParkedBytes` re-checks `disposed` (GC race).
- `extractBytes` gained an `ArrayBuffer.isView` fallback for cross-realm typed arrays.
- 11 new tests (24 total in `terminal-cache.test.ts`, up from 13) including loadAddon spy for WebGL lifecycle, kitty query writeToPty while parked, RAF migration on detach.

## Test plan

- [x] `npm run verify` — 379/379 passing (cargo check, cargo test, tsc, vitest)
- [ ] Manual: open 3+ workspaces with claude-code or vim running in each, type rapidly in one, confirm typing is responsive
- [ ] Manual: switch between workspaces several times, confirm TUI alt-screen state is preserved (no scramble) — the original bug 14735bf fixed
- [ ] Manual: leave a workspace parked while a chatty agent dumps output, switch back, confirm scrollback drains coherently