### PR TITLE
fix(update): enable in-app auto-update on Windows

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "codemux"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,8 +1,59 @@
+/// Returns the install-package format of the running app.
+///
+/// The frontend uses this to decide whether in-app auto-update
+/// (`downloadAndInstall`) is available for the current install:
+/// - `appimage` — Linux AppImage; the Tauri updater swaps it in place
+/// - `nsis` — Windows NSIS installer; the Tauri updater downloads and
+///   applies the new installer in place
+/// - `other` — `.deb` / `.rpm` and anything else, where updates are
+///   owned by the system package manager and the app can only point the
+///   user at the download page
+///
+/// Windows ships exclusively as an NSIS installer (see
+/// `release.yml` — the Windows leg builds with `--bundles nsis`), so
+/// every Windows install is auto-updatable.
 #[tauri::command]
 pub fn get_package_format() -> String {
-    if std::env::var("APPIMAGE").is_ok() {
+    if cfg!(target_os = "windows") {
+        "nsis".to_string()
+    } else if std::env::var("APPIMAGE").is_ok() {
         "appimage".to_string()
     } else {
         "other".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_format_is_a_known_value() {
+        // Whatever platform CI runs this on, the value must be one the
+        // frontend's `canAutoUpdateFormat` knows how to interpret.
+        let fmt = get_package_format();
+        assert!(
+            matches!(fmt.as_str(), "appimage" | "nsis" | "other"),
+            "unexpected package format: {fmt}"
+        );
+    }
+
+    /// Regression guard: Windows installs MUST report `nsis` so the
+    /// in-app updater is offered. Previously this returned `other` on
+    /// Windows, which silently downgraded every Windows user to a
+    /// manual download-and-reinstall flow.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_reports_nsis() {
+        assert_eq!(get_package_format(), "nsis");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_without_appimage_env_reports_other() {
+        // The CI runner is not an AppImage, so the env var is unset.
+        if std::env::var("APPIMAGE").is_err() {
+            assert_eq!(get_package_format(), "other");
+        }
     }
 }

--- a/src/components/update/update-toast.tsx
+++ b/src/components/update/update-toast.tsx
@@ -1,8 +1,25 @@
 import { useEffect, useRef } from "react";
 import { toast as sonnerToast } from "sonner";
+import { ArrowUpCircle } from "lucide-react";
 import { useUpdateChecker } from "@/hooks/use-update-checker";
 import { Button } from "@/components/ui/button";
 import { openUrl } from "@tauri-apps/plugin-opener";
+
+/**
+ * Opaque card shell for the update toast.
+ *
+ * Custom sonner toasts (`toast.custom`) do NOT inherit the `--normal-bg`
+ * styling the `<Toaster>` applies to standard toasts, so without an
+ * explicit background the toast renders see-through and unreadable. This
+ * shell pins a solid `bg-popover` surface with a border and shadow.
+ */
+function ToastShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="w-[340px] rounded-lg border border-border bg-popover px-4 py-3.5 text-popover-foreground shadow-lg">
+      {children}
+    </div>
+  );
+}
 
 export function UpdateToast() {
   const {
@@ -34,42 +51,54 @@ export function UpdateToast() {
     const render = () => {
       if (state === "downloading") {
         return (
-          <div>
-            <p className="text-sm font-medium mb-2">Downloading update...</p>
-            <div className="bg-muted rounded-full h-1.5 overflow-hidden">
+          <ToastShell>
+            <p className="text-sm font-semibold mb-2.5">Downloading update…</p>
+            <div className="bg-muted rounded-full h-2 overflow-hidden">
               <div
                 className="bg-primary h-full rounded-full transition-all duration-200"
                 style={{ width: `${downloadProgress}%` }}
               />
             </div>
-          </div>
+            <p className="text-xs text-muted-foreground mt-2">{downloadProgress}%</p>
+          </ToastShell>
         );
       }
 
       if (state === "ready") {
         return (
-          <div>
-            <p className="text-sm font-medium mb-1">Update ready</p>
+          <ToastShell>
+            <p className="text-sm font-semibold mb-1">Update ready</p>
             <p className="text-xs text-muted-foreground mb-3">
               Restart to apply v{updateVersion}
             </p>
-            <Button size="sm" className="w-full bg-foreground text-background hover:bg-foreground/90" onClick={installAndRestart}>
+            <Button
+              size="sm"
+              className="w-full bg-foreground text-background hover:bg-foreground/90"
+              onClick={installAndRestart}
+            >
               Restart Now
             </Button>
-          </div>
+          </ToastShell>
         );
       }
 
       // update-available
       return (
-        <div>
-          <p className="text-sm font-medium mb-1">Update available</p>
-          <p className="text-xs text-muted-foreground mb-3">
-            Codemux v{updateVersion} is ready
+        <ToastShell>
+          <div className="flex items-center gap-2 mb-1">
+            <ArrowUpCircle className="size-4 text-primary shrink-0" />
+            <p className="text-sm font-semibold">Update available</p>
+          </div>
+          <p className="text-xs text-muted-foreground mb-3.5">
+            Codemux v{updateVersion} is ready to install
           </p>
           <div className="flex gap-2">
             {canAutoUpdate ? (
-              <Button size="sm" className="flex-1 bg-foreground text-background hover:bg-foreground/90" onClick={startDownload}>
+              <Button
+                size="sm"
+                className="flex-1 bg-foreground text-background hover:bg-foreground/90"
+                onClick={startDownload}
+              >
                 Install &amp; Restart
               </Button>
             ) : (
@@ -89,7 +118,7 @@ export function UpdateToast() {
               Later
             </Button>
           </div>
-        </div>
+        </ToastShell>
       );
     };
 

--- a/src/hooks/use-update-checker.test.ts
+++ b/src/hooks/use-update-checker.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The hook module imports Tauri plugins at the top level. Stub them so the
+// pure helpers under test can be imported without a Tauri runtime present.
+vi.mock("@tauri-apps/plugin-updater", () => ({ check: vi.fn() }));
+vi.mock("@tauri-apps/plugin-process", () => ({ relaunch: vi.fn() }));
+vi.mock("@/tauri/commands", () => ({ getPackageFormat: vi.fn() }));
+
+import { canAutoUpdateFormat, isVersionDismissed } from "./use-update-checker";
+
+describe("canAutoUpdateFormat", () => {
+  it("treats AppImage installs as auto-updatable", () => {
+    expect(canAutoUpdateFormat("appimage")).toBe(true);
+  });
+
+  // Regression guard: before this fix `get_package_format()` returned
+  // "other" on Windows, so `canAutoUpdate` was false and every Windows
+  // user was downgraded to a manual download-and-reinstall flow despite
+  // the NSIS updater fully supporting in-app updates.
+  it("treats Windows NSIS installs as auto-updatable", () => {
+    expect(canAutoUpdateFormat("nsis")).toBe(true);
+  });
+
+  it("does not auto-update deb/rpm/other installs", () => {
+    expect(canAutoUpdateFormat("other")).toBe(false);
+    expect(canAutoUpdateFormat("deb")).toBe(false);
+    expect(canAutoUpdateFormat("rpm")).toBe(false);
+  });
+
+  it("rejects empty and unknown formats", () => {
+    expect(canAutoUpdateFormat("")).toBe(false);
+    expect(canAutoUpdateFormat("snap")).toBe(false);
+  });
+});
+
+describe("isVersionDismissed", () => {
+  // The dismissed version is held in an in-memory ref that starts as null
+  // on every launch — so a fresh launch always shows the toast again.
+  it("shows the toast on a fresh launch (nothing dismissed yet)", () => {
+    expect(isVersionDismissed(null, "0.5.1")).toBe(false);
+  });
+
+  it("hides the toast for a version dismissed this session", () => {
+    expect(isVersionDismissed("0.5.1", "0.5.1")).toBe(true);
+  });
+
+  // If a newer version is published while the app is running, the toast
+  // must reappear even though an older version was dismissed.
+  it("re-shows the toast when a newer version is published", () => {
+    expect(isVersionDismissed("0.5.0", "0.5.1")).toBe(false);
+  });
+});

--- a/src/hooks/use-update-checker.ts
+++ b/src/hooks/use-update-checker.ts
@@ -25,20 +25,31 @@ interface UpdateCheckerResult {
 const CHECK_INTERVAL = 4 * 60 * 60 * 1000; // 4 hours
 const INITIAL_DELAY = 5000; // 5 seconds
 
-function isDismissed(version: string): boolean {
-  try {
-    return localStorage.getItem(`codemux-update-dismissed-${version}`) === "true";
-  } catch {
-    return false;
-  }
+/**
+ * Install formats whose updates the Tauri updater can download and apply
+ * in place. Everything else (deb/rpm/unknown) can only be pointed at the
+ * release page. Keep this in sync with `get_package_format` in
+ * `src-tauri/src/commands/update.rs`.
+ */
+const AUTO_UPDATABLE_FORMATS = new Set(["appimage", "nsis"]);
+
+export function canAutoUpdateFormat(format: string): boolean {
+  return AUTO_UPDATABLE_FORMATS.has(format);
 }
 
-function setDismissed(version: string) {
-  try {
-    localStorage.setItem(`codemux-update-dismissed-${version}`, "true");
-  } catch {
-    // localStorage unavailable
-  }
+/**
+ * Whether the update toast should be treated as dismissed for `version`.
+ *
+ * Dismissal is intentionally in-memory only (a ref, not localStorage), so
+ * "Later" hides the toast for the current session but it re-appears on the
+ * next app launch — and immediately if a newer version is published —
+ * until the user actually updates.
+ */
+export function isVersionDismissed(
+  dismissedVersion: string | null,
+  currentVersion: string,
+): boolean {
+  return dismissedVersion !== null && dismissedVersion === currentVersion;
 }
 
 export function useUpdateChecker(): UpdateCheckerResult {
@@ -51,6 +62,9 @@ export function useUpdateChecker(): UpdateCheckerResult {
   const updateRef = useRef<Update | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Version the user dismissed this session. Not persisted — resets on
+  // every launch so the update prompt keeps nagging until they update.
+  const dismissedVersionRef = useRef<string | null>(null);
 
   const doCheck = useCallback(async () => {
     try {
@@ -59,7 +73,9 @@ export function useUpdateChecker(): UpdateCheckerResult {
       if (update) {
         updateRef.current = update;
         setUpdateVersion(update.version);
-        setDismissedState(isDismissed(update.version));
+        setDismissedState(
+          isVersionDismissed(dismissedVersionRef.current, update.version),
+        );
         setState("update-available");
       } else {
         setState("idle");
@@ -74,7 +90,7 @@ export function useUpdateChecker(): UpdateCheckerResult {
     if (import.meta.env.DEV) return;
 
     getPackageFormat()
-      .then((fmt) => setCanAutoUpdate(fmt === "appimage"))
+      .then((fmt) => setCanAutoUpdate(canAutoUpdateFormat(fmt)))
       .catch(() => setCanAutoUpdate(false));
 
     timeoutRef.current = setTimeout(() => {
@@ -133,9 +149,7 @@ export function useUpdateChecker(): UpdateCheckerResult {
   }, []);
 
   const dismiss = useCallback(() => {
-    if (updateVersion) {
-      setDismissed(updateVersion);
-    }
+    dismissedVersionRef.current = updateVersion;
     setDismissedState(true);
   }, [updateVersion]);
 


### PR DESCRIPTION
## Problem

The release pipeline produces a correct `latest.json` with a `windows-x86_64` entry, but the **updater client** only ever treated AppImage installs as auto-updatable: `get_package_format()` returned `"appimage"` (Linux) or `"other"`, and the toast's `canAutoUpdate` flag was `fmt === "appimage"`. On Windows it was always `false`, so users only saw a "Download" button that opened the GitHub releases page — they had to manually re-download and re-run the installer for every release, despite the bundled NSIS updater fully supporting in-app `downloadAndInstall()`.

A second, related papercut: dismissing the toast with **"Later"** wrote to `localStorage`, which hid that version's prompt *permanently*. The expected behavior is for it to keep nagging until the user actually updates.

## Changes

- **`get_package_format()`** now reports `"nsis"` on Windows (Windows ships exclusively as an NSIS installer).
- **The update hook** recognizes `nsis` as an auto-updatable format, so Windows now gets the real **"Install & Restart"** button.
- **Dismissal is in-memory only** (a ref, not `localStorage`). "Later" hides the toast for the current session; it reappears on the next launch — and immediately if a newer version is published — until the user updates.
- **The update toast renders on a solid surface.** Custom sonner toasts (`toast.custom`) don't inherit the `<Toaster>` background, so it rendered see-through and hard to read. It now has an opaque `bg-popover` card with a border + shadow, is wider, and is more legible.

## Testing

- `npm run verify` green: `cargo check`, full `cargo test`, `tsc`, and all 1705 vitest tests pass.
- New regression coverage:
  - Rust `#[cfg(target_os = "windows")]` test asserting `get_package_format()` returns `"nsis"` (runs on Windows CI).
  - vitest coverage for the format gate (`canAutoUpdateFormat`) and the dismissal behavior (`isVersionDismissed`).

## Follow-up (not in this PR)

A true end-to-end "the `.exe` actually self-replaces" test isn't practical in CI — recommend a one-time manual smoke test on the next release (install version N, publish N+1, confirm the running app self-updates). The unit guards above keep the format gate from silently regressing after that.