### PR TITLE
fix(workspace): expand leading ~ in user-supplied project paths

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -11,6 +11,9 @@ use std::path::Path;
 
 #[tauri::command]
 pub async fn check_is_git_repo(path: String) -> bool {
+    // Expand a leading `~` — the New Project / project-picker paths can be
+    // typed by hand, and `is_git_repo` does no shell-style expansion.
+    let path = crate::project::expand_tilde(&path);
     tokio::task::spawn_blocking(move || crate::git::is_git_repo(Path::new(&path)))
         .await
         .unwrap_or(false)
@@ -18,6 +21,7 @@ pub async fn check_is_git_repo(path: String) -> bool {
 
 #[tauri::command]
 pub async fn init_git_repo(path: String) -> Result<String, String> {
+    let path = crate::project::expand_tilde(&path);
     tokio::task::spawn_blocking(move || crate::git::git_init_repo(Path::new(&path)))
         .await
         .map_err(|e| format!("init_git_repo task join failed: {e}"))?
@@ -25,6 +29,12 @@ pub async fn init_git_repo(path: String) -> Result<String, String> {
 
 #[tauri::command]
 pub async fn create_empty_repo(parent_dir: String, name: String) -> Result<String, String> {
+    // The New Project screen lets the user *type* the location (placeholder
+    // `~/Projects`). A literal `~` is never expanded by the filesystem, so
+    // without this `create_dir_all` would make a phantom directory named `~`
+    // under the process cwd and the workspace would store a broken `~/...`
+    // path that no terminal can `chdir` into.
+    let parent_dir = crate::project::expand_tilde(&parent_dir);
     tokio::task::spawn_blocking(move || {
         let repo_path = Path::new(&parent_dir).join(&name);
         std::fs::create_dir_all(&repo_path)
@@ -451,6 +461,11 @@ pub async fn resolve_conflicts_with_agent(
 #[tauri::command]
 pub async fn git_clone_repo(url: String, target_dir: String) -> Result<String, String> {
     use std::time::Duration;
+
+    // The clone target is built from a hand-typed location in the New Project
+    // screen; a literal `~` would clone into a phantom `~` directory under the
+    // process cwd. Expand it so the repo lands where the user expects.
+    let target_dir = crate::project::expand_tilde(&target_dir);
 
     let result = tokio::time::timeout(
         Duration::from_secs(120),

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -103,6 +103,9 @@ pub(crate) fn create_workspace_impl(
     db: &crate::database::DatabaseStore,
     cwd: Option<String>,
 ) -> Result<String, String> {
+    // A workspace cwd must be absolute so its terminals can `chdir` into it;
+    // a hand-typed `~` path would otherwise be stored verbatim.
+    let cwd = cwd.map(|path| crate::project::expand_tilde(&path));
     let workspace_id = match &cwd {
         Some(path) => state.create_workspace_at_path(PathBuf::from(path)),
         None => state.create_workspace(),
@@ -199,6 +202,10 @@ pub fn create_empty_workspace(
     cwd: String,
     skip_setup: Option<bool>,
 ) -> Result<String, String> {
+    // Defense-in-depth: a workspace cwd must always be an absolute path so
+    // every terminal it spawns can `chdir` into it. A literal `~` here would
+    // be stored verbatim and leave terminals stranded in `$HOME`.
+    let cwd = crate::project::expand_tilde(&cwd);
     let repo_path = PathBuf::from(&cwd);
     let workspace_id = state.create_empty_workspace_at_path(repo_path.clone());
 

--- a/src-tauri/src/project.rs
+++ b/src-tauri/src/project.rs
@@ -15,3 +15,95 @@ pub fn current_project_root() -> PathBuf {
 
     cwd
 }
+
+/// Expand a leading `~/` (or a bare `~`) in a path-as-string into the
+/// process's `$HOME`. No-op for paths without a leading tilde or when
+/// `$HOME` is unset.
+///
+/// `chdir`, `std::fs`, and `git` do NOT expand `~` — that is a shell-only
+/// convention. Two places rely on this helper:
+///
+///  1. Project creation: the New Project screen lets the user *type* a
+///     location (the placeholder even suggests `~/Projects`). Without
+///     expansion, `create_empty_repo`/`git clone` build a path with a
+///     literal `~` and create a phantom directory named `~` under the
+///     process cwd; the workspace then stores `~/...` as its cwd and every
+///     terminal fails to `chdir` into it, landing in `$HOME` instead.
+///  2. Remote/tunneled PTY spawns pass `~/.codemux/worktrees/<...>` as cwd
+///     because the laptop side does not know the remote's `$HOME`; the
+///     daemon resolves it against its own `$HOME`.
+pub fn expand_tilde(path: &str) -> String {
+    expand_tilde_with(path, env::var("HOME").ok().as_deref())
+}
+
+/// Pure-function core of [`expand_tilde`], parameterized on `home` so unit
+/// tests don't have to mutate the process-wide `HOME` env var (which would
+/// pollute other tests in the same binary that read `$HOME`).
+pub fn expand_tilde_with(path: &str, home: Option<&str>) -> String {
+    if path == "~" {
+        return home
+            .map(|h| h.to_string())
+            .unwrap_or_else(|| path.to_string());
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = home {
+            return format!("{home}/{rest}");
+        }
+    }
+    path.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests exercise `expand_tilde_with`, the pure-function core that
+    // takes `home` as an argument — NOT `expand_tilde`, which reads `$HOME`
+    // globally. We deliberately don't touch `std::env::set_var("HOME", ...)`
+    // because that mutation is process-wide and pollutes any other test in
+    // the binary that reads `$HOME`.
+
+    #[test]
+    fn expand_tilde_slash_uses_home_env() {
+        assert_eq!(
+            expand_tilde_with("~/.codemux/worktrees/proj/branch", Some("/fake/home")),
+            "/fake/home/.codemux/worktrees/proj/branch"
+        );
+    }
+
+    #[test]
+    fn expand_tilde_bare_returns_home() {
+        assert_eq!(expand_tilde_with("~", Some("/another/home")), "/another/home");
+    }
+
+    #[test]
+    fn expand_tilde_absolute_path_unchanged() {
+        assert_eq!(
+            expand_tilde_with("/usr/local/bin", Some("/whatever")),
+            "/usr/local/bin"
+        );
+    }
+
+    #[test]
+    fn expand_tilde_relative_path_unchanged() {
+        assert_eq!(
+            expand_tilde_with("relative/path", Some("/whatever")),
+            "relative/path"
+        );
+    }
+
+    #[test]
+    fn expand_tilde_mid_path_tilde_unchanged() {
+        // We only handle a LEADING tilde — `foo/~/bar` is not a
+        // tilde-expansion form; treat it as a literal path.
+        assert_eq!(expand_tilde_with("foo/~/bar", Some("/whatever")), "foo/~/bar");
+    }
+
+    #[test]
+    fn expand_tilde_with_no_home_leaves_tilde_alone() {
+        // When `$HOME` isn't set the expansion is a no-op. Better to surface
+        // the resulting failure than to silently resolve somewhere unexpected.
+        assert_eq!(expand_tilde_with("~/foo", None), "~/foo");
+        assert_eq!(expand_tilde_with("~", None), "~");
+    }
+}

--- a/src-tauri/src/pty_daemon/server.rs
+++ b/src-tauri/src/pty_daemon/server.rs
@@ -548,7 +548,7 @@ async fn spawn_pty(
     // (on some shells) exit immediately, killing the session before a
     // single byte of prompt rendered. Expand here on the daemon side
     // where we know the local HOME.
-    let resolved_cwd = expand_tilde(&cwd);
+    let resolved_cwd = crate::project::expand_tilde(&cwd);
     let cwd_exists = std::path::Path::new(&resolved_cwd).exists();
     eprintln!(
         "[daemon::spawn] session={session_id} input_cwd={cwd:?} \
@@ -693,35 +693,6 @@ async fn spawn_pty(
     Ok(pid)
 }
 
-/// Expand a leading `~/` (or bare `~`) in a path-as-string into the
-/// process's `$HOME`. No-op for paths without a leading tilde or when
-/// `$HOME` is unset.
-///
-/// Why this lives on the daemon side: tunneled spawns from a remote
-/// workspace pass `~/.codemux/worktrees/<project>/<branch>` as cwd
-/// because the laptop side doesn't know the remote's `$HOME`. The
-/// daemon DOES know its own `$HOME`. Resolving here means the laptop
-/// stays portable and we avoid a round trip to ask "what's your HOME".
-fn expand_tilde(path: &str) -> String {
-    expand_tilde_with(path, std::env::var("HOME").ok().as_deref())
-}
-
-/// Pure-function core of `expand_tilde`, parameterized on `home` so
-/// unit tests don't have to mutate the process-wide `HOME` env var
-/// (which pollutes other tests that read $HOME — e.g. process_kill
-/// tests that compute paths from $HOME).
-fn expand_tilde_with(path: &str, home: Option<&str>) -> String {
-    if path == "~" {
-        return home.map(|h| h.to_string()).unwrap_or_else(|| path.to_string());
-    }
-    if let Some(rest) = path.strip_prefix("~/") {
-        if let Some(home) = home {
-            return format!("{home}/{rest}");
-        }
-    }
-    path.to_string()
-}
-
 #[cfg(unix)]
 fn kill_session_pid(pid: u32) {
     // Same single-SIGKILL killpg policy as the in-process path uses, for
@@ -742,70 +713,4 @@ fn kill_session_pid(pid: u32) {
 fn kill_session_pid(_pid: u32) {
     // Windows path TBD — TerminateProcess + JobObject. Tracked in
     // the windows-support follow-up; for the MVP we only run on Unix.
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // These tests exercise `expand_tilde_with`, the pure-function
-    // core that takes `home` as an argument — NOT `expand_tilde`,
-    // which reads $HOME globally. We deliberately don't touch
-    // `std::env::set_var("HOME", ...)` because that mutation is
-    // process-wide and pollutes any other test in the binary that
-    // reads $HOME (e.g. terminal::tests::process_kill — confirmed
-    // experimentally that env::set_var here caused 10 process_kill
-    // failures in the full-suite ordering).
-
-    #[test]
-    fn expand_tilde_slash_uses_home_env() {
-        assert_eq!(
-            expand_tilde_with(
-                "~/.codemux/worktrees/proj/branch",
-                Some("/fake/home"),
-            ),
-            "/fake/home/.codemux/worktrees/proj/branch"
-        );
-    }
-
-    #[test]
-    fn expand_tilde_bare_returns_home() {
-        assert_eq!(expand_tilde_with("~", Some("/another/home")), "/another/home");
-    }
-
-    #[test]
-    fn expand_tilde_absolute_path_unchanged() {
-        assert_eq!(
-            expand_tilde_with("/usr/local/bin", Some("/whatever")),
-            "/usr/local/bin"
-        );
-    }
-
-    #[test]
-    fn expand_tilde_relative_path_unchanged() {
-        assert_eq!(
-            expand_tilde_with("relative/path", Some("/whatever")),
-            "relative/path"
-        );
-    }
-
-    #[test]
-    fn expand_tilde_mid_path_tilde_unchanged() {
-        // We only handle a LEADING tilde — `foo/~/bar` is not a
-        // tilde-expansion form; treat it as a literal path.
-        assert_eq!(
-            expand_tilde_with("foo/~/bar", Some("/whatever")),
-            "foo/~/bar"
-        );
-    }
-
-    #[test]
-    fn expand_tilde_with_no_home_leaves_tilde_alone() {
-        // When $HOME isn't set on the actual remote daemon, the
-        // expansion is a no-op and the daemon's chdir would fail.
-        // Better to surface the failure than silently chdir
-        // somewhere unexpected.
-        assert_eq!(expand_tilde_with("~/foo", None), "~/foo");
-        assert_eq!(expand_tilde_with("~", None), "~");
-    }
 }


### PR DESCRIPTION
## Summary

Terminals in a newly-created project's workspace were opening in `$HOME` instead of the project directory.

**Root cause:** the New Project screen's "Location" field is free-text (placeholder `~/Projects`). A hand-typed `~` path was passed through verbatim — the filesystem never expands `~`, so:

- `create_empty_repo` / `git clone` built a path with a literal `~` and created a phantom directory named `~` under the process cwd (e.g. `/home/zeus/~/projects/<name>`)
- the workspace stored `~/...` as its `cwd`
- on PTY spawn, `chdir` into that path failed and the shell fell back to `$HOME`

Using the **Browse** button was always fine — the OS dialog returns absolute paths; only typed `~` paths broke. The bug has existed since the New Project screen shipped (commit `be555c5`, 2026-03-28).

## Changes

- Promote `expand_tilde` / `expand_tilde_with` (plus their unit tests) out of `pty_daemon/server.rs` into the shared `project` module — one source of truth; the daemon now uses it too.
- Apply `expand_tilde` at every path-entry command so a typed `~` can never become a literal directory: `check_is_git_repo`, `init_git_repo`, `create_empty_repo`, `git_clone_repo`, `create_workspace`, `create_empty_workspace`.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test` — 6 `expand_tilde` tests pass in their new home; `pty_daemon` / `commands::git` tests pass
- [ ] Manual: create a new project with a typed `~/...` location, confirm the repo lands at the real path and its terminals open in the project dir