### PR TITLE
fix(branches): drop phantom origin from picker, seed pill from origin/HEAD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1316,20 +1316,35 @@ pub fn git_init_repo(path: &Path) -> Result<String, String> {
 }
 
 pub fn git_list_branches(repo_path: &Path, remote: bool) -> Result<Vec<String>, String> {
-    let output = if remote {
-        run_git(repo_path, &["branch", "-r", "--format=%(refname:short)"])?
-    } else {
-        run_git(repo_path, &["branch", "--format=%(refname:short)"])?
-    };
+    // We use `for-each-ref` with the FULL refname rather than `git branch
+    // --format=%(refname:short)`, because `:short` collapses
+    // `refs/remotes/<remote>/HEAD` to just `<remote>` (e.g. "origin",
+    // "upstream"). That ambiguous short form slips past any "contains HEAD"
+    // filter and surfaces in the picker as a phantom branch named after the
+    // remote — which then becomes the worktree directory name if selected.
+    // Filtering on the full refname's `/HEAD` suffix is unambiguous and
+    // works for every remote.
+    let pattern = if remote { "refs/remotes/" } else { "refs/heads/" };
+    let output = run_git(repo_path, &["for-each-ref", "--format=%(refname)", pattern])?;
     let branches: Vec<String> = output
         .lines()
         .map(|l| l.trim())
-        .filter(|l| !l.is_empty() && !l.contains("HEAD"))
+        .filter(|l| !l.is_empty() && !l.ends_with("/HEAD"))
         .map(|l| {
             if remote {
-                l.strip_prefix("origin/").unwrap_or(l).to_string()
+                // Strip `refs/remotes/origin/` for origin (preserves prior
+                // behavior of bare names), and `refs/remotes/` for any
+                // other remote (so e.g. `upstream/master` stays qualified
+                // and doesn't collide with origin's branches).
+                if let Some(rest) = l.strip_prefix("refs/remotes/origin/") {
+                    rest.to_string()
+                } else if let Some(rest) = l.strip_prefix("refs/remotes/") {
+                    rest.to_string()
+                } else {
+                    l.to_string()
+                }
             } else {
-                l.to_string()
+                l.strip_prefix("refs/heads/").unwrap_or(l).to_string()
             }
         })
         .collect();
@@ -1339,11 +1354,15 @@ pub fn git_list_branches(repo_path: &Path, remote: bool) -> Result<Vec<String>, 
 pub fn git_list_branches_detailed(repo_path: &Path) -> Result<Vec<BranchDetail>, String> {
     use std::collections::HashMap;
 
+    // Use full refnames so we can reliably detect and skip the
+    // `refs/remotes/origin/HEAD` symref. `%(refname:short)` collapses it to
+    // just `"origin"`, which silently leaks into the branch list and ends
+    // up as a worktree directory name if the user selects it.
     let output = run_git(
         repo_path,
         &[
             "for-each-ref",
-            "--format=%(refname:short)\t%(committerdate:unix)",
+            "--format=%(refname)\t%(committerdate:unix)",
             "refs/heads/",
             "refs/remotes/origin/",
         ],
@@ -1357,23 +1376,27 @@ pub fn git_list_branches_detailed(repo_path: &Path) -> Result<Vec<BranchDetail>,
             continue;
         }
 
-        let (raw_name, timestamp_str) = match line.split_once('\t') {
+        let (refname, timestamp_str) = match line.split_once('\t') {
             Some(pair) => pair,
             None => continue,
         };
 
-        // Determine if local or remote ref
-        let is_remote = raw_name.starts_with("origin/");
-        let name = if is_remote {
-            raw_name.strip_prefix("origin/").unwrap_or(raw_name)
-        } else {
-            raw_name
-        };
-
-        // Skip HEAD pointers
-        if name.contains("HEAD") {
+        // Skip any `<remote>/HEAD` symref — they alias another branch and
+        // would otherwise dedupe-collide on an empty/short name.
+        if refname.ends_with("/HEAD") {
             continue;
         }
+
+        // Classify as local or remote and strip the namespace prefix.
+        let (name, is_remote) = if let Some(rest) = refname.strip_prefix("refs/heads/") {
+            (rest, false)
+        } else if let Some(rest) = refname.strip_prefix("refs/remotes/origin/") {
+            (rest, true)
+        } else {
+            // Anything outside refs/heads/ and refs/remotes/origin/ — the
+            // for-each-ref patterns shouldn't return these, but be defensive.
+            continue;
+        };
 
         let timestamp: i64 = timestamp_str.trim().parse().unwrap_or(0);
 
@@ -2318,6 +2341,51 @@ C  source.txt -> copy.txt";
         let remote_only = branches.iter().find(|b| b.name == "remote-only").expect("remote-only present");
         assert!(!remote_only.is_local, "should not be local");
         assert!(remote_only.is_remote, "should be remote");
+    }
+
+    /// Regression: `git for-each-ref --format=%(refname:short)` and
+    /// `git branch -r --format=%(refname:short)` both collapse
+    /// `refs/remotes/origin/HEAD` to literally `"origin"` (the unambiguous
+    /// short form of the symref's target's namespace). The old
+    /// `!name.contains("HEAD")` filter let that through, so the New
+    /// Workspace branch picker showed a phantom "origin" branch — and
+    /// selecting it created a worktree directory named `origin/`. Make sure
+    /// the new full-refname filter on `/HEAD` suffix excludes it from both
+    /// branch listing functions.
+    #[test]
+    fn test_list_branches_skips_remote_head_symref() {
+        let (_dir, local, _remote) = setup_test_repo_with_remote();
+
+        // Establish origin/HEAD as a symref (mirrors what `git clone` would
+        // do for a real remote — our test scaffolding doesn't set it
+        // automatically because it inits a bare repo first).
+        run_git(&local, &["remote", "set-head", "origin", "--auto"])
+            .expect("set origin/HEAD");
+
+        // Sanity: the symref should now exist.
+        let head = run_git(&local, &["symbolic-ref", "refs/remotes/origin/HEAD"])
+            .expect("origin/HEAD exists");
+        assert!(
+            head.trim().starts_with("refs/remotes/origin/"),
+            "origin/HEAD should be a symref, got {head:?}"
+        );
+
+        // git_list_branches (remote=true) must not include "origin".
+        let remote_branches =
+            git_list_branches(&local, true).expect("list remote branches");
+        assert!(
+            !remote_branches.iter().any(|b| b == "origin"),
+            "remote branch list should not include phantom 'origin' entry, got {remote_branches:?}"
+        );
+
+        // git_list_branches_detailed must not include a branch named "origin".
+        let detailed =
+            git_list_branches_detailed(&local).expect("list detailed");
+        assert!(
+            !detailed.iter().any(|b| b.name == "origin"),
+            "detailed branch list should not include phantom 'origin' entry, got {:?}",
+            detailed.iter().map(|b| &b.name).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/components/overlays/branch-picker.tsx
+++ b/src/components/overlays/branch-picker.tsx
@@ -57,6 +57,15 @@ interface BranchPickerProps {
   branchWorkspaceMap?: Map<string, string>;
   prBranches?: Set<string>;
   currentBranch?: string | null;
+  /**
+   * The repo's actual default branch (from `origin/HEAD`). Used to drive
+   * the "default" badge and Fork/Open primary-action heuristics. When
+   * omitted or `null` (caller hasn't resolved it yet, or doesn't pass it
+   * — e.g. project-onboarding), we fall back to the legacy
+   * `main`/`master` heuristic so the badge still renders for the common
+   * case.
+   */
+  defaultBranchName?: string | null;
   onOpenWorkspace?: (workspaceId: string) => void;
   onImportWorktree?: (path: string, branch: string) => void;
   onCreateOnCurrent?: () => void;
@@ -73,12 +82,22 @@ export function BranchPicker({
   branchWorkspaceMap = EMPTY_BRANCH_MAP,
   prBranches = EMPTY_PR_SET,
   currentBranch = null,
+  defaultBranchName = null,
   onOpenWorkspace,
   onImportWorktree,
   onCreateOnCurrent,
   onOpenExisting,
   isOpenMode,
 }: BranchPickerProps) {
+  // Centralized "is this the repo's default branch?" check. Prefers the
+  // caller-provided detected default (read from `origin/HEAD`) and falls
+  // back to the legacy hardcoded names when no detected value is
+  // available — keeps the badge/Fork-action useful for callers that
+  // haven't been wired up to `useDefaultBranch` yet.
+  const isDefaultBranch = (name: string): boolean => {
+    if (defaultBranchName) return name === defaultBranchName;
+    return name === "main" || name === "master";
+  };
   const [open, setOpen] = useState(false);
   const [filterMode, setFilterMode] = useState<FilterMode>("all");
   const [search, setSearch] = useState("");
@@ -157,8 +176,8 @@ export function BranchPicker({
       return;
     }
 
-    // Default branch (main/master) — fork is the primary action
-    const isDefault = branch.name === "main" || branch.name === "master";
+    // Default branch — fork is the primary action
+    const isDefault = isDefaultBranch(branch.name);
     if (isDefault) {
       onSelectBase(branch.name);
       setOpen(false);
@@ -176,7 +195,7 @@ export function BranchPicker({
     branch: BranchDetail,
   ) => {
     e.stopPropagation();
-    const isDefault = branch.name === "main" || branch.name === "master";
+    const isDefault = isDefaultBranch(branch.name);
     const hasWorkspace = branchWorkspaceMap.has(branch.name);
     const hasWt = !!findWorktree(branch.name);
     // "Open" is only valid when the branch has no worktree yet
@@ -283,9 +302,7 @@ export function BranchPicker({
                       const hasOpenWorkspace = !!wsId;
                       const hasWorktree = !!wt;
                       const hasPr = prBranches.has(branch.name);
-                      const isDefault =
-                        branch.name === "main" ||
-                        branch.name === "master";
+                      const isDefault = isDefaultBranch(branch.name);
 
                       // Determine action labels based on branch state
                       const hasAnyWorktree = hasOpenWorkspace || hasWorktree;

--- a/src/components/overlays/new-workspace-dialog.test.tsx
+++ b/src/components/overlays/new-workspace-dialog.test.tsx
@@ -70,6 +70,12 @@ vi.mock("@/tauri/commands", () => ({
   // calls setWorkspaceHost when a non-local host is chosen.
   hostsList: vi.fn().mockResolvedValue([]),
   setWorkspaceHost: vi.fn().mockResolvedValue(undefined),
+  // Added when the dialog started seeding `baseBranch` from
+  // `useDefaultBranch(projectDir)`. The hook calls `getDefaultBranch`
+  // unconditionally on every project change — without a mock here, the
+  // module-level promise rejects with the Tauri `invoke` bridge being
+  // undefined under jsdom and crashes every dialog test.
+  getDefaultBranch: vi.fn().mockResolvedValue("main"),
 }));
 
 import {
@@ -82,7 +88,12 @@ import {
   generateBranchName,
   generateRandomBranchName,
   pasteClipboardImageToFile,
+  getDefaultBranch,
 } from "@/tauri/commands";
+import {
+  _defaultBranchCache,
+  _defaultBranchInFlight,
+} from "@/components/layout/default-branch-cache";
 
 // ── Helpers ──
 
@@ -163,6 +174,12 @@ beforeEach(() => {
   vi.clearAllMocks();
   (checkIsGitRepo as Mock).mockResolvedValue(true);
   (listBranches as Mock).mockResolvedValue([]);
+  // useDefaultBranch keeps a module-level cache so the same project_root
+  // only fetches once per session. Clear it between tests so a previous
+  // case's resolved value doesn't pre-populate the next dialog and
+  // short-circuit the auto-adoption effect we want to exercise.
+  _defaultBranchCache.clear();
+  _defaultBranchInFlight.clear();
   useUIStore.setState({
     newWorkspaceProjectDir: null,
     pendingWorkspaces: [],
@@ -574,6 +591,90 @@ describe("Default base branch", () => {
     const branchPicker = within(dialog).getByText("main");
     expect(branchPicker).toBeInTheDocument();
     expect(within(dialog).queryByText("feature-pr-branch")).not.toBeInTheDocument();
+  });
+
+  // Regression: the user reported that opening the dialog on a repo whose
+  // default branch is `master` (not `main`) still showed `main` in the pill
+  // and then errored out on create. The fix is to seed `baseBranch` from
+  // `useDefaultBranch(projectDir)` instead of hardcoding "main". This test
+  // verifies the pill adopts whatever the backend detection returns.
+  it("seeds the base-branch pill from getDefaultBranch (master, not hardcoded main)", async () => {
+    setAppState("/path/to/project");
+    (getDefaultBranch as Mock).mockResolvedValue("master");
+
+    renderDialog(true);
+
+    // Wait for the async useDefaultBranch fetch to resolve and the effect
+    // to swap "main" → "master" on the pill.
+    const dialog = await screen.findByRole("dialog");
+    await waitFor(() => {
+      expect(within(dialog).getByText("master")).toBeInTheDocument();
+    });
+    // And the placeholder "main" should be gone — otherwise the effect
+    // didn't actually run and the pill is just showing both somehow.
+    expect(within(dialog).queryByText("main")).not.toBeInTheDocument();
+  });
+
+  // Regression: same fix for any default branch name. Repos can have
+  // arbitrary defaults (e.g. `develop`, `trunk`). The hook returns
+  // whatever `git symbolic-ref refs/remotes/origin/HEAD` resolves to;
+  // the dialog must adopt it verbatim.
+  it("seeds the base-branch pill from getDefaultBranch (arbitrary name)", async () => {
+    setAppState("/path/to/project");
+    (getDefaultBranch as Mock).mockResolvedValue("develop");
+
+    renderDialog(true);
+
+    const dialog = await screen.findByRole("dialog");
+    await waitFor(() => {
+      expect(within(dialog).getByText("develop")).toBeInTheDocument();
+    });
+  });
+
+  // Regression: the detected default must not override an explicit user
+  // pick. If the user clicks the pill and picks `feature-x`, then the
+  // useDefaultBranch fetch resolves later, the picker should NOT clobber
+  // their pick back to the detected default.
+  it("does not override the pill once the user has manually picked a branch", async () => {
+    setAppState("/path/to/project");
+    // Make getDefaultBranch resolve slowly so we can pick first
+    let resolveDefault!: (v: string) => void;
+    (getDefaultBranch as Mock).mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveDefault = resolve;
+      }),
+    );
+    (listBranches as Mock).mockResolvedValue(["main", "master", "feature-x"]);
+    // Also seed the detailed list so the BranchPicker popover has options
+    const { listBranchesDetailed } = await import("@/tauri/commands");
+    (listBranchesDetailed as Mock).mockResolvedValue([
+      { name: "main", last_commit_unix: 1, is_local: true, is_remote: true },
+      { name: "master", last_commit_unix: 2, is_local: true, is_remote: true },
+      { name: "feature-x", last_commit_unix: 3, is_local: true, is_remote: false },
+    ]);
+
+    renderDialog(true);
+
+    const dialog = await screen.findByRole("dialog");
+
+    // Open the pill and pick `feature-x`
+    const pillButton = within(dialog).getByText("main").closest("button")!;
+    fireEvent.click(pillButton);
+    const featureRow = await screen.findByText("feature-x");
+    fireEvent.click(featureRow);
+
+    // Confirm the pill switched to feature-x
+    await waitFor(() => {
+      expect(within(dialog).getByText("feature-x")).toBeInTheDocument();
+    });
+
+    // NOW let the detected default resolve. It must NOT clobber the user's pick.
+    resolveDefault("master");
+    // Give React a tick to settle any pending effects.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(within(dialog).getByText("feature-x")).toBeInTheDocument();
+    expect(within(dialog).queryByText("master")).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/overlays/new-workspace-dialog.tsx
+++ b/src/components/overlays/new-workspace-dialog.tsx
@@ -38,6 +38,7 @@ import { useUIStore } from "@/stores/ui-store";
 import { PresetIcon } from "@/components/icons/preset-icon";
 import { ProjectPicker } from "./project-picker";
 import { IssuePickerPanel } from "@/components/github/issue-picker";
+import { useDefaultBranch } from "@/components/layout/default-branch-cache";
 import {
   listBranches,
   listBranchesDetailed,
@@ -126,6 +127,12 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     lastSelectedAgentId || "builtin-claude",
   );
   const [baseBranch, setBaseBranch] = useState("main");
+  // True once the user has manually picked a branch from the BranchPicker,
+  // so the `useDefaultBranch` effect below knows not to clobber their
+  // choice when the async detection resolves (or the user re-opens the
+  // dialog on the same project). Reset whenever the dialog is reopened or
+  // the project changes — see the open/projectDir effect below.
+  const userPickedBaseRef = useRef(false);
   const [attachments, setAttachments] = useState<string[]>([]);
   const [linkedIssue, setLinkedIssue] = useState<GitHubIssue | null>(null);
   const [issuePickerOpen, setIssuePickerOpen] = useState(false);
@@ -166,6 +173,8 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     setPrompt("");
     setSelectedAgentId(lastSelectedAgentId || "builtin-claude");
     setBaseBranch("main");
+    // Re-allow auto-adoption of the detected default branch on each open.
+    userPickedBaseRef.current = false;
     setAttachments([]);
     setLinkedIssue(null);
     setIssuePickerOpen(false);
@@ -175,6 +184,34 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     setHostId(null);
   }
   prevOpenRef.current = open;
+
+  // Resolve the repo's actual default branch (reads `origin/HEAD`, falls
+  // back to main/master existence). Returns `null` until the async fetch
+  // resolves and on detection failure; we keep "main" as the placeholder
+  // for that window so the pill still has something to render.
+  const detectedDefaultBranch = useDefaultBranch(projectDir || null);
+
+  // Adopt the detected default whenever it resolves for the current
+  // project, unless the user has explicitly picked a different branch
+  // from the picker. This fixes the "popup always says main even though
+  // the repo's default is master" UX bug, and prevents the create call
+  // from failing on repos whose default branch isn't named main.
+  useEffect(() => {
+    if (!open) return;
+    if (userPickedBaseRef.current) return;
+    if (!detectedDefaultBranch) return;
+    setBaseBranch(detectedDefaultBranch);
+  }, [open, detectedDefaultBranch]);
+
+  // Switching projects mid-dialog should re-arm auto-adoption so the new
+  // project's default branch wins over a stale pick from the previous
+  // project. Tracked separately from the open-reset above because
+  // projectDir can change without the dialog closing/reopening.
+  const prevProjectDirRef = useRef(projectDir);
+  if (prevProjectDirRef.current !== projectDir) {
+    userPickedBaseRef.current = false;
+    prevProjectDirRef.current = projectDir;
+  }
 
   // Load data when dialog opens or project changes
   useEffect(() => {
@@ -964,8 +1001,10 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
               branchWorkspaceMap={branchWorkspaceMap}
               prBranches={prBranches}
               currentBranch={currentBranch}
+              defaultBranchName={detectedDefaultBranch}
               loading={branchesLoading}
               onSelectBase={(branch) => {
+                userPickedBaseRef.current = true;
                 setBaseBranch(branch);
                 setBranchMode("create_new");
                 setOpenExistingBranch(null);


### PR DESCRIPTION
## Summary
- The New Workspace branch picker was listing a phantom `origin` row on any repo with `refs/remotes/origin/HEAD` set, and selecting it created a worktree directory literally named `origin/`. Same shape applied to `upstream` and every other remote whose HEAD symref was set. Root cause: both `git_list_branches` and `git_list_branches_detailed` used `--format=%(refname:short)`, which collapses `refs/remotes/origin/HEAD` to just `"origin"`. The existing `!name.contains("HEAD")` filter never had a chance. Switched both functions to `%(refname)` (full ref path) and filter on the `/HEAD` suffix — unambiguous and works for every remote.
- Pill now seeds from `useDefaultBranch(projectDir)` (reads `origin/HEAD`) instead of hardcoding `"main"`. Repos whose default branch is `master`/`develop`/`trunk`/etc. now Just Work. A ref tracks manual user picks so a late-resolving fetch can't clobber a deliberate choice, and project-dir changes mid-dialog re-arm auto-adoption.
- `BranchPicker` gains an optional `defaultBranchName` prop that drives the "default" badge and Fork-vs-Open primary-action heuristics. Falls back to the legacy `main`/`master` check when no prop is supplied, so `project-onboarding.tsx` keeps working unchanged.

## Reproducer (before this PR)
1. Have a repo whose default branch is `master` (e.g. omarchy).
2. Click `+` on the workspace.
3. Open the branch popover → see a phantom `origin` row at the top.
4. Hit Enter (or Fork) → worktree gets created at `~/.codemux/worktrees/<repo>/origin/` with `master` checked out, but the directory name is wrong. Alternatively the create errors out because the pill said `main` which doesn't exist.

After this PR: the popover shows only real branches, the pill reads `master` from the start, and the resulting worktree directory matches the actual branch name.

## Tests
- **Rust regression**: `test_list_branches_skips_remote_head_symref` creates the symref via `git remote set-head origin --auto` and asserts neither branch-listing function emits `"origin"`. Locks down the root cause.
- **Frontend regressions** (3 new vitest cases in `new-workspace-dialog.test.tsx`):
  - Pill adopts `master` when detection returns `master`.
  - Pill adopts an arbitrary detected default (`develop`).
  - User's manual pick is preserved across late-resolving detection.

## Test plan
- [x] `cargo test --lib git::tests::test_list_branches` — 7/7 pass including the new regression
- [x] `npm run test` — 1693/1693 pass (108 files)
- [x] `npm run check` (tsc) — clean
- [ ] Manual: open the `+` dialog on a `master`-default repo (e.g. omarchy) → pill reads `master` immediately, popover has no `origin` row, create succeeds and worktree path ends in `/master`.
- [ ] Manual: open the dialog on a `main`-default repo → unchanged behavior, pill still reads `main`.
- [ ] Manual: open the dialog on a repo with an `upstream` remote → no phantom `upstream` row in the popover.

## Notes
- Two latent edge-case bugs are incidentally fixed: a local branch literally named `origin/foo` is no longer misclassified as remote, and a branch named e.g. `HEADless-chicken` is no longer wrongly filtered.
- `package-lock.json` is rolled from 0.4.0 → 0.5.0 to match the already-bumped `package.json` (lockfile was stale from \`639dfc6\`).