### PR TITLE
feat: Automations — scheduled agent runs

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -56,6 +56,7 @@ If the docs themselves feel stale or scattered, also read `docs/reference/DOCS_R
 - Session persistence: `docs/features/session-persistence.md`
 - Persistent agents (PTY daemon — now the default spawn path, no setting): `docs/features/persistent-agents.md`
 - Remote hosts (DevicePicker + codemux-remote + SSH transport + workspace push action): `docs/features/remote-hosts.md`
+- Automations (scheduled host-side agent runs): `docs/features/automations.md`; plan at `docs/plans/automations.md`; Superset research at `docs/research/superset-automations.md`
 - Agent hooks: `docs/features/hooks.md`
 - Execution backends / sandboxing: `docs/features/execution.md`
 - Observability (flags, metrics, safety config): `docs/features/observability.md`

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,6 +25,7 @@ If the docs themselves feel stale or scattered, also read `docs/reference/DOCS_R
 - `docs/features/*`: current subsystem capability and constraints
 - `docs/reference/*`: stable protocol and command references
 - `docs/plans/*`: active implementation notes and next steps
+- `docs/research/*`: supporting research feeding a specific plan in `docs/plans/`
 - `docs/archive/*`: superseded notes kept for context
 
 ## Current Entry Points
@@ -41,7 +42,7 @@ If the docs themselves feel stale or scattered, also read `docs/reference/DOCS_R
 - Worktree bootstrapping: `docs/features/worktree-setup.md`
 - Browser work: `docs/features/browser.md`, `docs/plans/browser.md`, `docs/reference/BROWSER-AGENT-COMMANDS.md` (browser stream stability fix archived at `docs/archive/browser-stream-fix.md`)
 - OpenFlow work: `docs/features/openflow.md`, `docs/plans/openflow.md`
-- MCP server (Codemux as host + as server): `docs/features/mcp-server.md`
+- MCP server (Codemux as host + as server): `docs/features/mcp-server.md`; vexis-agent integration plan (Phase 1 / 1.5 / 1.6 — all merged) at `docs/plans/vexis-agent-integration.md`, with supporting research at `docs/research/codemux-control-surfaces-current.md` and `docs/research/codemux-phase-1-5-research.md`
 - File editor: `docs/features/file-editor.md`
 - Diff viewer: `docs/features/diff-viewer.md`
 - File tree: `docs/features/file-tree.md`
@@ -53,8 +54,8 @@ If the docs themselves feel stale or scattered, also read `docs/reference/DOCS_R
 - Resource monitor (title-bar CPU/memory): `docs/features/resource-monitor.md`
 - Terminal presets: `docs/features/presets.md`
 - Session persistence: `docs/features/session-persistence.md`
-- Persistent agents (PTY daemon — step 1 of cloud push): `docs/features/persistent-agents.md`
-- Remote hosts (DevicePicker + codemux-remote + SSH transport — steps 2b/2c/2d of cloud push): `docs/features/remote-hosts.md`
+- Persistent agents (PTY daemon — now the default spawn path, no setting): `docs/features/persistent-agents.md`
+- Remote hosts (DevicePicker + codemux-remote + SSH transport + workspace push action): `docs/features/remote-hosts.md`
 - Agent hooks: `docs/features/hooks.md`
 - Execution backends / sandboxing: `docs/features/execution.md`
 - Observability (flags, metrics, safety config): `docs/features/observability.md`
@@ -96,6 +97,7 @@ The maintained docs system now lives entirely in:
 - `docs/core/*`
 - `docs/features/*`
 - `docs/plans/*`
+- `docs/research/*`
 - `docs/reference/*`
 - `docs/archive/*`
 - `docs/templates/*` as helper starting points for new docs

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -56,7 +56,7 @@ If the docs themselves feel stale or scattered, also read `docs/reference/DOCS_R
 - Session persistence: `docs/features/session-persistence.md`
 - Persistent agents (PTY daemon — now the default spawn path, no setting): `docs/features/persistent-agents.md`
 - Remote hosts (DevicePicker + codemux-remote + SSH transport + workspace push action): `docs/features/remote-hosts.md`
-- Automations (scheduled host-side agent runs): `docs/features/automations.md`; plan at `docs/plans/automations.md`; Superset research at `docs/research/superset-automations.md`
+- Automations (scheduled host-side agent runs): `docs/features/automations.md`; roadmap at `docs/plans/automations.md`; Phase 2 (sync + remote-host) detailed plan at `docs/plans/automations-sync.md`; Superset research at `docs/research/superset-automations.md`
 - Agent hooks: `docs/features/hooks.md`
 - Execution backends / sandboxing: `docs/features/execution.md`
 - Observability (flags, metrics, safety config): `docs/features/observability.md`

--- a/docs/core/PLAN.md
+++ b/docs/core/PLAN.md
@@ -69,6 +69,14 @@ The Phase numbering above (1-18) is the original product roadmap. Step-numbered 
 
 ## Recently Completed
 
+- **Refined-minimal UI pass.** Sidebar redesigned (refined-minimal aesthetic), slim Changes panel + ADE-native right sidebar, settings panel aligned with shared primitives, title-bar menu consolidated into the sidebar footer, preset-bar icons + tab-bar drop indicator aligned, agent-chat composer polished (Local pill dropped, dev spawn button removed, sidebar "New agent" locked to home).
+- **Default-branch detection (`v0.5.0`).** Sidebar branch pill is seeded from `origin/HEAD` and follows live remote-branch changes; derivative-branch picker drops the phantom `origin/<name>` rows so a user can't pick a remote-only ref by accident.
+- **Per-worktree notification mute.** Right-click → "Mute notifications" on a sidebar workspace row toggles `notifications_muted`; muted state shows a bell-off icon and skips agent-completion notifications.
+- **Title-bar resource monitor.** CPU/memory monitor in the title bar with accurate per-process counting (no longer counts threads as processes).
+- **Hooks: agent status across Codex / Gemini / OpenCode / Pi.** Status indicators (red/amber/green dots) now light up for every supported provider, not just Claude. Claude idle reminder is filtered out so it no longer raises a phantom stuck-red dot.
+- **SSH workspace push with Claude conversation sync (`v0.4.0`–`v0.5.0`).** The "push workspace to host" action that was deferred in step 2d has landed: rsync the worktree, spawn the remote daemon, attach the local UI through the SSH-forwarded socket, and sync the Claude conversation across local/remote ends. New `ssh::push`, `ssh::registry`, `ssh::tunnel_supervisor` modules.
+- **Persistent PTY daemon promoted to default.** Every shell now spawns inside `codemux pty-daemon`; the setting was removed (only the `CODEMUX_DISABLE_PTY_DAEMON=1` panic-button env var remains). Agents survive app close, the supervisor adopts the running daemon on relaunch, and the 3-failures-in-60s crash circuit breaker disables the daemon path safely on regression.
+- **MCP server Phase 1 / 1.5 / 1.6 (vexis-agent integration).** Added `terminal_write`, `terminal_read`, `workspace_open`, `app_status`, `port_list` (Phase 1); `worktree_create`, `preset_apply`, `preset_list` (Phase 1.5); `workspace_close`, `pane_close`, `issue_list`, `issue_get`, `issue_link_workspace` (Phase 1.6). Tool count went 31 → 44.
 - **Browser stream stability fix (LANDED).** Unified port keying around `workspace_id`, PID-tracked daemons (was port-tracked), atomic teardown, symmetric `TcpListener::bind` bind probe, reactive `stream_url` reconnect on the frontend. Eliminates the silent stream failure that appeared after multiple concurrent worktrees used the browser. Plan archived at `docs/archive/browser-stream-fix.md`.
 - **Browser viewport presets.** `codemux browser viewport <mobile|tablet|desktop|WxH|reset>` resizes the actual viewport via CDP so CSS media queries fire and screenshots capture at the simulated dimensions. MCP exposes `browser_viewport` + `browser_viewport_presets`.
 - **Performance pass** (`v0.2.3`–`v0.2.4`): high-frequency app-state emits coalesced into 16ms windows, `transition-all` scoped, markdown view + workspace-tied components stop re-rendering on every backend tick, workspace-switch mount-time IPC roundtrips cut, editor file read + language module import parallelised, worktree-include listener no longer re-attaches every tick, primitive fingerprint for `ensure-draft-when-empty` effect, all git/gh shell-outs moved off the GTK main thread.
@@ -85,7 +93,7 @@ The Phase numbering above (1-18) is the original product roadmap. Step-numbered 
 - Auto-update system (AppImage / NSIS in-app update, toast notification)
 - Built-in file editor with CodeMirror, syntax highlighting, markdown preview
 - AI merge conflict resolver with temp-branch safety model
-- MCP server for agent self-orchestration (31 tools via JSON-RPC 2.0)
+- MCP server for agent self-orchestration (44 tools via JSON-RPC 2.0, expanded through Phase 1 / 1.5 / 1.6 vexis-agent integration steps)
 - Settings panel (keyboard shortcuts, appearance, project scripts, beta features, sync, skills, MCP, permissions)
 - Auth system (GitHub OAuth, email/password, email verification, encrypted token storage)
 - Synced settings (per-user server-synced with offline cache)

--- a/docs/core/STATUS.md
+++ b/docs/core/STATUS.md
@@ -8,9 +8,9 @@
 
 ## Current Headline
 
-Codemux is past Linux MVP and shipping cross-platform binaries. The workspace shell, terminal management, git integration, presets, settings sync, and most ADE features are real and daily-drivable on both Linux and Windows. Latest released tag is `v0.2.5`.
+Codemux is past Linux MVP and shipping cross-platform binaries. The workspace shell, terminal management, git integration, presets, settings sync, and most ADE features are real and daily-drivable on both Linux and Windows. Latest released version is `v0.5.0`.
 
-The biggest change since the last reindex pass is **Step 13 Beta Features**: the agent-chat surface (Step 6–12: chat pane, multi-provider model picker, skills sync, attachments, mode pills, slash commands, plan proposals, MCP host runtime, …) is implemented and merged to `main` but **OFF by default**. Users opt in via Settings → Beta Features, which flips both `enable_agent_chat` and `enable_lazy_workspace_creation` together. The legacy main-branch experience (preset bar, terminal panes, empty-state splash) is preserved for users who don't opt in.
+Since the last reindex pass the agent-chat surface (Step 6–12: chat pane, multi-provider picker, skills sync, attachments, mode pills, slash commands, plan proposals, MCP host runtime, …) remains merged to `main` and Beta-gated; the **persistent PTY daemon** is now the default spawn path (every shell survives app close, the env-var escape hatch is the only off-switch), the **SSH workspace-push** action that was deferred in step 2d has landed (push a worktree to a user-owned host with Claude conversation sync), and the right sidebar + Settings panel have been redesigned to a **refined-minimal aesthetic** to match the rest of the app. The MCP server inventory has grown from 31 to **44 tools** across the Phase 1 / 1.5 / 1.6 vexis-agent integration steps.
 
 OpenFlow and the browser pane are still being hardened. OpenFlow is intentionally disabled on Windows until the bash-wrapper rewrite lands.
 
@@ -30,6 +30,7 @@ The repo structure is clean and domain-split:
 - Pane splits, resize, drag-swap, close
 - **Terminal pane persistence across workspace switch**: xterm.js `Terminal` instance + PTY-output channel survive component unmount via the module-level cache in `src/components/terminal/terminal-cache.ts`. Workspace switches reparent the wrapper into a hidden parking node instead of disposing, so alt-screen TUIs (Claude Code, lazygit, btop, vim) keep rendering correctly on return. Disposal is driven by AppState diffs in `useTerminalCacheGc` so close-pane / close-tab / close-workspace / PTY-exit all reach `disposeTerminal`.
 - **Session persistence**: terminal scrollback save/restore across restarts (Windows-only backend backstop in `scrollback::flush_cache_to_disk`), adapter-based resume for CLI tools (Claude Code `--resume`/`--continue` via hook-captured session IDs)
+- **Persistent PTY daemon** (`pty_daemon::server` + `client` + `supervisor` + `manifest`): every shell spawn now routes through a detached `codemux pty-daemon` subprocess so agents survive app close. On relaunch the supervisor adopts the running daemon and reattaches live sessions. **Default-on**, no setting; `CODEMUX_DISABLE_PTY_DAEMON=1` is the only escape hatch. Graceful fallback to the in-process portable-pty path on every error site, plus a 3-failures-in-60s crash circuit breaker that disables the daemon path for the rest of the process lifetime. Unix only; Windows still uses the in-process path until the named-pipe IPC is wired.
 
 ### Git & GitHub
 - Git worktree-based workspaces (create from new/existing branch, import orphans, derivative-branch picker with recency)
@@ -37,6 +38,7 @@ The repo structure is clean and domain-split:
 - Full-pane diff viewer tab (unified/split layouts, section filters incl. `against_base`, hunk/file navigation, focus mode)
 - Review tab (renamed from PR tab, React Query refactor): PR creation, header, reviews, checks, deployments, merge controls
 - Sidebar PR status icon per workspace with stale-clearing on branch switch and DRAFT collapse
+- **Default-branch detection** drives the sidebar branch pill: seed from `origin/HEAD`, follow live remote-branch changes, and the derivative-branch picker drops the phantom `origin/<name>` rows so users never pick a remote-only ref by accident
 - "Checkout default branch" workspace action
 - Git sidebar enrichment (branch, ahead/behind, diff stats, PR badge) with non-blocking activate + visibility-based gate
 - Sidebar ahead/behind arrows refresh against fresh remote refs
@@ -83,6 +85,7 @@ The repo structure is clean and domain-split:
 - Workspace alerts with severity levels
 - Desktop notification toast + chime when an off-screen agent finishes
 - Notification sound playback wired on all three platforms (Linux: `paplay` + freedesktop `complete.oga`; macOS: `afplay` + Glass.aiff; Windows: PowerShell SystemSounds)
+- **Per-worktree mute** (`set_workspace_muted` + sidebar context-menu toggle): silences agent-completion notifications for a specific workspace without touching global sound state; muted state surfaces as a sidebar row icon
 
 ### Auth & sync
 - GitHub OAuth, email/password with email verification, encrypted token storage (AES-256-GCM, machine-bound key)
@@ -110,6 +113,8 @@ The repo structure is clean and domain-split:
 - Sans-serif chrome (DM Sans), monospace terminals
 - Terminal colors fully theme-reactive via CSS variables + MutationObserver
 - Fallback Tokyonight-inspired theme when Omarchy unavailable
+- **Refined-minimal sidebar redesign**: slim Changes panel + ADE-native right sidebar, consolidated title-bar menu into the sidebar footer, aligned preset-bar icons + tab-bar drop indicator, sidebar workspace rows redesigned with new hover/active states
+- **Refined-minimal Settings panel**: every section now uses shared primitives, back-button hit area widened, panel layout matches the sidebar aesthetic
 
 ### Agent Chat (Beta — opt-in via Settings → Beta Features)
 - Full multi-provider chat pane with streaming, approvals, mode pills (Ask / Allow always / Plan / Debug), and permission-mode restart
@@ -129,13 +134,14 @@ The repo structure is clean and domain-split:
 
 ### Infrastructure
 - Global overlay manager (single overlay at a time)
-- MCP server exposing 31 tools via JSON-RPC 2.0 (browser, workspace, pane, git, notification, viewport presets)
+- MCP server exposing **44 tools** via JSON-RPC 2.0 (browser tier 1/2/3 + info + viewport, workspace incl. open/close, pane incl. close, git, notification, terminal read/write, app_status, port_list, worktree_create, preset_apply/list, issue_list/get/link_workspace — Phase 1, 1.5, and 1.6 vexis-agent integration tools all merged)
 - CLI and socket control (Unix socket on Linux/macOS, named pipe on Windows). Control-endpoint errors now surface instead of being swallowed.
 - Per-workspace display isolation (X11/Wayland sandboxing for agent-spawned GUI apps — opt-in for human persona, default-on for agent persona)
 - Local project memory (`codemux memory show/set/add`, `codemux handoff`)
 - Auto-update via Tauri updater (Linux AppImage + Windows NSIS, signed with the same Ed25519 key, shared `latest.json`)
 - Onboarding skip affordance + re-trap fix
 - Dev builds isolated from installed release (separate data dirs)
+- **Remote hosts + workspace push**: Settings → Hosts with real `hosts_test_connection` probe + `hosts_bootstrap_install` install flow, slim `codemux-remote` server binary (`[[bin]] codemux_remote.rs`), and SSH transport (`ssh::probe`/`bootstrap`/`tunnel`/`tunnel_supervisor`/`push`/`registry`) so a workspace can be pushed to a user-owned SSH host. Push synchronizes the worktree, spawns the remote daemon, attaches the local UI through an SSH-forwarded socket, and **syncs the Claude conversation** across local/remote ends. `WorkspaceSnapshot.host_id` + shared `<DevicePicker>` pill wires the host selection into the new-workspace dialog.
 
 ### Performance
 - High-frequency app-state emits coalesced into 16 ms windows
@@ -167,7 +173,7 @@ The repo structure is clean and domain-split:
 
 ## Windows Support
 
-Windows support shipped in `v0.1.20` and `v0.1.21` and has been hardened progressively through every subsequent release. Latest published Windows binaries (NSIS `.exe` installer + auto-update via the shared `latest.json`) ship on `v0.2.5`.
+Windows support shipped in `v0.1.20` and `v0.1.21` and has been hardened progressively through every subsequent release. Latest published Windows binaries (NSIS `.exe` installer + auto-update via the shared `latest.json`) ship on `v0.5.0`.
 
 What's in place:
 

--- a/docs/features/automations.md
+++ b/docs/features/automations.md
@@ -114,9 +114,13 @@ layers still to come.
   the API. A per-host scoped token would limit blast radius if a host
   is compromised — a future hardening.
 - **No run-now.** A one-shot `automation_run` tool is still deferred.
-- **No workspace lifecycle.** `workspace_sync_from_host` and the
-  automation-workspace pull-back guard (`docs/plans/automations-sync.md`
-  Phase F) are not built.
+- **Remote-host automations cannot obtain the project repo yet.** An
+  automation on a separate host needs the repo *on that host*. The
+  GitHub-backbone transport — the host clones the project's git remote,
+  runs produce branches, a setup-time GitHub-access preflight check —
+  is specced as Phase F in `docs/plans/automations-sync.md` but not
+  built. **"This machine" automations are unaffected** — the repo and
+  the result branch are local.
 
 ## Important Touch Points
 

--- a/docs/features/automations.md
+++ b/docs/features/automations.md
@@ -1,0 +1,131 @@
+# Automations
+
+- Purpose: Describe the current capability and constraints of the Automations feature.
+- Audience: Anyone working in or around scheduled agent runs.
+- Authority: Canonical feature-level reality doc.
+- Update when: Behavior, constraints, or major touch points change.
+- Read next: `docs/plans/automations.md`, `docs/research/superset-automations.md`
+
+## What This Feature Is
+
+An automation is a named prompt + agent + recurrence that runs on a host
+the user picks. The schedule fires on the chosen host; each fire creates
+a fresh workspace and runs the agent in it. Automations are account-bound
+so every signed-in device sees the same list.
+
+The feature is being built in layers. This doc describes what is **landed
+in the repo today** — the plan in `docs/plans/automations.md` tracks the
+layers still to come.
+
+## Current Model
+
+- **Persistence** — `automations` and `automation_runs` tables in the
+  local SQLite database (`database.rs`, schema v5). They carry the same
+  `server_id` / `deleted_at` / `dirty` columns as `hosts`, so the
+  account-sync layer can be added with no migration.
+- **Recurrence** — an automation's `schedule` is a complete RFC 5545
+  iCalendar block (a `DTSTART` line plus one `RRULE` line). The
+  `automations::recurrence` module wraps the `rrule` crate to validate a
+  schedule and compute the next occurrence, with IANA-timezone / DST
+  correctness.
+- **Next-run bookkeeping** — `next_run_at` is derived state. The command
+  layer recomputes it from *now* on every create, schedule edit, and
+  resume, so a paused automation never fires a backlog when resumed.
+- **Scheduler** — `automations::scheduler` holds the decision logic
+  (`is_due`, `fire_key`) and the `tick` loop. `fire_key` floors a fire
+  to its minute and is the `scheduled_for` dedup key. A background task
+  in `lib.rs` runs `tick` once a minute against the local database.
+- **Executor** — `automations::executor` takes each fired run, creates
+  an isolated git worktree, runs the agent headlessly with the prompt,
+  and writes the terminal status back. The desktop scheduler task spawns
+  one executor per fire.
+- **Run history** — one `automation_runs` row per fire. The
+  `UNIQUE(automation_id, scheduled_for)` constraint makes a re-delivered
+  tick idempotent. Status flows `scheduled → running → succeeded |
+  failed | skipped_offline | skipped_busy`. Run rows are kept
+  indefinitely; only host-side worktrees are pruned (per
+  `retention_limit`).
+
+## What Works Today
+
+- Full automation CRUD over the local database, with create-time
+  validation (name/prompt/agent/schedule/timezone/retention bounds, and
+  a real RFC 5545 parse of the schedule).
+- Pause / resume, with resume recomputing the next fire time.
+- **A live scheduler.** A background task in the desktop app calls
+  `automations::scheduler::tick` once a minute: due automations get a
+  run row recorded and their `next_run_at` advanced; overlapping fires
+  are serialised (`skipped_busy`); the per-minute `fire_key` keeps a
+  double tick idempotent. Each fresh run is emitted as an
+  `automations://fire` event and surfaced to the user as a toast.
+- **A fire runs the agent.** `automations::executor::execute_run`
+  creates an isolated git worktree off the automation's project (a
+  fresh `automation-<slug>-<timestamp>` branch), spawns the chosen
+  agent headlessly with the prompt (`claude --print` / `codex exec`),
+  and records the terminal `succeeded` / `failed` status plus the
+  workspace path on the run row.
+- **Settings → Automations UI** — a sidebar list + detail pane to
+  create, edit, pause/resume, and delete automations, with a
+  frequency/time/weekday schedule builder (and a raw RFC 5545 escape
+  hatch) and a per-automation run-history view.
+- Desktop command surface — `automations_list`, `automations_get`,
+  `automations_create`, `automations_update`, `automations_set_enabled`,
+  `automations_delete`, `automations_runs`.
+- Agent / MCP control surface — eight tools (`automation_list`,
+  `automation_get`, `automation_create`, `automation_update`,
+  `automation_delete`, `automation_pause`, `automation_resume`,
+  `automation_runs`), each routed through the control socket to the same
+  shared `commands::automations::*_impl` helpers the desktop uses.
+- Unit coverage — 35 tests across the recurrence engine, scheduler
+  decision logic + tick loop, the fire executor (agent-command mapping,
+  branch slugging, worktree creation against a real temp repo), and
+  database CRUD / dedup / run lifecycle.
+
+## Current Constraints
+
+- **Host targeting is not yet routed.** The desktop scheduler executes
+  every fired automation locally regardless of `host_id`. Honouring a
+  remote `host_id` needs account sync + the `codemux-remote scheduler`
+  subcommand (below).
+- **No stuck-run reconciler.** If the app quits mid-run, that run stays
+  `running` and the overlap guard keeps the automation `skipped_busy`
+  until the row is cleared. A reconciler is tracked in the plan.
+- **No account sync yet.** Automations carry the `dirty` flag but
+  `automations_sync` and the `/api/automations` endpoints do not exist,
+  so the list is local to one install.
+- **Desktop-only scheduler.** The minute tick runs inside the desktop
+  app. The `codemux-remote scheduler` subcommand for always-on hosts is
+  not built — it is blocked on account sync (a remote host's database
+  has no automations until sync delivers them).
+- **No run-now.** A one-shot `automation_run` tool is deferred until a
+  fire can dispatch real work.
+- **`host_id` is unvalidated.** It is stored as a plain integer; nothing
+  yet checks the referenced host exists or is reachable.
+
+## Important Touch Points
+
+- `src-tauri/src/database.rs` — `automations` / `automation_runs` schema,
+  records, CRUD (`AutomationRecord`, `AutomationRunRecord`,
+  `AutomationInput`).
+- `src-tauri/src/automations/recurrence.rs` — schedule validation + next
+  occurrence.
+- `src-tauri/src/automations/scheduler.rs` — `is_due` / `fire_key` /
+  `tick`.
+- `src-tauri/src/automations/executor.rs` — worktree creation + agent
+  spawn for a fired run.
+- `src-tauri/src/commands/automations.rs` — shared `*_impl` helpers +
+  Tauri command wrappers.
+- `src-tauri/src/control.rs` — `automation_*` control-socket handlers.
+- `src-tauri/src/mcp_server.rs` — the eight `automation_*` MCP tools.
+- `src-tauri/src/lib.rs` — the once-a-minute scheduler background task.
+- `src/components/settings/automations-section.tsx` — the Settings UI.
+- `src/hooks/use-automation-fire-toast.ts` — the fire-event toast.
+
+## Notes
+
+- The `rrule` crate is the recurrence engine; it bundles `chrono-tz` for
+  the IANA timezone database.
+- The deliberate divergence from Superset (cloud-cron dispatch) is that
+  Codemux schedules on the host itself — see
+  `docs/research/superset-automations.md` for why that enables real
+  completion status, overlap prevention, and local retention.

--- a/docs/features/automations.md
+++ b/docs/features/automations.md
@@ -110,9 +110,16 @@ layers still to come.
   the remote into `~/.codemux/automation-repos/`, branching off a
   freshly-fetched `origin/<default>`. A run records its branch and any
   PR URL, so run history reads like a PR list.
-- **GitHub-access preflight.** "Test connection" on a host also probes
-  `git` and `gh auth status`, so a host that can't reach GitHub is
-  flagged at setup, not at the first 9am run.
+- **Preflight checks.** Two layers, both informational (neither blocks):
+  "Test connection" on a host probes `git` + `gh auth status`; and the
+  New Automation form (plus the detail view) runs a per-repo
+  `git ls-remote` over SSH — the canonical "can this host reach *this*
+  repository" probe — with a "Check again" affordance. A host that
+  can't reach the repo is flagged at setup, not at the first 9am run.
+- **Health at a glance.** Each automation in the list carries a dot
+  driven by its most recent run — green healthy, amber if the last run
+  failed, grey when paused. A misconfigured host self-heals: fix its
+  credentials and the next run clears the dot, no button required.
 - Coverage — 1471 Rust unit tests (recurrence, scheduler + tick + host
   routing, the executor incl. real-git clone/fetch/worktree-base,
   account sync, reconciler, service units, the preflight probe, database

--- a/docs/features/automations.md
+++ b/docs/features/automations.md
@@ -102,10 +102,22 @@ layers still to come.
   always-on host. Host bootstrap provisions it: it writes the scheduler
   token + host identity and registers a systemd user service (via
   `automations::service`) with lingering, so it survives reboots.
-- Unit coverage — 43 Rust tests (recurrence, scheduler decision + tick +
-  host routing, the fire executor, account sync, the reconciler, the
-  service-unit generators, database CRUD / dedup / run lifecycle), plus
-  16 server tests for the `/api/automations` endpoints.
+- **Remote-host repo transport (the GitHub backbone).** Each automation
+  carries the project's git remote URL, resolved from the chosen
+  project. The executor's `resolve_repo` uses the local `project_path`
+  when it is present (the desktop / "This machine" case, branching off
+  HEAD), and otherwise clones — or `git fetch`es an existing clone of —
+  the remote into `~/.codemux/automation-repos/`, branching off a
+  freshly-fetched `origin/<default>`. A run records its branch and any
+  PR URL, so run history reads like a PR list.
+- **GitHub-access preflight.** "Test connection" on a host also probes
+  `git` and `gh auth status`, so a host that can't reach GitHub is
+  flagged at setup, not at the first 9am run.
+- Coverage — 1471 Rust unit tests (recurrence, scheduler + tick + host
+  routing, the executor incl. real-git clone/fetch/worktree-base,
+  account sync, reconciler, service units, the preflight probe, database
+  CRUD / migration / run lifecycle) + 263 server tests for the
+  `/api/automations` endpoints; `tsc` / `vitest` green.
 
 ## Current Constraints
 
@@ -114,13 +126,10 @@ layers still to come.
   the API. A per-host scoped token would limit blast radius if a host
   is compromised — a future hardening.
 - **No run-now.** A one-shot `automation_run` tool is still deferred.
-- **Remote-host automations cannot obtain the project repo yet.** An
-  automation on a separate host needs the repo *on that host*. The
-  GitHub-backbone transport — the host clones the project's git remote,
-  runs produce branches, a setup-time GitHub-access preflight check —
-  is specced as Phase F in `docs/plans/automations-sync.md` but not
-  built. **"This machine" automations are unaffected** — the repo and
-  the result branch are local.
+- **The host needs its own GitHub credentials.** A remote host clones
+  and the agent reads/writes GitHub using the host's own `git` + `gh`
+  auth — Codemux injects no token (matching Superset). The preflight
+  flags a host that lacks them.
 
 ## Important Touch Points
 

--- a/docs/features/automations.md
+++ b/docs/features/automations.md
@@ -64,7 +64,9 @@ layers still to come.
   agent headlessly with the prompt (`claude --print` / `codex exec`),
   and records the terminal `succeeded` / `failed` status plus the
   workspace path on the run row.
-- **Settings → Automations UI** — a sidebar list + detail pane to
+- **Automations view** — a first-class destination opened from the left
+  sidebar (under "New agent", above the project list — the same
+  placement Codex and Superset use). A sidebar list + detail pane to
   create, edit, pause/resume, and delete automations, with a
   frequency/time/weekday schedule builder (and a raw RFC 5545 escape
   hatch) and a per-automation run-history view.
@@ -118,7 +120,9 @@ layers still to come.
 - `src-tauri/src/control.rs` — `automation_*` control-socket handlers.
 - `src-tauri/src/mcp_server.rs` — the eight `automation_*` MCP tools.
 - `src-tauri/src/lib.rs` — the once-a-minute scheduler background task.
-- `src/components/settings/automations-section.tsx` — the Settings UI.
+- `src/components/automations/automations-view.tsx` +
+  `automations-section.tsx` — the full-screen Automations view.
+- `src/components/layout/sidebar-action-row.tsx` — the sidebar entry.
 - `src/hooks/use-automation-fire-toast.ts` — the fire-event toast.
 
 ## Notes

--- a/docs/features/automations.md
+++ b/docs/features/automations.md
@@ -89,36 +89,30 @@ layers still to come.
   startup (desktop and `codemux-remote`), so a crashed run can never
   pin its automation in `skipped_busy`.
 - **Account sync** — `automations_sync` pulls/pushes the automation
-  registry through the Codemux API (`/api/automations`), mirroring
-  `hosts_sync`: a fire-and-forget sync after every mutation, a startup
-  pull, and a pull on every scheduler tick. Host targeting crosses the
-  wire as the host's `server_id`. A `404` is treated as a harmless skip
-  so the client works before the endpoints are deployed.
+  registry through the Codemux API's live `/api/automations` endpoints,
+  mirroring `hosts_sync`: a fire-and-forget sync after every mutation, a
+  startup pull, and a pull on every scheduler tick. Host targeting
+  crosses the wire as the host's `server_id`; the remote scheduler pulls
+  host-scoped (`?hostServerId=`).
 - **Host routing** — `scheduler::tick` takes a `local_only` switch: the
   desktop runs only automations targeting this machine (`host_id IS
   NULL`); a `codemux-remote scheduler` runs the rest.
 - **`codemux-remote scheduler`** — a subcommand on the remote binary
   that runs the same reconcile + pull + tick + execute loop on an
-  always-on host.
-- **Persistent-service units** — `automations::service` generates the
-  systemd unit / launchd plist that keeps the remote scheduler alive
-  across reboots.
-- Unit coverage — 43 tests across the recurrence engine, scheduler
-  decision logic + tick loop + host routing, the fire executor, account
-  sync (mockito), the reconciler, the service-unit generators, and
-  database CRUD / dedup / run lifecycle.
+  always-on host. Host bootstrap provisions it: it writes the scheduler
+  token + host identity and registers a systemd user service (via
+  `automations::service`) with lingering, so it survives reboots.
+- Unit coverage — 43 Rust tests (recurrence, scheduler decision + tick +
+  host routing, the fire executor, account sync, the reconciler, the
+  service-unit generators, database CRUD / dedup / run lifecycle), plus
+  16 server tests for the `/api/automations` endpoints.
 
 ## Current Constraints
 
-- **The `/api/automations` endpoints are not deployed.** The sync
-  client is complete and degrades gracefully (`404` = skip), but until
-  the server side ships (separate API repo) the registry stays local to
-  one install and remote hosts receive no automations.
-- **The remote scheduler is not yet auto-installed.** The
-  `codemux-remote scheduler` subcommand and its service units exist,
-  but host bootstrap does not yet write the scheduler token or register
-  the service — that wiring waits on the API (it needs the token
-  endpoint). See `docs/plans/automations-sync.md` Phase E.
+- **Scheduler tokens are full account tokens.** The host bootstrap
+  copies the desktop's auth token to the host so its scheduler can call
+  the API. A per-host scoped token would limit blast radius if a host
+  is compromised — a future hardening.
 - **No run-now.** A one-shot `automation_run` tool is still deferred.
 - **No workspace lifecycle.** `workspace_sync_from_host` and the
   automation-workspace pull-back guard (`docs/plans/automations-sync.md`

--- a/docs/features/automations.md
+++ b/docs/features/automations.md
@@ -39,6 +39,12 @@ layers still to come.
   an isolated git worktree, runs the agent headlessly with the prompt,
   and writes the terminal status back. The desktop scheduler task spawns
   one executor per fire.
+- **Sync** — `automations_sync` replicates the registry through the
+  Codemux API, the same dirty-flag / tombstone model as `hosts_sync`.
+  Only `automations` syncs; `automation_runs` stay per-device.
+- **Remote execution** — `codemux-remote scheduler` runs the identical
+  reconcile + tick + executor loop on an always-on host; host routing
+  keeps each scheduler to its own automations.
 - **Run history** — one `automation_runs` row per fire. The
   `UNIQUE(automation_id, scheduled_for)` constraint makes a re-delivered
   tick idempotent. Status flows `scheduled → running → succeeded |
@@ -78,31 +84,45 @@ layers still to come.
   `automation_delete`, `automation_pause`, `automation_resume`,
   `automation_runs`), each routed through the control socket to the same
   shared `commands::automations::*_impl` helpers the desktop uses.
-- Unit coverage — 35 tests across the recurrence engine, scheduler
-  decision logic + tick loop, the fire executor (agent-command mapping,
-  branch slugging, worktree creation against a real temp repo), and
+- **Stuck-run reconciler** — `reconcile_stale_runs` fails any run left
+  `running`/`scheduled` by a crash or quit; it runs at scheduler
+  startup (desktop and `codemux-remote`), so a crashed run can never
+  pin its automation in `skipped_busy`.
+- **Account sync** — `automations_sync` pulls/pushes the automation
+  registry through the Codemux API (`/api/automations`), mirroring
+  `hosts_sync`: a fire-and-forget sync after every mutation, a startup
+  pull, and a pull on every scheduler tick. Host targeting crosses the
+  wire as the host's `server_id`. A `404` is treated as a harmless skip
+  so the client works before the endpoints are deployed.
+- **Host routing** — `scheduler::tick` takes a `local_only` switch: the
+  desktop runs only automations targeting this machine (`host_id IS
+  NULL`); a `codemux-remote scheduler` runs the rest.
+- **`codemux-remote scheduler`** — a subcommand on the remote binary
+  that runs the same reconcile + pull + tick + execute loop on an
+  always-on host.
+- **Persistent-service units** — `automations::service` generates the
+  systemd unit / launchd plist that keeps the remote scheduler alive
+  across reboots.
+- Unit coverage — 43 tests across the recurrence engine, scheduler
+  decision logic + tick loop + host routing, the fire executor, account
+  sync (mockito), the reconciler, the service-unit generators, and
   database CRUD / dedup / run lifecycle.
 
 ## Current Constraints
 
-- **Host targeting is not yet routed.** The desktop scheduler executes
-  every fired automation locally regardless of `host_id`. Honouring a
-  remote `host_id` needs account sync + the `codemux-remote scheduler`
-  subcommand (below).
-- **No stuck-run reconciler.** If the app quits mid-run, that run stays
-  `running` and the overlap guard keeps the automation `skipped_busy`
-  until the row is cleared. A reconciler is tracked in the plan.
-- **No account sync yet.** Automations carry the `dirty` flag but
-  `automations_sync` and the `/api/automations` endpoints do not exist,
-  so the list is local to one install.
-- **Desktop-only scheduler.** The minute tick runs inside the desktop
-  app. The `codemux-remote scheduler` subcommand for always-on hosts is
-  not built — it is blocked on account sync (a remote host's database
-  has no automations until sync delivers them).
-- **No run-now.** A one-shot `automation_run` tool is deferred until a
-  fire can dispatch real work.
-- **`host_id` is unvalidated.** It is stored as a plain integer; nothing
-  yet checks the referenced host exists or is reachable.
+- **The `/api/automations` endpoints are not deployed.** The sync
+  client is complete and degrades gracefully (`404` = skip), but until
+  the server side ships (separate API repo) the registry stays local to
+  one install and remote hosts receive no automations.
+- **The remote scheduler is not yet auto-installed.** The
+  `codemux-remote scheduler` subcommand and its service units exist,
+  but host bootstrap does not yet write the scheduler token or register
+  the service — that wiring waits on the API (it needs the token
+  endpoint). See `docs/plans/automations-sync.md` Phase E.
+- **No run-now.** A one-shot `automation_run` tool is still deferred.
+- **No workspace lifecycle.** `workspace_sync_from_host` and the
+  automation-workspace pull-back guard (`docs/plans/automations-sync.md`
+  Phase F) are not built.
 
 ## Important Touch Points
 
@@ -114,12 +134,17 @@ layers still to come.
 - `src-tauri/src/automations/scheduler.rs` — `is_due` / `fire_key` /
   `tick`.
 - `src-tauri/src/automations/executor.rs` — worktree creation + agent
-  spawn for a fired run.
-- `src-tauri/src/commands/automations.rs` — shared `*_impl` helpers +
-  Tauri command wrappers.
+  spawn (`run_fire` / `apply_outcome`, Tauri-free; `execute_run` is the
+  desktop wrapper).
+- `src-tauri/src/automations/service.rs` — systemd / launchd unit
+  generation for the remote scheduler.
+- `src-tauri/src/automations_sync.rs` — account sync (pull / push).
+- `src-tauri/src/commands/automations.rs` — shared `*_impl` helpers,
+  Tauri command wrappers, `schedule_automations_sync`.
 - `src-tauri/src/control.rs` — `automation_*` control-socket handlers.
 - `src-tauri/src/mcp_server.rs` — the eight `automation_*` MCP tools.
-- `src-tauri/src/lib.rs` — the once-a-minute scheduler background task.
+- `src-tauri/src/bin/codemux_remote.rs` — the `scheduler` subcommand.
+- `src-tauri/src/lib.rs` — the once-a-minute desktop scheduler task.
 - `src/components/automations/automations-view.tsx` +
   `automations-section.tsx` — the full-screen Automations view.
 - `src/components/layout/sidebar-action-row.tsx` — the sidebar entry.

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -1,7 +1,7 @@
 # MCP Server
 
 - Purpose: Describe Codemux's two-sided MCP integration — Codemux as an
-  MCP **server** (exposing 29 control-plane tools to external agents)
+  MCP **server** (exposing 44 control-plane tools to external agents)
   AND as an MCP **host** (running user-installed MCP servers and
   forwarding their tools into agent-chat sessions).
 - Audience: Anyone working on agent integration, MCP tooling, or
@@ -17,8 +17,9 @@
 Codemux occupies both sides of the Model Context Protocol:
 
 1. **MCP server** (original role) — Codemux runs `codemux mcp`, a
-   JSON-RPC 2.0 server over stdio that exposes 29 tools (browser,
-   workspace, pane, git, notification) so external agents can drive
+   JSON-RPC 2.0 server over stdio that exposes 44 tools (browser,
+   workspace, pane, git, notification, terminal, app status, ports,
+   worktree create, presets, issues) so external agents can drive
    Codemux programmatically.
 2. **MCP host / client** (Step 9) — Codemux's agent-chat runtime
    discovers user-installed MCP servers from every supported
@@ -59,7 +60,13 @@ implementations as the Tauri command layer and CLI. Git tools shell out
 to `git` in the workspace directory. The workspace is resolved from
 `CODEMUX_WORKSPACE_ID` env var.
 
-### Tools (29)
+### Tools (44)
+
+The Phase 1 / 1.5 / 1.6 vexis-agent integration tools (terminal,
+workspace lifecycle, ports, worktree, presets, issues) are now
+checked into the registry. The test guard at
+`mcp_server.rs:1609` pins the count — bump it whenever a tool is
+added or removed.
 
 | Category | Count | Tools |
 |---|---|---|
@@ -67,10 +74,15 @@ to `git` in the workspace directory. The workspace is resolved from
 | Browser — Tier 2: CDP/Vision-based | 5 | `browser_click_at`, `browser_type_at`, `browser_scroll_at`, `browser_key_press`, `browser_drag` |
 | Browser — Tier 3: OS-level Input | 2 | `browser_click_os`, `browser_type_os` |
 | Browser — Info & Evaluation | 3 | `browser_get_styles`, `browser_wait`, `browser_evaluate` |
-| Workspace | 3 | `workspace_list`, `workspace_info`, `workspace_create` |
-| Pane | 3 | `pane_list`, `pane_split_right`, `pane_split_down` |
+| Browser — Viewport | 2 | `browser_viewport`, `browser_viewport_presets` |
+| Workspace | 4 | `workspace_list`, `workspace_info`, `workspace_create`, `workspace_open` (Phase 1), `workspace_close` (Phase 1.6) |
+| Pane | 4 | `pane_list`, `pane_split_right`, `pane_split_down`, `pane_close` (Phase 1.6) |
 | Notification | 1 | `notify` |
 | Git | 5 | `git_status`, `git_diff`, `git_stage`, `git_commit`, `git_push` |
+| Terminal | 2 | `terminal_write`, `terminal_read` (Phase 1) |
+| App / runtime | 2 | `app_status`, `port_list` (Phase 1) |
+| Worktree / presets | 3 | `worktree_create`, `preset_apply`, `preset_list` (Phase 1.5) |
+| Issues | 3 | `issue_list`, `issue_get`, `issue_link_workspace` (Phase 1.6) |
 
 ## Host side: cross-provider MCP runtime (Step 9)
 
@@ -125,7 +137,7 @@ parses the union, discovering servers users have configured anywhere.
 | `~/.cursor/mcp.json` | `CursorUser` | Cursor's format = Anthropic's |
 | `<project>/.cursor/mcp.json` | `CursorProject` |  |
 
-Codemux's own MCP server (the 29-tool one above) is **always-on**: a
+Codemux's own MCP server (the 44-tool one above) is **always-on**: a
 hardcoded entry in `codemux_self_config()` that's pinned to the top of
 the registry and not user-toggleable.
 
@@ -212,7 +224,7 @@ approval-store code; the prefix IS the discriminator.
 Settings → Editor & Workflow → MCP Servers.
 
 - **Codemux row**: pinned to top, "always on" badge, no toggle, shows
-  "Running, 29 tools" once primed.
+  "Running, 44 tools" once primed.
 - **User MCP rows**: grouped by source (`Claude · User`, `Cursor · User`,
   `Codemux · User`, etc.) with inline `Switch` toggles, live status
   badges, and "View tools" hover-reveal that opens
@@ -240,7 +252,7 @@ Settings, so toggling from either place is consistent. A bottom row
 ## What Works Today
 
 - Cross-provider MCP server runtime (Claude-side) — Stage 1–6 of Step 9.
-- Codemux's own MCP server with 29 tools (the original role, unchanged).
+- Codemux's own MCP server with 44 tools (the original role, expanded through the Phase 1 / 1.5 / 1.6 vexis-agent integration steps).
 - Discovery from Codemux / Claude / Cursor config paths with dedupe.
 - Lazy spawn on first chat session start (or Settings panel mount,
   whichever first), bounded await so chat-start isn't slowed by a
@@ -285,7 +297,7 @@ Settings, so toggling from either place is consistent. A bottom row
 
 ### Server side (original role)
 
-- `src-tauri/src/mcp_server.rs` — JSON-RPC server, 29-tool registry,
+- `src-tauri/src/mcp_server.rs` — JSON-RPC server, 44-tool registry,
   `upsert_mcp_config` config writer
 - `src-tauri/src/cli.rs` — `codemux mcp` CLI entry point
 - `src-tauri/src/agent_browser.rs` — DOM snapshot script used by

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -25,20 +25,21 @@ Notifications originate from the Rust backend. Desktop notifications use `notify
 - Notification sound toggle in sidebar footer and settings (Linux uses `paplay` with the freedesktop `complete.oga`; macOS uses `afplay` with Glass.aiff; Windows uses PowerShell SystemSounds)
 - Click-to-focus on Linux: notify-rust `wait_for_action` listens for the libnotify default action and focuses the Codemux window, including a `hyprctl dispatch focuswindow` to jump back to whichever Hyprland workspace the app lives on
 - Global toast notices for errors and status messages (bottom-right)
-- Agent status indicators (red/amber/green dots) in sidebar and tab bar for Claude Code sessions
+- Agent status indicators (red/amber/green dots) in sidebar and tab bar for **Claude Code, Codex, Gemini, OpenCode, and Pi** sessions (the hook server tracks per-adapter status; the idle reminder is filtered so it no longer raises a phantom red dot)
+- **Per-worktree mute**: a right-click → "Mute notifications" action on the sidebar workspace row toggles `notifications_muted` via the `set_workspace_muted` Tauri command. Muted workspaces show a sidebar bell-off icon and skip agent-completion notifications without changing global sound state.
 
 ## Current Constraints
 
 - Sound playback uses system sounds; no in-app ringtone selection or per-volume control yet
-- No notification filtering or per-type muting
 - No notification history beyond current session
 - macOS / Windows click-to-focus relies on platform notification handling rather than an explicit action listener
 
 ## Important Touch Points
 
 - `src-tauri/src/notifications.rs` — desktop notification dispatch, sound playback, click-to-focus action handler
-- `src-tauri/src/hooks.rs` — `handle_lifecycle_event` fires the agent-completion notification when the pane is not in the active workspace (or the window is unfocused)
-- `src-tauri/src/commands/workspace.rs` — `notify_attention()` (MCP-driven attention requests), `set_notification_sound_enabled()`
+- `src-tauri/src/hooks.rs` — `handle_lifecycle_event` fires the agent-completion notification when the pane is not in the active workspace (or the window is unfocused); also filters the per-adapter status set so muted workspaces and Claude idle reminders don't raise the red dot
+- `src-tauri/src/commands/workspace.rs` — `notify_attention()` (MCP-driven attention requests), `set_notification_sound_enabled()`, `set_workspace_muted()`
 - `src/components/ui/status-indicator.tsx` — agent status dots (permission/working/review)
 - `src/components/layout/app-sidebar.tsx` — sidebar notification badges
+- `src/components/layout/sidebar-workspace-row.tsx` — per-worktree mute toggle + bell-off icon
 - `src/tauri/events.ts` — event subscriptions for state changes

--- a/docs/features/remote-hosts.md
+++ b/docs/features/remote-hosts.md
@@ -14,7 +14,7 @@
 | **2c** | Binary | New `[[bin]] codemux-remote` target. Slim CLI with `version` + `pty-daemon --socket` subcommands. Reuses `codemux_lib::pty_daemon::server::run` — same wire protocol as the in-app daemon. |
 | **2d** | SSH transport | `ssh::probe`, `ssh::bootstrap`, `ssh::tunnel` modules. Real `hosts_test_connection` (replaces the 2a stub). `hosts_bootstrap_install` Tauri command + consent modal in the Hosts pane. |
 
-What is **not** in 2d (deferred to a follow-up): the "Push workspace to host" action that actually rsyncs the worktree, spawns the tunnel, and reattaches the UI to the remote daemon. The plumbing for that exists now — `TunnelHandle::local_socket()` returns a path the existing `PtyDaemonClient::connect(&path)` dials unchanged — but wiring it into the workspace push/pull UX is its own UX surface.
+The "Push workspace to host" action that was originally deferred from 2d has since landed (`8c72b44`). The push flow rsyncs the worktree to the host, spawns the remote daemon, attaches the local UI through the SSH-forwarded socket, and synchronizes the **Claude conversation** across local/remote ends. New transport-side modules: `ssh::push`, `ssh::registry`, `ssh::tunnel_supervisor`.
 
 ## DevicePicker (2b)
 
@@ -143,24 +143,25 @@ The pane built in 2a now uses the real probe + bootstrap:
 
 All 22 new tests pass alongside the prior suite (1382 lib tests, 1721 frontend tests, no regressions; one pre-existing env-related lib failure unrelated to this change).
 
-## Follow-ups (not in 2b–2d)
+## Follow-ups (remaining after the push action landed)
 
 | | |
 |---|---|
 | Chat new-session DevicePicker wiring | Drop `<DevicePicker>` into the chat composer's entry surface. ~30 min. |
 | Workspace header badge | Subtle host name pill in workspace title for non-local workspaces. ~1 hour. |
 | Workspace list filter | "This device / All / per-host" dropdown matching superset's `V2WorkspacesHeader`. ~2 hours. |
-| "Push workspace to host" action | rsync + tunnel spawn + reattach UI. The transport is wired; this is the UX flow that strings it together. ~1 day. |
 | "Pull workspace back" action | Reverse of push. ~half day. |
 | Release skill update | Cross-compile + bundling for the four `codemux-remote` targets. Concrete diff in the release pipeline. ~half day. |
-| Auto-reconnect on tunnel drop | Currently the tunnel handle exits when SSH dies. A supervisor that auto-reconnects with backoff (1s→30s, watchdog) is the next layer up. Matches the pattern superset uses in `tunnel-client.ts`. |
+| Tunnel auto-reconnect polish | `ssh::tunnel_supervisor` is in place; tune the backoff (1s→30s, watchdog) and surface the reconnect state in the UI. |
+
+Landed since the original 2b–2d cut: **"Push workspace to host" action** (`8c72b44`) — rsync the worktree, spawn the remote daemon, attach the local UI through the SSH-forwarded socket, and synchronize the Claude conversation across local/remote ends.
 
 ## Important Touch Points
 
 - `src-tauri/src/state/state_impl.rs` — `WorkspaceSnapshot.host_id`, `set_workspace_host_id`.
 - `src-tauri/src/commands/hosts.rs` — `set_workspace_host`, `hosts_test_connection` (real impl), `hosts_bootstrap_install`.
 - `src-tauri/src/bin/codemux_remote.rs` — slim binary entry point.
-- `src-tauri/src/ssh/probe.rs` / `bootstrap.rs` / `tunnel.rs` — SSH transport.
+- `src-tauri/src/ssh/probe.rs` / `bootstrap.rs` / `tunnel.rs` / `tunnel_supervisor.rs` / `push.rs` / `registry.rs` — SSH transport (push action + reconnect supervisor landed after 2d).
 - `src/components/hosts/device-picker.tsx` — shared pill component.
 - `src/components/overlays/new-workspace-dialog.tsx` — DevicePicker wired into bottom bar.
 - `src/components/settings/hosts-section.tsx` — uses real probe + bootstrap modal.

--- a/docs/plans/automations-sync.md
+++ b/docs/plans/automations-sync.md
@@ -40,9 +40,15 @@ is a **registry only** (no cloud scheduler); each host runs its own
 - 43 Rust unit tests + 16 server tests; `cargo check` / `tsc` /
   `vitest` green.
 
-Still open: **Phase F** (workspace lifecycle). One hardening note: the
-host scheduler currently uses a copy of the desktop's account token; a
-per-host scoped token would be a better blast-radius limit.
+Still open: **Phase F** — the GitHub-backbone repo transport. This is
+the last load-bearing piece for remote-host automations: a remote host
+has no copy of the project repo until F is built (D/E ship the
+scheduler and service, but not the repo). "This machine" automations
+do not need F and already work end-to-end.
+
+One hardening note: the host scheduler currently uses a copy of the
+desktop's account token; a per-host scoped token would be a better
+blast-radius limit.
 
 ## Prerequisite refactor — de-couple the executor from Tauri
 
@@ -167,25 +173,94 @@ Extend `ssh/bootstrap.rs` (`bootstrap_remote`, `bootstrap.rs:220-289`).
    to a `nohup` + manual note. Gate behind a consent prompt like the
    existing remote-binary install.
 
-## Phase F — Workspace lifecycle (later)
+## Phase F — Remote-host projects: the GitHub backbone
 
-Lower priority; lets a user view an automation's workspace locally
-without killing the automation.
+This phase makes a remote-host automation actually able to run — Phases
+D/E deliver the scheduler and service, but the host still has no copy of
+the project repo. It also corrects an earlier design dead-end.
 
-- `workspace_sync_from_host`: reuse `build_pull_rsync_argv` (`push.rs`)
-  **without `--delete`** and **without** clearing `host_id` — a
-  non-destructive mirror (research §6).
-- Add an `automation_id` column to workspaces; guard
-  `workspace_pull_back` to reject automation-owned workspaces at its top
-  (`hosts.rs:653`, before the `host_id` unwrap) so an MCP caller cannot
-  pull a running automation out from under itself.
-- A dedicated automation icon on these workspaces.
+### Design correction (supersedes earlier thinking)
+
+An earlier draft proposed seeding the host's repo by **rsyncing or
+`git push`-ing the project over the desktop↔host SSH link**, to avoid
+needing git credentials on the host. That is dropped. Reasoning:
+
+- The automations worth running — triage PRs, label issues, fix an
+  issue, weekly dependency bumps — all need the **agent** to read and
+  write GitHub at runtime (`gh issue list`, comment, push a branch,
+  `gh pr create`). So the host needs working git + `gh` credentials
+  **regardless** of how the repo arrived.
+- Given that, "the host clones the repo from its git remote" costs no
+  extra credential. The SSH-transport machinery solved a problem that
+  does not exist for the real use cases, while adding a bespoke
+  two-working-copies sync path. Dropped.
+- This also matches Superset: its host-service clones from
+  `repoCloneUrl` with the host's own git credentials and never injects
+  a token (`host-service/.../resolve-repo.ts:278-315`). Superset's
+  cloud GitHub App is for cloud PR-sync only and never reaches the
+  host or the agent.
+
+### The model
+
+GitHub (or any git remote) is the backbone. Both directions go through
+it; the host and the desktop are independent clones.
+
+1. **Project → remote URL.** A Codemux project is a local repo. At
+   automation-create time, resolve its remote with
+   `git -C <project> remote get-url origin` and store it on the
+   automation (a new `project_remote` column alongside `project_path`).
+   A project with no remote can only target **This machine**.
+2. **Host clone.** The `codemux-remote scheduler`, the first time it
+   needs a project, runs `git clone <project_remote>` into a host-local
+   path (e.g. `~/.codemux/automation-repos/<slug>`). Auth is the host's
+   own git credentials (SSH key / credential helper / `gh`) — Codemux
+   injects no token. Later runs `git fetch` and branch off fresh
+   `origin/<default>` (Superset's "locals are often stale" fix).
+3. **Host GitHub credentials = the host's own.** The agent inherits the
+   host shell's `git` + `gh` auth. Codemux does not build or manage a
+   GitHub App for the host side. Host prerequisites to document: `git`
+   with `user.name`/`user.email` set, git credentials/SSH for the
+   remote, and an authenticated `gh` for any issue/PR work.
+4. **Results travel as branches.** The agent commits to
+   `automation-<slug>-<timestamp>` and pushes it (and may `gh pr
+   create`). To bring a run home, the **desktop** `git fetch`es that
+   branch from the remote — the dev machine already has remote access —
+   and Codemux materialises it as a workspace in the project. No
+   rsync, no SSH mirror, no merge-on-pull: it is just a branch landing
+   next to the user's work, integrated on their terms.
+
+### What to build
+
+- **`project_remote` on `automations`** (local schema + the API table +
+  the sync wire format). Resolve it in `commands::automations` at
+  create/update from the chosen project.
+- **Host clone/fetch** in `automations::executor` (or a sibling): given
+  `project_remote`, ensure a host-local clone exists, `git fetch`, then
+  the existing worktree-create branches off `origin/<default>`. On the
+  desktop / "This machine" this step is a no-op — the repo is `project_path`.
+- **Preflight check** — the genuine improvement over Superset, which has
+  none. When a remote-host automation is created (and as part of
+  `hosts_test_connection`), probe the host over SSH for: `git` present +
+  identity configured; `gh` present + `gh auth status` OK; the
+  `project_remote` reachable. Surface a clear, actionable warning at
+  setup time ("This host can't reach `<repo>` — run `gh auth login` on
+  it, or add a deploy key"). Inform, do not hard-block: a local-only
+  automation can still run. Extends the existing `GhStatus` check.
+- **Run → branch/PR linkage** — add `branch` and `pr_url` to
+  `automation_runs`; the executor records the branch, and the agent's
+  `gh pr create` (if any) is captured. The Automations run-history list
+  then reads like a PR list. Superset has neither column — this is ours.
+- **"Pull this run home"** action on a run row — desktop-side
+  `git fetch` of the run's branch + materialise a workspace.
 
 ## Suggested sequencing
 
-A (reconciler) → B (API, server-side, can run in parallel) → C (client
-sync) → D (remote scheduler) → E (bootstrap). F any time after D.
-A is independent and worth landing on its own.
+A (reconciler) → B (API) → C (client sync) → D (remote scheduler) →
+E (bootstrap) → **F (GitHub backbone)**. A is independent. Note that
+**D + E without F cannot run a remote-host automation usefully** — the
+host has no repo until F — so F is not optional polish; it is the last
+load-bearing piece of the remote-host story. "This machine" automations
+need none of D/E/F and already work.
 
 ## Open questions
 
@@ -196,9 +271,16 @@ A is independent and worth landing on its own.
   automation) and/or prune server-side after N days.
 - Non-systemd / non-launchd hosts — is a `nohup` fallback acceptable for
   v1, or require systemd/launchd?
-- Does the remote scheduler need the desktop online at all? No — once
-  bootstrapped it polls the API directly. Confirm the token works
-  without an active SSH tunnel.
+- Should the executor append a standard "commit, push the branch, open
+  a PR" instruction to the agent prompt, or leave push/PR entirely to
+  the user's prompt (as Superset does)? Leaning: leave it to the prompt
+  for v1, but always record whatever branch/PR results.
+- Private-repo auth on the host — deploy key vs. fine-grained PAT vs.
+  the user's `gh` token. Codemux should not store these; the preflight
+  check just verifies one of them works.
+- A project with no git remote — confine it to "This machine", or also
+  allow a no-remote SSH-rsync fallback later? Leaning: This-machine-only
+  for now.
 
 ## Likely touch points
 
@@ -211,3 +293,7 @@ A is independent and worth landing on its own.
 - `src-tauri/src/ssh/bootstrap.rs` — token + service registration
 - `src-tauri/src/lib.rs` — startup reconcile, host-id routing
 - API repo — `/api/automations*` endpoints + scheduler-token
+- Phase F: `automations/executor.rs` — host clone/fetch before worktree;
+  `commands/automations.rs` — resolve `project_remote`; `commands/hosts.rs`
+  — GitHub-access preflight in `hosts_test_connection`; `database.rs` +
+  the API `automations` table — `project_remote`, run `branch` / `pr_url`

--- a/docs/plans/automations-sync.md
+++ b/docs/plans/automations-sync.md
@@ -1,0 +1,194 @@
+# Plan: Automations — Account Sync & Remote-Host Execution (Phase 2)
+
+- Purpose: Detailed implementation plan for the second phase of
+  Automations — account sync and running automations on remote hosts.
+- Audience: Whoever implements this phase.
+- Authority: Active work plan only, not current truth.
+- Update when: Steps, sequencing, or open questions change.
+- Read next: `docs/features/automations.md`, `docs/plans/automations.md`,
+  `docs/research/superset-automations.md`
+
+## Goal
+
+Phase 1 shipped a working local Automations feature (data model,
+recurrence, scheduler, executor, control surface, UI — all on one
+machine). Phase 2 makes it account-bound and multi-host:
+
+- Automations and their run history sync through the Codemux API so
+  every signed-in device sees the same list.
+- A `codemux-remote scheduler` service runs an automation on a chosen
+  remote host (always-on VPS / home server), not just the desktop.
+- The desktop and each remote host run only the automations routed to
+  them.
+
+The architecture is unchanged from `docs/plans/automations.md`: the API
+is a **registry only** (no cloud scheduler); each host runs its own
+`scheduler::tick` + `executor`.
+
+## Prerequisite refactor — de-couple the executor from Tauri
+
+`automations::executor::execute_run` currently takes a `tauri::AppHandle`
+and reaches the DB through `with_db(handle, …)`. The remote binary has no
+Tauri. Before Phase 2 work:
+
+- Split the executor so its core takes `&DatabaseStore` directly:
+  `execute_run(db: &DatabaseStore, automation, run)`. The desktop
+  scheduler task in `lib.rs` acquires the `State` and calls it; the
+  `codemux-remote scheduler` loop passes its own `DatabaseStore`.
+- This keeps `automations::executor` Tauri-free, matching `recurrence`
+  and `scheduler`.
+
+## Phase A — Stuck-run reconciler (standalone, do first)
+
+Smallest, highest-confidence piece; no API dependency. A run left
+`running` by an app/host crash keeps its automation permanently
+`skipped_busy` (the overlap guard in `scheduler::has_active_run` counts
+`running`).
+
+1. Add `DatabaseStore::reconcile_stale_runs(older_than: &str) -> usize`
+   in `database.rs`: `UPDATE automation_runs SET status='failed',
+   finished_at=datetime('now'), error='Run did not complete (process or
+   app exited)' WHERE status IN ('scheduled','running') AND started_at <
+   ?1` (and a `created_at` fallback for rows never started).
+2. Call it once at scheduler startup — in the `lib.rs` background task
+   before the first tick, and in the `codemux-remote scheduler` startup
+   (Phase D) — with a generous ceiling (e.g. now − 6h).
+3. Unit-test against an in-memory DB: a `running` row with an old
+   `started_at` flips to `failed`; a fresh one is untouched.
+
+## Phase B — API server: schema + endpoints
+
+Server-side, in the API repo (`codemux-api-infrastructure` skill, the
+VPS). Mirrors the existing `/api/hosts` convention.
+
+1. **Tables** (Postgres): `automations` and `automation_runs`, columns
+   matching the SQLite schema (`database.rs:227-310`), keyed by
+   `user_id`. `automations` is the registry; `automation_runs` is
+   append-only history.
+2. **Endpoints**, all bearer-auth, scoped to the authenticated user
+   (single-owner, like Superset — see research §7):
+   - `GET /api/automations` → `{ automations: [...] }`
+   - `POST /api/automations` → `{ automation }`
+   - `PATCH /api/automations/:serverId`
+   - `DELETE /api/automations/:serverId`
+   - `GET /api/automations/:serverId/runs` → `{ runs: [...] }`
+   - `POST /api/automations/:serverId/runs` → `{ run }` (append)
+3. **Scheduler-token issuance**: `POST /api/hosts/:serverId/scheduler-token`
+   → a short-lived-ish, host-scoped token the remote uses to pull its
+   automations and push runs. Scoped to that host only — never the
+   user's session token (research §7 confirms this shape).
+4. Until these are deployed the client treats `404` as a harmless skip,
+   exactly as `hosts_sync` already does (`hosts_sync.rs:133`) — so the
+   client half of Phase C can land and lie dormant.
+
+## Phase C — `automations_sync.rs` (client sync)
+
+Model on `hosts_sync.rs` (the `automations` table already carries the
+identical `server_id` / `deleted_at` / `dirty` columns + partial index —
+`database.rs:227-253` — so **no migration**). Borrow the `api_client`
+split from `skills_sync` to keep HTTP isolated.
+
+1. **DB helpers** in `database.rs` (deferred from Phase 1 — add now):
+   `list_dirty_automations`, `mark_automation_synced(id, server_id)`,
+   `upsert_automation_from_server(...)`, `purge_acknowledged_automation_
+   deletes`, and for runs `list_unsynced_runs` / `mark_run_synced` /
+   `upsert_run_from_server`.
+2. **`src-tauri/src/automations_sync.rs`**: `pull` / `push` /
+   `try_sync_with_app(app)`, mirroring `hosts_sync.rs:76-313`. Auth via
+   `auth::api_base_url()` + `Bearer` from `load_token(db)`. Pull does the
+   server-side deletion sweep (`hosts_sync.rs:163-184`). Runs are
+   append-only — push on creation, pull-only, no conflict logic.
+3. **Trigger**: `schedule_background_sync(app)` fire-and-forget after
+   every mutation in `commands/automations.rs` (the pattern in
+   `commands/hosts.rs:847-853`), plus a pull on foreground. Guard
+   concurrent runs with a `static AtomicBool` (`hosts_sync.rs:71`).
+4. **Optional**: a `SyncEngine`-style state (`skills_sync/mod.rs:72`)
+   for a real sync indicator in the Automations view, instead of the
+   bare per-row `dirty` dot.
+
+## Phase D — `codemux-remote scheduler` subcommand + host routing
+
+1. **Subcommand**: add `Scheduler { … }` to the clap `enum Command` in
+   `bin/codemux_remote.rs:62-76` (Unix-only, like the rest of the file).
+2. **The loop**: open the remote's local DB (`database::init_database()`),
+   then every `scheduler::TICK_INTERVAL_SECS`:
+   a. pull this host's automations from the API into the local DB
+      (host-scoped token from Phase E);
+   b. `scheduler::tick(&db, now)`;
+   c. for each fired run, `executor::execute_run(&db, …)` (the
+      Tauri-free core from the prerequisite refactor);
+   d. push new/updated run rows back to the API.
+   Run the Phase A reconciler once at startup.
+3. **Host routing**: the desktop scheduler task should execute only
+   `host_id == None` automations; a host's scheduler executes only the
+   automations whose `host_id` resolves to itself. Add a host-id filter
+   parameter to `scheduler::tick` (or filter its input). The remote
+   learns its own identity from the bootstrap-written host id (Phase E).
+4. The remote host must have the agent CLIs (`claude` / `codex`)
+   installed and authenticated — document this as a host prerequisite;
+   a missing binary surfaces as a `failed` run with a clear error
+   (already handled by `executor::run_inner`).
+
+## Phase E — Bootstrap: token + persistent service
+
+Extend `ssh/bootstrap.rs` (`bootstrap_remote`, `bootstrap.rs:220-289`).
+
+1. **Token file**: after the `chmod +x` step (`bootstrap.rs:273`), call
+   the Phase B token endpoint and write the result to
+   `~/.local/share/codemux/scheduler-token` on the host via
+   `ssh … 'umask 077; cat > …'`. Write the host's server id alongside it
+   so the scheduler knows which automations are its own.
+2. **Persistent service** (greenfield — research §5 confirms no existing
+   service code): write a systemd **user** unit
+   `~/.config/systemd/user/codemux-scheduler.service` invoking the
+   absolute `~/.local/bin/codemux-remote scheduler`, then
+   `systemctl --user enable --now codemux-scheduler`. Use the same
+   absolute-path discipline as the tunnel (`hosts.rs:429-440`). For
+   macOS hosts, a `launchd` plist; for hosts without either, fall back
+   to a `nohup` + manual note. Gate behind a consent prompt like the
+   existing remote-binary install.
+
+## Phase F — Workspace lifecycle (later)
+
+Lower priority; lets a user view an automation's workspace locally
+without killing the automation.
+
+- `workspace_sync_from_host`: reuse `build_pull_rsync_argv` (`push.rs`)
+  **without `--delete`** and **without** clearing `host_id` — a
+  non-destructive mirror (research §6).
+- Add an `automation_id` column to workspaces; guard
+  `workspace_pull_back` to reject automation-owned workspaces at its top
+  (`hosts.rs:653`, before the `host_id` unwrap) so an MCP caller cannot
+  pull a running automation out from under itself.
+- A dedicated automation icon on these workspaces.
+
+## Suggested sequencing
+
+A (reconciler) → B (API, server-side, can run in parallel) → C (client
+sync) → D (remote scheduler) → E (bootstrap). F any time after D.
+A is independent and worth landing on its own.
+
+## Open questions
+
+- Scheduler-token lifetime and rotation — fixed long-lived per-host, or
+  refreshed? Leaning long-lived, revoked when the host is removed.
+- `automation_runs` volume — append-only history syncing every run for
+  every device could grow. Cap the pull window (e.g. last 100 per
+  automation) and/or prune server-side after N days.
+- Non-systemd / non-launchd hosts — is a `nohup` fallback acceptable for
+  v1, or require systemd/launchd?
+- Does the remote scheduler need the desktop online at all? No — once
+  bootstrapped it polls the API directly. Confirm the token works
+  without an active SSH tunnel.
+
+## Likely touch points
+
+- `src-tauri/src/automations/executor.rs` — Tauri-free core refactor
+- `src-tauri/src/automations/scheduler.rs` — host-id routing filter
+- `src-tauri/src/database.rs` — sync helpers, `reconcile_stale_runs`
+- `src-tauri/src/automations_sync.rs` — new sync module
+- `src-tauri/src/commands/automations.rs` — `schedule_background_sync`
+- `src-tauri/src/bin/codemux_remote.rs` — `Scheduler` subcommand
+- `src-tauri/src/ssh/bootstrap.rs` — token + service registration
+- `src-tauri/src/lib.rs` — startup reconcile, host-id routing
+- API repo — `/api/automations*` endpoints + scheduler-token

--- a/docs/plans/automations-sync.md
+++ b/docs/plans/automations-sync.md
@@ -27,24 +27,24 @@ is a **registry only** (no cloud scheduler); each host runs its own
 
 ## Status
 
-**Phases A–E are done.** Landed on this branch and verified:
+**Phases A–F are done.** The feature works end-to-end. Landed on this
+branch and verified:
 
 - Prerequisite refactor, Phase A (reconciler), Phase C
   (`automations_sync`), Phase D (host routing + `codemux-remote
   scheduler`), Phase E (`automations::service` + the
   `provision_scheduler` bootstrap wiring).
 - **Phase B is deployed to production** — `/api/automations` GET / POST
-  / PATCH / DELETE (+ `?hostServerId=` filter) on `api.codemux.org`,
-  backed by the `codemux_automations` table. 16 server tests; verified
-  end-to-end against the live API (signup → token → automation CRUD).
-- 43 Rust unit tests + 16 server tests; `cargo check` / `tsc` /
-  `vitest` green.
-
-Still open: **Phase F** — the GitHub-backbone repo transport. This is
-the last load-bearing piece for remote-host automations: a remote host
-has no copy of the project repo until F is built (D/E ship the
-scheduler and service, but not the repo). "This machine" automations
-do not need F and already work end-to-end.
+  / PATCH / DELETE (+ `?hostServerId=` filter, + `project_remote`) on
+  `api.codemux.org`, backed by the `codemux_automations` table.
+- **Phase F — the GitHub backbone — is built.** Each automation carries
+  the project's git remote URL; the executor's `resolve_repo` uses the
+  local path when present and otherwise clones / fetches the remote
+  (`~/.codemux/automation-repos/`), branching off `origin/<default>`.
+  Runs record their branch + PR URL. "Test connection" probes the
+  host's `git` / `gh` (the preflight).
+- 1471 Rust unit tests + 263 server tests; verified end-to-end against
+  the live API (`project_remote` round-trip). `tsc` / `vitest` green.
 
 One hardening note: the host scheduler currently uses a copy of the
 desktop's account token; a per-host scoped token would be a better

--- a/docs/plans/automations-sync.md
+++ b/docs/plans/automations-sync.md
@@ -41,8 +41,12 @@ branch and verified:
   the project's git remote URL; the executor's `resolve_repo` uses the
   local path when present and otherwise clones / fetches the remote
   (`~/.codemux/automation-repos/`), branching off `origin/<default>`.
-  Runs record their branch + PR URL. "Test connection" probes the
-  host's `git` / `gh` (the preflight).
+  Runs record their branch + PR URL.
+- **Preflight.** "Test connection" probes the host's `git` / `gh`; the
+  New Automation form runs a per-repo `git ls-remote` over SSH so a host
+  that can't reach *this* repository is flagged at setup (non-blocking,
+  with "Check again"). The automation list shows a per-row health dot
+  from the last run's status; a fixed host self-heals on the next run.
 - 1471 Rust unit tests + 263 server tests; verified end-to-end against
   the live API (`project_remote` round-trip). `tsc` / `vitest` green.
 

--- a/docs/plans/automations-sync.md
+++ b/docs/plans/automations-sync.md
@@ -25,6 +25,19 @@ The architecture is unchanged from `docs/plans/automations.md`: the API
 is a **registry only** (no cloud scheduler); each host runs its own
 `scheduler::tick` + `executor`.
 
+## Status
+
+Landed on this branch: the **Prerequisite refactor**, **Phase A**
+(reconciler), **Phase C** (`automations_sync`), **Phase D** (host
+routing + `codemux-remote scheduler` subcommand), and the testable part
+of **Phase E** (`automations::service` unit generators). All verified —
+43 automation unit tests, `cargo check` / `tsc` / `vitest` green.
+
+Still open: **Phase B** (the API server endpoints — a separate repo, not
+deployable from this branch); the **Phase E bootstrap wiring** (token
+provisioning + service registration, which needs Phase B's token
+endpoint and a real host); and **Phase F** (workspace lifecycle).
+
 ## Prerequisite refactor — de-couple the executor from Tauri
 
 `automations::executor::execute_run` currently takes a `tauri::AppHandle`

--- a/docs/plans/automations-sync.md
+++ b/docs/plans/automations-sync.md
@@ -27,16 +27,22 @@ is a **registry only** (no cloud scheduler); each host runs its own
 
 ## Status
 
-Landed on this branch: the **Prerequisite refactor**, **Phase A**
-(reconciler), **Phase C** (`automations_sync`), **Phase D** (host
-routing + `codemux-remote scheduler` subcommand), and the testable part
-of **Phase E** (`automations::service` unit generators). All verified —
-43 automation unit tests, `cargo check` / `tsc` / `vitest` green.
+**Phases A–E are done.** Landed on this branch and verified:
 
-Still open: **Phase B** (the API server endpoints — a separate repo, not
-deployable from this branch); the **Phase E bootstrap wiring** (token
-provisioning + service registration, which needs Phase B's token
-endpoint and a real host); and **Phase F** (workspace lifecycle).
+- Prerequisite refactor, Phase A (reconciler), Phase C
+  (`automations_sync`), Phase D (host routing + `codemux-remote
+  scheduler`), Phase E (`automations::service` + the
+  `provision_scheduler` bootstrap wiring).
+- **Phase B is deployed to production** — `/api/automations` GET / POST
+  / PATCH / DELETE (+ `?hostServerId=` filter) on `api.codemux.org`,
+  backed by the `codemux_automations` table. 16 server tests; verified
+  end-to-end against the live API (signup → token → automation CRUD).
+- 43 Rust unit tests + 16 server tests; `cargo check` / `tsc` /
+  `vitest` green.
+
+Still open: **Phase F** (workspace lifecycle). One hardening note: the
+host scheduler currently uses a copy of the desktop's account token; a
+per-host scoped token would be a better blast-radius limit.
 
 ## Prerequisite refactor — de-couple the executor from Tauri
 

--- a/docs/plans/automations.md
+++ b/docs/plans/automations.md
@@ -32,25 +32,21 @@ The host scheduler owns the agent session, so `succeeded`/`failed` are real term
 
 ## Active Priorities
 
-Phase 2 (account sync + remote-host execution) is **done and deployed** —
-the `/api/automations` endpoints are live on `api.codemux.org`, the
-desktop syncs against them, and host bootstrap provisions the remote
-scheduler. See `docs/plans/automations-sync.md`. What remains:
+Phase 2 (account sync + remote-host execution) is **done and deployed**,
+including the Phase F GitHub-backbone repo transport — the
+`/api/automations` endpoints are live on `api.codemux.org`, the desktop
+syncs against them, host bootstrap provisions the remote scheduler, and
+a remote host obtains the repo by cloning the project's git remote. See
+`docs/plans/automations-sync.md`. What remains is hardening and polish:
 
-1. **Remote-host repo transport (the GitHub backbone).** A remote host
-   has no copy of the project repo yet — the last load-bearing piece of
-   remote-host automations. The host clones the project's git remote
-   with its own credentials; runs produce branches; a setup-time
-   GitHub-access preflight check warns if the host can't reach the repo.
-   Fully specced as Phase F in `docs/plans/automations-sync.md`.
-   ("This machine" automations need none of this and already work.)
-2. **Scoped scheduler tokens.** The host scheduler currently uses a copy
+1. **Scoped scheduler tokens.** The host scheduler currently uses a copy
    of the desktop's account token; a per-host scoped token would limit
    blast radius if a host is compromised.
-3. **Polish.** A one-shot `automation_run` MCP tool; the
+2. **Polish.** A one-shot `automation_run` MCP tool; the
    `retention_limit` worktree prune; run completion/failure piped into
    the notification system (`docs/features/notifications.md`); a
-   dedicated automation workspace icon.
+   dedicated automation workspace icon; the desktop "pull this run's
+   branch home" action.
 
 ## Open Questions
 

--- a/docs/plans/automations.md
+++ b/docs/plans/automations.md
@@ -32,35 +32,27 @@ The host scheduler owns the agent session, so `succeeded`/`failed` are real term
 
 ## Active Priorities
 
-The feature works end-to-end on the local machine: define → schedule →
-tick → fire → worktree → agent run → terminal status → UI. Remaining
-work, in dependency order — items 1–5 are the "account sync + remote
-host" phase, broken down step-by-step in `docs/plans/automations-sync.md`:
+The feature works end-to-end on the local machine, and the Phase 2
+client work (sync, host routing, the remote scheduler, the reconciler)
+has landed — see *Already Landed*. What remains:
 
-1. **Stuck-run reconciler.** A run left `running` by an app quit keeps
-   its automation `skipped_busy` forever. Add a startup sweep that fails
-   runs whose `started_at` is older than a generous ceiling.
-2. **API schema + endpoints.** `automations` / `automation_runs` tables
-   on the API server; REST CRUD; per-host scoped-token issuance wired
-   into host bootstrap. Ownership checks (single-owner).
-3. **Account sync.** `automations_sync.rs` mirrored on `hosts_sync.rs`,
-   pushing the `dirty` rows the local schema already tracks. Background
-   sync after each mutation, like `commands::hosts`.
-4. **`codemux-remote scheduler` subcommand + host routing.** The same
-   `scheduler::tick` + `executor` as a persistent service on a remote
-   host; the desktop then runs only `host_id`-null automations and lets
-   the remote handle the rest. Blocked on account sync — a remote host
-   has no automations until sync delivers them.
-5. **Bootstrap changes.** `hosts_bootstrap_install` writes the scoped
-   token and registers the scheduler as a persistent service (systemd).
-6. **Workspace lifecycle commands.** New `workspace_sync_from_host`
-   (non-destructive mirror, reuses `ssh/push.rs` rsync helpers); an
-   `automation_id` column on workspaces; guard `workspace_pull_back` to
-   reject automation workspaces.
-7. **Polish.** A one-shot `automation_run` MCP tool; the
-   `retention_limit` worktree prune; wire run completion/failure into
-   the notification system (`docs/features/notifications.md`); dedicated
-   automation workspace icon; optional prompt version history.
+1. **API server endpoints.** `automations` / `automation_runs` tables
+   and `/api/automations*` REST endpoints, plus the per-host
+   scheduler-token endpoint, on the API server (separate repo). The
+   desktop sync client is finished and degrades gracefully (`404` =
+   skip) until these deploy.
+2. **Host bootstrap wiring.** `hosts_bootstrap_install` writes the
+   scheduler token and registers the `codemux-remote scheduler` service
+   (`automations::service` generates the units). Needs item 1 for the
+   token endpoint.
+3. **Workspace lifecycle.** `workspace_sync_from_host` (non-destructive
+   mirror), an `automation_id` column on workspaces, and a
+   `workspace_pull_back` guard for automation workspaces — Phase F in
+   `docs/plans/automations-sync.md`.
+4. **Polish.** A one-shot `automation_run` MCP tool; the
+   `retention_limit` worktree prune; run completion/failure piped into
+   the notification system (`docs/features/notifications.md`); a
+   dedicated automation workspace icon.
 
 ## Open Questions
 
@@ -112,11 +104,27 @@ Automations feature — local foundation, scheduler, and UI (this branch):
 - **Automations view** — a full-screen view opened from the left sidebar
   (under "New agent", above projects): create / edit / pause / resume /
   delete with a schedule builder and run-history view; a fire-event toast.
-- **Tests** — 35 unit tests (recurrence, scheduler decision + tick loop,
-  executor incl. worktree creation against a real temp repo, database
-  CRUD / dedup / run lifecycle) plus the existing frontend suite;
-  `cargo check` / `tsc` / `vitest` all green, apart from one pre-existing
-  unrelated `agent_browser` env test.
+- **Automations view** + sidebar entry (Phase 1).
+
+Phase 2 — account sync + remote-host execution (this branch):
+
+- **Stuck-run reconciler** — `reconcile_stale_runs`, run at every
+  scheduler startup.
+- **Account sync** — `automations_sync` (pull / push, host-identity
+  translation), wired into every mutation + the scheduler loop.
+- **Host routing** — `scheduler::tick`'s `local_only` switch.
+- **`codemux-remote scheduler`** — the remote-binary subcommand running
+  the reconcile + pull + tick + execute loop.
+- **Service units** — `automations::service` (systemd / launchd).
+- **Executor refactor** — `run_fire` / `apply_outcome` are Tauri-free so
+  the desktop and the remote share one code path.
+- **Tests** — 43 unit tests; `cargo check` / `tsc` / `vitest` all green,
+  apart from one pre-existing unrelated `agent_browser` env test.
+
+What is still open (see `docs/plans/automations-sync.md`): the
+`/api/automations` server endpoints (separate API repo); the host
+bootstrap writing a scheduler token + registering the service; and
+Phase F (workspace lifecycle).
 
 Pre-existing platform Automations builds on:
 

--- a/docs/plans/automations.md
+++ b/docs/plans/automations.md
@@ -32,24 +32,19 @@ The host scheduler owns the agent session, so `succeeded`/`failed` are real term
 
 ## Active Priorities
 
-The feature works end-to-end on the local machine, and the Phase 2
-client work (sync, host routing, the remote scheduler, the reconciler)
-has landed — see *Already Landed*. What remains:
+Phase 2 (account sync + remote-host execution) is **done and deployed** —
+the `/api/automations` endpoints are live on `api.codemux.org`, the
+desktop syncs against them, and host bootstrap provisions the remote
+scheduler. See `docs/plans/automations-sync.md`. What remains:
 
-1. **API server endpoints.** `automations` / `automation_runs` tables
-   and `/api/automations*` REST endpoints, plus the per-host
-   scheduler-token endpoint, on the API server (separate repo). The
-   desktop sync client is finished and degrades gracefully (`404` =
-   skip) until these deploy.
-2. **Host bootstrap wiring.** `hosts_bootstrap_install` writes the
-   scheduler token and registers the `codemux-remote scheduler` service
-   (`automations::service` generates the units). Needs item 1 for the
-   token endpoint.
-3. **Workspace lifecycle.** `workspace_sync_from_host` (non-destructive
+1. **Workspace lifecycle.** `workspace_sync_from_host` (non-destructive
    mirror), an `automation_id` column on workspaces, and a
    `workspace_pull_back` guard for automation workspaces — Phase F in
    `docs/plans/automations-sync.md`.
-4. **Polish.** A one-shot `automation_run` MCP tool; the
+2. **Scoped scheduler tokens.** The host scheduler currently uses a copy
+   of the desktop's account token; a per-host scoped token would limit
+   blast radius if a host is compromised.
+3. **Polish.** A one-shot `automation_run` MCP tool; the
    `retention_limit` worktree prune; run completion/failure piped into
    the notification system (`docs/features/notifications.md`); a
    dedicated automation workspace icon.

--- a/docs/plans/automations.md
+++ b/docs/plans/automations.md
@@ -18,8 +18,8 @@ Let a user define an Automation — a named prompt + agent + recurrence — that
 - **Edit propagation:** the remote binary polls the API. Auth is a per-host scoped token provisioned during the existing `hosts_bootstrap_install` flow. Edits made from any device (or via MCP) reach the host without the desktop needing to be online.
 - **Fire flow:** the scheduler creates a fresh workspace + worktree itself (deterministic, same code path as `workspace_push_to_host`), branch `slug-<timestamp>` off the project default branch, then spawns the chosen agent inside it with the prompt. The agent does not self-create the workspace via MCP — workspace creation is infrastructure.
 - **Offline:** host off → no tick → a `skipped_offline` run row is written on next boot. No cloud worker needed.
-- **Sidebar:** automation run-workspaces never auto-appear in the main project sidebar. They render only in the Automations panel. A sidebar entry appears only when the user explicitly syncs one in (mirrors how Superset gates the sidebar on per-device local state).
-- **Sync vs pull:** new `workspace_sync_from_host` action — a non-destructive host→local mirror; host stays canonical, `host_id` unchanged, automation keeps running. `workspace_pull_back` is hard-blocked for automation workspaces (UI hidden + command rejects, so an MCP caller cannot kill an automation either).
+- **Sidebar:** automation run-workspaces never auto-appear in the main project sidebar. They render only in the Automations panel. A sidebar entry appears only when the user explicitly brings one in.
+- **Remote-host repo transport:** GitHub (or any git remote) is the backbone — the host clones the project's remote with its own git credentials; runs produce branches the agent pushes; the desktop `git fetch`es a run's branch to bring it home. Detailed in `docs/plans/automations-sync.md` Phase F. (An earlier rsync/SSH-mirror idea was dropped — see that doc's "Design correction".)
 - **MCP:** full CRUD + run — 11 tools, mirroring Superset's surface.
 - **Run model:** fresh workspace per fire.
 - **Retention:** keep the last 10 *completed* run-workspaces per automation on the host (plus any currently-running one); auto-prune older worktrees. Never prune a run the user has synced locally. `automation_runs` log rows are kept regardless — history survives worktree pruning.
@@ -37,10 +37,13 @@ the `/api/automations` endpoints are live on `api.codemux.org`, the
 desktop syncs against them, and host bootstrap provisions the remote
 scheduler. See `docs/plans/automations-sync.md`. What remains:
 
-1. **Workspace lifecycle.** `workspace_sync_from_host` (non-destructive
-   mirror), an `automation_id` column on workspaces, and a
-   `workspace_pull_back` guard for automation workspaces — Phase F in
-   `docs/plans/automations-sync.md`.
+1. **Remote-host repo transport (the GitHub backbone).** A remote host
+   has no copy of the project repo yet — the last load-bearing piece of
+   remote-host automations. The host clones the project's git remote
+   with its own credentials; runs produce branches; a setup-time
+   GitHub-access preflight check warns if the host can't reach the repo.
+   Fully specced as Phase F in `docs/plans/automations-sync.md`.
+   ("This machine" automations need none of this and already work.)
 2. **Scoped scheduler tokens.** The host scheduler currently uses a copy
    of the desktop's account token; a per-host scoped token would limit
    blast radius if a host is compromised.
@@ -65,8 +68,8 @@ Implementation-time detail still to settle: token leak/rotation handling within 
 
 - `src-tauri/src/bin/codemux_remote.rs` — add the `scheduler` subcommand
 - `src-tauri/src/ssh/bootstrap.rs` — provision scoped token, register persistent service
-- `src-tauri/src/ssh/push.rs` — reuse rsync helpers for `workspace_sync_from_host`
-- `src-tauri/src/commands/hosts.rs` — `workspace_push_to_host`, `workspace_pull_back` (add guard), new `workspace_sync_from_host`
+- `src-tauri/src/automations/executor.rs` — host clone/fetch of the project remote before the worktree create (Phase F)
+- `src-tauri/src/commands/hosts.rs` — GitHub-access preflight in `hosts_test_connection` (Phase F)
 - `src-tauri/src/hosts_sync.rs` — pattern to mirror as new `src-tauri/src/automations_sync.rs`
 - `src-tauri/src/database.rs` — new `automations` / `automation_runs` tables, `automation_id` on workspaces
 - `src-tauri/src/mcp_server.rs` — register the 11 automation tools
@@ -116,10 +119,12 @@ Phase 2 — account sync + remote-host execution (this branch):
 - **Tests** — 43 unit tests; `cargo check` / `tsc` / `vitest` all green,
   apart from one pre-existing unrelated `agent_browser` env test.
 
-What is still open (see `docs/plans/automations-sync.md`): the
-`/api/automations` server endpoints (separate API repo); the host
-bootstrap writing a scheduler token + registering the service; and
-Phase F (workspace lifecycle).
+Account sync + remote scheduler also shipped since: the
+`/api/automations` endpoints are deployed on `api.codemux.org`, and
+host bootstrap provisions the scheduler token + service. What is still
+open (see `docs/plans/automations-sync.md`): Phase F — the
+GitHub-backbone repo transport that lets a remote host obtain the
+project repo.
 
 Pre-existing platform Automations builds on:
 

--- a/docs/plans/automations.md
+++ b/docs/plans/automations.md
@@ -1,0 +1,133 @@
+# Plan: Automations
+
+- Purpose: Track the design and build order for the Automations feature — scheduled agent runs on a user-chosen host.
+- Audience: Anyone implementing Automations.
+- Authority: Active work plan only, not current truth.
+- Update when: Priorities, open questions, or likely touch points change.
+- Read next: `docs/research/superset-automations.md`, `docs/features/remote-hosts.md`, `docs/core/STATUS.md`
+
+## Goal
+
+Let a user define an Automation — a named prompt + agent + recurrence — that runs on a host they pick from their connected hosts. The schedule lives in the Codemux API (account-bound, so every signed-in device sees the same list), but the schedule *fires* on the chosen host via the `codemux-remote` binary. Each fire creates a fresh workspace + worktree and runs the agent in it. Run history is account-bound; the resulting workspaces stay on the host and never auto-appear on the user's main desktop unless they explicitly sync one in. The model follows Superset (see research doc) but is deliberately host-side scheduled so Codemux can track real completion, prevent overlap, reconcile stuck runs, and enforce retention.
+
+## Architecture (locked decisions)
+
+- **Registry:** `automations` + `automation_runs` tables on the Codemux API server (the existing auth/hosts/settings VPS). Plain CRUD endpoints — no scheduler worker, no cron tick on the VPS. Storage is kilobytes per user.
+- **Scheduler:** a new `codemux-remote scheduler` subcommand on the chosen host. Polls the API (~30s, immediately after each fire), ticks via an `rrule` crate, runs as a persistent service so it survives host reboots.
+- **Target host:** every automation picks its own host (`automations.target_host_id`) — different automations can run on different hosts. A "host" is any machine connected as a Codemux host and running the `codemux-remote scheduler` service; that includes a user's own always-on desktop/laptop connected as a host. There is no separate "run inside the desktop app" scheduler — one scheduler implementation, and automations fire whether or not the Codemux app is open.
+- **Edit propagation:** the remote binary polls the API. Auth is a per-host scoped token provisioned during the existing `hosts_bootstrap_install` flow. Edits made from any device (or via MCP) reach the host without the desktop needing to be online.
+- **Fire flow:** the scheduler creates a fresh workspace + worktree itself (deterministic, same code path as `workspace_push_to_host`), branch `slug-<timestamp>` off the project default branch, then spawns the chosen agent inside it with the prompt. The agent does not self-create the workspace via MCP — workspace creation is infrastructure.
+- **Offline:** host off → no tick → a `skipped_offline` run row is written on next boot. No cloud worker needed.
+- **Sidebar:** automation run-workspaces never auto-appear in the main project sidebar. They render only in the Automations panel. A sidebar entry appears only when the user explicitly syncs one in (mirrors how Superset gates the sidebar on per-device local state).
+- **Sync vs pull:** new `workspace_sync_from_host` action — a non-destructive host→local mirror; host stays canonical, `host_id` unchanged, automation keeps running. `workspace_pull_back` is hard-blocked for automation workspaces (UI hidden + command rejects, so an MCP caller cannot kill an automation either).
+- **MCP:** full CRUD + run — 11 tools, mirroring Superset's surface.
+- **Run model:** fresh workspace per fire.
+- **Retention:** keep the last 10 *completed* run-workspaces per automation on the host (plus any currently-running one); auto-prune older worktrees. Never prune a run the user has synced locally. `automation_runs` log rows are kept regardless — history survives worktree pruning.
+- **Overlap:** one run at a time per automation. If a fire lands while that automation's previous run is still going, write a `skipped_busy` row and skip it — the next scheduled occurrence is the natural retry. Different automations still run concurrently with each other; only the same automation is serialized. (Superset stacks duplicate workspaces here — deliberately rejected as poor UX.)
+
+## Run lifecycle
+
+`scheduled` → `running` → `succeeded` | `failed` | `skipped_offline` | `skipped_busy`.
+The host scheduler owns the agent session, so `succeeded`/`failed` are real terminal states (Superset cannot do this — it only records `dispatched`). A reconciler in the scheduler marks any `running` row whose agent session has died as `failed`.
+
+## Active Priorities
+
+The feature works end-to-end on the local machine: define → schedule →
+tick → fire → worktree → agent run → terminal status → UI. Remaining
+work, in dependency order:
+
+1. **Stuck-run reconciler.** A run left `running` by an app quit keeps
+   its automation `skipped_busy` forever. Add a startup sweep that fails
+   runs whose `started_at` is older than a generous ceiling.
+2. **API schema + endpoints.** `automations` / `automation_runs` tables
+   on the API server; REST CRUD; per-host scoped-token issuance wired
+   into host bootstrap. Ownership checks (single-owner).
+3. **Account sync.** `automations_sync.rs` mirrored on `hosts_sync.rs`,
+   pushing the `dirty` rows the local schema already tracks. Background
+   sync after each mutation, like `commands::hosts`.
+4. **`codemux-remote scheduler` subcommand + host routing.** The same
+   `scheduler::tick` + `executor` as a persistent service on a remote
+   host; the desktop then runs only `host_id`-null automations and lets
+   the remote handle the rest. Blocked on account sync — a remote host
+   has no automations until sync delivers them.
+5. **Bootstrap changes.** `hosts_bootstrap_install` writes the scoped
+   token and registers the scheduler as a persistent service (systemd).
+6. **Workspace lifecycle commands.** New `workspace_sync_from_host`
+   (non-destructive mirror, reuses `ssh/push.rs` rsync helpers); an
+   `automation_id` column on workspaces; guard `workspace_pull_back` to
+   reject automation workspaces.
+7. **Polish.** A one-shot `automation_run` MCP tool; the
+   `retention_limit` worktree prune; wire run completion/failure into
+   the notification system (`docs/features/notifications.md`); dedicated
+   automation workspace icon; optional prompt version history.
+
+## Open Questions
+
+No outstanding design questions — the items below were raised and resolved:
+
+- **Retention** is count-based: last 10 completed runs per automation, configurable.
+- **Overlap:** one run at a time per automation; an overlapping fire becomes `skipped_busy` with no retry.
+- **`mcpScope` is dropped from v1.** A do-nothing forward-compat field is schema noise — add real MCP-server scoping only when there is a concrete need.
+- **Scheduler token** reuses the existing host credential lifecycle (issued at host bootstrap, removed when the host is removed) — no separate token-management surface.
+- **No desktop-app scheduler.** Automations always target a host; a user's own always-on machine can be connected as a host. One scheduler implementation only.
+
+Implementation-time detail still to settle: token leak/rotation handling within the host credential lifecycle.
+
+## Likely Touch Points
+
+- `src-tauri/src/bin/codemux_remote.rs` — add the `scheduler` subcommand
+- `src-tauri/src/ssh/bootstrap.rs` — provision scoped token, register persistent service
+- `src-tauri/src/ssh/push.rs` — reuse rsync helpers for `workspace_sync_from_host`
+- `src-tauri/src/commands/hosts.rs` — `workspace_push_to_host`, `workspace_pull_back` (add guard), new `workspace_sync_from_host`
+- `src-tauri/src/hosts_sync.rs` — pattern to mirror as new `src-tauri/src/automations_sync.rs`
+- `src-tauri/src/database.rs` — new `automations` / `automation_runs` tables, `automation_id` on workspaces
+- `src-tauri/src/mcp_server.rs` — register the 11 automation tools
+- Codemux API server (see `codemux-api-infrastructure` skill) — `/api/automations`, `/api/automations/:id/runs`, token issuance
+- `src/` renderer — new Automations panel, automation workspace icon, sync-locally action
+- `docs/features/` — add `automations.md` once shipping; update `remote-hosts.md` and `notifications.md`
+
+## Already Landed
+
+Automations feature — local foundation, scheduler, and UI (this branch):
+
+- **Data model** — `automations` + `automation_runs` tables (`database.rs`,
+  schema v5) with sync-ready `server_id` / `deleted_at` / `dirty` columns;
+  records + full CRUD; idempotent per-minute run inserts; terminal run
+  lifecycle.
+- **Recurrence engine** — `automations::recurrence` (RFC 5545 via the
+  `rrule` crate): validate a schedule, compute the next occurrence,
+  DST-correct.
+- **Scheduler** — `automations::scheduler`: `is_due` / `fire_key` and the
+  `tick` loop (records runs, serialises overlap as `skipped_busy`,
+  advances `next_run_at`). A once-a-minute background task in `lib.rs`
+  drives it and emits `automations://fire` events.
+- **Executor** — `automations::executor`: per fire, creates an isolated
+  git worktree off the project, spawns the agent headlessly with the
+  prompt (`claude --print` / `codex exec`), and records the terminal
+  `succeeded` / `failed` status. The scheduler task spawns one per fire.
+- **Desktop command surface** — seven `automations_*` Tauri commands.
+- **Agent / MCP control surface** — eight `automation_*` MCP tools routed
+  through `control.rs` to shared `*_impl` helpers.
+- **Settings → Automations UI** — create / edit / pause / resume / delete
+  with a schedule builder and run-history view; a fire-event toast.
+- **Tests** — 35 unit tests (recurrence, scheduler decision + tick loop,
+  executor incl. worktree creation against a real temp repo, database
+  CRUD / dedup / run lifecycle) plus the existing frontend suite;
+  `cargo check` / `tsc` / `vitest` all green, apart from one pre-existing
+  unrelated `agent_browser` env test.
+
+Pre-existing platform Automations builds on:
+
+- Push workspace to host (`workspace_push_to_host`) and pull-back
+  (`workspace_pull_back`) — full rsync + remote PTY respawn.
+- `codemux-remote` binary, auto-installed during host bootstrap; survives
+  laptop reconnects. Remote PTY daemon keeps agents alive across desktop
+  close.
+- Account-bound sync for hosts, settings, and skills via the API server —
+  the pattern `automations_sync.rs` will copy.
+
+## Notes
+
+- No scheduling logic runs on the Codemux API server — it is a registry only. This keeps server cost negligible and means automations do not depend on the Codemux VPS being up.
+- The host-side scheduler is the deliberate divergence from Superset (which schedules in the cloud). It is what enables real completion status, overlap prevention, stuck-run reconciliation, and local retention — all gaps in Superset.
+- Supporting research: `docs/research/superset-automations.md`.

--- a/docs/plans/automations.md
+++ b/docs/plans/automations.md
@@ -34,7 +34,8 @@ The host scheduler owns the agent session, so `succeeded`/`failed` are real term
 
 The feature works end-to-end on the local machine: define → schedule →
 tick → fire → worktree → agent run → terminal status → UI. Remaining
-work, in dependency order:
+work, in dependency order — items 1–5 are the "account sync + remote
+host" phase, broken down step-by-step in `docs/plans/automations-sync.md`:
 
 1. **Stuck-run reconciler.** A run left `running` by an app quit keeps
    its automation `skipped_busy` forever. Add a startup sweep that fails
@@ -108,8 +109,9 @@ Automations feature — local foundation, scheduler, and UI (this branch):
 - **Desktop command surface** — seven `automations_*` Tauri commands.
 - **Agent / MCP control surface** — eight `automation_*` MCP tools routed
   through `control.rs` to shared `*_impl` helpers.
-- **Settings → Automations UI** — create / edit / pause / resume / delete
-  with a schedule builder and run-history view; a fire-event toast.
+- **Automations view** — a full-screen view opened from the left sidebar
+  (under "New agent", above projects): create / edit / pause / resume /
+  delete with a schedule builder and run-history view; a fire-event toast.
 - **Tests** — 35 unit tests (recurrence, scheduler decision + tick loop,
   executor incl. worktree creation against a real temp repo, database
   CRUD / dedup / run lifecycle) plus the existing frontend suite;

--- a/docs/reference/FEATURES.md
+++ b/docs/reference/FEATURES.md
@@ -115,6 +115,8 @@
 - Desktop notifications via system notification daemon (notify-rust)
 - Desktop notification triggers window focus, raise, and Hyprland window manager integration
 - Notification sound toggle in sidebar footer
+- **Per-worktree mute** (right-click → "Mute notifications"): silences agent-completion notifications for one workspace; muted state shows a bell-off icon in the sidebar row
+- Agent status indicators (red/amber/green dots) light up for Claude, Codex, Gemini, OpenCode, and Pi sessions
 - Global toast notices for errors and status messages (bottom-right)
 
 ## Project Memory
@@ -196,10 +198,13 @@
 
 ## MCP Server (Codemux as server)
 
-- JSON-RPC 2.0 MCP server over stdio transport (31 tools)
+- JSON-RPC 2.0 MCP server over stdio transport (**44 tools**)
 - Three-tier browser automation: DOM selectors, CDP coordinates, OS-level input
 - Workspace, pane, notification, and git tools for agent self-orchestration
 - Browser viewport presets (`browser_viewport`, `browser_viewport_presets`)
+- Phase 1 vexis-agent tools: `terminal_write`, `terminal_read`, `workspace_open`, `app_status`, `port_list`
+- Phase 1.5 vexis-agent tools: `worktree_create`, `preset_apply`, `preset_list`
+- Phase 1.6 vexis-agent lifecycle + issue tools: `workspace_close`, `pane_close`, `issue_list`, `issue_get`, `issue_link_workspace`
 - Auto-configuration for Claude Code and Claude Desktop
 - Launched via `codemux mcp`
 
@@ -281,6 +286,22 @@
 - Server-synced settings with offline cache
 - Workspace-level project config (setup/teardown scripts, worktree includes)
 - Beta Features section that flips the Step 13 agent-chat toggle (controls `enable_agent_chat` and `enable_lazy_workspace_creation` together)
+
+## Remote Hosts + Workspace Push
+
+- Settings → Hosts pane with SSH probe + bootstrap-install consent modal
+- Slim `codemux-remote` server binary (bundled per-target into the laptop app) installs to `~/.local/bin/` on the host
+- SSH transport: probe → bootstrap → tunnel → tunnel supervisor with auto-reconnect
+- `WorkspaceSnapshot.host_id` model + shared `<DevicePicker>` pill component wired into the new-workspace dialog
+- **Push workspace to host** action: rsync the worktree, spawn the remote daemon, attach the local UI through an SSH-forwarded socket, and sync the Claude conversation across local/remote ends
+
+## Persistent Agents
+
+- Every shell spawn runs inside a detached `codemux pty-daemon` subprocess so agents survive app close
+- Supervisor adopts the running daemon on relaunch and reattaches live sessions (alt-screen TUIs and CLI agents resume in-place)
+- Default-on, no setting; `CODEMUX_DISABLE_PTY_DAEMON=1` is the only escape hatch
+- Graceful fallback to in-process portable-pty at every error site; 3-failures-in-60s crash circuit breaker
+- Unix only (Linux + macOS); Windows still uses the in-process path until the named-pipe IPC is wired
 
 ## CLI / Socket Control
 

--- a/docs/research/superset-automations.md
+++ b/docs/research/superset-automations.md
@@ -1,0 +1,45 @@
+# Research: Superset Automations
+
+- Purpose: Capture how `superset-sh/superset` implements its "Automations" feature, as input to `docs/plans/automations.md`.
+- Audience: Anyone implementing Codemux Automations.
+- Authority: Supporting research only. The plan is `docs/plans/automations.md`.
+- Update when: Re-investigating Superset, or correcting a finding below.
+- Read next: `docs/plans/automations.md`
+
+## What Superset's Automations are
+
+A scheduled prompt-to-agent run. An automation row holds `{ name, prompt, agent, rrule, timezone, targetHostId?, projectId|workspaceId?, dtstart, enabled, mcpScope[] }`, scoped to one owner user + org, stored in Superset's cloud Postgres (Neon).
+
+## Scheduling and dispatch
+
+- Recurrence on the wire is **RRule (RFC 5545)** + IANA timezone, not cron. Cron is CLI-side sugar only.
+- A **cloud cron heartbeat** (Upstash QStash) ticks Superset's API server. Each tick selects rows where `nextRunAt <= now()` and enqueues one dispatch message per automation. `nextRunAt` advances regardless of outcome.
+- Dispatch mints a short-lived (300s) scoped user JWT, calls the host-service over Superset's relay to create a workspace + worktree, then makes a second call to start the agent in it.
+- The host-service runs on the **user's own machine** — Superset does not host execution infrastructure. Workspaces land at the same path layout as a manually created workspace.
+
+## Sidebar behavior (verified from code)
+
+Automation-created workspaces do **not** appear in the main project sidebar by default. The sidebar inner-joins the Electric-synced `v2Workspaces` collection against a **per-device, localStorage-only** `v2WorkspaceLocalState` collection. The dispatcher never writes a local-state row, so the workspace exists as synced data but stays invisible until the user explicitly opens it from the Automations page. There is no `automationId`/`source` column on the workspace table — the link runs the other way: `automation_runs.workspaceId`.
+
+## Gaps in Superset worth beating
+
+- **No completion tracking.** Run statuses are only `dispatching / dispatched / skipped_offline / dispatch_failed`. "Agent finished" is never detected, because dispatch is stateless cloud cron.
+- **No overlap protection.** A long agent run plus a tight schedule stacks duplicate workspaces. A reconciler for stuck `dispatching` rows was specced but never shipped.
+- **No retention / cleanup.** `new_per_run` mode creates a fresh workspace every fire and never deletes it.
+- **No user notifications** on completion/failure — only internal Sentry.
+- Fallback host selection orders by `updatedAt` ascending — picks the *least* recently updated host; likely a bug.
+
+## Patterns worth copying
+
+- Idempotency via a unique index on `(automationId, scheduledFor)` with `scheduledFor` floored to the minute, plus a matching dispatch dedup id.
+- Per-run branch name `slugify(name, 30)-YYYY-MM-DD-HH-MM-SS`, branched from the project default branch. No auto-commit, no PR — git output is whatever the agent does.
+- Un-pausing recomputes `nextRunAt` from now, so a paused automation never fires a backlog.
+- RRule exhaustion auto-disables the automation.
+- Prompt stored separately from schedule metadata (`get_prompt`/`set_prompt`), so `list` stays cheap and prompts round-trip byte-exact.
+- Lightweight prompt version history: one row per `(automation, author, 10-min window)`, tagged `human` / `agent` / `restore`.
+- MCP surface: 11 tools — `create / list / get / update / delete / pause / resume / run / logs / get_prompt / set_prompt`. Each is a thin wrapper over the same backend the UI uses.
+- `mcpScope` field exists to scope which MCP servers a run may use (currently inert in Superset — forward-compat placeholder).
+
+## Key difference for Codemux
+
+Superset schedules in the cloud and dispatches to a host. Codemux will **schedule on the host itself** (the `codemux-remote` binary). That host-side, stateful scheduler is what lets Codemux fix Superset's biggest gaps: it owns the agent session, so it can record real `succeeded`/`failed` status, do a true in-flight overlap check, reconcile stuck runs, and enforce retention locally.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -684,6 +684,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +782,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.28",
+ "rrule",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3552,6 +3563,15 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
@@ -3694,6 +3714,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher 1.0.2",
 ]
@@ -4349,6 +4378,19 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rrule"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720acfb4980b9d8a6a430f6d7a11933e701ebbeba5eee39cc9d8c5f932aaff74"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "log",
+ "regex",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,6 +78,10 @@ png = "0.17"
 # Cross-platform process + system metrics for the resource monitor.
 # Powers per-terminal CPU/memory aggregation in resource_metrics.rs.
 sysinfo = "0.33"
+# RFC 5545 recurrence-rule engine for the Automations feature. Parses
+# an iCalendar DTSTART+RRULE block and computes the next occurrence
+# with IANA-timezone / DST correctness. Used by automations::recurrence.
+rrule = "0.14"
 
 [target.'cfg(unix)'.dependencies]
 tauri-plugin-dialog = { version = "2", default-features = false, features = ["xdg-portal"] }

--- a/src-tauri/src/automations/executor.rs
+++ b/src-tauri/src/automations/executor.rs
@@ -76,13 +76,18 @@ fn worktree_destination(project: &Path, branch: &str) -> Result<PathBuf, String>
         .join(branch))
 }
 
-/// Create an isolated git worktree at `worktree_dir` on a new `branch`
-/// off the project's current HEAD. Returns a flat error string on any
-/// failure (path missing, not a git repo, branch clash, git absent).
+/// Create an isolated git worktree at `worktree_dir` on a new `branch`.
+///
+/// `base` is the ref the branch starts from: `None` → the repo's
+/// current `HEAD` (the local case), `Some(ref)` → that ref (a
+/// freshly-fetched `origin/<default>` for a host clone). Returns a flat
+/// error string on any failure (path missing, not a git repo, branch
+/// clash, git absent).
 pub fn prepare_worktree(
     project: &Path,
     worktree_dir: &Path,
     branch: &str,
+    base: Option<&str>,
 ) -> Result<(), String> {
     if !project.is_dir() {
         return Err(format!(
@@ -94,13 +99,17 @@ pub fn prepare_worktree(
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("Failed to create worktree parent directory: {error}"))?;
     }
-    let output = std::process::Command::new("git")
-        .arg("-C")
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C")
         .arg(project)
         .args(["worktree", "add"])
         .arg(worktree_dir)
         .arg("-b")
-        .arg(branch)
+        .arg(branch);
+    if let Some(base_ref) = base {
+        cmd.arg(base_ref);
+    }
+    let output = cmd
         .output()
         .map_err(|error| format!("Failed to run git: {error}"))?;
     if !output.status.success() {
@@ -112,11 +121,172 @@ pub fn prepare_worktree(
     Ok(())
 }
 
+// ── Project repo resolution (the GitHub backbone) ──
+//
+// An automation run needs the project repo *on the machine the run
+// executes on*. On the desktop / "This machine" that is `project_path`.
+// On a separate host that path does not exist, so the host clones the
+// project's git remote — see `docs/plans/automations-sync.md` Phase F.
+
+/// A project repository resolved to a usable path on this machine, plus
+/// the ref a new worktree should branch off.
+struct ResolvedRepo {
+    path: PathBuf,
+    /// `None` → branch off the repo's current `HEAD` (the local case).
+    /// `Some(ref)` → branch off this ref — a freshly-fetched
+    /// `origin/<default>` for a host clone.
+    base: Option<String>,
+}
+
+/// Host-local directory holding clones of automation projects.
+fn automation_repos_dir() -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+    Ok(home.join(".codemux").join("automation-repos"))
+}
+
+/// A filesystem-safe directory name for a clone, from the remote URL's
+/// final path segment (`git@github.com:me/whatsapp-rag.git` →
+/// `whatsapp-rag`).
+fn repo_dir_name(remote_url: &str) -> String {
+    let trimmed = remote_url.trim_end_matches('/');
+    let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    let segment = trimmed.rsplit(['/', ':']).next().unwrap_or("project");
+    let slug: String = segment
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        "project".to_string()
+    } else {
+        slug.to_string()
+    }
+}
+
+/// Resolve the automation's project to a local git repo on this machine.
+///
+/// Local case — `project_path` is here and is a git repo: use it, and
+/// branch off its current `HEAD`. Host case — clone, or `git fetch` an
+/// existing clone of, `project_remote` into `~/.codemux/
+/// automation-repos/`, and branch off the freshly-fetched
+/// `origin/<default>`.
+fn resolve_repo(automation: &AutomationRecord) -> Result<ResolvedRepo, String> {
+    if let Some(path) = &automation.project_path {
+        let candidate = Path::new(path);
+        if candidate.join(".git").exists() {
+            return Ok(ResolvedRepo {
+                path: candidate.to_path_buf(),
+                base: None,
+            });
+        }
+    }
+    let remote = automation.project_remote.as_deref().ok_or_else(|| {
+        "This automation has no project repo on this machine and no git \
+         remote to clone from. Pick a project that has a git remote."
+            .to_string()
+    })?;
+    let clone_dir = automation_repos_dir()?.join(repo_dir_name(remote));
+    ensure_clone(remote, &clone_dir)?;
+    let base = default_remote_branch(&clone_dir)
+        .unwrap_or_else(|| "origin/HEAD".to_string());
+    Ok(ResolvedRepo {
+        path: clone_dir,
+        base: Some(base),
+    })
+}
+
+/// Clone `remote` into `clone_dir` if absent; otherwise `git fetch` it.
+/// Git authenticates with the host's own credentials — Codemux injects
+/// no token (matching Superset's clone behaviour).
+fn ensure_clone(remote: &str, clone_dir: &Path) -> Result<(), String> {
+    if clone_dir.join(".git").exists() {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(clone_dir)
+            .args(["fetch", "--prune", "origin"])
+            .output()
+            .map_err(|error| format!("Failed to run git fetch: {error}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "git fetch failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+        return Ok(());
+    }
+    if let Some(parent) = clone_dir.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create clone directory: {error}"))?;
+    }
+    let output = std::process::Command::new("git")
+        .args(["clone", remote])
+        .arg(clone_dir)
+        .output()
+        .map_err(|error| format!("Failed to run git clone: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git clone failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+/// `origin/<default-branch>` for a clone, resolved via `origin/HEAD`.
+fn default_remote_branch(clone_dir: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(clone_dir)
+        .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let reference = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if reference.is_empty() {
+        None
+    } else {
+        Some(reference)
+    }
+}
+
+/// Best-effort: the URL of a PR for `branch`, via `gh pr list`. `None`
+/// when `gh` is absent, unauthenticated, or no PR exists.
+fn detect_pr_url(worktree: &Path, branch: &str) -> Option<String> {
+    let output = std::process::Command::new("gh")
+        .arg("pr")
+        .arg("list")
+        .args(["--head", branch])
+        .args(["--json", "url"])
+        .args(["--jq", ".[0].url // empty"])
+        .current_dir(worktree)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if url.is_empty() {
+        None
+    } else {
+        Some(url)
+    }
+}
+
 /// Terminal outcome of executing a fire — written to the run row by
 /// whichever scheduler owns the run.
 pub struct FireOutcome {
     pub status: &'static str,
     pub workspace_id: Option<String>,
+    pub branch: Option<String>,
+    pub pr_url: Option<String>,
     pub error: Option<String>,
 }
 
@@ -127,19 +297,26 @@ fn with_db<R>(handle: &AppHandle, f: impl FnOnce(&DatabaseStore) -> R) -> R {
     f(&db)
 }
 
-/// Execute a fire — create the worktree, run the agent — and return the
-/// terminal outcome. Tauri-free, so both the desktop scheduler task and
-/// the `codemux-remote scheduler` loop call the same code.
+/// Execute a fire — resolve the repo, create the worktree, run the
+/// agent — and return the terminal outcome. Tauri-free, so the desktop
+/// scheduler task and the `codemux-remote scheduler` loop share it.
 pub async fn run_fire(automation: &AutomationRecord) -> FireOutcome {
-    match run_inner(automation).await {
-        Ok(workdir) => FireOutcome {
+    // The branch is deterministic and known up front, so it is recorded
+    // on the run whatever the outcome.
+    let branch = automation_branch(&automation.name, Utc::now());
+    match run_inner(automation, &branch).await {
+        Ok((workdir, pr_url)) => FireOutcome {
             status: "succeeded",
             workspace_id: Some(workdir),
+            branch: Some(branch),
+            pr_url,
             error: None,
         },
         Err((workdir, error)) => FireOutcome {
             status: "failed",
             workspace_id: workdir,
+            branch: Some(branch),
+            pr_url: None,
             error: Some(error),
         },
     }
@@ -157,6 +334,8 @@ pub fn apply_outcome(db: &DatabaseStore, run_id: i64, outcome: &FireOutcome) {
         run_id,
         outcome.status,
         outcome.workspace_id.as_deref(),
+        outcome.branch.as_deref(),
+        outcome.pr_url.as_deref(),
         outcome.error.as_deref(),
     );
 }
@@ -176,23 +355,22 @@ pub async fn execute_run(
     with_db(&handle, |db| apply_outcome(db, run.id, &outcome));
 }
 
-/// Fallible body of `execute_run`. On failure returns the workspace
-/// path (when a worktree was created) alongside the error, so the run
-/// row can still point at the partial workspace.
+/// Fallible body of `execute_run`. On success returns the worktree path
+/// and any PR URL detected; on failure returns the worktree path (when
+/// one was created) alongside the error, so the run row can still point
+/// at the partial workspace.
 async fn run_inner(
     automation: &AutomationRecord,
-) -> Result<String, (Option<String>, String)> {
-    let project = automation
-        .project_path
-        .clone()
-        .ok_or((None, "Automation has no project path set".to_string()))?;
-    let project_path = PathBuf::from(&project);
+    branch: &str,
+) -> Result<(String, Option<String>), (Option<String>, String)> {
+    // Resolve the project to a repo on *this* machine — the local path
+    // if it is here, otherwise a clone of the git remote.
+    let repo = resolve_repo(automation).map_err(|error| (None, error))?;
 
-    let branch = automation_branch(&automation.name, Utc::now());
     let worktree_dir =
-        worktree_destination(&project_path, &branch).map_err(|error| (None, error))?;
+        worktree_destination(&repo.path, branch).map_err(|error| (None, error))?;
 
-    prepare_worktree(&project_path, &worktree_dir, &branch)
+    prepare_worktree(&repo.path, &worktree_dir, branch, repo.base.as_deref())
         .map_err(|error| (None, error))?;
 
     let workdir = worktree_dir.to_string_lossy().to_string();
@@ -213,7 +391,10 @@ async fn run_inner(
         })?;
 
     if status.success() {
-        Ok(workdir)
+        // Best-effort: if the agent pushed a branch and opened a PR,
+        // record the URL so run history reads like a PR list.
+        let pr_url = detect_pr_url(&worktree_dir, branch);
+        Ok((workdir, pr_url))
     } else {
         Err((
             Some(workdir),
@@ -286,7 +467,7 @@ mod tests {
 
         let dest = tempfile::tempdir().unwrap();
         let worktree = dest.path().join("wt");
-        prepare_worktree(repo.path(), &worktree, "automation-test-1").unwrap();
+        prepare_worktree(repo.path(), &worktree, "automation-test-1", None).unwrap();
 
         // A worktree has a `.git` file (not directory) pointing back at
         // the main repo.
@@ -301,6 +482,7 @@ mod tests {
             Path::new("/nonexistent/codemux/project"),
             &dest.path().join("wt"),
             "automation-test-2",
+            None,
         );
         assert!(result.is_err());
     }
@@ -311,8 +493,154 @@ mod tests {
         // must fail rather than silently doing nothing.
         let plain = tempfile::tempdir().unwrap();
         let dest = tempfile::tempdir().unwrap();
-        let result =
-            prepare_worktree(plain.path(), &dest.path().join("wt"), "automation-test-3");
+        let result = prepare_worktree(
+            plain.path(),
+            &dest.path().join("wt"),
+            "automation-test-3",
+            None,
+        );
         assert!(result.is_err());
+    }
+
+    // ── Phase F: repo resolution (the GitHub backbone) ──
+
+    /// Run `git` in `dir`, asserting success.
+    fn git(dir: &Path, args: &[&str]) {
+        let ok = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .output()
+            .unwrap()
+            .status
+            .success();
+        assert!(ok, "git {args:?} failed in {}", dir.display());
+    }
+
+    /// A temp git repo with one commit, returned as a held `TempDir`.
+    fn temp_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        git(dir.path(), &["init", "-q"]);
+        git(dir.path(), &["config", "user.email", "t@example.com"]);
+        git(dir.path(), &["config", "user.name", "Test"]);
+        git(dir.path(), &["commit", "--allow-empty", "-q", "-m", "init"]);
+        dir
+    }
+
+    fn automation_with(
+        project_path: Option<&str>,
+        project_remote: Option<&str>,
+    ) -> AutomationRecord {
+        AutomationRecord {
+            id: 1,
+            server_id: None,
+            name: "Test".to_string(),
+            prompt: "do the thing".to_string(),
+            agent: "claude".to_string(),
+            schedule: "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY".to_string(),
+            timezone: "UTC".to_string(),
+            host_id: None,
+            project_path: project_path.map(str::to_string),
+            project_remote: project_remote.map(str::to_string),
+            enabled: true,
+            retention_limit: 10,
+            last_run_at: None,
+            next_run_at: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            deleted_at: None,
+            dirty: false,
+        }
+    }
+
+    #[test]
+    fn repo_dir_name_takes_the_final_segment() {
+        assert_eq!(repo_dir_name("git@github.com:me/whatsapp-rag.git"), "whatsapp-rag");
+        assert_eq!(repo_dir_name("https://github.com/me/my-repo"), "my-repo");
+        assert_eq!(repo_dir_name("https://github.com/me/my-repo/"), "my-repo");
+        // No usable segment → a stable fallback.
+        assert_eq!(repo_dir_name("////"), "project");
+    }
+
+    #[test]
+    fn ensure_clone_clones_then_fetches_idempotently() {
+        // A source repo, mirror-cloned to a bare "remote".
+        let source = temp_repo();
+        let remote_dir = tempfile::tempdir().unwrap();
+        let remote = remote_dir.path().join("bare.git");
+        let ok = std::process::Command::new("git")
+            .args(["clone", "--bare", "-q"])
+            .arg(source.path())
+            .arg(&remote)
+            .output()
+            .unwrap()
+            .status
+            .success();
+        assert!(ok, "bare clone failed");
+
+        let dest = tempfile::tempdir().unwrap();
+        let clone_dir = dest.path().join("clone");
+        let remote_str = remote.to_string_lossy().to_string();
+
+        // First call clones.
+        ensure_clone(&remote_str, &clone_dir).unwrap();
+        assert!(clone_dir.join(".git").is_dir());
+        // Second call fetches an existing clone — must not error.
+        ensure_clone(&remote_str, &clone_dir).unwrap();
+
+        // The clone exposes a default remote branch.
+        let base = default_remote_branch(&clone_dir);
+        assert!(
+            base.as_deref().map(|b| b.starts_with("origin/")).unwrap_or(false),
+            "expected origin/<branch>, got {base:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_repo_uses_a_local_project_path_when_present() {
+        let repo = temp_repo();
+        let path = repo.path().to_string_lossy().to_string();
+        let resolved = resolve_repo(&automation_with(Some(&path), None)).unwrap();
+        assert_eq!(resolved.path, repo.path());
+        // A local repo branches off its own HEAD.
+        assert!(resolved.base.is_none());
+    }
+
+    #[test]
+    fn resolve_repo_errors_without_a_path_or_remote() {
+        // No project_path on this machine and no remote to clone.
+        let result = resolve_repo(&automation_with(Some("/nonexistent/x"), None));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn prepare_worktree_branches_off_an_explicit_base() {
+        let repo = temp_repo();
+        // A second commit on a side branch to use as the base.
+        git(repo.path(), &["checkout", "-q", "-b", "side"]);
+        git(repo.path(), &["commit", "--allow-empty", "-q", "-m", "side commit"]);
+        git(repo.path(), &["checkout", "-q", "-"]);
+
+        let dest = tempfile::tempdir().unwrap();
+        let worktree = dest.path().join("wt");
+        prepare_worktree(repo.path(), &worktree, "automation-based", Some("side"))
+            .unwrap();
+        assert!(worktree.join(".git").exists());
+
+        // The worktree's HEAD descends from `side` — its tip commit
+        // matches `side`'s tip.
+        let head = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&worktree)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap();
+        let side = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo.path())
+            .args(["rev-parse", "side"])
+            .output()
+            .unwrap();
+        assert_eq!(head.stdout, side.stdout);
     }
 }

--- a/src-tauri/src/automations/executor.rs
+++ b/src-tauri/src/automations/executor.rs
@@ -1,0 +1,296 @@
+//! Fire executor — turns a fired automation run into a real agent run.
+//!
+//! When `scheduler::tick` records a fire, the desktop scheduler task
+//! hands the run here. The executor:
+//!
+//! 1. creates an isolated git worktree off the automation's project,
+//!    on a fresh per-fire branch;
+//! 2. spawns the chosen agent headlessly with the prompt;
+//! 3. records the terminal `succeeded` / `failed` status (and the
+//!    workspace path) back on the run row.
+//!
+//! The pure pieces — `agent_command`, `automation_branch` — are unit
+//! tested; `prepare_worktree` is covered against a real temp repo.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use tauri::{AppHandle, Manager};
+
+use crate::database::{AutomationRecord, AutomationRunRecord, DatabaseStore};
+
+/// Map an agent name to the headless CLI invocation that runs a single
+/// prompt to completion. Pure.
+pub fn agent_command(agent: &str, prompt: &str) -> Result<(String, Vec<String>), String> {
+    match agent {
+        "claude" => Ok((
+            "claude".to_string(),
+            vec!["--print".to_string(), prompt.to_string()],
+        )),
+        "codex" => Ok((
+            "codex".to_string(),
+            vec!["exec".to_string(), prompt.to_string()],
+        )),
+        other => Err(format!(
+            "Automation agent '{other}' is not supported (expected 'claude' or 'codex')"
+        )),
+    }
+}
+
+/// Build the per-fire branch name: a slug of the automation name plus a
+/// UTC timestamp, so every run lands on its own branch.
+pub fn automation_branch(name: &str, at: DateTime<Utc>) -> String {
+    let mut slug = String::new();
+    let mut prev_dash = false;
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            slug.push('-');
+            prev_dash = true;
+        }
+    }
+    let slug = slug.trim_matches('-');
+    let slug: String = slug.chars().take(32).collect();
+    let slug = if slug.is_empty() {
+        "automation".to_string()
+    } else {
+        slug
+    };
+    format!("automation-{slug}-{}", at.format("%Y%m%d-%H%M%S"))
+}
+
+/// Compute the worktree directory for a fire — `~/.codemux/worktrees/
+/// <project>/<branch>`, the same layout push-to-host uses.
+fn worktree_destination(project: &Path, branch: &str) -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+    let project_name = project
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "project".to_string());
+    Ok(home
+        .join(".codemux")
+        .join("worktrees")
+        .join(project_name)
+        .join(branch))
+}
+
+/// Create an isolated git worktree at `worktree_dir` on a new `branch`
+/// off the project's current HEAD. Returns a flat error string on any
+/// failure (path missing, not a git repo, branch clash, git absent).
+pub fn prepare_worktree(
+    project: &Path,
+    worktree_dir: &Path,
+    branch: &str,
+) -> Result<(), String> {
+    if !project.is_dir() {
+        return Err(format!(
+            "Project path does not exist: {}",
+            project.display()
+        ));
+    }
+    if let Some(parent) = worktree_dir.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("Failed to create worktree parent directory: {error}"))?;
+    }
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project)
+        .args(["worktree", "add"])
+        .arg(worktree_dir)
+        .arg("-b")
+        .arg(branch)
+        .output()
+        .map_err(|error| format!("Failed to run git: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+/// Run a short DB operation without holding the Tauri `State` borrow
+/// across an await point.
+fn with_db<R>(handle: &AppHandle, f: impl FnOnce(&DatabaseStore) -> R) -> R {
+    let db: tauri::State<'_, DatabaseStore> = handle.state();
+    f(&db)
+}
+
+/// Execute one fired run end-to-end and record its terminal status.
+pub async fn execute_run(
+    handle: AppHandle,
+    automation: AutomationRecord,
+    run: AutomationRunRecord,
+) {
+    with_db(&handle, |db| {
+        let _ = db.mark_automation_run_started(run.id);
+    });
+
+    match run_inner(&automation).await {
+        Ok(workdir) => {
+            with_db(&handle, |db| {
+                let _ = db.finish_automation_run(
+                    run.id,
+                    "succeeded",
+                    Some(workdir.as_str()),
+                    None,
+                );
+            });
+        }
+        Err((workdir, error)) => {
+            eprintln!("[codemux::automations] run {} failed: {error}", run.id);
+            with_db(&handle, |db| {
+                let _ = db.finish_automation_run(
+                    run.id,
+                    "failed",
+                    workdir.as_deref(),
+                    Some(error.as_str()),
+                );
+            });
+        }
+    }
+}
+
+/// Fallible body of `execute_run`. On failure returns the workspace
+/// path (when a worktree was created) alongside the error, so the run
+/// row can still point at the partial workspace.
+async fn run_inner(
+    automation: &AutomationRecord,
+) -> Result<String, (Option<String>, String)> {
+    let project = automation
+        .project_path
+        .clone()
+        .ok_or((None, "Automation has no project path set".to_string()))?;
+    let project_path = PathBuf::from(&project);
+
+    let branch = automation_branch(&automation.name, Utc::now());
+    let worktree_dir =
+        worktree_destination(&project_path, &branch).map_err(|error| (None, error))?;
+
+    prepare_worktree(&project_path, &worktree_dir, &branch)
+        .map_err(|error| (None, error))?;
+
+    let workdir = worktree_dir.to_string_lossy().to_string();
+
+    let (program, args) = agent_command(&automation.agent, &automation.prompt)
+        .map_err(|error| (Some(workdir.clone()), error))?;
+
+    let status = tokio::process::Command::new(&program)
+        .args(&args)
+        .current_dir(&worktree_dir)
+        .status()
+        .await
+        .map_err(|error| {
+            (
+                Some(workdir.clone()),
+                format!("Failed to launch '{program}': {error}"),
+            )
+        })?;
+
+    if status.success() {
+        Ok(workdir)
+    } else {
+        Err((
+            Some(workdir),
+            format!("Agent '{program}' exited with {status}"),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn agent_command_maps_claude_to_print_mode() {
+        let (program, args) = agent_command("claude", "do the thing").unwrap();
+        assert_eq!(program, "claude");
+        assert_eq!(args, vec!["--print".to_string(), "do the thing".to_string()]);
+    }
+
+    #[test]
+    fn agent_command_maps_codex_to_exec_mode() {
+        let (program, args) = agent_command("codex", "do the thing").unwrap();
+        assert_eq!(program, "codex");
+        assert_eq!(args, vec!["exec".to_string(), "do the thing".to_string()]);
+    }
+
+    #[test]
+    fn agent_command_rejects_an_unknown_agent() {
+        assert!(agent_command("gpt-9000", "x").is_err());
+    }
+
+    #[test]
+    fn automation_branch_slugifies_and_timestamps() {
+        let at = Utc.with_ymd_and_hms(2026, 1, 2, 9, 7, 0).unwrap();
+        assert_eq!(
+            automation_branch("Daily Issue Triage!", at),
+            "automation-daily-issue-triage-20260102-090700"
+        );
+    }
+
+    #[test]
+    fn automation_branch_falls_back_when_name_has_no_word_chars() {
+        let at = Utc.with_ymd_and_hms(2026, 1, 2, 9, 7, 0).unwrap();
+        assert_eq!(
+            automation_branch("***", at),
+            "automation-automation-20260102-090700"
+        );
+    }
+
+    #[test]
+    fn prepare_worktree_creates_an_isolated_branch() {
+        // A real temp git repo with one commit, then a worktree add.
+        let repo = tempfile::tempdir().unwrap();
+        let run = |args: &[&str]| {
+            let ok = std::process::Command::new("git")
+                .arg("-C")
+                .arg(repo.path())
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        run(&["init", "-q"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        run(&["commit", "--allow-empty", "-q", "-m", "init"]);
+
+        let dest = tempfile::tempdir().unwrap();
+        let worktree = dest.path().join("wt");
+        prepare_worktree(repo.path(), &worktree, "automation-test-1").unwrap();
+
+        // A worktree has a `.git` file (not directory) pointing back at
+        // the main repo.
+        assert!(worktree.is_dir());
+        assert!(worktree.join(".git").exists());
+    }
+
+    #[test]
+    fn prepare_worktree_rejects_a_missing_project() {
+        let dest = tempfile::tempdir().unwrap();
+        let result = prepare_worktree(
+            Path::new("/nonexistent/codemux/project"),
+            &dest.path().join("wt"),
+            "automation-test-2",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn prepare_worktree_rejects_a_non_git_directory() {
+        // An ordinary directory is not a repo — `git worktree add`
+        // must fail rather than silently doing nothing.
+        let plain = tempfile::tempdir().unwrap();
+        let dest = tempfile::tempdir().unwrap();
+        let result =
+            prepare_worktree(plain.path(), &dest.path().join("wt"), "automation-test-3");
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/automations/executor.rs
+++ b/src-tauri/src/automations/executor.rs
@@ -112,6 +112,14 @@ pub fn prepare_worktree(
     Ok(())
 }
 
+/// Terminal outcome of executing a fire — written to the run row by
+/// whichever scheduler owns the run.
+pub struct FireOutcome {
+    pub status: &'static str,
+    pub workspace_id: Option<String>,
+    pub error: Option<String>,
+}
+
 /// Run a short DB operation without holding the Tauri `State` borrow
 /// across an await point.
 fn with_db<R>(handle: &AppHandle, f: impl FnOnce(&DatabaseStore) -> R) -> R {
@@ -119,7 +127,43 @@ fn with_db<R>(handle: &AppHandle, f: impl FnOnce(&DatabaseStore) -> R) -> R {
     f(&db)
 }
 
-/// Execute one fired run end-to-end and record its terminal status.
+/// Execute a fire — create the worktree, run the agent — and return the
+/// terminal outcome. Tauri-free, so both the desktop scheduler task and
+/// the `codemux-remote scheduler` loop call the same code.
+pub async fn run_fire(automation: &AutomationRecord) -> FireOutcome {
+    match run_inner(automation).await {
+        Ok(workdir) => FireOutcome {
+            status: "succeeded",
+            workspace_id: Some(workdir),
+            error: None,
+        },
+        Err((workdir, error)) => FireOutcome {
+            status: "failed",
+            workspace_id: workdir,
+            error: Some(error),
+        },
+    }
+}
+
+/// Write a [`FireOutcome`] to its run row. Shared by every scheduler.
+pub fn apply_outcome(db: &DatabaseStore, run_id: i64, outcome: &FireOutcome) {
+    if outcome.status == "failed" {
+        eprintln!(
+            "[codemux::automations] run {run_id} failed: {}",
+            outcome.error.as_deref().unwrap_or("unknown error")
+        );
+    }
+    let _ = db.finish_automation_run(
+        run_id,
+        outcome.status,
+        outcome.workspace_id.as_deref(),
+        outcome.error.as_deref(),
+    );
+}
+
+/// Desktop scheduler entry point: mark the run started, execute it, and
+/// record the outcome. The Tauri `State` borrow is re-acquired per DB
+/// touch via `with_db`, never held across the agent-process await.
 pub async fn execute_run(
     handle: AppHandle,
     automation: AutomationRecord,
@@ -128,30 +172,8 @@ pub async fn execute_run(
     with_db(&handle, |db| {
         let _ = db.mark_automation_run_started(run.id);
     });
-
-    match run_inner(&automation).await {
-        Ok(workdir) => {
-            with_db(&handle, |db| {
-                let _ = db.finish_automation_run(
-                    run.id,
-                    "succeeded",
-                    Some(workdir.as_str()),
-                    None,
-                );
-            });
-        }
-        Err((workdir, error)) => {
-            eprintln!("[codemux::automations] run {} failed: {error}", run.id);
-            with_db(&handle, |db| {
-                let _ = db.finish_automation_run(
-                    run.id,
-                    "failed",
-                    workdir.as_deref(),
-                    Some(error.as_str()),
-                );
-            });
-        }
-    }
+    let outcome = run_fire(&automation).await;
+    with_db(&handle, |db| apply_outcome(db, run.id, &outcome));
 }
 
 /// Fallible body of `execute_run`. On failure returns the workspace

--- a/src-tauri/src/automations/mod.rs
+++ b/src-tauri/src/automations/mod.rs
@@ -18,3 +18,4 @@
 pub mod executor;
 pub mod recurrence;
 pub mod scheduler;
+pub mod service;

--- a/src-tauri/src/automations/mod.rs
+++ b/src-tauri/src/automations/mod.rs
@@ -1,0 +1,20 @@
+//! Automations — scheduled agent runs on a chosen host.
+//!
+//! An automation is a named prompt + agent + recurrence. The schedule
+//! fires on a host the user picks; each fire creates a fresh workspace
+//! and runs the agent in it.
+//!
+//! This module owns the recurrence engine. The rest of the feature is
+//! split across the codebase by layer:
+//!
+//! - persistence — `database.rs` (`automations` / `automation_runs`)
+//! - desktop command surface — `commands::automations`
+//! - agent / MCP control surface — `control.rs` + `mcp_server.rs`
+//!
+//! Keeping recurrence isolated here lets the desktop (create-time
+//! validation) and the host scheduler (the tick loop) call the exact
+//! same logic.
+
+pub mod executor;
+pub mod recurrence;
+pub mod scheduler;

--- a/src-tauri/src/automations/recurrence.rs
+++ b/src-tauri/src/automations/recurrence.rs
@@ -1,0 +1,135 @@
+//! RFC 5545 recurrence handling for automations.
+//!
+//! An automation's `schedule` field is a complete iCalendar block — a
+//! `DTSTART` line plus exactly one `RRULE` line, for example:
+//!
+//! ```text
+//! DTSTART;TZID=America/New_York:20260101T090000
+//! RRULE:FREQ=DAILY
+//! ```
+//!
+//! This module wraps the `rrule` crate to validate such strings and to
+//! compute the next fire time. The `rrule` crate evaluates occurrences
+//! against the `DTSTART` timezone, so DST transitions are handled
+//! correctly (a `BYHOUR=9` daily rule stays at 09:00 wall-clock across
+//! a clock change).
+
+use chrono::{DateTime, Utc};
+use rrule::{RRuleSet, Tz};
+
+/// Validate a schedule string, returning a human-readable error the
+/// UI / MCP can surface verbatim.
+pub fn validate(schedule: &str) -> Result<(), String> {
+    parse(schedule).map(|_| ())
+}
+
+/// Compute the first occurrence strictly after `after`.
+///
+/// Returns `Ok(None)` when the rule has no further occurrences — a
+/// bounded `COUNT=` / `UNTIL=` rule that is already exhausted. The
+/// caller treats that as "disable this automation".
+pub fn next_occurrence(
+    schedule: &str,
+    after: DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, String> {
+    let rule = parse(schedule)?;
+    // The `rrule` crate's `after` bound is *inclusive*, so an occurrence
+    // landing exactly on `after` would be returned and a just-fired
+    // automation could immediately re-fire. We want the strictly-next
+    // fire, so ask for a small batch and skip anything at or before
+    // `after` (at most one occurrence can equal it).
+    let result = rule.after(after.with_timezone(&Tz::UTC)).all(4);
+    Ok(result
+        .dates
+        .into_iter()
+        .map(|dt| dt.with_timezone(&Utc))
+        .find(|dt| *dt > after))
+}
+
+/// Parse a schedule string into an `RRuleSet`, mapping every failure
+/// mode to a flat `String` error.
+fn parse(schedule: &str) -> Result<RRuleSet, String> {
+    let trimmed = schedule.trim();
+    if trimmed.is_empty() {
+        return Err("Schedule is empty".to_string());
+    }
+    trimmed
+        .parse::<RRuleSet>()
+        .map_err(|e| format!("Invalid recurrence rule: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn validate_accepts_a_well_formed_daily_rule() {
+        let schedule = "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY";
+        assert!(validate(schedule).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_an_empty_schedule() {
+        assert!(validate("").is_err());
+        assert!(validate("   \n  ").is_err());
+    }
+
+    #[test]
+    fn validate_accepts_a_tzid_anchored_rule() {
+        // The schedule builder in the UI emits TZID-anchored DTSTART
+        // lines so daily/weekly rules keep their wall-clock time across
+        // DST. Confirm the crate parses that form.
+        let schedule = "DTSTART;TZID=America/New_York:20260101T090000\nRRULE:FREQ=DAILY";
+        assert!(validate(schedule).is_ok());
+        let next = next_occurrence(
+            schedule,
+            Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        )
+        .unwrap();
+        assert!(next.is_some());
+    }
+
+    #[test]
+    fn validate_rejects_a_rule_without_a_dtstart() {
+        // `RRULE` alone is not a valid `RRuleSet` — it has no anchor.
+        assert!(validate("RRULE:FREQ=DAILY").is_err());
+    }
+
+    #[test]
+    fn validate_rejects_garbage() {
+        assert!(validate("not a recurrence rule").is_err());
+    }
+
+    #[test]
+    fn next_occurrence_finds_the_following_day() {
+        let schedule = "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY";
+        let after = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+        let next = next_occurrence(schedule, after).unwrap();
+        assert_eq!(next, Some(Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap()));
+    }
+
+    #[test]
+    fn next_occurrence_is_exclusive_of_the_after_instant() {
+        // `after` lands exactly on a 09:00 occurrence — that instant
+        // must be skipped and the following day returned.
+        let schedule = "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY";
+        let after = Utc.with_ymd_and_hms(2026, 1, 5, 9, 0, 0).unwrap();
+        let next = next_occurrence(schedule, after).unwrap();
+        assert_eq!(next, Some(Utc.with_ymd_and_hms(2026, 1, 6, 9, 0, 0).unwrap()));
+    }
+
+    #[test]
+    fn next_occurrence_returns_none_when_a_bounded_rule_is_exhausted() {
+        // Daily for three days starting 2026-01-01; asking after the
+        // last occurrence yields nothing.
+        let schedule = "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY;COUNT=3";
+        let after = Utc.with_ymd_and_hms(2026, 1, 10, 0, 0, 0).unwrap();
+        assert_eq!(next_occurrence(schedule, after).unwrap(), None);
+    }
+
+    #[test]
+    fn next_occurrence_propagates_a_parse_error() {
+        assert!(next_occurrence("garbage", Utc::now()).is_err());
+    }
+}

--- a/src-tauri/src/automations/scheduler.rs
+++ b/src-tauri/src/automations/scheduler.rs
@@ -134,10 +134,23 @@ pub fn tick(
                 }
             }
             Err(error) => {
+                // A schedule we can't parse must not leave `next_run_at`
+                // in the past — that would re-fire the automation on
+                // every tick. Clear it so the automation goes dormant
+                // instead of spamming runs once a minute.
                 eprintln!(
-                    "[codemux::scheduler] invalid schedule on automation {}: {error}",
+                    "[codemux::scheduler] invalid schedule on automation {}: {error} \
+                     — clearing next run so it stops re-firing",
                     automation.id
                 );
+                if let Err(clear_error) =
+                    db.set_automation_next_run(automation.id, None)
+                {
+                    eprintln!(
+                        "[codemux::scheduler] failed to clear next run for automation {}: {clear_error}",
+                        automation.id
+                    );
+                }
             }
         }
     }
@@ -289,6 +302,42 @@ mod tests {
         // A second tick at the same instant: the schedule has advanced,
         // so nothing fires and no duplicate run is recorded.
         assert!(tick(&db, now, false).is_empty());
+        assert_eq!(db.list_automation_runs(a.id, 10).len(), 1);
+    }
+
+    #[test]
+    fn tick_clears_next_run_on_an_unparseable_schedule() {
+        // A schedule the recurrence engine can't parse must not pin the
+        // automation at a past `next_run_at` — that would re-fire it on
+        // every tick, once a minute, forever. `tick` clears
+        // `next_run_at` instead, so the automation fires at most once
+        // and then goes dormant.
+        let db = crate::database::init_test_database();
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = db
+            .insert_automation(&crate::database::AutomationInput {
+                name: "Broken".to_string(),
+                prompt: "p".to_string(),
+                agent: "claude".to_string(),
+                schedule: "this is not a valid RRULE".to_string(),
+                timezone: "UTC".to_string(),
+                host_id: None,
+                project_path: None,
+                project_remote: None,
+                retention_limit: 10,
+            })
+            .unwrap();
+        db.set_automation_next_run(a.id, Some("2026-01-02T09:00:00+00:00"))
+            .unwrap();
+
+        // First tick fires the due slot, then fails to compute the next.
+        assert_eq!(tick(&db, now, false).len(), 1);
+        // `next_run_at` is cleared — the automation is now dormant.
+        assert!(db.get_automation(a.id).unwrap().next_run_at.is_none());
+
+        // A later tick must not fire it again — no runaway runs.
+        let later = Utc.with_ymd_and_hms(2026, 1, 2, 9, 1, 0).unwrap();
+        assert!(tick(&db, later, false).is_empty());
         assert_eq!(db.list_automation_runs(a.id, 10).len(), 1);
     }
 

--- a/src-tauri/src/automations/scheduler.rs
+++ b/src-tauri/src/automations/scheduler.rs
@@ -163,6 +163,7 @@ mod tests {
             timezone: "UTC".to_string(),
             host_id: None,
             project_path: None,
+            project_remote: None,
             enabled,
             retention_limit: 10,
             last_run_at: None,
@@ -241,6 +242,7 @@ mod tests {
                 timezone: "UTC".to_string(),
                 host_id: None,
                 project_path: None,
+                project_remote: None,
                 retention_limit: 10,
             })
             .unwrap();
@@ -333,6 +335,7 @@ mod tests {
                 timezone: "UTC".to_string(),
                 host_id: Some(7),
                 project_path: None,
+                project_remote: None,
                 retention_limit: 10,
             })
             .unwrap();

--- a/src-tauri/src/automations/scheduler.rs
+++ b/src-tauri/src/automations/scheduler.rs
@@ -73,10 +73,22 @@ fn has_active_run(db: &DatabaseStore, automation_id: i64) -> bool {
 /// Returns the freshly-created `scheduled` runs — the caller (the
 /// executor) turns each into a workspace + agent. `skipped_busy` runs
 /// are recorded but not returned, as there is nothing to execute.
-pub fn tick(db: &DatabaseStore, now: DateTime<Utc>) -> Vec<AutomationRunRecord> {
+///
+/// `local_only` is the host-routing switch: the desktop scheduler
+/// passes `true` and runs only automations targeting this machine
+/// (`host_id IS NULL`) — a host-assigned automation is the job of that
+/// host's `codemux-remote scheduler`, which passes `false`.
+pub fn tick(
+    db: &DatabaseStore,
+    now: DateTime<Utc>,
+    local_only: bool,
+) -> Vec<AutomationRunRecord> {
     let mut fired = Vec::new();
 
     for automation in db.list_automations() {
+        if local_only && automation.host_id.is_some() {
+            continue;
+        }
         if !is_due(&automation, now) {
             continue;
         }
@@ -242,7 +254,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
         let a = insert_due(&db, Some("2026-01-02T09:00:00+00:00"));
 
-        let fired = tick(&db, now);
+        let fired = tick(&db, now, false);
         assert_eq!(fired.len(), 1);
         assert_eq!(fired[0].automation_id, a.id);
         assert_eq!(fired[0].status, "scheduled");
@@ -262,7 +274,7 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
         insert_due(&db, Some("2026-01-02T10:00:00+00:00"));
 
-        assert!(tick(&db, now).is_empty());
+        assert!(tick(&db, now, false).is_empty());
     }
 
     #[test]
@@ -271,10 +283,10 @@ mod tests {
         let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
         let a = insert_due(&db, Some("2026-01-02T09:00:00+00:00"));
 
-        assert_eq!(tick(&db, now).len(), 1);
+        assert_eq!(tick(&db, now, false).len(), 1);
         // A second tick at the same instant: the schedule has advanced,
         // so nothing fires and no duplicate run is recorded.
-        assert!(tick(&db, now).is_empty());
+        assert!(tick(&db, now, false).is_empty());
         assert_eq!(db.list_automation_runs(a.id, 10).len(), 1);
     }
 
@@ -288,7 +300,7 @@ mod tests {
         db.record_automation_run(a.id, "running", "2026-01-01T09:00:00Z", None, None)
             .unwrap();
 
-        let fired = tick(&db, now);
+        let fired = tick(&db, now, false);
         // Overlap: nothing is handed to the executor...
         assert!(fired.is_empty());
         // ...but the skip is recorded for this minute.
@@ -303,7 +315,34 @@ mod tests {
         let a = insert_due(&db, Some("2026-01-02T09:00:00+00:00"));
         db.set_automation_enabled(a.id, false).unwrap();
 
-        assert!(tick(&db, now).is_empty());
+        assert!(tick(&db, now, false).is_empty());
         assert_eq!(db.list_automation_runs(a.id, 10).len(), 0);
+    }
+
+    #[test]
+    fn tick_local_only_skips_host_assigned_automations() {
+        let db = crate::database::init_test_database();
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        // An automation targeting a remote host (host_id = Some).
+        let a = db
+            .insert_automation(&crate::database::AutomationInput {
+                name: "Remote".to_string(),
+                prompt: "p".to_string(),
+                agent: "claude".to_string(),
+                schedule: "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY".to_string(),
+                timezone: "UTC".to_string(),
+                host_id: Some(7),
+                project_path: None,
+                retention_limit: 10,
+            })
+            .unwrap();
+        db.set_automation_next_run(a.id, Some("2026-01-02T09:00:00+00:00"))
+            .unwrap();
+
+        // Desktop scheduler (`local_only = true`): host-assigned
+        // automation is skipped.
+        assert!(tick(&db, now, true).is_empty());
+        // Remote scheduler (`local_only = false`): it fires.
+        assert_eq!(tick(&db, now, false).len(), 1);
     }
 }

--- a/src-tauri/src/automations/scheduler.rs
+++ b/src-tauri/src/automations/scheduler.rs
@@ -1,0 +1,309 @@
+//! Scheduler decision logic for automations.
+//!
+//! This module is the pure core of the host-side scheduler: given an
+//! automation and the current time it answers "should this fire now?"
+//! and "what is the dedup key for this fire?". The I/O loop that polls
+//! the registry, creates a workspace and spawns the agent lives in the
+//! `codemux-remote` binary and calls into here — keeping the decision
+//! logic pure makes it unit-testable without a host or a clock.
+
+use crate::automations::recurrence;
+use crate::database::{AutomationRecord, AutomationRunRecord, DatabaseStore};
+use chrono::{DateTime, SecondsFormat, Timelike, Utc};
+
+/// How often the host-side loop evaluates the schedule. A minute-grained
+/// recurrence never needs finer resolution, and `fire_key` collapses any
+/// jitter within a minute to a single idempotent run.
+pub const TICK_INTERVAL_SECS: u64 = 60;
+
+/// Floor an instant to the start of its minute and format it as the
+/// canonical `scheduled_for` dedup key — RFC 3339, UTC, second
+/// precision. `record_automation_run`'s `UNIQUE(automation_id,
+/// scheduled_for)` constraint then makes a re-delivered tick within the
+/// same minute a no-op insert.
+pub fn fire_key(at: DateTime<Utc>) -> String {
+    at.with_second(0)
+        .and_then(|t| t.with_nanosecond(0))
+        .unwrap_or(at)
+        .to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+/// Whether an automation is due to fire at `now`: it must be enabled and
+/// carry a `next_run_at` that has arrived. A paused automation, or one
+/// whose recurrence is exhausted (no `next_run_at`), is never due.
+pub fn is_due(automation: &AutomationRecord, now: DateTime<Utc>) -> bool {
+    if !automation.enabled {
+        return false;
+    }
+    match automation.next_run_at.as_deref().and_then(parse_utc) {
+        Some(next) => next <= now,
+        None => false,
+    }
+}
+
+/// Parse an RFC 3339 timestamp to `DateTime<Utc>`, returning `None` on
+/// any malformed value rather than panicking the scheduler loop.
+fn parse_utc(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// Whether an automation already has a run that has not reached a
+/// terminal state — used for the one-run-at-a-time overlap guard.
+fn has_active_run(db: &DatabaseStore, automation_id: i64) -> bool {
+    db.list_automation_runs(automation_id, 20)
+        .iter()
+        .any(|run| run.status == "scheduled" || run.status == "running")
+}
+
+/// Evaluate the whole schedule once.
+///
+/// For every due automation this:
+/// 1. records a run for the current minute — `scheduled` normally, or
+///    `skipped_busy` when a previous run is still in flight (overlap is
+///    serialised per automation, not stacked);
+/// 2. advances `next_run_at` to the following occurrence, or clears it
+///    when a bounded recurrence is exhausted.
+///
+/// The per-minute `fire_key` plus the `UNIQUE(automation_id,
+/// scheduled_for)` constraint make a tick idempotent, so a missed or
+/// double tick never produces duplicate runs.
+///
+/// Returns the freshly-created `scheduled` runs — the caller (the
+/// executor) turns each into a workspace + agent. `skipped_busy` runs
+/// are recorded but not returned, as there is nothing to execute.
+pub fn tick(db: &DatabaseStore, now: DateTime<Utc>) -> Vec<AutomationRunRecord> {
+    let mut fired = Vec::new();
+
+    for automation in db.list_automations() {
+        if !is_due(&automation, now) {
+            continue;
+        }
+
+        let key = fire_key(now);
+        let busy = has_active_run(db, automation.id);
+        let status = if busy { "skipped_busy" } else { "scheduled" };
+
+        match db.record_automation_run(automation.id, status, &key, automation.host_id, None) {
+            Ok(Some(run)) => {
+                if busy {
+                    eprintln!(
+                        "[codemux::scheduler] automation {} skipped: previous run still active",
+                        automation.id
+                    );
+                } else {
+                    fired.push(run);
+                }
+            }
+            // `None` means this minute was already recorded — idempotent.
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!(
+                    "[codemux::scheduler] failed to record run for automation {}: {error}",
+                    automation.id
+                );
+            }
+        }
+
+        // Advance the schedule regardless of the run outcome, so the
+        // automation moves on to its next slot instead of re-firing
+        // this one.
+        match recurrence::next_occurrence(&automation.schedule, now) {
+            Ok(next) => {
+                let next_str = next.map(|dt| dt.to_rfc3339());
+                if let Err(error) =
+                    db.set_automation_next_run(automation.id, next_str.as_deref())
+                {
+                    eprintln!(
+                        "[codemux::scheduler] failed to advance automation {}: {error}",
+                        automation.id
+                    );
+                }
+            }
+            Err(error) => {
+                eprintln!(
+                    "[codemux::scheduler] invalid schedule on automation {}: {error}",
+                    automation.id
+                );
+            }
+        }
+    }
+
+    fired
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    /// Build an `AutomationRecord` with the given enabled flag and
+    /// `next_run_at`; other fields are irrelevant to scheduling.
+    fn automation(enabled: bool, next_run_at: Option<&str>) -> AutomationRecord {
+        AutomationRecord {
+            id: 1,
+            server_id: None,
+            name: "Test".to_string(),
+            prompt: "do the thing".to_string(),
+            agent: "claude".to_string(),
+            schedule: "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY".to_string(),
+            timezone: "UTC".to_string(),
+            host_id: None,
+            project_path: None,
+            enabled,
+            retention_limit: 10,
+            last_run_at: None,
+            next_run_at: next_run_at.map(str::to_string),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            deleted_at: None,
+            dirty: false,
+        }
+    }
+
+    #[test]
+    fn fire_key_floors_to_the_minute() {
+        let at = Utc.with_ymd_and_hms(2026, 1, 2, 9, 7, 43).unwrap();
+        assert_eq!(fire_key(at), "2026-01-02T09:07:00Z");
+    }
+
+    #[test]
+    fn fire_key_is_stable_across_a_minute() {
+        let early = Utc.with_ymd_and_hms(2026, 1, 2, 9, 7, 1).unwrap();
+        let late = Utc.with_ymd_and_hms(2026, 1, 2, 9, 7, 59).unwrap();
+        assert_eq!(fire_key(early), fire_key(late));
+    }
+
+    #[test]
+    fn due_when_enabled_and_next_run_has_arrived() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = automation(true, Some("2026-01-02T09:00:00+00:00"));
+        assert!(is_due(&a, now));
+
+        let earlier = automation(true, Some("2026-01-02T08:00:00+00:00"));
+        assert!(is_due(&earlier, now));
+    }
+
+    #[test]
+    fn not_due_when_next_run_is_in_the_future() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = automation(true, Some("2026-01-02T10:00:00+00:00"));
+        assert!(!is_due(&a, now));
+    }
+
+    #[test]
+    fn not_due_when_paused_even_if_next_run_has_arrived() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = automation(false, Some("2026-01-02T09:00:00+00:00"));
+        assert!(!is_due(&a, now));
+    }
+
+    #[test]
+    fn not_due_when_recurrence_is_exhausted() {
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = automation(true, None);
+        assert!(!is_due(&a, now));
+    }
+
+    #[test]
+    fn not_due_when_next_run_is_malformed() {
+        // A garbage timestamp must not panic the loop — it is simply
+        // never due until the value is corrected.
+        let now = Utc::now();
+        let a = automation(true, Some("not-a-timestamp"));
+        assert!(!is_due(&a, now));
+    }
+
+    // ── tick ──
+
+    /// Insert a daily automation and set its `next_run_at`, returning the
+    /// stored record.
+    fn insert_due(db: &DatabaseStore, next_run: Option<&str>) -> AutomationRecord {
+        let a = db
+            .insert_automation(&crate::database::AutomationInput {
+                name: "Test".to_string(),
+                prompt: "do the thing".to_string(),
+                agent: "claude".to_string(),
+                schedule: "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY".to_string(),
+                timezone: "UTC".to_string(),
+                host_id: None,
+                project_path: None,
+                retention_limit: 10,
+            })
+            .unwrap();
+        db.set_automation_next_run(a.id, next_run).unwrap();
+        db.get_automation(a.id).unwrap()
+    }
+
+    #[test]
+    fn tick_fires_a_due_automation_and_advances_it() {
+        let db = crate::database::init_test_database();
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = insert_due(&db, Some("2026-01-02T09:00:00+00:00"));
+
+        let fired = tick(&db, now);
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].automation_id, a.id);
+        assert_eq!(fired[0].status, "scheduled");
+
+        // The schedule moved on, so the same slot will not fire again.
+        let advanced = db.get_automation(a.id).unwrap();
+        assert!(advanced.next_run_at.is_some());
+        assert_ne!(
+            advanced.next_run_at.as_deref(),
+            Some("2026-01-02T09:00:00+00:00")
+        );
+    }
+
+    #[test]
+    fn tick_ignores_an_automation_whose_next_run_is_in_the_future() {
+        let db = crate::database::init_test_database();
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        insert_due(&db, Some("2026-01-02T10:00:00+00:00"));
+
+        assert!(tick(&db, now).is_empty());
+    }
+
+    #[test]
+    fn tick_does_not_refire_the_same_slot() {
+        let db = crate::database::init_test_database();
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = insert_due(&db, Some("2026-01-02T09:00:00+00:00"));
+
+        assert_eq!(tick(&db, now).len(), 1);
+        // A second tick at the same instant: the schedule has advanced,
+        // so nothing fires and no duplicate run is recorded.
+        assert!(tick(&db, now).is_empty());
+        assert_eq!(db.list_automation_runs(a.id, 10).len(), 1);
+    }
+
+    #[test]
+    fn tick_records_skipped_busy_when_a_previous_run_is_still_active() {
+        let db = crate::database::init_test_database();
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = insert_due(&db, Some("2026-01-02T09:00:00+00:00"));
+
+        // A still-running run from an earlier fire.
+        db.record_automation_run(a.id, "running", "2026-01-01T09:00:00Z", None, None)
+            .unwrap();
+
+        let fired = tick(&db, now);
+        // Overlap: nothing is handed to the executor...
+        assert!(fired.is_empty());
+        // ...but the skip is recorded for this minute.
+        let runs = db.list_automation_runs(a.id, 10);
+        assert!(runs.iter().any(|r| r.status == "skipped_busy"));
+    }
+
+    #[test]
+    fn tick_skips_a_paused_automation() {
+        let db = crate::database::init_test_database();
+        let now = Utc.with_ymd_and_hms(2026, 1, 2, 9, 0, 0).unwrap();
+        let a = insert_due(&db, Some("2026-01-02T09:00:00+00:00"));
+        db.set_automation_enabled(a.id, false).unwrap();
+
+        assert!(tick(&db, now).is_empty());
+        assert_eq!(db.list_automation_runs(a.id, 10).len(), 0);
+    }
+}

--- a/src-tauri/src/automations/service.rs
+++ b/src-tauri/src/automations/service.rs
@@ -1,0 +1,97 @@
+//! Service-manager unit generation for the `codemux-remote scheduler`.
+//!
+//! For an automation host to run automations reliably the scheduler
+//! must survive reboots and logout — so it is registered as a
+//! persistent **user** service. This module generates the unit
+//! definitions (pure, unit-tested).
+//!
+//! The SSH wiring that writes these to a host and enables them belongs
+//! in `ssh/bootstrap.rs`; it is wired once the account API is deployed
+//! and the host bootstrap can also provision a scheduler token — see
+//! `docs/plans/automations-sync.md` Phase E.
+
+/// A systemd **user** service unit for the scheduler.
+///
+/// `exec_path` is the absolute path to the `codemux-remote` binary on
+/// the host (bootstrap installs it at `~/.local/bin/codemux-remote`).
+/// Installed at `~/.config/systemd/user/codemux-scheduler.service`,
+/// then `systemctl --user enable --now codemux-scheduler`.
+pub fn systemd_unit(exec_path: &str) -> String {
+    format!(
+        "[Unit]\n\
+         Description=Codemux automation scheduler\n\
+         After=network-online.target\n\
+         Wants=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         ExecStart={exec_path} scheduler\n\
+         Restart=always\n\
+         RestartSec=10\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n"
+    )
+}
+
+/// A launchd `LaunchAgent` plist for macOS hosts. `exec_path` is the
+/// absolute `codemux-remote` path; `label` is the service label (e.g.
+/// `org.codemux.scheduler`). Installed under
+/// `~/Library/LaunchAgents/<label>.plist`.
+pub fn launchd_plist(exec_path: &str, label: &str) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+         \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+         <plist version=\"1.0\">\n\
+         <dict>\n\
+         \x20 <key>Label</key>\n\
+         \x20 <string>{label}</string>\n\
+         \x20 <key>ProgramArguments</key>\n\
+         \x20 <array>\n\
+         \x20   <string>{exec_path}</string>\n\
+         \x20   <string>scheduler</string>\n\
+         \x20 </array>\n\
+         \x20 <key>RunAtLoad</key>\n\
+         \x20 <true/>\n\
+         \x20 <key>KeepAlive</key>\n\
+         \x20 <true/>\n\
+         </dict>\n\
+         </plist>\n"
+    )
+}
+
+/// Default systemd unit file name for the scheduler service.
+pub const SYSTEMD_UNIT_NAME: &str = "codemux-scheduler.service";
+
+/// Default launchd label for the scheduler service.
+pub const LAUNCHD_LABEL: &str = "org.codemux.scheduler";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn systemd_unit_runs_the_scheduler_subcommand() {
+        let unit = systemd_unit("/home/u/.local/bin/codemux-remote");
+        assert!(unit.contains("ExecStart=/home/u/.local/bin/codemux-remote scheduler"));
+        // Survives crashes and reboots.
+        assert!(unit.contains("Restart=always"));
+        assert!(unit.contains("WantedBy=default.target"));
+        // Waits for the network — the scheduler polls the account API.
+        assert!(unit.contains("Wants=network-online.target"));
+    }
+
+    #[test]
+    fn launchd_plist_runs_the_scheduler_and_keeps_it_alive() {
+        let plist = launchd_plist("/usr/local/bin/codemux-remote", LAUNCHD_LABEL);
+        assert!(plist.contains("<string>org.codemux.scheduler</string>"));
+        assert!(plist.contains("<string>/usr/local/bin/codemux-remote</string>"));
+        assert!(plist.contains("<string>scheduler</string>"));
+        assert!(plist.contains("<key>KeepAlive</key>"));
+        assert!(plist.contains("<key>RunAtLoad</key>"));
+        // A well-formed plist document.
+        assert!(plist.trim_start().starts_with("<?xml"));
+        assert!(plist.contains("</plist>"));
+    }
+}

--- a/src-tauri/src/automations_sync.rs
+++ b/src-tauri/src/automations_sync.rs
@@ -35,6 +35,8 @@ pub struct ServerAutomation {
     pub host_server_id: Option<String>,
     #[serde(rename = "projectPath")]
     pub project_path: Option<String>,
+    #[serde(rename = "projectRemote", default)]
+    pub project_remote: Option<String>,
     pub enabled: bool,
     #[serde(rename = "retentionLimit")]
     pub retention_limit: i64,
@@ -67,6 +69,8 @@ struct AutomationUpsertBody<'a> {
     host_server_id: Option<String>,
     #[serde(rename = "projectPath")]
     project_path: Option<&'a str>,
+    #[serde(rename = "projectRemote")]
+    project_remote: Option<&'a str>,
     enabled: bool,
     #[serde(rename = "retentionLimit")]
     retention_limit: i64,
@@ -173,6 +177,7 @@ pub async fn pull(
             &a.timezone,
             host_id,
             a.project_path.as_deref(),
+            a.project_remote.as_deref(),
             a.enabled,
             a.retention_limit,
             &a.created_at,
@@ -198,6 +203,7 @@ pub async fn pull(
                     &row.timezone,
                     row.host_id,
                     row.project_path.as_deref(),
+                    row.project_remote.as_deref(),
                     row.enabled,
                     row.retention_limit,
                     &row.created_at,
@@ -255,6 +261,7 @@ fn upsert_body<'a>(
         timezone: &row.timezone,
         host_server_id: row.host_id.and_then(|id| local_to_server.get(&id).cloned()),
         project_path: row.project_path.as_deref(),
+        project_remote: row.project_remote.as_deref(),
         enabled: row.enabled,
         retention_limit: row.retention_limit,
     }
@@ -373,6 +380,7 @@ mod tests {
             timezone: "UTC".to_string(),
             host_id: None,
             project_path: Some("/repo".to_string()),
+            project_remote: None,
             retention_limit: 10,
         }
     }

--- a/src-tauri/src/automations_sync.rs
+++ b/src-tauri/src/automations_sync.rs
@@ -1,0 +1,446 @@
+//! Automations sync — pull/push the user's automation registry across
+//! their devices. A near-copy of `hosts_sync.rs`.
+//!
+//! Only the `automations` table syncs; `automation_runs` are per-device
+//! history and stay local.
+//!
+//! Host identity crosses the wire as the host's `server_id`
+//! (`hostServerId`), not the local integer `host_id` — local ids differ
+//! per device. On pull, an unknown `hostServerId` resolves to a null
+//! `host_id` (shown as a removed/unknown host until the host syncs in).
+//!
+//! Failure policy matches `hosts_sync`: a failed push leaves the row
+//! `dirty` and logs once; the next sync retries. `404` from the API is
+//! treated as "endpoint not deployed yet" — a harmless skip.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde::{Deserialize, Serialize};
+use tauri::Manager;
+
+use crate::auth::{api_base_url, is_token_expired, load_token};
+use crate::database::{AutomationRecord, DatabaseStore};
+
+/// Wire shape from `GET /api/automations` and `POST /api/automations`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerAutomation {
+    pub id: String,
+    pub name: String,
+    pub prompt: String,
+    pub agent: String,
+    pub schedule: String,
+    pub timezone: String,
+    #[serde(rename = "hostServerId")]
+    pub host_server_id: Option<String>,
+    #[serde(rename = "projectPath")]
+    pub project_path: Option<String>,
+    pub enabled: bool,
+    #[serde(rename = "retentionLimit")]
+    pub retention_limit: i64,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    #[serde(rename = "deletedAt")]
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListAutomationsResponse {
+    automations: Vec<ServerAutomation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OneAutomationResponse {
+    automation: ServerAutomation,
+}
+
+#[derive(Debug, Serialize)]
+struct AutomationUpsertBody<'a> {
+    name: &'a str,
+    prompt: &'a str,
+    agent: &'a str,
+    schedule: &'a str,
+    timezone: &'a str,
+    #[serde(rename = "hostServerId")]
+    host_server_id: Option<String>,
+    #[serde(rename = "projectPath")]
+    project_path: Option<&'a str>,
+    enabled: bool,
+    #[serde(rename = "retentionLimit")]
+    retention_limit: i64,
+}
+
+/// Guards against overlapping sync runs (foreground sync vs. the
+/// fire-and-forget sync each mutation triggers).
+static SYNC_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Build the two host-identity maps: local `host_id` → `server_id`, and
+/// `server_id` → local `host_id`. Only hosts that have synced (have a
+/// `server_id`) appear.
+fn host_maps(db: &DatabaseStore) -> (HashMap<i64, String>, HashMap<String, i64>) {
+    let mut local_to_server = HashMap::new();
+    let mut server_to_local = HashMap::new();
+    for host in db.list_hosts_for_sync() {
+        if let Some(sid) = host.server_id {
+            local_to_server.insert(host.id, sid.clone());
+            server_to_local.insert(sid, host.id);
+        }
+    }
+    (local_to_server, server_to_local)
+}
+
+/// Resolve the local DB + token from app state and run pull-then-push.
+/// `Ok(())` when the user is not signed in — sync is not an error then.
+pub async fn try_sync_with_app(app: &tauri::AppHandle) -> Result<(), String> {
+    let db = app.state::<DatabaseStore>();
+    let token = match valid_token(&db) {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    let db_ref: &DatabaseStore = &db;
+    let pull_err = pull(&token, db_ref).await.err();
+    let push_err = push(&token, db_ref).await.err();
+    match (pull_err, push_err) {
+        (None, None) => Ok(()),
+        (Some(p), None) => Err(format!("pull failed: {p}")),
+        (None, Some(p)) => Err(format!("push failed: {p}")),
+        (Some(a), Some(b)) => Err(format!("pull failed: {a}; push failed: {b}")),
+    }
+}
+
+fn valid_token(db: &DatabaseStore) -> Option<String> {
+    let (token, expires_at) = load_token(db)?;
+    if is_token_expired(&expires_at) {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+/// Pull server automations into the local DB. Idempotent. A local row
+/// whose `server_id` is missing from the response was deleted on
+/// another device and is tombstoned locally.
+pub async fn pull(token: &str, db: &DatabaseStore) -> Result<(), String> {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{base}/api/automations"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+    if !resp.status().is_success() {
+        // 404 = endpoint not deployed yet — harmless skip.
+        if resp.status().as_u16() == 404 {
+            return Ok(());
+        }
+        return Err(format!("API error: {}", resp.status()));
+    }
+    let body: ListAutomationsResponse =
+        resp.json().await.map_err(|e| format!("Parse: {e}"))?;
+
+    let (_local_to_server, server_to_local) = host_maps(db);
+    let local = db.list_automations_for_sync();
+    let server_ids: std::collections::HashSet<String> =
+        body.automations.iter().map(|a| a.id.clone()).collect();
+
+    for a in &body.automations {
+        let host_id = a
+            .host_server_id
+            .as_ref()
+            .and_then(|sid| server_to_local.get(sid).copied());
+        db.upsert_automation_from_server(
+            &a.id,
+            &a.name,
+            &a.prompt,
+            &a.agent,
+            &a.schedule,
+            &a.timezone,
+            host_id,
+            a.project_path.as_deref(),
+            a.enabled,
+            a.retention_limit,
+            &a.created_at,
+            &a.updated_at,
+            a.deleted_at.as_deref(),
+        )?;
+    }
+
+    // Server-side deletion sweep.
+    for row in &local {
+        if let Some(sid) = &row.server_id {
+            if !server_ids.contains(sid) && row.deleted_at.is_none() {
+                eprintln!(
+                    "[automations-sync] server no longer has {sid}; tombstoning locally"
+                );
+                let now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+                db.upsert_automation_from_server(
+                    sid,
+                    &row.name,
+                    &row.prompt,
+                    &row.agent,
+                    &row.schedule,
+                    &row.timezone,
+                    row.host_id,
+                    row.project_path.as_deref(),
+                    row.enabled,
+                    row.retention_limit,
+                    &row.created_at,
+                    &now,
+                    Some(&now),
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Push dirty local automations. Each row is handled independently so
+/// one failure does not strand the rest.
+pub async fn push(token: &str, db: &DatabaseStore) -> Result<(), String> {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+    let (local_to_server, _server_to_local) = host_maps(db);
+    let dirty = db.list_dirty_automations();
+    let mut any_failed = false;
+
+    for row in &dirty {
+        let result = if row.deleted_at.is_some() {
+            push_delete(&client, &base, token, row, db).await
+        } else if row.server_id.is_none() {
+            push_insert(&client, &base, token, row, &local_to_server, db).await
+        } else {
+            push_update(&client, &base, token, row, &local_to_server, db).await
+        };
+        if let Err(error) = result {
+            eprintln!("[automations-sync] push failed for local id {}: {error}", row.id);
+            any_failed = true;
+        }
+    }
+
+    db.purge_acknowledged_automation_deletes()?;
+
+    if any_failed {
+        Err("one or more automation pushes failed; see logs".into())
+    } else {
+        Ok(())
+    }
+}
+
+fn upsert_body<'a>(
+    row: &'a AutomationRecord,
+    local_to_server: &HashMap<i64, String>,
+) -> AutomationUpsertBody<'a> {
+    AutomationUpsertBody {
+        name: &row.name,
+        prompt: &row.prompt,
+        agent: &row.agent,
+        schedule: &row.schedule,
+        timezone: &row.timezone,
+        host_server_id: row.host_id.and_then(|id| local_to_server.get(&id).cloned()),
+        project_path: row.project_path.as_deref(),
+        enabled: row.enabled,
+        retention_limit: row.retention_limit,
+    }
+}
+
+async fn push_insert(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+    row: &AutomationRecord,
+    local_to_server: &HashMap<i64, String>,
+    db: &DatabaseStore,
+) -> Result<(), String> {
+    let resp = client
+        .post(format!("{base}/api/automations"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&upsert_body(row, local_to_server))
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("API error: {}", resp.status()));
+    }
+    let parsed: OneAutomationResponse =
+        resp.json().await.map_err(|e| format!("Parse: {e}"))?;
+    db.mark_automation_synced(row.id, Some(&parsed.automation.id))?;
+    Ok(())
+}
+
+async fn push_update(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+    row: &AutomationRecord,
+    local_to_server: &HashMap<i64, String>,
+    db: &DatabaseStore,
+) -> Result<(), String> {
+    let server_id = row
+        .server_id
+        .as_ref()
+        .ok_or_else(|| "push_update called without server_id".to_string())?;
+    let resp = client
+        .patch(format!("{base}/api/automations/{server_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&upsert_body(row, local_to_server))
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("API error: {}", resp.status()));
+    }
+    db.mark_automation_synced(row.id, None)?;
+    Ok(())
+}
+
+async fn push_delete(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+    row: &AutomationRecord,
+    db: &DatabaseStore,
+) -> Result<(), String> {
+    let server_id = match &row.server_id {
+        Some(sid) => sid,
+        None => {
+            // Created and deleted before it ever synced — nothing on
+            // the server. Clear `dirty` so the tombstone is purged.
+            db.mark_automation_synced(row.id, None)?;
+            return Ok(());
+        }
+    };
+    let resp = client
+        .delete(format!("{base}/api/automations/{server_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+    // 404 = already gone server-side — also a success for our purposes.
+    if !resp.status().is_success() && resp.status().as_u16() != 404 {
+        return Err(format!("API error: {}", resp.status()));
+    }
+    // Clear `dirty` so `purge_acknowledged_automation_deletes` removes
+    // the tombstone on the next pass.
+    db.mark_automation_synced(row.id, None)?;
+    Ok(())
+}
+
+/// Foreground sync with the in-progress guard. Used at scheduler
+/// startup and by the periodic pull in the tick loop.
+pub async fn sync_automations(token: &str, db: &DatabaseStore) -> Result<(), String> {
+    if SYNC_IN_PROGRESS.swap(true, Ordering::SeqCst) {
+        return Ok(());
+    }
+    let result = async {
+        pull(token, db).await?;
+        push(token, db).await?;
+        Ok(())
+    }
+    .await;
+    SYNC_IN_PROGRESS.store(false, Ordering::SeqCst);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::{init_test_database, AutomationInput};
+    use serial_test::serial;
+
+    fn sample_input() -> AutomationInput {
+        AutomationInput {
+            name: "Triage".to_string(),
+            prompt: "review issues".to_string(),
+            agent: "claude".to_string(),
+            schedule: "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY".to_string(),
+            timezone: "UTC".to_string(),
+            host_id: None,
+            project_path: Some("/repo".to_string()),
+            retention_limit: 10,
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn pull_upserts_server_automations() {
+        let mut server = mockito::Server::new_async().await;
+        std::env::set_var("CODEMUX_API_URL", server.url());
+        let mock = server
+            .mock("GET", "/api/automations")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"automations":[{"id":"srv-1","name":"Nightly",
+                "prompt":"p","agent":"claude",
+                "schedule":"DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY",
+                "timezone":"UTC","hostServerId":null,"projectPath":"/r",
+                "enabled":true,"retentionLimit":10,
+                "createdAt":"2026-01-01T00:00:00Z",
+                "updatedAt":"2026-01-01T00:00:00Z","deletedAt":null}]}"#,
+            )
+            .create_async()
+            .await;
+
+        let db = init_test_database();
+        pull("token", &db).await.unwrap();
+        mock.assert_async().await;
+
+        let rows = db.list_automations();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "Nightly");
+        assert_eq!(rows[0].server_id.as_deref(), Some("srv-1"));
+        assert!(!rows[0].dirty, "server-sourced rows are clean");
+        std::env::remove_var("CODEMUX_API_URL");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn pull_treats_404_as_a_harmless_skip() {
+        let mut server = mockito::Server::new_async().await;
+        std::env::set_var("CODEMUX_API_URL", server.url());
+        server
+            .mock("GET", "/api/automations")
+            .with_status(404)
+            .create_async()
+            .await;
+        let db = init_test_database();
+        assert!(pull("token", &db).await.is_ok());
+        std::env::remove_var("CODEMUX_API_URL");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn push_uploads_a_dirty_row_and_marks_it_synced() {
+        let mut server = mockito::Server::new_async().await;
+        std::env::set_var("CODEMUX_API_URL", server.url());
+        let mock = server
+            .mock("POST", "/api/automations")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"automation":{"id":"srv-9","name":"Triage","prompt":"p",
+                "agent":"claude","schedule":"s","timezone":"UTC",
+                "hostServerId":null,"projectPath":null,"enabled":true,
+                "retentionLimit":10,"createdAt":"x","updatedAt":"x",
+                "deletedAt":null}}"#,
+            )
+            .create_async()
+            .await;
+
+        let db = init_test_database();
+        let created = db.insert_automation(&sample_input()).unwrap();
+        assert!(created.dirty);
+
+        push("token", &db).await.unwrap();
+        mock.assert_async().await;
+
+        let row = db.get_automation(created.id).unwrap();
+        assert!(!row.dirty, "a pushed row is no longer dirty");
+        assert_eq!(row.server_id.as_deref(), Some("srv-9"));
+        std::env::remove_var("CODEMUX_API_URL");
+    }
+}

--- a/src-tauri/src/automations_sync.rs
+++ b/src-tauri/src/automations_sync.rs
@@ -168,6 +168,25 @@ pub async fn pull(
             .host_server_id
             .as_ref()
             .and_then(|sid| server_to_local.get(sid).copied());
+
+        // The automation targets a remote host, but that host has not
+        // synced to this device yet, so we can't resolve its local id.
+        // Importing it now would store `host_id = NULL` — which the
+        // desktop scheduler reads as "this machine" and would run a
+        // remote-host automation locally. Skip it; a later sync (once
+        // the host row arrives) imports it correctly. Tombstones still
+        // fall through so a deletion always propagates.
+        if a.deleted_at.is_none()
+            && a.host_server_id.is_some()
+            && host_id.is_none()
+        {
+            eprintln!(
+                "[automations-sync] deferring {}: target host not synced yet",
+                a.id
+            );
+            continue;
+        }
+
         db.upsert_automation_from_server(
             &a.id,
             &a.name,
@@ -415,6 +434,43 @@ mod tests {
         assert_eq!(rows[0].name, "Nightly");
         assert_eq!(rows[0].server_id.as_deref(), Some("srv-1"));
         assert!(!rows[0].dirty, "server-sourced rows are clean");
+        std::env::remove_var("CODEMUX_API_URL");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn pull_defers_an_automation_whose_target_host_is_not_synced() {
+        // The automation targets a remote host, but that host has not
+        // synced to this device yet. Importing it would store
+        // `host_id = NULL`, which the desktop scheduler reads as "this
+        // machine" — it would run a remote-host automation on the
+        // wrong machine. Pull must skip it until the host row arrives.
+        let mut server = mockito::Server::new_async().await;
+        std::env::set_var("CODEMUX_API_URL", server.url());
+        let mock = server
+            .mock("GET", "/api/automations")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"automations":[{"id":"srv-2","name":"OnHost",
+                "prompt":"p","agent":"claude",
+                "schedule":"DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY",
+                "timezone":"UTC","hostServerId":"host-srv-99","projectPath":null,
+                "enabled":true,"retentionLimit":10,
+                "createdAt":"2026-01-01T00:00:00Z",
+                "updatedAt":"2026-01-01T00:00:00Z","deletedAt":null}]}"#,
+            )
+            .create_async()
+            .await;
+
+        let db = init_test_database();
+        pull("token", &db, None).await.unwrap();
+        mock.assert_async().await;
+
+        assert!(
+            db.list_automations().is_empty(),
+            "an automation for an unknown host is deferred, not imported"
+        );
         std::env::remove_var("CODEMUX_API_URL");
     }
 

--- a/src-tauri/src/automations_sync.rs
+++ b/src-tauri/src/automations_sync.rs
@@ -100,7 +100,7 @@ pub async fn try_sync_with_app(app: &tauri::AppHandle) -> Result<(), String> {
         None => return Ok(()),
     };
     let db_ref: &DatabaseStore = &db;
-    let pull_err = pull(&token, db_ref).await.err();
+    let pull_err = pull(&token, db_ref, None).await.err();
     let push_err = push(&token, db_ref).await.err();
     match (pull_err, push_err) {
         (None, None) => Ok(()),
@@ -122,11 +122,24 @@ fn valid_token(db: &DatabaseStore) -> Option<String> {
 /// Pull server automations into the local DB. Idempotent. A local row
 /// whose `server_id` is missing from the response was deleted on
 /// another device and is tombstoned locally.
-pub async fn pull(token: &str, db: &DatabaseStore) -> Result<(), String> {
+///
+/// `host_filter` scopes the pull to one host's automations (by host
+/// `server_id`): the desktop passes `None` and pulls the whole
+/// registry; a `codemux-remote scheduler` passes its own host id so it
+/// only receives — and therefore only runs — automations routed to it.
+pub async fn pull(
+    token: &str,
+    db: &DatabaseStore,
+    host_filter: Option<&str>,
+) -> Result<(), String> {
     let base = api_base_url();
     let client = reqwest::Client::new();
+    let mut url = format!("{base}/api/automations");
+    if let Some(host) = host_filter {
+        url.push_str(&format!("?hostServerId={}", urlencoding::encode(host)));
+    }
     let resp = client
-        .get(format!("{base}/api/automations"))
+        .get(&url)
         .header("Authorization", format!("Bearer {token}"))
         .send()
         .await
@@ -336,7 +349,7 @@ pub async fn sync_automations(token: &str, db: &DatabaseStore) -> Result<(), Str
         return Ok(());
     }
     let result = async {
-        pull(token, db).await?;
+        pull(token, db, None).await?;
         push(token, db).await?;
         Ok(())
     }
@@ -386,7 +399,7 @@ mod tests {
             .await;
 
         let db = init_test_database();
-        pull("token", &db).await.unwrap();
+        pull("token", &db, None).await.unwrap();
         mock.assert_async().await;
 
         let rows = db.list_automations();
@@ -408,7 +421,7 @@ mod tests {
             .create_async()
             .await;
         let db = init_test_database();
-        assert!(pull("token", &db).await.is_ok());
+        assert!(pull("token", &db, None).await.is_ok());
         std::env::remove_var("CODEMUX_API_URL");
     }
 

--- a/src-tauri/src/bin/codemux_remote.rs
+++ b/src-tauri/src/bin/codemux_remote.rs
@@ -177,6 +177,17 @@ async fn scheduler_loop() -> ExitCode {
              automations already in the local database"
         );
     }
+    // This host's own server id, written by the laptop's bootstrap.
+    // It scopes the account pull so this host only receives — and only
+    // runs — the automations routed to it.
+    let host_id = read_scheduler_host();
+    if token.is_some() && host_id.is_none() {
+        eprintln!(
+            "[codemux-remote] no host identity found; the account pull \
+             cannot be host-scoped — skipping it to avoid running other \
+             hosts' automations"
+        );
+    }
     eprintln!("[codemux-remote] automation scheduler started");
 
     let mut ticker = tokio::time::interval(std::time::Duration::from_secs(
@@ -187,10 +198,14 @@ async fn scheduler_loop() -> ExitCode {
     loop {
         ticker.tick().await;
 
-        // Pull this host's automations from the account. A 404 (API
-        // not deployed yet) is treated as a harmless skip inside `pull`.
-        if let Some(token) = &token {
-            if let Err(error) = codemux_lib::automations_sync::pull(token, &db).await {
+        // Pull this host's automations from the account, scoped to
+        // this host's id. Only runs when both the token and the host
+        // identity are present — an unscoped pull would deliver other
+        // hosts' automations and run them here.
+        if let (Some(token), Some(host_id)) = (&token, &host_id) {
+            if let Err(error) =
+                codemux_lib::automations_sync::pull(token, &db, Some(host_id)).await
+            {
                 eprintln!("[codemux-remote] automation pull failed: {error}");
             }
         }
@@ -208,15 +223,27 @@ async fn scheduler_loop() -> ExitCode {
     }
 }
 
-/// Read the per-host scheduler token the laptop's bootstrap writes to
+/// Read the scheduler token the laptop's bootstrap writes to
 /// `~/.local/share/codemux/scheduler-token`. `None` when absent.
 #[cfg(unix)]
 fn read_scheduler_token() -> Option<String> {
-    let path = dirs::data_dir()?.join("codemux").join("scheduler-token");
+    read_scheduler_file("scheduler-token")
+}
+
+/// Read this host's own server id, written by bootstrap to
+/// `~/.local/share/codemux/scheduler-host`. `None` when absent.
+#[cfg(unix)]
+fn read_scheduler_host() -> Option<String> {
+    read_scheduler_file("scheduler-host")
+}
+
+#[cfg(unix)]
+fn read_scheduler_file(name: &str) -> Option<String> {
+    let path = dirs::data_dir()?.join("codemux").join(name);
     std::fs::read_to_string(path)
         .ok()
         .map(|contents| contents.trim().to_string())
-        .filter(|token| !token.is_empty())
+        .filter(|value| !value.is_empty())
 }
 
 // The pre-existing `#[cfg(not(unix))] fn run_daemon` stub used

--- a/src-tauri/src/bin/codemux_remote.rs
+++ b/src-tauri/src/bin/codemux_remote.rs
@@ -69,6 +69,11 @@ enum Command {
         #[arg(long)]
         socket: PathBuf,
     },
+    /// Run the automation scheduler: poll the account for this host's
+    /// automations, fire those that are due, and run the agent. Meant
+    /// to run as a persistent user service (systemd / launchd),
+    /// registered by the laptop's host bootstrap.
+    Scheduler,
     /// Print version info as JSON. The laptop's bootstrap probe uses
     /// this to confirm a working installation before attempting a
     /// daemon start.
@@ -92,6 +97,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Some(Command::PtyDaemon { socket }) => run_daemon(socket),
+        Some(Command::Scheduler) => run_scheduler(),
     }
 }
 
@@ -120,6 +126,97 @@ fn run_daemon(socket: PathBuf) -> ExitCode {
             ExitCode::from(1)
         }
     }
+}
+
+/// Run the automation scheduler loop on this host.
+///
+/// Same `scheduler::tick` + `executor` the desktop runs, but driven
+/// against this host's own database with no Tauri runtime. Automations
+/// reach this host's database via `automations_sync::pull` (host-scoped
+/// by the bootstrap-provisioned token); until the account API is
+/// deployed the pull is a harmless 404 skip and the loop simply ticks
+/// whatever is already local.
+#[cfg(unix)]
+fn run_scheduler() -> ExitCode {
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(error) => {
+            eprintln!("[codemux-remote] tokio runtime: {error}");
+            return ExitCode::from(2);
+        }
+    };
+    runtime.block_on(scheduler_loop())
+}
+
+#[cfg(unix)]
+async fn scheduler_loop() -> ExitCode {
+    use codemux_lib::automations::{executor, scheduler};
+
+    let db = match codemux_lib::database::init_database() {
+        Ok(db) => db,
+        Err(error) => {
+            eprintln!("[codemux-remote] database: {error}");
+            return ExitCode::from(1);
+        }
+    };
+
+    // Recover runs orphaned by a previous crash before the first tick.
+    let ceiling = (chrono::Utc::now() - chrono::Duration::hours(6)).to_rfc3339();
+    let reconciled = db.reconcile_stale_runs(&ceiling);
+    if reconciled > 0 {
+        eprintln!("[codemux-remote] reconciled {reconciled} stale run(s)");
+    }
+
+    let token = read_scheduler_token();
+    if token.is_none() {
+        eprintln!(
+            "[codemux-remote] no scheduler token found; running only \
+             automations already in the local database"
+        );
+    }
+    eprintln!("[codemux-remote] automation scheduler started");
+
+    let mut ticker = tokio::time::interval(std::time::Duration::from_secs(
+        scheduler::TICK_INTERVAL_SECS,
+    ));
+    ticker.tick().await; // consume the immediate first tick
+
+    loop {
+        ticker.tick().await;
+
+        // Pull this host's automations from the account. A 404 (API
+        // not deployed yet) is treated as a harmless skip inside `pull`.
+        if let Some(token) = &token {
+            if let Err(error) = codemux_lib::automations_sync::pull(token, &db).await {
+                eprintln!("[codemux-remote] automation pull failed: {error}");
+            }
+        }
+
+        // `local_only = false`: a host scheduler runs every automation
+        // its database holds (the account query is already host-scoped).
+        let fired = scheduler::tick(&db, chrono::Utc::now(), false);
+        for run in fired {
+            if let Some(automation) = db.get_automation(run.automation_id) {
+                let _ = db.mark_automation_run_started(run.id);
+                let outcome = executor::run_fire(&automation).await;
+                executor::apply_outcome(&db, run.id, &outcome);
+            }
+        }
+    }
+}
+
+/// Read the per-host scheduler token the laptop's bootstrap writes to
+/// `~/.local/share/codemux/scheduler-token`. `None` when absent.
+#[cfg(unix)]
+fn read_scheduler_token() -> Option<String> {
+    let path = dirs::data_dir()?.join("codemux").join("scheduler-token");
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|contents| contents.trim().to_string())
+        .filter(|token| !token.is_empty())
 }
 
 // The pre-existing `#[cfg(not(unix))] fn run_daemon` stub used

--- a/src-tauri/src/commands/automations.rs
+++ b/src-tauri/src/commands/automations.rs
@@ -1,0 +1,258 @@
+//! Tauri commands for the Automations feature.
+//!
+//! These wrap the `DatabaseStore` CRUD with frontend-shaped errors and
+//! keep the derived `next_run_at` column in step with the `schedule`:
+//! every create, schedule edit, or resume recomputes the next fire time
+//! from now, so a paused automation never fires a backlog when resumed.
+//!
+//! Account sync is intentionally not wired here yet — automations carry
+//! the same `dirty` flag as hosts, so a future `automations_sync` can
+//! push deltas without any change to this surface.
+
+use crate::automations::recurrence;
+use crate::database::{AutomationInput, AutomationRecord, AutomationRunRecord, DatabaseStore};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+/// Maximum prompt length. Matches the cap other agentic tools use for a
+/// single instruction blob and keeps a stray paste from bloating the DB.
+const MAX_PROMPT_LEN: usize = 100_000;
+const MAX_NAME_LEN: usize = 200;
+const MAX_AGENT_LEN: usize = 50;
+const MAX_SCHEDULE_LEN: usize = 2_000;
+const MAX_TIMEZONE_LEN: usize = 100;
+const MAX_RETENTION: i64 = 1_000;
+
+/// Frontend-facing view of an automation. Drops `deleted_at` (soft-delete
+/// tombstones never reach the UI) but keeps `dirty` so a later sync-status
+/// indicator has the data it needs.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AutomationView {
+    pub id: i64,
+    pub server_id: Option<String>,
+    pub name: String,
+    pub prompt: String,
+    pub agent: String,
+    pub schedule: String,
+    pub timezone: String,
+    pub host_id: Option<i64>,
+    pub project_path: Option<String>,
+    pub enabled: bool,
+    pub retention_limit: i64,
+    pub last_run_at: Option<String>,
+    pub next_run_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub dirty: bool,
+}
+
+impl From<AutomationRecord> for AutomationView {
+    fn from(r: AutomationRecord) -> Self {
+        Self {
+            id: r.id,
+            server_id: r.server_id,
+            name: r.name,
+            prompt: r.prompt,
+            agent: r.agent,
+            schedule: r.schedule,
+            timezone: r.timezone,
+            host_id: r.host_id,
+            project_path: r.project_path,
+            enabled: r.enabled,
+            retention_limit: r.retention_limit,
+            last_run_at: r.last_run_at,
+            next_run_at: r.next_run_at,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            dirty: r.dirty,
+        }
+    }
+}
+
+/// Normalise and validate user input shared by create and update.
+/// Returns a cleaned `AutomationInput` (trimmed strings) on success.
+fn clean_input(mut input: AutomationInput) -> Result<AutomationInput, String> {
+    input.name = input.name.trim().to_string();
+    input.agent = input.agent.trim().to_string();
+    input.schedule = input.schedule.trim().to_string();
+    input.timezone = input.timezone.trim().to_string();
+    input.project_path = input
+        .project_path
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty());
+
+    if input.name.is_empty() {
+        return Err("Automation name cannot be empty".into());
+    }
+    if input.name.len() > MAX_NAME_LEN {
+        return Err(format!("Automation name is too long (max {MAX_NAME_LEN} chars)"));
+    }
+    if input.prompt.trim().is_empty() {
+        return Err("Automation prompt cannot be empty".into());
+    }
+    if input.prompt.len() > MAX_PROMPT_LEN {
+        return Err(format!("Automation prompt is too long (max {MAX_PROMPT_LEN} chars)"));
+    }
+    if input.agent.is_empty() {
+        return Err("An agent must be selected".into());
+    }
+    if input.agent.len() > MAX_AGENT_LEN {
+        return Err("Agent name is too long".into());
+    }
+    if input.schedule.len() > MAX_SCHEDULE_LEN {
+        return Err(format!("Schedule is too long (max {MAX_SCHEDULE_LEN} chars)"));
+    }
+    if input.timezone.is_empty() {
+        return Err("A timezone must be set".into());
+    }
+    if input.timezone.len() > MAX_TIMEZONE_LEN {
+        return Err("Timezone name is too long".into());
+    }
+    if input.retention_limit < 1 || input.retention_limit > MAX_RETENTION {
+        return Err(format!("Retention limit must be between 1 and {MAX_RETENTION}"));
+    }
+    // The schedule must be a valid RFC 5545 recurrence — reject garbage
+    // at the boundary so the host scheduler never has to.
+    recurrence::validate(&input.schedule)?;
+    Ok(input)
+}
+
+/// Recompute and persist `next_run_at` from the current time. The
+/// schedule is already validated by `clean_input`, so a parse failure
+/// here is unexpected — surface it rather than silently swallowing it.
+fn refresh_next_run(db: &DatabaseStore, id: i64, schedule: &str) -> Result<(), String> {
+    let next = recurrence::next_occurrence(schedule, Utc::now())?;
+    db.set_automation_next_run(id, next.map(|dt| dt.to_rfc3339()).as_deref())
+}
+
+// ── Shared implementation ──
+//
+// The `*_impl` functions take a plain `&DatabaseStore` so both the Tauri
+// command surface (desktop UI) and the control socket (agents / MCP)
+// run the exact same validation and `next_run_at` bookkeeping. The
+// `#[tauri::command]` wrappers below are thin adapters over them.
+
+pub fn list_automations_impl(db: &DatabaseStore) -> Vec<AutomationView> {
+    db.list_automations().into_iter().map(Into::into).collect()
+}
+
+pub fn get_automation_impl(db: &DatabaseStore, id: i64) -> Result<AutomationView, String> {
+    db.get_automation(id)
+        .map(Into::into)
+        .ok_or_else(|| format!("No automation with id {id}"))
+}
+
+pub fn create_automation_impl(
+    db: &DatabaseStore,
+    input: AutomationInput,
+) -> Result<AutomationView, String> {
+    let input = clean_input(input)?;
+    let record = db.insert_automation(&input)?;
+    refresh_next_run(db, record.id, &record.schedule)?;
+    db.get_automation(record.id)
+        .map(Into::into)
+        .ok_or_else(|| "Automation disappeared immediately after creation".to_string())
+}
+
+pub fn update_automation_impl(
+    db: &DatabaseStore,
+    id: i64,
+    input: AutomationInput,
+) -> Result<AutomationView, String> {
+    let input = clean_input(input)?;
+    let record = db.update_automation(id, &input)?;
+    // The schedule may have changed — recompute the next fire time.
+    refresh_next_run(db, id, &record.schedule)?;
+    db.get_automation(id)
+        .map(Into::into)
+        .ok_or_else(|| format!("No automation with id {id}"))
+}
+
+/// Pause or resume an automation. Resuming recomputes `next_run_at` from
+/// now so the automation never fires the slots it missed while paused.
+pub fn set_automation_enabled_impl(
+    db: &DatabaseStore,
+    id: i64,
+    enabled: bool,
+) -> Result<AutomationView, String> {
+    let record = db.set_automation_enabled(id, enabled)?;
+    if enabled {
+        refresh_next_run(db, id, &record.schedule)?;
+    } else {
+        db.set_automation_next_run(id, None)?;
+    }
+    db.get_automation(id)
+        .map(Into::into)
+        .ok_or_else(|| format!("No automation with id {id}"))
+}
+
+pub fn delete_automation_impl(db: &DatabaseStore, id: i64) -> Result<(), String> {
+    db.delete_automation(id)
+}
+
+/// Run history for one automation, newest fire first. `limit` is
+/// clamped to 1..=100.
+pub fn list_automation_runs_impl(
+    db: &DatabaseStore,
+    automation_id: i64,
+    limit: Option<u32>,
+) -> Vec<AutomationRunRecord> {
+    let limit = limit.unwrap_or(20).clamp(1, 100);
+    db.list_automation_runs(automation_id, limit)
+}
+
+// ── Tauri command surface ──
+
+#[tauri::command]
+pub fn automations_list(db: State<'_, DatabaseStore>) -> Vec<AutomationView> {
+    list_automations_impl(db.inner())
+}
+
+#[tauri::command]
+pub fn automations_get(
+    db: State<'_, DatabaseStore>,
+    id: i64,
+) -> Result<AutomationView, String> {
+    get_automation_impl(db.inner(), id)
+}
+
+#[tauri::command]
+pub fn automations_create(
+    db: State<'_, DatabaseStore>,
+    input: AutomationInput,
+) -> Result<AutomationView, String> {
+    create_automation_impl(db.inner(), input)
+}
+
+#[tauri::command]
+pub fn automations_update(
+    db: State<'_, DatabaseStore>,
+    id: i64,
+    input: AutomationInput,
+) -> Result<AutomationView, String> {
+    update_automation_impl(db.inner(), id, input)
+}
+
+#[tauri::command]
+pub fn automations_set_enabled(
+    db: State<'_, DatabaseStore>,
+    id: i64,
+    enabled: bool,
+) -> Result<AutomationView, String> {
+    set_automation_enabled_impl(db.inner(), id, enabled)
+}
+
+#[tauri::command]
+pub fn automations_delete(db: State<'_, DatabaseStore>, id: i64) -> Result<(), String> {
+    delete_automation_impl(db.inner(), id)
+}
+
+#[tauri::command]
+pub fn automations_runs(
+    db: State<'_, DatabaseStore>,
+    automation_id: i64,
+    limit: Option<u32>,
+) -> Vec<AutomationRunRecord> {
+    list_automation_runs_impl(db.inner(), automation_id, limit)
+}

--- a/src-tauri/src/commands/automations.rs
+++ b/src-tauri/src/commands/automations.rs
@@ -38,6 +38,7 @@ pub struct AutomationView {
     pub timezone: String,
     pub host_id: Option<i64>,
     pub project_path: Option<String>,
+    pub project_remote: Option<String>,
     pub enabled: bool,
     pub retention_limit: i64,
     pub last_run_at: Option<String>,
@@ -59,6 +60,7 @@ impl From<AutomationRecord> for AutomationView {
             timezone: r.timezone,
             host_id: r.host_id,
             project_path: r.project_path,
+            project_remote: r.project_remote,
             enabled: r.enabled,
             retention_limit: r.retention_limit,
             last_run_at: r.last_run_at,
@@ -67,6 +69,27 @@ impl From<AutomationRecord> for AutomationView {
             updated_at: r.updated_at,
             dirty: r.dirty,
         }
+    }
+}
+
+/// Resolve a project's `origin` remote URL — the GitHub backbone a host
+/// without `project_path` clones from. `None` for a repo with no
+/// `origin` (such an automation can only run on "This machine").
+fn resolve_project_remote(project_path: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_path)
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if url.is_empty() {
+        None
+    } else {
+        Some(url)
     }
 }
 
@@ -81,6 +104,19 @@ fn clean_input(mut input: AutomationInput) -> Result<AutomationInput, String> {
         .project_path
         .map(|p| p.trim().to_string())
         .filter(|p| !p.is_empty());
+    // Resolve the project's git remote so a remote host can obtain the
+    // repo. An explicit caller-supplied value (e.g. from MCP) wins;
+    // otherwise derive it from the chosen project.
+    input.project_remote = input
+        .project_remote
+        .map(|r| r.trim().to_string())
+        .filter(|r| !r.is_empty())
+        .or_else(|| {
+            input
+                .project_path
+                .as_deref()
+                .and_then(resolve_project_remote)
+        });
 
     if input.name.is_empty() {
         return Err("Automation name cannot be empty".into());

--- a/src-tauri/src/commands/automations.rs
+++ b/src-tauri/src/commands/automations.rs
@@ -43,6 +43,9 @@ pub struct AutomationView {
     pub retention_limit: i64,
     pub last_run_at: Option<String>,
     pub next_run_at: Option<String>,
+    /// Status of the most recent run — drives the at-a-glance health
+    /// dot in the list. `None` until the automation has fired.
+    pub last_run_status: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub dirty: bool,
@@ -65,11 +68,21 @@ impl From<AutomationRecord> for AutomationView {
             retention_limit: r.retention_limit,
             last_run_at: r.last_run_at,
             next_run_at: r.next_run_at,
+            // Populated by `list_automations_impl`; a bare conversion
+            // has no run data.
+            last_run_status: None,
             created_at: r.created_at,
             updated_at: r.updated_at,
             dirty: r.dirty,
         }
     }
+}
+
+/// Result of probing whether a host can reach an automation's repo.
+#[derive(Debug, Serialize)]
+pub struct RepoAccessResult {
+    pub ok: bool,
+    pub message: String,
 }
 
 /// Resolve a project's `origin` remote URL — the GitHub backbone a host
@@ -170,7 +183,21 @@ fn refresh_next_run(db: &DatabaseStore, id: i64, schedule: &str) -> Result<(), S
 // `#[tauri::command]` wrappers below are thin adapters over them.
 
 pub fn list_automations_impl(db: &DatabaseStore) -> Vec<AutomationView> {
-    db.list_automations().into_iter().map(Into::into).collect()
+    db.list_automations()
+        .into_iter()
+        .map(|record| {
+            // Stamp the latest run's status so the list can show a
+            // health dot without the frontend fetching per-row history.
+            let last_run_status = db
+                .list_automation_runs(record.id, 1)
+                .into_iter()
+                .next()
+                .map(|run| run.status);
+            let mut view: AutomationView = record.into();
+            view.last_run_status = last_run_status;
+            view
+        })
+        .collect()
 }
 
 pub fn get_automation_impl(db: &DatabaseStore, id: i64) -> Result<AutomationView, String> {
@@ -318,4 +345,142 @@ pub fn automations_runs(
     limit: Option<u32>,
 ) -> Vec<AutomationRunRecord> {
     list_automation_runs_impl(db.inner(), automation_id, limit)
+}
+
+// ── Repo-access preflight ──
+//
+// `git ls-remote` does a real authentication handshake against the
+// exact repo URL without cloning — the canonical "can this host reach
+// this repository" probe. It is read-only and remote-agnostic (works
+// for GitHub, GitLab, a private server).
+
+/// Marker the host-side probe echoes on a successful `git ls-remote`.
+const REPO_PROBE_MARKER: &str = "CODEMUX_LSREMOTE_OK";
+
+/// Whether the host-side probe output indicates success. Pure.
+fn interpret_repo_probe(stdout: &str) -> bool {
+    stdout.contains(REPO_PROBE_MARKER)
+}
+
+/// Check whether the automation's host can reach its project repo.
+///
+/// "This machine" always passes — it uses the local project directly.
+/// For a remote host this SSHes in and runs `git ls-remote`; a failure
+/// is reported (never thrown) so the form can warn without blocking.
+///
+/// The repo is identified by `project_remote` when known (the detail
+/// view has it), else resolved from `project_path` (the create form
+/// only has the path).
+#[tauri::command]
+pub async fn automations_check_repo_access(
+    db: State<'_, DatabaseStore>,
+    host_id: Option<i64>,
+    project_path: Option<String>,
+    project_remote: Option<String>,
+) -> Result<RepoAccessResult, String> {
+    let host_id = match host_id {
+        Some(id) => id,
+        None => {
+            return Ok(RepoAccessResult {
+                ok: true,
+                message: "Runs on this machine — the project is used directly."
+                    .to_string(),
+            })
+        }
+    };
+    let resolved = project_remote
+        .map(|r| r.trim().to_string())
+        .filter(|r| !r.is_empty())
+        .or_else(|| {
+            project_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|p| !p.is_empty())
+                .and_then(resolve_project_remote)
+        });
+    let remote = match resolved {
+        Some(r) => r,
+        None => {
+            return Ok(RepoAccessResult {
+                ok: false,
+                message: "This project has no git remote, so it can only run \
+                          on this machine."
+                    .to_string(),
+            })
+        }
+    };
+    // The remote URL is interpolated into a single-quoted token in the
+    // host-side command; a `'` would break out of the quoting. No git
+    // URL contains one, so reject it rather than risk an injection.
+    if remote.contains('\'') {
+        return Ok(RepoAccessResult {
+            ok: false,
+            message: "The project's git remote URL contains an unexpected \
+                      character."
+                .to_string(),
+        });
+    }
+    let host = db
+        .list_hosts()
+        .into_iter()
+        .find(|h| h.id == host_id)
+        .ok_or_else(|| format!("Host not found: {host_id}"))?;
+
+    let probe = tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        tokio::process::Command::new("ssh")
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg("-o")
+            .arg("ConnectTimeout=10")
+            .arg(&host.ssh_target)
+            .arg(format!(
+                "GIT_TERMINAL_PROMPT=0 git ls-remote --heads '{remote}' \
+                 >/dev/null 2>&1 && echo {REPO_PROBE_MARKER}"
+            ))
+            .output(),
+    )
+    .await;
+
+    match probe {
+        Ok(Ok(output)) if interpret_repo_probe(&String::from_utf8_lossy(&output.stdout)) => {
+            Ok(RepoAccessResult {
+                ok: true,
+                message: format!("{} can reach this repository.", host.name),
+            })
+        }
+        Ok(Ok(_)) => Ok(RepoAccessResult {
+            ok: false,
+            message: format!(
+                "{} can't reach this repository. Give it access — an SSH \
+                 deploy key, or a `gh auth login` with access to the repo — \
+                 then check again. You can still create the automation.",
+                host.name
+            ),
+        }),
+        Ok(Err(error)) => Ok(RepoAccessResult {
+            ok: false,
+            message: format!("Couldn't run the check: {error}"),
+        }),
+        Err(_) => Ok(RepoAccessResult {
+            ok: false,
+            message: format!("Timed out reaching {}.", host.name),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::interpret_repo_probe;
+
+    #[test]
+    fn repo_probe_succeeds_when_the_marker_is_present() {
+        assert!(interpret_repo_probe("CODEMUX_LSREMOTE_OK\n"));
+    }
+
+    #[test]
+    fn repo_probe_fails_on_empty_or_unmarked_output() {
+        assert!(!interpret_repo_probe(""));
+        assert!(!interpret_repo_probe("fatal: Authentication failed\n"));
+    }
 }

--- a/src-tauri/src/commands/automations.rs
+++ b/src-tauri/src/commands/automations.rs
@@ -202,6 +202,18 @@ pub fn list_automation_runs_impl(
     db.list_automation_runs(automation_id, limit)
 }
 
+/// Fire-and-forget background sync after a mutation, so the user's
+/// other devices pick up the change within seconds. A failed sync is
+/// logged, not surfaced — the row stays `dirty` and the next sync
+/// retries. Mirrors `commands::hosts::schedule_background_sync`.
+pub fn schedule_automations_sync(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = crate::automations_sync::try_sync_with_app(&app).await {
+            eprintln!("[codemux::automations] background sync failed: {error}");
+        }
+    });
+}
+
 // ── Tauri command surface ──
 
 #[tauri::command]
@@ -219,33 +231,48 @@ pub fn automations_get(
 
 #[tauri::command]
 pub fn automations_create(
+    app: tauri::AppHandle,
     db: State<'_, DatabaseStore>,
     input: AutomationInput,
 ) -> Result<AutomationView, String> {
-    create_automation_impl(db.inner(), input)
+    let view = create_automation_impl(db.inner(), input)?;
+    schedule_automations_sync(app);
+    Ok(view)
 }
 
 #[tauri::command]
 pub fn automations_update(
+    app: tauri::AppHandle,
     db: State<'_, DatabaseStore>,
     id: i64,
     input: AutomationInput,
 ) -> Result<AutomationView, String> {
-    update_automation_impl(db.inner(), id, input)
+    let view = update_automation_impl(db.inner(), id, input)?;
+    schedule_automations_sync(app);
+    Ok(view)
 }
 
 #[tauri::command]
 pub fn automations_set_enabled(
+    app: tauri::AppHandle,
     db: State<'_, DatabaseStore>,
     id: i64,
     enabled: bool,
 ) -> Result<AutomationView, String> {
-    set_automation_enabled_impl(db.inner(), id, enabled)
+    let view = set_automation_enabled_impl(db.inner(), id, enabled)?;
+    schedule_automations_sync(app);
+    Ok(view)
 }
 
 #[tauri::command]
-pub fn automations_delete(db: State<'_, DatabaseStore>, id: i64) -> Result<(), String> {
-    delete_automation_impl(db.inner(), id)
+pub fn automations_delete(
+    app: tauri::AppHandle,
+    db: State<'_, DatabaseStore>,
+    id: i64,
+) -> Result<(), String> {
+    delete_automation_impl(db.inner(), id)?;
+    schedule_automations_sync(app);
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/hosts.rs
+++ b/src-tauri/src/commands/hosts.rs
@@ -119,6 +119,51 @@ pub fn set_workspace_host(
     Ok(())
 }
 
+/// Turn the host-side `git`/`gh` probe output into a human note for the
+/// connection-test message. Pure — unit-tested.
+///
+/// This is the automations preflight: an automation that triages PRs or
+/// issues needs the host to have `git` and an authenticated `gh`, so the
+/// "Test connection" result flags it up at setup time rather than at the
+/// first 9am run.
+fn interpret_github_probe(stdout: &str) -> String {
+    let git_ok = stdout.contains("GIT_OK");
+    let gh_ok = stdout.contains("GH_OK");
+    if !git_ok {
+        " · ⚠ git not found — automations on this host need git installed"
+            .to_string()
+    } else if !gh_ok {
+        " · ⚠ gh not signed in — run `gh auth login` on this host for \
+         PR/issue automations"
+            .to_string()
+    } else {
+        " · GitHub access ready".to_string()
+    }
+}
+
+/// SSH to the host and probe `git` + `gh` in one round-trip. Returns a
+/// note to append to the connection-test message, or an empty string if
+/// the probe itself could not run.
+#[cfg(unix)]
+async fn probe_host_github(ssh_target: &str) -> String {
+    let output = tokio::process::Command::new("ssh")
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg("-o")
+        .arg("ConnectTimeout=10")
+        .arg(ssh_target)
+        .arg(
+            "git --version >/dev/null 2>&1 && echo GIT_OK; \
+             gh auth status >/dev/null 2>&1 && echo GH_OK",
+        )
+        .output()
+        .await;
+    match output {
+        Ok(out) => interpret_github_probe(&String::from_utf8_lossy(&out.stdout)),
+        Err(_) => String::new(),
+    }
+}
+
 /// Test whether the configured SSH target is reachable, and whether
 /// `codemux-remote` is already installed there.
 ///
@@ -155,17 +200,20 @@ pub async fn hosts_test_connection(
             ProbeOutcome::Reachable {
                 codemux_remote_version: Some(version),
                 uname,
-            } => HostTestResult {
-                ok: true,
-                message: format!(
-                    "Connected. codemux-remote v{version} is installed{}",
-                    uname
-                        .map(|u| format!(" ({u})"))
-                        .unwrap_or_default()
-                ),
-                needs_install: false,
-                uname: None,
-            },
+            } => {
+                // Automations preflight — flag a host that can't reach
+                // GitHub before an automation silently fails at run time.
+                let github_note = probe_host_github(&host.ssh_target).await;
+                HostTestResult {
+                    ok: true,
+                    message: format!(
+                        "Connected. codemux-remote v{version} is installed{}{github_note}",
+                        uname.map(|u| format!(" ({u})")).unwrap_or_default()
+                    ),
+                    needs_install: false,
+                    uname: None,
+                }
+            }
             ProbeOutcome::Reachable {
                 codemux_remote_version: None,
                 uname,
@@ -1218,5 +1266,38 @@ fn terminate_workspace_sessions(
             &pty_state.sessions,
             &sid,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::interpret_github_probe;
+
+    #[test]
+    fn github_probe_reports_ready_when_git_and_gh_are_present() {
+        let note = interpret_github_probe("GIT_OK\nGH_OK\n");
+        assert!(note.contains("ready"));
+        assert!(!note.contains("⚠"));
+    }
+
+    #[test]
+    fn github_probe_flags_missing_git() {
+        // No GIT_OK — git itself is absent.
+        let note = interpret_github_probe("GH_OK\n");
+        assert!(note.contains("⚠"));
+        assert!(note.contains("git"));
+    }
+
+    #[test]
+    fn github_probe_flags_unauthenticated_gh() {
+        // git is present but `gh auth status` failed.
+        let note = interpret_github_probe("GIT_OK\n");
+        assert!(note.contains("⚠"));
+        assert!(note.contains("gh auth login"));
+    }
+
+    #[test]
+    fn github_probe_flags_an_empty_probe_as_missing_git() {
+        assert!(interpret_github_probe("").contains("⚠"));
     }
 }

--- a/src-tauri/src/commands/hosts.rs
+++ b/src-tauri/src/commands/hosts.rs
@@ -248,13 +248,47 @@ pub async fn hosts_bootstrap_install(
         )
         .await;
         Ok(match outcome {
-            BootstrapResult::Installed { reported_version } => HostBootstrapResult {
-                ok: true,
-                message: format!(
-                    "codemux-remote v{reported_version} installed on {}",
-                    host.name
-                ),
-            },
+            BootstrapResult::Installed { reported_version } => {
+                // Best-effort: also provision the automation scheduler
+                // so the host can run automations. A failure here does
+                // NOT fail the install — push-workspace works without
+                // it, and not every host runs systemd. Skipped silently
+                // when the user is signed out or the host has not yet
+                // synced (no server id to identify it by).
+                let scheduler_note = match (
+                    crate::auth::load_token(&db).map(|(token, _)| token),
+                    host.server_id.clone(),
+                ) {
+                    (Some(token), Some(server_id)) => {
+                        match crate::ssh::bootstrap::provision_scheduler(
+                            &host.ssh_target,
+                            "~/.local/bin/codemux-remote",
+                            &token,
+                            &server_id,
+                            std::time::Duration::from_secs(30),
+                        )
+                        .await
+                        {
+                            Ok(()) => " · automation scheduler enabled".to_string(),
+                            Err(error) => {
+                                eprintln!(
+                                    "[codemux::hosts] scheduler provisioning failed: {error}"
+                                );
+                                " · (automation scheduler not enabled — see logs)"
+                                    .to_string()
+                            }
+                        }
+                    }
+                    _ => String::new(),
+                };
+                HostBootstrapResult {
+                    ok: true,
+                    message: format!(
+                        "codemux-remote v{reported_version} installed on {}{scheduler_note}",
+                        host.name
+                    ),
+                }
+            }
             BootstrapResult::BinaryNotBundled { wanted_target } => {
                 HostBootstrapResult {
                     ok: false,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_chat;
 pub mod ai;
 pub mod auth;
+pub mod automations;
 pub mod branch_name;
 pub mod browser;
 pub mod database;
@@ -25,6 +26,7 @@ pub mod workspace;
 pub use agent_chat::*;
 pub use ai::*;
 pub use auth::*;
+pub use automations::*;
 pub use branch_name::*;
 pub use browser::*;
 pub use database::*;

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1237,6 +1237,96 @@ async fn dispatch_request(app: &AppHandle, request: ControlRequest) -> ControlRe
                 Ok(serde_json::json!({ "workspace_id": ws_id, "status": "complete" }))
             })
         }
+        // ── Automations ──
+        //
+        // Agent / MCP control surface. Each arm delegates to the shared
+        // `commands::automations::*_impl` helpers so the validation and
+        // `next_run_at` bookkeeping match the desktop command surface
+        // exactly.
+        "automation_list" => (|| -> Result<Value, String> {
+            let db: State<'_, crate::database::DatabaseStore> = app.state();
+            serde_json::to_value(crate::commands::automations::list_automations_impl(&db))
+                .map_err(|error| error.to_string())
+        })(),
+        "automation_get" => (|| -> Result<Value, String> {
+            let db: State<'_, crate::database::DatabaseStore> = app.state();
+            let id = request
+                .params
+                .get("id")
+                .and_then(Value::as_i64)
+                .ok_or("automation_get requires an integer `id`")?;
+            let view = crate::commands::automations::get_automation_impl(&db, id)?;
+            serde_json::to_value(view).map_err(|error| error.to_string())
+        })(),
+        "automation_create" => (|| -> Result<Value, String> {
+            let db: State<'_, crate::database::DatabaseStore> = app.state();
+            let input: crate::database::AutomationInput = serde_json::from_value(
+                request.params.get("input").cloned().unwrap_or(Value::Null),
+            )
+            .map_err(|error| format!("Invalid automation input: {error}"))?;
+            let view = crate::commands::automations::create_automation_impl(&db, input)?;
+            serde_json::to_value(view).map_err(|error| error.to_string())
+        })(),
+        "automation_update" => (|| -> Result<Value, String> {
+            let db: State<'_, crate::database::DatabaseStore> = app.state();
+            let id = request
+                .params
+                .get("id")
+                .and_then(Value::as_i64)
+                .ok_or("automation_update requires an integer `id`")?;
+            let input: crate::database::AutomationInput = serde_json::from_value(
+                request.params.get("input").cloned().unwrap_or(Value::Null),
+            )
+            .map_err(|error| format!("Invalid automation input: {error}"))?;
+            let view = crate::commands::automations::update_automation_impl(&db, id, input)?;
+            serde_json::to_value(view).map_err(|error| error.to_string())
+        })(),
+        "automation_set_enabled" => (|| -> Result<Value, String> {
+            let db: State<'_, crate::database::DatabaseStore> = app.state();
+            let id = request
+                .params
+                .get("id")
+                .and_then(Value::as_i64)
+                .ok_or("automation_set_enabled requires an integer `id`")?;
+            let enabled = request
+                .params
+                .get("enabled")
+                .and_then(Value::as_bool)
+                .ok_or("automation_set_enabled requires a boolean `enabled`")?;
+            let view =
+                crate::commands::automations::set_automation_enabled_impl(&db, id, enabled)?;
+            serde_json::to_value(view).map_err(|error| error.to_string())
+        })(),
+        "automation_delete" => (|| -> Result<Value, String> {
+            let db: State<'_, crate::database::DatabaseStore> = app.state();
+            let id = request
+                .params
+                .get("id")
+                .and_then(Value::as_i64)
+                .ok_or("automation_delete requires an integer `id`")?;
+            crate::commands::automations::delete_automation_impl(&db, id)?;
+            Ok(serde_json::json!({ "deleted": id }))
+        })(),
+        "automation_runs" => (|| -> Result<Value, String> {
+            let db: State<'_, crate::database::DatabaseStore> = app.state();
+            let automation_id = request
+                .params
+                .get("automation_id")
+                .and_then(Value::as_i64)
+                .ok_or("automation_runs requires an integer `automation_id`")?;
+            let limit = request
+                .params
+                .get("limit")
+                .and_then(Value::as_u64)
+                .map(|value| value as u32);
+            let runs = crate::commands::automations::list_automation_runs_impl(
+                &db,
+                automation_id,
+                limit,
+            );
+            serde_json::to_value(serde_json::json!({ "runs": runs }))
+                .map_err(|error| error.to_string())
+        })(),
         _ => Err(format!("Unknown control command: {}", request.command)),
     };
 

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1265,6 +1265,7 @@ async fn dispatch_request(app: &AppHandle, request: ControlRequest) -> ControlRe
             )
             .map_err(|error| format!("Invalid automation input: {error}"))?;
             let view = crate::commands::automations::create_automation_impl(&db, input)?;
+            crate::commands::automations::schedule_automations_sync(app.clone());
             serde_json::to_value(view).map_err(|error| error.to_string())
         })(),
         "automation_update" => (|| -> Result<Value, String> {
@@ -1279,6 +1280,7 @@ async fn dispatch_request(app: &AppHandle, request: ControlRequest) -> ControlRe
             )
             .map_err(|error| format!("Invalid automation input: {error}"))?;
             let view = crate::commands::automations::update_automation_impl(&db, id, input)?;
+            crate::commands::automations::schedule_automations_sync(app.clone());
             serde_json::to_value(view).map_err(|error| error.to_string())
         })(),
         "automation_set_enabled" => (|| -> Result<Value, String> {
@@ -1295,6 +1297,7 @@ async fn dispatch_request(app: &AppHandle, request: ControlRequest) -> ControlRe
                 .ok_or("automation_set_enabled requires a boolean `enabled`")?;
             let view =
                 crate::commands::automations::set_automation_enabled_impl(&db, id, enabled)?;
+            crate::commands::automations::schedule_automations_sync(app.clone());
             serde_json::to_value(view).map_err(|error| error.to_string())
         })(),
         "automation_delete" => (|| -> Result<Value, String> {
@@ -1305,6 +1308,7 @@ async fn dispatch_request(app: &AppHandle, request: ControlRequest) -> ControlRe
                 .and_then(Value::as_i64)
                 .ok_or("automation_delete requires an integer `id`")?;
             crate::commands::automations::delete_automation_impl(&db, id)?;
+            crate::commands::automations::schedule_automations_sync(app.clone());
             Ok(serde_json::json!({ "deleted": id }))
         })(),
         "automation_runs" => (|| -> Result<Value, String> {

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-const SCHEMA_VERSION: u32 = 5;
+const SCHEMA_VERSION: u32 = 6;
 
 pub struct DatabaseStore {
     conn: Mutex<Connection>,
@@ -235,6 +235,7 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
             timezone TEXT NOT NULL DEFAULT 'UTC',
             host_id INTEGER,
             project_path TEXT,
+            project_remote TEXT,
             enabled INTEGER NOT NULL DEFAULT 1,
             retention_limit INTEGER NOT NULL DEFAULT 10,
             last_run_at TEXT,
@@ -270,6 +271,8 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
             finished_at TEXT,
             host_id INTEGER,
             workspace_id TEXT,
+            branch TEXT,
+            pr_url TEXT,
             error TEXT,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             UNIQUE(automation_id, scheduled_for)
@@ -280,6 +283,24 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
         ",
     )
     .map_err(|e| format!("Failed to create database schema: {e}"))?;
+
+    // Additive column migrations. `CREATE TABLE IF NOT EXISTS` above is a
+    // no-op on a database that already has the table, so a column added
+    // to an existing table needs an explicit `ALTER TABLE`. Each is
+    // idempotent: on a fresh database the column is already present and
+    // SQLite returns a "duplicate column name" error, which we swallow.
+    for stmt in [
+        "ALTER TABLE automations ADD COLUMN project_remote TEXT",
+        "ALTER TABLE automation_runs ADD COLUMN branch TEXT",
+        "ALTER TABLE automation_runs ADD COLUMN pr_url TEXT",
+    ] {
+        if let Err(e) = conn.execute(stmt, []) {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column name") {
+                return Err(format!("Schema migration failed ({stmt}): {msg}"));
+            }
+        }
+    }
 
     // Set (or advance) schema version. `IF NOT EXISTS` on every CREATE
     // above means re-running this on a v1 DB silently adds the new
@@ -805,8 +826,12 @@ pub struct AutomationRecord {
     pub timezone: String,
     /// Target host row id, or `None` when not yet assigned.
     pub host_id: Option<i64>,
-    /// Repository path the run operates in.
+    /// Local path of the project repository (valid on the machine that
+    /// created the automation).
     pub project_path: Option<String>,
+    /// The project's git remote URL — how a host that lacks
+    /// `project_path` obtains the repo (it clones this).
+    pub project_remote: Option<String>,
     pub enabled: bool,
     /// How many completed run worktrees the host keeps before pruning.
     pub retention_limit: i64,
@@ -831,6 +856,10 @@ pub struct AutomationRunRecord {
     pub finished_at: Option<String>,
     pub host_id: Option<i64>,
     pub workspace_id: Option<String>,
+    /// The branch the run's worktree was created on.
+    pub branch: Option<String>,
+    /// URL of the pull request the run opened, if any.
+    pub pr_url: Option<String>,
     pub error: Option<String>,
     pub created_at: String,
 }
@@ -845,15 +874,20 @@ pub struct AutomationInput {
     pub timezone: String,
     pub host_id: Option<i64>,
     pub project_path: Option<String>,
+    /// The project's git remote URL. The command layer resolves it from
+    /// the chosen project; callers may leave it `None`.
+    #[serde(default)]
+    pub project_remote: Option<String>,
     pub retention_limit: i64,
 }
 
 const AUTOMATION_COLUMNS: &str = "id, server_id, name, prompt, agent, schedule, \
-     timezone, host_id, project_path, enabled, retention_limit, last_run_at, \
-     next_run_at, created_at, updated_at, deleted_at, dirty";
+     timezone, host_id, project_path, project_remote, enabled, retention_limit, \
+     last_run_at, next_run_at, created_at, updated_at, deleted_at, dirty";
 
 const AUTOMATION_RUN_COLUMNS: &str = "id, automation_id, status, scheduled_for, \
-     started_at, finished_at, host_id, workspace_id, error, created_at";
+     started_at, finished_at, host_id, workspace_id, branch, pr_url, error, \
+     created_at";
 
 impl DatabaseStore {
     /// Insert a new automation. Marked `dirty` so a future sync pushes it.
@@ -865,8 +899,8 @@ impl DatabaseStore {
         conn.execute(
             "INSERT INTO automations
                 (user_id, name, prompt, agent, schedule, timezone,
-                 host_id, project_path, retention_limit, dirty)
-             VALUES ('local', ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1)",
+                 host_id, project_path, project_remote, retention_limit, dirty)
+             VALUES ('local', ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1)",
             params![
                 input.name,
                 input.prompt,
@@ -875,6 +909,7 @@ impl DatabaseStore {
                 input.timezone,
                 input.host_id,
                 input.project_path,
+                input.project_remote,
                 input.retention_limit,
             ],
         )
@@ -940,9 +975,9 @@ impl DatabaseStore {
                 "UPDATE automations
                  SET name = ?1, prompt = ?2, agent = ?3, schedule = ?4,
                      timezone = ?5, host_id = ?6, project_path = ?7,
-                     retention_limit = ?8, updated_at = datetime('now'),
-                     dirty = 1
-                 WHERE id = ?9 AND user_id = 'local' AND deleted_at IS NULL",
+                     project_remote = ?8, retention_limit = ?9,
+                     updated_at = datetime('now'), dirty = 1
+                 WHERE id = ?10 AND user_id = 'local' AND deleted_at IS NULL",
                 params![
                     input.name,
                     input.prompt,
@@ -951,6 +986,7 @@ impl DatabaseStore {
                     input.timezone,
                     input.host_id,
                     input.project_path,
+                    input.project_remote,
                     input.retention_limit,
                     id,
                 ],
@@ -1085,17 +1121,23 @@ impl DatabaseStore {
         run_id: i64,
         status: &str,
         workspace_id: Option<&str>,
+        branch: Option<&str>,
+        pr_url: Option<&str>,
         error: Option<&str>,
     ) -> Result<(), String> {
         let conn = self.conn.lock().unwrap();
+        // `COALESCE` on workspace_id / branch / pr_url means a `None`
+        // never clobbers a value an earlier write already set.
         conn.execute(
             "UPDATE automation_runs
              SET status = ?1,
                  finished_at = datetime('now'),
                  workspace_id = COALESCE(?2, workspace_id),
-                 error = ?3
-             WHERE id = ?4",
-            params![status, workspace_id, error, run_id],
+                 branch = COALESCE(?3, branch),
+                 pr_url = COALESCE(?4, pr_url),
+                 error = ?5
+             WHERE id = ?6",
+            params![status, workspace_id, branch, pr_url, error, run_id],
         )
         .map_err(|e| format!("Failed to finish automation run: {e}"))?;
         Ok(())
@@ -1237,6 +1279,7 @@ impl DatabaseStore {
         timezone: &str,
         host_id: Option<i64>,
         project_path: Option<&str>,
+        project_remote: Option<&str>,
         enabled: bool,
         retention_limit: i64,
         created_at: &str,
@@ -1249,13 +1292,15 @@ impl DatabaseStore {
                 "UPDATE automations
                  SET name = ?1, prompt = ?2, agent = ?3, schedule = ?4,
                      timezone = ?5, host_id = ?6, project_path = ?7,
-                     enabled = ?8, retention_limit = ?9, created_at = ?10,
-                     updated_at = ?11, deleted_at = ?12, dirty = 0
-                 WHERE user_id = 'local' AND server_id = ?13",
+                     project_remote = ?8, enabled = ?9, retention_limit = ?10,
+                     created_at = ?11, updated_at = ?12, deleted_at = ?13,
+                     dirty = 0
+                 WHERE user_id = 'local' AND server_id = ?14",
                 params![
                     name, prompt, agent, schedule, timezone, host_id,
-                    project_path, enabled as i64, retention_limit,
-                    created_at, updated_at, deleted_at, server_id,
+                    project_path, project_remote, enabled as i64,
+                    retention_limit, created_at, updated_at, deleted_at,
+                    server_id,
                 ],
             )
             .map_err(|e| format!("Failed to update automation from server: {e}"))?;
@@ -1263,14 +1308,15 @@ impl DatabaseStore {
             conn.execute(
                 "INSERT INTO automations
                     (user_id, server_id, name, prompt, agent, schedule,
-                     timezone, host_id, project_path, enabled,
-                     retention_limit, created_at, updated_at, deleted_at, dirty)
+                     timezone, host_id, project_path, project_remote,
+                     enabled, retention_limit, created_at, updated_at,
+                     deleted_at, dirty)
                  VALUES ('local', ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                         ?11, ?12, ?13, 0)",
+                         ?11, ?12, ?13, ?14, 0)",
                 params![
                     server_id, name, prompt, agent, schedule, timezone,
-                    host_id, project_path, enabled as i64, retention_limit,
-                    created_at, updated_at, deleted_at,
+                    host_id, project_path, project_remote, enabled as i64,
+                    retention_limit, created_at, updated_at, deleted_at,
                 ],
             )
             .map_err(|e| format!("Failed to insert automation from server: {e}"))?;
@@ -1292,8 +1338,8 @@ impl DatabaseStore {
 }
 
 fn row_to_automation(row: &rusqlite::Row<'_>) -> rusqlite::Result<AutomationRecord> {
-    let enabled_int: i64 = row.get(9)?;
-    let dirty_int: i64 = row.get(16)?;
+    let enabled_int: i64 = row.get(10)?;
+    let dirty_int: i64 = row.get(17)?;
     Ok(AutomationRecord {
         id: row.get(0)?,
         server_id: row.get(1)?,
@@ -1304,13 +1350,14 @@ fn row_to_automation(row: &rusqlite::Row<'_>) -> rusqlite::Result<AutomationReco
         timezone: row.get(6)?,
         host_id: row.get(7)?,
         project_path: row.get(8)?,
+        project_remote: row.get(9)?,
         enabled: enabled_int != 0,
-        retention_limit: row.get(10)?,
-        last_run_at: row.get(11)?,
-        next_run_at: row.get(12)?,
-        created_at: row.get(13)?,
-        updated_at: row.get(14)?,
-        deleted_at: row.get(15)?,
+        retention_limit: row.get(11)?,
+        last_run_at: row.get(12)?,
+        next_run_at: row.get(13)?,
+        created_at: row.get(14)?,
+        updated_at: row.get(15)?,
+        deleted_at: row.get(16)?,
         dirty: dirty_int != 0,
     })
 }
@@ -1325,8 +1372,10 @@ fn row_to_automation_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<Automation
         finished_at: row.get(5)?,
         host_id: row.get(6)?,
         workspace_id: row.get(7)?,
-        error: row.get(8)?,
-        created_at: row.get(9)?,
+        branch: row.get(8)?,
+        pr_url: row.get(9)?,
+        error: row.get(10)?,
+        created_at: row.get(11)?,
     })
 }
 
@@ -3243,6 +3292,7 @@ mod tests {
             timezone: "UTC".to_string(),
             host_id: None,
             project_path: Some("/home/user/repo".to_string()),
+            project_remote: None,
             retention_limit: 10,
         }
     }
@@ -3357,8 +3407,15 @@ mod tests {
         assert!(run.started_at.is_none());
 
         db.mark_automation_run_started(run.id).unwrap();
-        db.finish_automation_run(run.id, "succeeded", Some("ws-42"), None)
-            .unwrap();
+        db.finish_automation_run(
+            run.id,
+            "succeeded",
+            Some("ws-42"),
+            Some("automation-deploy-check-20260301-080000"),
+            None,
+            None,
+        )
+        .unwrap();
 
         let runs = db.list_automation_runs(a.id, 10);
         assert_eq!(runs.len(), 1);
@@ -3367,6 +3424,10 @@ mod tests {
         assert!(finished.started_at.is_some());
         assert!(finished.finished_at.is_some());
         assert_eq!(finished.workspace_id.as_deref(), Some("ws-42"));
+        assert_eq!(
+            finished.branch.as_deref(),
+            Some("automation-deploy-check-20260301-080000")
+        );
     }
 
     #[test]

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1175,9 +1175,13 @@ impl DatabaseStore {
     ///
     /// A run is stale when it is still `scheduled` or `running` and its
     /// `started_at` (or `created_at`, for a run that never started) is
-    /// older than `older_than` (an RFC 3339 timestamp). Without this a
-    /// crashed run would keep its automation permanently `skipped_busy`.
-    /// Returns the number of rows reconciled.
+    /// older than `older_than`. Returns the number of rows reconciled.
+    ///
+    /// Both sides are wrapped in `datetime()`: `started_at` / `created_at`
+    /// are stored in SQLite's `'YYYY-MM-DD HH:MM:SS'` form while callers
+    /// pass an RFC 3339 ceiling — a raw string `<` would compare the
+    /// space against the `T` and mis-judge same-day runs. `datetime()`
+    /// normalises both formats before comparing.
     pub fn reconcile_stale_runs(&self, older_than: &str) -> usize {
         let conn = self.conn.lock().unwrap();
         conn.execute(
@@ -1186,7 +1190,7 @@ impl DatabaseStore {
                  finished_at = datetime('now'),
                  error = 'Run did not complete — process or app exited'
              WHERE status IN ('scheduled', 'running')
-               AND COALESCE(started_at, created_at) < ?1",
+               AND datetime(COALESCE(started_at, created_at)) < datetime(?1)",
             params![older_than],
         )
         .unwrap_or(0)
@@ -3492,6 +3496,29 @@ mod tests {
         // A ceiling in the distant past — the run's created_at (now) is
         // newer, so nothing is stale.
         assert_eq!(db.reconcile_stale_runs("2000-01-01T00:00:00Z"), 0);
+        assert_eq!(db.list_automation_runs(a.id, 10)[0].status, "running");
+    }
+
+    #[test]
+    fn reconcile_stale_runs_compares_mixed_timestamp_formats() {
+        // `created_at` is stored in SQLite's `'YYYY-MM-DD HH:MM:SS'`
+        // form, while the real callers pass an RFC 3339 ceiling
+        // (`now - 6h`). A raw string `<` would compare the space
+        // against the `T` at offset 10 and wrongly judge a run from
+        // earlier *today* as stale. The previous tests used year-2000
+        // and year-2999 ceilings, where the year differs first and
+        // hides the bug — this one uses a same-day ceiling so only
+        // correct `datetime()` normalisation passes it.
+        let db = init_test_database();
+        let a = db.insert_automation(&sample_automation("MixedFmt")).unwrap();
+        db.record_automation_run(a.id, "running", "2026-01-01T09:00:00Z", None, None)
+            .unwrap();
+        let ceiling = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+        assert_eq!(
+            db.reconcile_stale_runs(&ceiling),
+            0,
+            "a run created moments ago is newer than a ceiling one hour back"
+        );
         assert_eq!(db.list_automation_runs(a.id, 10)[0].status, "running");
     }
 }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1128,6 +1128,167 @@ impl DatabaseStore {
         };
         rows.filter_map(|r| r.ok()).collect()
     }
+
+    /// Fail runs left in a non-terminal state by a crash or quit.
+    ///
+    /// A run is stale when it is still `scheduled` or `running` and its
+    /// `started_at` (or `created_at`, for a run that never started) is
+    /// older than `older_than` (an RFC 3339 timestamp). Without this a
+    /// crashed run would keep its automation permanently `skipped_busy`.
+    /// Returns the number of rows reconciled.
+    pub fn reconcile_stale_runs(&self, older_than: &str) -> usize {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE automation_runs
+             SET status = 'failed',
+                 finished_at = datetime('now'),
+                 error = 'Run did not complete — process or app exited'
+             WHERE status IN ('scheduled', 'running')
+               AND COALESCE(started_at, created_at) < ?1",
+            params![older_than],
+        )
+        .unwrap_or(0)
+    }
+
+    // ── Automation account-sync helpers ──
+    //
+    // These mirror the `hosts` sync surface so `automations_sync` can
+    // be a near-copy of `hosts_sync`. Only the `automations` registry
+    // syncs; `automation_runs` are per-device history.
+
+    /// Every automation row for the local user, including soft-deleted
+    /// tombstones — the sync layer needs the tombstones to push.
+    pub fn list_automations_for_sync(&self) -> Vec<AutomationRecord> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = match conn.prepare(&format!(
+            "SELECT {AUTOMATION_COLUMNS} FROM automations WHERE user_id = 'local'"
+        )) {
+            Ok(s) => s,
+            Err(error) => {
+                eprintln!("[codemux::database] list_automations_for_sync prepare failed: {error}");
+                return Vec::new();
+            }
+        };
+        let rows = match stmt.query_map([], row_to_automation) {
+            Ok(r) => r,
+            Err(error) => {
+                eprintln!("[codemux::database] list_automations_for_sync query failed: {error}");
+                return Vec::new();
+            }
+        };
+        rows.filter_map(|r| r.ok()).collect()
+    }
+
+    /// Automation rows with unpushed changes (`dirty = 1`).
+    pub fn list_dirty_automations(&self) -> Vec<AutomationRecord> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = match conn.prepare(&format!(
+            "SELECT {AUTOMATION_COLUMNS} FROM automations
+             WHERE user_id = 'local' AND dirty = 1"
+        )) {
+            Ok(s) => s,
+            Err(error) => {
+                eprintln!("[codemux::database] list_dirty_automations prepare failed: {error}");
+                return Vec::new();
+            }
+        };
+        let rows = match stmt.query_map([], row_to_automation) {
+            Ok(r) => r,
+            Err(error) => {
+                eprintln!("[codemux::database] list_dirty_automations query failed: {error}");
+                return Vec::new();
+            }
+        };
+        rows.filter_map(|r| r.ok()).collect()
+    }
+
+    /// Clear `dirty` after a successful push; optionally stamp the
+    /// server-assigned id on the first upload.
+    pub fn mark_automation_synced(
+        &self,
+        id: i64,
+        server_id: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        if let Some(sid) = server_id {
+            conn.execute(
+                "UPDATE automations SET dirty = 0, server_id = ?1 WHERE id = ?2",
+                params![sid, id],
+            )
+        } else {
+            conn.execute("UPDATE automations SET dirty = 0 WHERE id = ?1", params![id])
+        }
+        .map_err(|e| format!("Failed to mark automation synced: {e}"))?;
+        Ok(())
+    }
+
+    /// Upsert a row received from the server, matched by `server_id`.
+    /// Always written `dirty = 0` (server rows are authoritative).
+    /// `next_run_at` / `last_run_at` are derived per-device and are not
+    /// carried over the wire, so a server upsert leaves them untouched.
+    #[allow(clippy::too_many_arguments)]
+    pub fn upsert_automation_from_server(
+        &self,
+        server_id: &str,
+        name: &str,
+        prompt: &str,
+        agent: &str,
+        schedule: &str,
+        timezone: &str,
+        host_id: Option<i64>,
+        project_path: Option<&str>,
+        enabled: bool,
+        retention_limit: i64,
+        created_at: &str,
+        updated_at: &str,
+        deleted_at: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn
+            .execute(
+                "UPDATE automations
+                 SET name = ?1, prompt = ?2, agent = ?3, schedule = ?4,
+                     timezone = ?5, host_id = ?6, project_path = ?7,
+                     enabled = ?8, retention_limit = ?9, created_at = ?10,
+                     updated_at = ?11, deleted_at = ?12, dirty = 0
+                 WHERE user_id = 'local' AND server_id = ?13",
+                params![
+                    name, prompt, agent, schedule, timezone, host_id,
+                    project_path, enabled as i64, retention_limit,
+                    created_at, updated_at, deleted_at, server_id,
+                ],
+            )
+            .map_err(|e| format!("Failed to update automation from server: {e}"))?;
+        if updated == 0 {
+            conn.execute(
+                "INSERT INTO automations
+                    (user_id, server_id, name, prompt, agent, schedule,
+                     timezone, host_id, project_path, enabled,
+                     retention_limit, created_at, updated_at, deleted_at, dirty)
+                 VALUES ('local', ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+                         ?11, ?12, ?13, 0)",
+                params![
+                    server_id, name, prompt, agent, schedule, timezone,
+                    host_id, project_path, enabled as i64, retention_limit,
+                    created_at, updated_at, deleted_at,
+                ],
+            )
+            .map_err(|e| format!("Failed to insert automation from server: {e}"))?;
+        }
+        Ok(())
+    }
+
+    /// Hard-delete tombstones the server has confirmed removed. The
+    /// `automation_runs` FK cascade clears their history rows too.
+    pub fn purge_acknowledged_automation_deletes(&self) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM automations WHERE deleted_at IS NOT NULL AND dirty = 0",
+            [],
+        )
+        .map_err(|e| format!("Failed to purge automation tombstones: {e}"))?;
+        Ok(())
+    }
 }
 
 fn row_to_automation(row: &rusqlite::Row<'_>) -> rusqlite::Result<AutomationRecord> {
@@ -3229,5 +3390,47 @@ mod tests {
                 "2026-01-01T09:00:00Z",
             ]
         );
+    }
+
+    #[test]
+    fn reconcile_stale_runs_fails_only_non_terminal_runs() {
+        let db = init_test_database();
+        let a = db.insert_automation(&sample_automation("Reconcile")).unwrap();
+        let scheduled = db
+            .record_automation_run(a.id, "scheduled", "2026-01-01T09:00:00Z", None, None)
+            .unwrap()
+            .unwrap();
+        let running = db
+            .record_automation_run(a.id, "running", "2026-01-01T10:00:00Z", None, None)
+            .unwrap()
+            .unwrap();
+        let done = db
+            .record_automation_run(a.id, "succeeded", "2026-01-01T11:00:00Z", None, None)
+            .unwrap()
+            .unwrap();
+
+        // A ceiling far in the future makes every run older than it.
+        let reconciled = db.reconcile_stale_runs("2999-01-01T00:00:00Z");
+        assert_eq!(reconciled, 2, "only the two non-terminal runs are stale");
+
+        let runs = db.list_automation_runs(a.id, 10);
+        let status = |id: i64| {
+            runs.iter().find(|r| r.id == id).unwrap().status.clone()
+        };
+        assert_eq!(status(scheduled.id), "failed");
+        assert_eq!(status(running.id), "failed");
+        assert_eq!(status(done.id), "succeeded", "terminal runs are untouched");
+    }
+
+    #[test]
+    fn reconcile_stale_runs_leaves_recent_runs_alone() {
+        let db = init_test_database();
+        let a = db.insert_automation(&sample_automation("Recent")).unwrap();
+        db.record_automation_run(a.id, "running", "2026-01-01T09:00:00Z", None, None)
+            .unwrap();
+        // A ceiling in the distant past — the run's created_at (now) is
+        // newer, so nothing is stale.
+        assert_eq!(db.reconcile_stale_runs("2000-01-01T00:00:00Z"), 0);
+        assert_eq!(db.list_automation_runs(a.id, 10)[0].status, "running");
     }
 }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1,10 +1,10 @@
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-const SCHEMA_VERSION: u32 = 4;
+const SCHEMA_VERSION: u32 = 5;
 
 pub struct DatabaseStore {
     conn: Mutex<Connection>,
@@ -206,6 +206,77 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
         CREATE INDEX IF NOT EXISTS idx_hosts_dirty
             ON hosts(user_id, dirty)
             WHERE dirty = 1;
+
+        -- Automations — scheduled agent runs on a chosen host.
+        --
+        -- An automation is a named prompt + agent + recurrence. The
+        -- recurrence lives in `schedule` as a complete iCalendar block
+        -- (a DTSTART line plus one RRULE line, RFC 5545); `timezone`
+        -- holds the IANA zone for display. The host-side scheduler
+        -- (codemux-remote) reads `next_run_at` to decide when to fire.
+        --
+        -- `host_id` is a plain integer, NOT a foreign key: hosts are
+        -- soft-deleted then physically purged by the sync layer, and a
+        -- hard FK would block that purge. A dangling `host_id` is
+        -- surfaced to the user as a removed-host state rather than
+        -- corrupting the row.
+        --
+        -- `server_id` / `deleted_at` / `dirty` mirror the `hosts` table
+        -- so the account-sync layer (a future `automations_sync`) can
+        -- be added with no schema migration.
+        CREATE TABLE IF NOT EXISTS automations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL DEFAULT 'local',
+            server_id TEXT,
+            name TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            agent TEXT NOT NULL DEFAULT 'claude',
+            schedule TEXT NOT NULL,
+            timezone TEXT NOT NULL DEFAULT 'UTC',
+            host_id INTEGER,
+            project_path TEXT,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            retention_limit INTEGER NOT NULL DEFAULT 10,
+            last_run_at TEXT,
+            next_run_at TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            deleted_at TEXT,
+            dirty INTEGER NOT NULL DEFAULT 1,
+            UNIQUE(user_id, server_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_automations_user
+            ON automations(user_id, deleted_at);
+        CREATE INDEX IF NOT EXISTS idx_automations_dirty
+            ON automations(user_id, dirty)
+            WHERE dirty = 1;
+
+        -- Automation runs — one row per fire (or skipped fire).
+        --
+        -- `UNIQUE(automation_id, scheduled_for)` is the idempotency key:
+        -- `scheduled_for` is floored to the minute by the caller, so a
+        -- re-delivered tick for the same minute is a no-op insert. Run
+        -- rows are kept indefinitely (history is cheap, text-only); only
+        -- the agent worktrees on the host are pruned, per the
+        -- automation's `retention_limit`.
+        CREATE TABLE IF NOT EXISTS automation_runs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            automation_id INTEGER NOT NULL
+                REFERENCES automations(id) ON DELETE CASCADE,
+            status TEXT NOT NULL DEFAULT 'scheduled',
+            scheduled_for TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            host_id INTEGER,
+            workspace_id TEXT,
+            error TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(automation_id, scheduled_for)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_automation_runs_automation
+            ON automation_runs(automation_id, scheduled_for DESC);
         ",
     )
     .map_err(|e| format!("Failed to create database schema: {e}"))?;
@@ -708,6 +779,393 @@ fn row_to_host(row: &rusqlite::Row<'_>) -> rusqlite::Result<HostRecord> {
         updated_at: row.get(5)?,
         deleted_at: row.get(6)?,
         dirty: dirty_int != 0,
+    })
+}
+
+// ── Automations ──
+//
+// CRUD over the `automations` and `automation_runs` tables. Automations
+// reuse the soft-delete + `dirty` flag convention from `hosts` so the
+// account-sync layer can be bolted on later without a migration. Run
+// rows are append-only history and are never pruned here — only the
+// agent worktrees on the host are reclaimed, by the host scheduler.
+
+/// One scheduled automation: a named prompt + agent + recurrence that
+/// fires on a chosen host.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AutomationRecord {
+    pub id: i64,
+    pub server_id: Option<String>,
+    pub name: String,
+    pub prompt: String,
+    pub agent: String,
+    /// Complete iCalendar recurrence block (DTSTART + RRULE, RFC 5545).
+    pub schedule: String,
+    /// IANA timezone name, for display.
+    pub timezone: String,
+    /// Target host row id, or `None` when not yet assigned.
+    pub host_id: Option<i64>,
+    /// Repository path the run operates in.
+    pub project_path: Option<String>,
+    pub enabled: bool,
+    /// How many completed run worktrees the host keeps before pruning.
+    pub retention_limit: i64,
+    pub last_run_at: Option<String>,
+    pub next_run_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+    pub dirty: bool,
+}
+
+/// One fire of an automation (or a skipped fire).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AutomationRunRecord {
+    pub id: i64,
+    pub automation_id: i64,
+    /// `scheduled` | `running` | `succeeded` | `failed`
+    /// | `skipped_offline` | `skipped_busy`.
+    pub status: String,
+    pub scheduled_for: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub host_id: Option<i64>,
+    pub workspace_id: Option<String>,
+    pub error: Option<String>,
+    pub created_at: String,
+}
+
+/// Editable fields of an automation, shared by create and update.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AutomationInput {
+    pub name: String,
+    pub prompt: String,
+    pub agent: String,
+    pub schedule: String,
+    pub timezone: String,
+    pub host_id: Option<i64>,
+    pub project_path: Option<String>,
+    pub retention_limit: i64,
+}
+
+const AUTOMATION_COLUMNS: &str = "id, server_id, name, prompt, agent, schedule, \
+     timezone, host_id, project_path, enabled, retention_limit, last_run_at, \
+     next_run_at, created_at, updated_at, deleted_at, dirty";
+
+const AUTOMATION_RUN_COLUMNS: &str = "id, automation_id, status, scheduled_for, \
+     started_at, finished_at, host_id, workspace_id, error, created_at";
+
+impl DatabaseStore {
+    /// Insert a new automation. Marked `dirty` so a future sync pushes it.
+    pub fn insert_automation(
+        &self,
+        input: &AutomationInput,
+    ) -> Result<AutomationRecord, String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO automations
+                (user_id, name, prompt, agent, schedule, timezone,
+                 host_id, project_path, retention_limit, dirty)
+             VALUES ('local', ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1)",
+            params![
+                input.name,
+                input.prompt,
+                input.agent,
+                input.schedule,
+                input.timezone,
+                input.host_id,
+                input.project_path,
+                input.retention_limit,
+            ],
+        )
+        .map_err(|e| format!("Failed to insert automation: {e}"))?;
+        let id = conn.last_insert_rowid();
+        conn.query_row(
+            &format!("SELECT {AUTOMATION_COLUMNS} FROM automations WHERE id = ?1"),
+            params![id],
+            row_to_automation,
+        )
+        .map_err(|e| format!("Failed to re-read inserted automation: {e}"))
+    }
+
+    /// All non-deleted automations for the local user, name-sorted.
+    pub fn list_automations(&self) -> Vec<AutomationRecord> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = match conn.prepare(&format!(
+            "SELECT {AUTOMATION_COLUMNS} FROM automations
+             WHERE user_id = 'local' AND deleted_at IS NULL
+             ORDER BY name COLLATE NOCASE ASC"
+        )) {
+            Ok(s) => s,
+            Err(error) => {
+                eprintln!("[codemux::database] list_automations prepare failed: {error}");
+                return Vec::new();
+            }
+        };
+        let rows = match stmt.query_map([], row_to_automation) {
+            Ok(r) => r,
+            Err(error) => {
+                eprintln!("[codemux::database] list_automations query_map failed: {error}");
+                return Vec::new();
+            }
+        };
+        rows.filter_map(|r| r.ok()).collect()
+    }
+
+    /// Fetch one automation by id. `None` if it does not exist or is
+    /// soft-deleted.
+    pub fn get_automation(&self, id: i64) -> Option<AutomationRecord> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            &format!(
+                "SELECT {AUTOMATION_COLUMNS} FROM automations
+                 WHERE id = ?1 AND user_id = 'local' AND deleted_at IS NULL"
+            ),
+            params![id],
+            row_to_automation,
+        )
+        .optional()
+        .unwrap_or(None)
+    }
+
+    /// Update the editable fields of an automation. Marks it `dirty`.
+    pub fn update_automation(
+        &self,
+        id: i64,
+        input: &AutomationInput,
+    ) -> Result<AutomationRecord, String> {
+        let conn = self.conn.lock().unwrap();
+        let affected = conn
+            .execute(
+                "UPDATE automations
+                 SET name = ?1, prompt = ?2, agent = ?3, schedule = ?4,
+                     timezone = ?5, host_id = ?6, project_path = ?7,
+                     retention_limit = ?8, updated_at = datetime('now'),
+                     dirty = 1
+                 WHERE id = ?9 AND user_id = 'local' AND deleted_at IS NULL",
+                params![
+                    input.name,
+                    input.prompt,
+                    input.agent,
+                    input.schedule,
+                    input.timezone,
+                    input.host_id,
+                    input.project_path,
+                    input.retention_limit,
+                    id,
+                ],
+            )
+            .map_err(|e| format!("Failed to update automation: {e}"))?;
+        if affected == 0 {
+            return Err(format!("No automation with id {id}"));
+        }
+        conn.query_row(
+            &format!("SELECT {AUTOMATION_COLUMNS} FROM automations WHERE id = ?1"),
+            params![id],
+            row_to_automation,
+        )
+        .map_err(|e| format!("Failed to re-read updated automation: {e}"))
+    }
+
+    /// Pause or resume an automation.
+    pub fn set_automation_enabled(
+        &self,
+        id: i64,
+        enabled: bool,
+    ) -> Result<AutomationRecord, String> {
+        let conn = self.conn.lock().unwrap();
+        let affected = conn
+            .execute(
+                "UPDATE automations
+                 SET enabled = ?1, updated_at = datetime('now'), dirty = 1
+                 WHERE id = ?2 AND user_id = 'local' AND deleted_at IS NULL",
+                params![enabled as i64, id],
+            )
+            .map_err(|e| format!("Failed to set automation enabled: {e}"))?;
+        if affected == 0 {
+            return Err(format!("No automation with id {id}"));
+        }
+        conn.query_row(
+            &format!("SELECT {AUTOMATION_COLUMNS} FROM automations WHERE id = ?1"),
+            params![id],
+            row_to_automation,
+        )
+        .map_err(|e| format!("Failed to re-read automation: {e}"))
+    }
+
+    /// Record the computed next fire time. Scheduler bookkeeping — does
+    /// not mark the row `dirty` or bump `updated_at`, since it is
+    /// derived state, not a user edit.
+    pub fn set_automation_next_run(
+        &self,
+        id: i64,
+        next_run_at: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE automations SET next_run_at = ?1 WHERE id = ?2",
+            params![next_run_at, id],
+        )
+        .map_err(|e| format!("Failed to set automation next_run_at: {e}"))?;
+        Ok(())
+    }
+
+    /// Soft-delete an automation: stamp `deleted_at` and mark `dirty` so
+    /// the tombstone syncs. Run-history rows are left intact.
+    pub fn delete_automation(&self, id: i64) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        let affected = conn
+            .execute(
+                "UPDATE automations
+                 SET deleted_at = datetime('now'),
+                     updated_at = datetime('now'), dirty = 1
+                 WHERE id = ?1 AND user_id = 'local' AND deleted_at IS NULL",
+                params![id],
+            )
+            .map_err(|e| format!("Failed to soft-delete automation: {e}"))?;
+        if affected == 0 {
+            return Err(format!("No automation with id {id}"));
+        }
+        Ok(())
+    }
+
+    /// Insert a run row. `scheduled_for` must already be floored to the
+    /// minute by the caller; the `UNIQUE(automation_id, scheduled_for)`
+    /// constraint makes a re-delivered fire idempotent — returns
+    /// `Ok(None)` when a row for that minute already exists.
+    pub fn record_automation_run(
+        &self,
+        automation_id: i64,
+        status: &str,
+        scheduled_for: &str,
+        host_id: Option<i64>,
+        workspace_id: Option<&str>,
+    ) -> Result<Option<AutomationRunRecord>, String> {
+        let conn = self.conn.lock().unwrap();
+        let affected = conn
+            .execute(
+                "INSERT INTO automation_runs
+                    (automation_id, status, scheduled_for, host_id, workspace_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(automation_id, scheduled_for) DO NOTHING",
+                params![automation_id, status, scheduled_for, host_id, workspace_id],
+            )
+            .map_err(|e| format!("Failed to record automation run: {e}"))?;
+        if affected == 0 {
+            return Ok(None);
+        }
+        let id = conn.last_insert_rowid();
+        conn.query_row(
+            &format!("SELECT {AUTOMATION_RUN_COLUMNS} FROM automation_runs WHERE id = ?1"),
+            params![id],
+            row_to_automation_run,
+        )
+        .map(Some)
+        .map_err(|e| format!("Failed to re-read automation run: {e}"))
+    }
+
+    /// Mark a run as started (the agent session is now live).
+    pub fn mark_automation_run_started(&self, run_id: i64) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE automation_runs
+             SET status = 'running', started_at = datetime('now')
+             WHERE id = ?1",
+            params![run_id],
+        )
+        .map_err(|e| format!("Failed to mark automation run started: {e}"))?;
+        Ok(())
+    }
+
+    /// Move a run to a terminal state. `workspace_id` is written only
+    /// when `Some`, so a late workspace id does not clobber an earlier
+    /// one.
+    pub fn finish_automation_run(
+        &self,
+        run_id: i64,
+        status: &str,
+        workspace_id: Option<&str>,
+        error: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE automation_runs
+             SET status = ?1,
+                 finished_at = datetime('now'),
+                 workspace_id = COALESCE(?2, workspace_id),
+                 error = ?3
+             WHERE id = ?4",
+            params![status, workspace_id, error, run_id],
+        )
+        .map_err(|e| format!("Failed to finish automation run: {e}"))?;
+        Ok(())
+    }
+
+    /// Recent runs for an automation, newest fire first.
+    pub fn list_automation_runs(
+        &self,
+        automation_id: i64,
+        limit: u32,
+    ) -> Vec<AutomationRunRecord> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = match conn.prepare(&format!(
+            "SELECT {AUTOMATION_RUN_COLUMNS} FROM automation_runs
+             WHERE automation_id = ?1
+             ORDER BY scheduled_for DESC LIMIT ?2"
+        )) {
+            Ok(s) => s,
+            Err(error) => {
+                eprintln!("[codemux::database] list_automation_runs prepare failed: {error}");
+                return Vec::new();
+            }
+        };
+        let rows = match stmt.query_map(params![automation_id, limit], row_to_automation_run) {
+            Ok(r) => r,
+            Err(error) => {
+                eprintln!("[codemux::database] list_automation_runs query_map failed: {error}");
+                return Vec::new();
+            }
+        };
+        rows.filter_map(|r| r.ok()).collect()
+    }
+}
+
+fn row_to_automation(row: &rusqlite::Row<'_>) -> rusqlite::Result<AutomationRecord> {
+    let enabled_int: i64 = row.get(9)?;
+    let dirty_int: i64 = row.get(16)?;
+    Ok(AutomationRecord {
+        id: row.get(0)?,
+        server_id: row.get(1)?,
+        name: row.get(2)?,
+        prompt: row.get(3)?,
+        agent: row.get(4)?,
+        schedule: row.get(5)?,
+        timezone: row.get(6)?,
+        host_id: row.get(7)?,
+        project_path: row.get(8)?,
+        enabled: enabled_int != 0,
+        retention_limit: row.get(10)?,
+        last_run_at: row.get(11)?,
+        next_run_at: row.get(12)?,
+        created_at: row.get(13)?,
+        updated_at: row.get(14)?,
+        deleted_at: row.get(15)?,
+        dirty: dirty_int != 0,
+    })
+}
+
+fn row_to_automation_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<AutomationRunRecord> {
+    Ok(AutomationRunRecord {
+        id: row.get(0)?,
+        automation_id: row.get(1)?,
+        status: row.get(2)?,
+        scheduled_for: row.get(3)?,
+        started_at: row.get(4)?,
+        finished_at: row.get(5)?,
+        host_id: row.get(6)?,
+        workspace_id: row.get(7)?,
+        error: row.get(8)?,
+        created_at: row.get(9)?,
     })
 }
 
@@ -2611,5 +3069,165 @@ mod tests {
             .collect();
         sids.sort();
         assert_eq!(sids, vec!["srv-desktop".to_string(), "srv-laptop".to_string()]);
+    }
+
+    // ── Automations ──
+
+    fn sample_automation(name: &str) -> AutomationInput {
+        AutomationInput {
+            name: name.to_string(),
+            prompt: "Triage open issues".to_string(),
+            agent: "claude".to_string(),
+            schedule: "DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY".to_string(),
+            timezone: "UTC".to_string(),
+            host_id: None,
+            project_path: Some("/home/user/repo".to_string()),
+            retention_limit: 10,
+        }
+    }
+
+    #[test]
+    fn automation_crud() {
+        let db = init_test_database();
+        assert_eq!(db.list_automations().len(), 0);
+
+        let created = db
+            .insert_automation(&sample_automation("Daily triage"))
+            .unwrap();
+        assert_eq!(created.name, "Daily triage");
+        assert!(created.enabled, "new automations default to enabled");
+        assert_eq!(created.retention_limit, 10);
+        assert!(created.dirty, "a fresh insert is dirty until synced");
+        assert!(
+            created.next_run_at.is_none(),
+            "next_run_at is derived state set by the command layer, not the insert"
+        );
+
+        let fetched = db.get_automation(created.id).unwrap();
+        assert_eq!(fetched.prompt, "Triage open issues");
+        assert_eq!(db.list_automations().len(), 1);
+
+        let mut edit = sample_automation("Daily triage");
+        edit.prompt = "Triage and label issues".to_string();
+        let updated = db.update_automation(created.id, &edit).unwrap();
+        assert_eq!(updated.prompt, "Triage and label issues");
+
+        // Soft-delete drops it from both `list` and `get`.
+        db.delete_automation(created.id).unwrap();
+        assert_eq!(db.list_automations().len(), 0);
+        assert!(db.get_automation(created.id).is_none());
+
+        // A soft-deleted automation can no longer be updated.
+        assert!(db.update_automation(created.id, &edit).is_err());
+    }
+
+    #[test]
+    fn automation_enabled_toggle() {
+        let db = init_test_database();
+        let a = db
+            .insert_automation(&sample_automation("Nightly build"))
+            .unwrap();
+        assert!(a.enabled);
+
+        let paused = db.set_automation_enabled(a.id, false).unwrap();
+        assert!(!paused.enabled);
+
+        let resumed = db.set_automation_enabled(a.id, true).unwrap();
+        assert!(resumed.enabled);
+    }
+
+    #[test]
+    fn automation_next_run_is_settable_and_clearable() {
+        let db = init_test_database();
+        let a = db
+            .insert_automation(&sample_automation("Weekly report"))
+            .unwrap();
+
+        db.set_automation_next_run(a.id, Some("2026-02-01T09:00:00+00:00"))
+            .unwrap();
+        assert_eq!(
+            db.get_automation(a.id).unwrap().next_run_at.as_deref(),
+            Some("2026-02-01T09:00:00+00:00")
+        );
+
+        db.set_automation_next_run(a.id, None).unwrap();
+        assert!(db.get_automation(a.id).unwrap().next_run_at.is_none());
+    }
+
+    #[test]
+    fn automation_run_insert_is_idempotent_per_minute() {
+        let db = init_test_database();
+        let a = db
+            .insert_automation(&sample_automation("Hourly sync"))
+            .unwrap();
+
+        let first = db
+            .record_automation_run(a.id, "running", "2026-01-01T09:00:00Z", None, None)
+            .unwrap();
+        assert!(first.is_some());
+
+        // A re-delivered fire for the same minute is a no-op.
+        let dup = db
+            .record_automation_run(a.id, "running", "2026-01-01T09:00:00Z", None, None)
+            .unwrap();
+        assert!(dup.is_none());
+
+        // A different minute is a distinct run.
+        let next = db
+            .record_automation_run(a.id, "running", "2026-01-01T10:00:00Z", None, None)
+            .unwrap();
+        assert!(next.is_some());
+
+        assert_eq!(db.list_automation_runs(a.id, 10).len(), 2);
+    }
+
+    #[test]
+    fn automation_run_lifecycle_reaches_a_terminal_state() {
+        let db = init_test_database();
+        let a = db
+            .insert_automation(&sample_automation("Deploy check"))
+            .unwrap();
+
+        let run = db
+            .record_automation_run(a.id, "scheduled", "2026-03-01T08:00:00Z", Some(1), None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.status, "scheduled");
+        assert!(run.started_at.is_none());
+
+        db.mark_automation_run_started(run.id).unwrap();
+        db.finish_automation_run(run.id, "succeeded", Some("ws-42"), None)
+            .unwrap();
+
+        let runs = db.list_automation_runs(a.id, 10);
+        assert_eq!(runs.len(), 1);
+        let finished = &runs[0];
+        assert_eq!(finished.status, "succeeded");
+        assert!(finished.started_at.is_some());
+        assert!(finished.finished_at.is_some());
+        assert_eq!(finished.workspace_id.as_deref(), Some("ws-42"));
+    }
+
+    #[test]
+    fn automation_runs_are_listed_newest_fire_first() {
+        let db = init_test_database();
+        let a = db.insert_automation(&sample_automation("Ordering")).unwrap();
+        db.record_automation_run(a.id, "succeeded", "2026-01-01T09:00:00Z", None, None)
+            .unwrap();
+        db.record_automation_run(a.id, "succeeded", "2026-01-03T09:00:00Z", None, None)
+            .unwrap();
+        db.record_automation_run(a.id, "succeeded", "2026-01-02T09:00:00Z", None, None)
+            .unwrap();
+
+        let runs = db.list_automation_runs(a.id, 10);
+        let order: Vec<&str> = runs.iter().map(|r| r.scheduled_for.as_str()).collect();
+        assert_eq!(
+            order,
+            vec![
+                "2026-01-03T09:00:00Z",
+                "2026-01-02T09:00:00Z",
+                "2026-01-01T09:00:00Z",
+            ]
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1559,6 +1559,7 @@ pub fn run() {
             commands::automations_set_enabled,
             commands::automations_delete,
             commands::automations_runs,
+            commands::automations_check_repo_access,
             commands::get_package_format,
             resource_metrics::get_resource_metrics,
             commands::debug_log,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub mod agent_provider;
 pub mod ai;
 pub mod auth;
 pub mod automations;
+pub mod automations_sync;
 pub mod branch_name;
 pub mod json_rpc_child;
 pub mod mcp_server;
@@ -874,6 +875,28 @@ pub fn run() {
             // `codemux-remote scheduler` subcommand.
             let scheduler_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
+                // Recover runs orphaned by a previous crash or quit
+                // before the first tick — a run stuck `running` would
+                // otherwise keep its automation `skipped_busy` forever.
+                {
+                    let db: tauri::State<'_, database::DatabaseStore> =
+                        scheduler_handle.state();
+                    let ceiling = (chrono::Utc::now()
+                        - chrono::Duration::hours(6))
+                    .to_rfc3339();
+                    let reconciled = db.reconcile_stale_runs(&ceiling);
+                    if reconciled > 0 {
+                        eprintln!(
+                            "[codemux::scheduler] reconciled {reconciled} stale run(s)"
+                        );
+                    }
+                }
+                // Pull the automation registry from the account once at
+                // startup so this device sees automations created
+                // elsewhere.
+                commands::automations::schedule_automations_sync(
+                    scheduler_handle.clone(),
+                );
                 let mut ticker = tokio::time::interval(std::time::Duration::from_secs(
                     automations::scheduler::TICK_INTERVAL_SECS,
                 ));
@@ -883,6 +906,12 @@ pub fn run() {
                 ticker.tick().await;
                 loop {
                     ticker.tick().await;
+                    // Pull registry changes from the user's other
+                    // devices on every tick so the local list stays
+                    // fresh; the in-progress guard collapses overlap.
+                    commands::automations::schedule_automations_sync(
+                        scheduler_handle.clone(),
+                    );
                     // Evaluate the schedule, then resolve each fired run
                     // to its automation. Both are short, synchronous DB
                     // touches scoped so the `State` borrow never crosses
@@ -893,7 +922,10 @@ pub fn run() {
                     )> = {
                         let db: tauri::State<'_, database::DatabaseStore> =
                             scheduler_handle.state();
-                        automations::scheduler::tick(&db, chrono::Utc::now())
+                        // `local_only = true`: the desktop runs only
+                        // automations targeting this machine; a
+                        // host-assigned automation is its host's job.
+                        automations::scheduler::tick(&db, chrono::Utc::now(), true)
                             .into_iter()
                             .filter_map(|run| {
                                 db.get_automation(run.automation_id)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod agent_context;
 pub mod agent_provider;
 pub mod ai;
 pub mod auth;
+pub mod automations;
 pub mod branch_name;
 pub mod json_rpc_child;
 pub mod mcp_server;
@@ -860,6 +861,68 @@ pub fn run() {
             // Errors are intentionally swallowed: repos without remotes,
             // transient offline state, and rejected creds are routine and
             // shouldn't pollute the log on every tick.
+
+            // ── Automation scheduler ──
+            //
+            // Evaluates the automation schedule once a minute.
+            // `automations::scheduler::tick` records a run row for every
+            // due automation and advances its `next_run_at`; each
+            // freshly-fired run is emitted as an `automations://fire`
+            // event so the frontend executor can create the workspace
+            // and start the agent. This is the desktop's scheduler —
+            // remote hosts run the same `tick` via the
+            // `codemux-remote scheduler` subcommand.
+            let scheduler_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let mut ticker = tokio::time::interval(std::time::Duration::from_secs(
+                    automations::scheduler::TICK_INTERVAL_SECS,
+                ));
+                // `interval`'s first tick is immediate — consume it so
+                // the first real evaluation happens one interval in,
+                // after the app has settled.
+                ticker.tick().await;
+                loop {
+                    ticker.tick().await;
+                    // Evaluate the schedule, then resolve each fired run
+                    // to its automation. Both are short, synchronous DB
+                    // touches scoped so the `State` borrow never crosses
+                    // an await.
+                    let fired: Vec<(
+                        database::AutomationRecord,
+                        database::AutomationRunRecord,
+                    )> = {
+                        let db: tauri::State<'_, database::DatabaseStore> =
+                            scheduler_handle.state();
+                        automations::scheduler::tick(&db, chrono::Utc::now())
+                            .into_iter()
+                            .filter_map(|run| {
+                                db.get_automation(run.automation_id)
+                                    .map(|automation| (automation, run))
+                            })
+                            .collect()
+                    };
+                    for (automation, run) in fired {
+                        // Surface the fire to any open window…
+                        if let Err(error) =
+                            scheduler_handle.emit("automations://fire", &run)
+                        {
+                            eprintln!(
+                                "[codemux::scheduler] failed to emit fire event: {error}"
+                            );
+                        }
+                        // …and execute it: create a worktree and run
+                        // the agent, recording the terminal status.
+                        tauri::async_runtime::spawn(
+                            automations::executor::execute_run(
+                                scheduler_handle.clone(),
+                                automation,
+                                run,
+                            ),
+                        );
+                    }
+                }
+            });
+
             let fetch_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 const TICK_SECS: u64 = 60;
@@ -1457,6 +1520,13 @@ pub fn run() {
             commands::set_workspace_host,
             commands::workspace_push_to_host,
             commands::workspace_pull_back,
+            commands::automations_list,
+            commands::automations_get,
+            commands::automations_create,
+            commands::automations_update,
+            commands::automations_set_enabled,
+            commands::automations_delete,
+            commands::automations_runs,
             commands::get_package_format,
             resource_metrics::get_resource_metrics,
             commands::debug_log,

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -345,6 +345,108 @@ fn register_tools() -> Vec<McpTool> {
                 }
             }),
         },
+        // -- Automation tools --
+        McpTool {
+            name: "automation_list",
+            description: "List all automations (scheduled agent runs) for the signed-in user.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {}
+            }),
+        },
+        McpTool {
+            name: "automation_get",
+            description: "Get a single automation by id, including its prompt and schedule.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer", "description": "Automation id" }
+                },
+                "required": ["id"]
+            }),
+        },
+        McpTool {
+            name: "automation_create",
+            description: "Create an automation: a named prompt + agent that runs on a schedule. The schedule is an RFC 5545 recurrence.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string", "description": "Short human-readable name" },
+                    "prompt": { "type": "string", "description": "The instruction the agent runs each time it fires" },
+                    "agent": { "type": "string", "description": "Agent to run, e.g. \"claude\" or \"codex\"" },
+                    "schedule": { "type": "string", "description": "RFC 5545 recurrence: a DTSTART line and one RRULE line joined by a newline, e.g. \"DTSTART:20260101T090000Z\\nRRULE:FREQ=DAILY\"" },
+                    "timezone": { "type": "string", "description": "IANA timezone name, e.g. \"America/New_York\". Defaults to \"UTC\"" },
+                    "host_id": { "type": "integer", "description": "Target host id (from the Hosts list). Optional — may be assigned later" },
+                    "project_path": { "type": "string", "description": "Absolute path of the repository the run operates in (optional)" },
+                    "retention_limit": { "type": "integer", "description": "How many completed run worktrees the host keeps (1-1000, default 10)" }
+                },
+                "required": ["name", "prompt", "agent", "schedule"]
+            }),
+        },
+        McpTool {
+            name: "automation_update",
+            description: "Update an existing automation. All editable fields must be supplied — this replaces them.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer", "description": "Automation id" },
+                    "name": { "type": "string" },
+                    "prompt": { "type": "string" },
+                    "agent": { "type": "string" },
+                    "schedule": { "type": "string", "description": "RFC 5545 recurrence (DTSTART + RRULE)" },
+                    "timezone": { "type": "string", "description": "IANA timezone name" },
+                    "host_id": { "type": "integer" },
+                    "project_path": { "type": "string" },
+                    "retention_limit": { "type": "integer" }
+                },
+                "required": ["id", "name", "prompt", "agent", "schedule"]
+            }),
+        },
+        McpTool {
+            name: "automation_delete",
+            description: "Delete an automation. Run history is retained.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer", "description": "Automation id" }
+                },
+                "required": ["id"]
+            }),
+        },
+        McpTool {
+            name: "automation_pause",
+            description: "Pause an automation so it stops firing until resumed.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer", "description": "Automation id" }
+                },
+                "required": ["id"]
+            }),
+        },
+        McpTool {
+            name: "automation_resume",
+            description: "Resume a paused automation. The next fire time is recomputed from now, so no missed runs are replayed.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "integer", "description": "Automation id" }
+                },
+                "required": ["id"]
+            }),
+        },
+        McpTool {
+            name: "automation_runs",
+            description: "List the run history of an automation, newest fire first.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "automation_id": { "type": "integer", "description": "Automation id" },
+                    "limit": { "type": "integer", "description": "Max rows to return (1-100, default 20)" }
+                },
+                "required": ["automation_id"]
+            }),
+        },
         // -- Pane tools --
         McpTool {
             name: "pane_list",
@@ -997,6 +1099,56 @@ async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
             call_socket("create_workspace", params).await
         }
 
+        // -- Automation tools --
+        "automation_list" => call_socket("automation_list", json!({})).await,
+        "automation_get" => {
+            call_socket("automation_get", json!({ "id": arguments.get("id") })).await
+        }
+        "automation_create" => {
+            call_socket(
+                "automation_create",
+                json!({ "input": automation_input_from_args(&arguments) }),
+            )
+            .await
+        }
+        "automation_update" => {
+            call_socket(
+                "automation_update",
+                json!({
+                    "id": arguments.get("id"),
+                    "input": automation_input_from_args(&arguments),
+                }),
+            )
+            .await
+        }
+        "automation_delete" => {
+            call_socket("automation_delete", json!({ "id": arguments.get("id") })).await
+        }
+        "automation_pause" => {
+            call_socket(
+                "automation_set_enabled",
+                json!({ "id": arguments.get("id"), "enabled": false }),
+            )
+            .await
+        }
+        "automation_resume" => {
+            call_socket(
+                "automation_set_enabled",
+                json!({ "id": arguments.get("id"), "enabled": true }),
+            )
+            .await
+        }
+        "automation_runs" => {
+            call_socket(
+                "automation_runs",
+                json!({
+                    "automation_id": arguments.get("automation_id"),
+                    "limit": arguments.get("limit"),
+                }),
+            )
+            .await
+        }
+
         // -- Pane tools --
         "pane_list" => {
             call_socket("get_app_state", json!({})).await.map(|data| {
@@ -1265,6 +1417,30 @@ async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
             }),
         ),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Automation argument helper
+// ---------------------------------------------------------------------------
+
+/// Assemble the `AutomationInput` object the control socket expects from
+/// the flat arguments an MCP `automation_create` / `automation_update`
+/// call provides. Missing optional fields fall back to sensible
+/// defaults; the control handler runs the authoritative validation.
+fn automation_input_from_args(arguments: &Value) -> Value {
+    json!({
+        "name": arguments.get("name").and_then(Value::as_str).unwrap_or_default(),
+        "prompt": arguments.get("prompt").and_then(Value::as_str).unwrap_or_default(),
+        "agent": arguments.get("agent").and_then(Value::as_str).unwrap_or("claude"),
+        "schedule": arguments.get("schedule").and_then(Value::as_str).unwrap_or_default(),
+        "timezone": arguments.get("timezone").and_then(Value::as_str).unwrap_or("UTC"),
+        "host_id": arguments.get("host_id").and_then(Value::as_i64),
+        "project_path": arguments.get("project_path").and_then(Value::as_str),
+        "retention_limit": arguments
+            .get("retention_limit")
+            .and_then(Value::as_i64)
+            .unwrap_or(10),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1603,10 +1779,10 @@ mod tests {
     fn tool_registry_has_all_tools() {
         let tools = register_tools();
         // Tool count bumped from 39 → 44 with the Phase 1.6 lifecycle +
-        // issue tools: workspace_close, pane_close, issue_list,
-        // issue_get, issue_link_workspace. Keep this number in sync
-        // with register_tools() when adding new entries.
-        assert_eq!(tools.len(), 44);
+        // issue tools, then 44 → 52 with the eight automation tools.
+        // Keep this number in sync with register_tools() when adding
+        // new entries.
+        assert_eq!(tools.len(), 52);
         let names: Vec<&str> = tools.iter().map(|t| t.name).collect();
         assert!(names.contains(&"browser_navigate"));
         assert!(names.contains(&"browser_click"));
@@ -1614,6 +1790,10 @@ mod tests {
         assert!(names.contains(&"browser_screenshot"));
         assert!(names.contains(&"workspace_list"));
         assert!(names.contains(&"workspace_info"));
+        assert!(names.contains(&"automation_list"));
+        assert!(names.contains(&"automation_create"));
+        assert!(names.contains(&"automation_pause"));
+        assert!(names.contains(&"automation_runs"));
         assert!(names.contains(&"pane_list"));
         assert!(names.contains(&"notify"));
         assert!(names.contains(&"git_status"));
@@ -1749,11 +1929,10 @@ mod tests {
         let resp = dispatch(req).await.unwrap();
         let result = resp.result.unwrap();
         let tools = result["tools"].as_array().unwrap();
-        // Bumped from 39 → 44 with the Phase 1.6 lifecycle + issue
-        // tools (workspace_close, pane_close, issue_list, issue_get,
-        // issue_link_workspace). See tool_registry_has_all_tools for
-        // the canonical count.
-        assert_eq!(tools.len(), 44);
+        // Bumped 39 → 44 with the Phase 1.6 lifecycle + issue tools,
+        // then 44 → 52 with the eight automation tools. See
+        // tool_registry_has_all_tools for the canonical count.
+        assert_eq!(tools.len(), 52);
         for tool in tools {
             assert!(tool.get("name").is_some());
             assert!(tool.get("description").is_some());

--- a/src-tauri/src/ssh/bootstrap.rs
+++ b/src-tauri/src/ssh/bootstrap.rs
@@ -345,6 +345,127 @@ async fn run_capture_with_timeout(
     Ok(String::from_utf8_lossy(&out.stdout).to_string())
 }
 
+/// Provision the automation scheduler on a freshly-bootstrapped host.
+///
+/// Writes the scheduler auth token + this host's server id, installs a
+/// systemd **user** service running `codemux-remote scheduler`, and
+/// enables it with lingering so it survives logout and reboots.
+///
+/// Best-effort by contract: the caller treats a failure as non-fatal —
+/// a host's push-workspace capability does not depend on the scheduler,
+/// and not every host runs systemd.
+pub async fn provision_scheduler(
+    ssh_target: &str,
+    remote_install_path: &str,
+    token: &str,
+    host_server_id: &str,
+    deadline: Duration,
+) -> Result<(), String> {
+    use crate::automations::service;
+
+    // Token + host-identity files. `umask 077` lands them 0600 — the
+    // token is account-bearing.
+    ssh_write_file(
+        ssh_target,
+        "~/.local/share/codemux/scheduler-token",
+        token,
+        deadline,
+    )
+    .await
+    .map_err(|e| format!("writing scheduler token: {e}"))?;
+    ssh_write_file(
+        ssh_target,
+        "~/.local/share/codemux/scheduler-host",
+        host_server_id,
+        deadline,
+    )
+    .await
+    .map_err(|e| format!("writing host identity: {e}"))?;
+
+    // systemd user unit. `~` in the install path becomes `%h` so the
+    // unit's ExecStart is an absolute path systemd will accept.
+    let exec_path = remote_install_path.replacen('~', "%h", 1);
+    let unit = service::systemd_unit(&exec_path);
+    ssh_write_file(
+        ssh_target,
+        &format!("~/.config/systemd/user/{}", service::SYSTEMD_UNIT_NAME),
+        &unit,
+        deadline,
+    )
+    .await
+    .map_err(|e| format!("writing systemd unit: {e}"))?;
+
+    // Enable lingering (so the service runs without an active login)
+    // and start the unit.
+    run_with_timeout(
+        Command::new("ssh")
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg("-o")
+            .arg("ConnectTimeout=10")
+            .arg(ssh_target)
+            .arg(format!(
+                "loginctl enable-linger \"$USER\" >/dev/null 2>&1; \
+                 systemctl --user daemon-reload && \
+                 systemctl --user enable --now {}",
+                service::SYSTEMD_UNIT_NAME
+            )),
+        deadline,
+    )
+    .await
+    .map_err(|e| format!("enabling the scheduler service: {e}"))
+}
+
+/// `ssh <target> 'umask 077; mkdir -p <dir>; cat > <path>'` with
+/// `content` streamed over stdin so a secret never appears in an
+/// argv the host's process list could expose.
+async fn ssh_write_file(
+    ssh_target: &str,
+    remote_path: &str,
+    content: &str,
+    deadline: Duration,
+) -> Result<(), String> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut child = Command::new("ssh")
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg("-o")
+        .arg("ConnectTimeout=10")
+        .arg(ssh_target)
+        .arg(format!(
+            "umask 077 && mkdir -p \"$(dirname {p})\" && cat > {p}",
+            p = remote_path
+        ))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("ssh spawn failed: {e}"))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(content.as_bytes())
+            .await
+            .map_err(|e| format!("failed to stream content: {e}"))?;
+        // `stdin` drops here, closing the pipe so `cat` sees EOF.
+    }
+
+    let out = timeout(deadline, child.wait_with_output())
+        .await
+        .map_err(|_| "operation timed out".to_string())?
+        .map_err(|e| format!("ssh failed: {e}"))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("exit status {}", out.status)
+        } else {
+            stderr
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { useSkillsSync } from "@/hooks/use-skills-sync";
 import { useScrollbackSerializer } from "@/hooks/use-scrollback-serializer";
 import { useTerminalCacheGc } from "@/hooks/use-terminal-cache-gc";
 import { useTerminalThemeSync } from "@/hooks/use-terminal-theme-sync";
+import { useAutomationFireToast } from "@/hooks/use-automation-fire-toast";
 import { AppShell } from "@/components/layout/app-shell";
 import { Toaster } from "@/components/ui/sonner";
 import { UpdateToast } from "@/components/update/update-toast";
@@ -63,6 +64,7 @@ function App() {
   useEnsureDraftWhenEmpty();
   useTerminalCacheGc();
   useTerminalThemeSync();
+  useAutomationFireToast();
 
   if (isLoading || !isAuthenticated) {
     return <LoginScreen />;

--- a/src/components/automations/automations-section.tsx
+++ b/src/components/automations/automations-section.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import {
+  automationsCheckRepoAccess,
   automationsCreate,
   automationsDelete,
   automationsList,
@@ -38,6 +39,7 @@ import {
   type AutomationRunView,
   type AutomationView,
   type HostView,
+  type RepoAccessResult,
 } from "@/tauri/commands";
 
 /** A repository the user has opened — the source for the project picker. */
@@ -446,12 +448,20 @@ export function AutomationsSection() {
                 >
                   <span
                     aria-hidden
-                    title={automation.enabled ? "Enabled" : "Paused"}
+                    title={
+                      !automation.enabled
+                        ? "Paused"
+                        : automation.last_run_status === "failed"
+                          ? "Last run failed"
+                          : "Enabled"
+                    }
                     className={cn(
                       "mt-[5px] size-1.5 shrink-0 rounded-full transition-colors",
-                      automation.enabled
-                        ? "bg-success"
-                        : "bg-muted-foreground/40",
+                      !automation.enabled
+                        ? "bg-muted-foreground/40"
+                        : automation.last_run_status === "failed"
+                          ? "bg-warning"
+                          : "bg-success",
                     )}
                   />
                   <span className="min-w-0 flex-1">
@@ -595,6 +605,12 @@ function AutomationDetail({
           {describeSchedule(automation.schedule)} · {agentLabel} · {hostLabel}
         </p>
       </div>
+
+      <RepoAccessRow
+        hostId={automation.host_id}
+        projectPath={automation.project_path}
+        projectRemote={automation.project_remote}
+      />
 
       <div className="grid grid-cols-2 gap-3">
         <FactCard label="Next run" value={formatStamp(automation.next_run_at)} />
@@ -869,6 +885,12 @@ function AutomationForm({
         </Field>
       </div>
 
+      <RepoAccessRow
+        hostId={draft.hostId}
+        projectPath={draft.projectPath || null}
+        projectRemote={null}
+      />
+
       <ScheduleField draft={draft} patch={patch} patchBuilder={patchBuilder} />
 
       <div className="grid grid-cols-2 gap-4">
@@ -1088,6 +1110,83 @@ function ProjectField({
         />
       )}
     </Field>
+  );
+}
+
+/** Live "can this host reach the repo" status. Renders nothing for
+ *  "This machine" (the project is local — no access question). For a
+ *  remote host it probes on mount and offers a "Check again" link, so
+ *  the user fixes credentials and re-verifies without waiting for a
+ *  scheduled run. Never blocks — purely informational. */
+function RepoAccessRow({
+  hostId,
+  projectPath,
+  projectRemote,
+}: {
+  hostId: number | null;
+  projectPath: string | null;
+  projectRemote: string | null;
+}) {
+  const [checking, setChecking] = useState(false);
+  const [result, setResult] = useState<RepoAccessResult | null>(null);
+
+  const check = useCallback(() => {
+    setChecking(true);
+    setResult(null);
+    automationsCheckRepoAccess(hostId, projectPath, projectRemote)
+      .then(setResult)
+      .catch((err) =>
+        setResult({
+          ok: false,
+          message: typeof err === "string" ? err : String(err),
+        }),
+      )
+      .finally(() => setChecking(false));
+  }, [hostId, projectPath, projectRemote]);
+
+  useEffect(() => {
+    check();
+  }, [check]);
+
+  // "This machine" uses the local project — no repo-access question.
+  if (hostId === null) return null;
+
+  return (
+    <div className="flex items-start gap-2 text-[11.5px] leading-relaxed">
+      {checking ? (
+        <>
+          <Loader2 className="mt-0.5 size-3 shrink-0 animate-spin text-muted-foreground/60" />
+          <span className="text-muted-foreground/70">
+            Checking repository access…
+          </span>
+        </>
+      ) : result ? (
+        <>
+          <span
+            aria-hidden
+            className={cn(
+              "mt-1 size-1.5 shrink-0 rounded-full",
+              result.ok ? "bg-success" : "bg-warning",
+            )}
+          />
+          <span
+            className={cn(
+              "min-w-0",
+              result.ok ? "text-muted-foreground/75" : "text-warning",
+            )}
+          >
+            {result.message}
+          </span>
+          <button
+            type="button"
+            onClick={check}
+            className="ml-auto shrink-0 text-muted-foreground/60 hover:text-foreground transition-colors"
+          >
+            Check again
+          </button>
+        </>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/components/automations/automations-section.tsx
+++ b/src/components/automations/automations-section.tsx
@@ -11,6 +11,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -736,11 +737,24 @@ function RunHistory({ automationId }: { automationId: number }) {
             <li
               key={run.id}
               title={run.error ?? undefined}
-              className="flex items-center gap-3 px-3 py-2"
+              className="flex items-center gap-2.5 px-3 py-2"
             >
-              <span className="font-mono text-[11.5px] tabular-nums text-muted-foreground/80">
+              <span className="shrink-0 font-mono text-[11.5px] tabular-nums text-muted-foreground/80">
                 {formatStamp(run.scheduled_for)}
               </span>
+              {run.pr_url ? (
+                <button
+                  type="button"
+                  onClick={() => void openUrl(run.pr_url as string)}
+                  className="min-w-0 truncate text-left text-[11px] text-foreground/70 hover:text-foreground hover:underline"
+                >
+                  Pull request ↗
+                </button>
+              ) : run.branch ? (
+                <span className="min-w-0 truncate font-mono text-[10.5px] text-muted-foreground/55">
+                  {run.branch}
+                </span>
+              ) : null}
               <span
                 className={cn(
                   "ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",

--- a/src/components/automations/automations-section.tsx
+++ b/src/components/automations/automations-section.tsx
@@ -355,6 +355,41 @@ export function AutomationsSection() {
     );
   }
 
+  // First run: no automations and not mid-create. A single inviting
+  // hero reads far better than an empty sidebar beside an empty pane.
+  if (automations.length === 0 && draft === null) {
+    return (
+      <div className="flex h-full min-h-[460px] items-center justify-center">
+        <div className="max-w-sm space-y-4 text-center">
+          <div className="mx-auto flex size-14 items-center justify-center rounded-2xl border border-border/50 bg-muted/40">
+            <CalendarClock className="size-6 text-muted-foreground/70" />
+          </div>
+          <div className="space-y-1.5">
+            <h3 className="text-[15px] font-semibold tracking-tight text-foreground">
+              No automations yet
+            </h3>
+            <p className="text-[12.5px] leading-relaxed text-muted-foreground/80">
+              Run an agent on a schedule — triage issues each morning,
+              sweep stale branches nightly, post a weekly summary. It runs
+              on the host you choose, even with your laptop closed.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-8 gap-1.5 text-[12.5px]"
+            onClick={startCreate}
+          >
+            <Plus className="size-3.5" />
+            New automation
+          </Button>
+          {error && <p className="text-[12px] text-destructive">{error}</p>}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full min-h-[460px] gap-6">
       {/* Sidebar */}
@@ -374,40 +409,59 @@ export function AutomationsSection() {
           </div>
         )}
 
-        <ul className="space-y-px">
-          {automations.map((automation) => (
-            <li key={automation.id}>
-              <button
-                type="button"
-                onClick={() => {
-                  setSelectedId(automation.id);
-                  setDraft(null);
-                }}
-                className={cn(
-                  "group/row flex w-full items-center gap-2.5 rounded-md px-2.5 h-8 text-left text-[13px] transition-colors",
-                  selectedId === automation.id && draft === null
-                    ? "bg-muted text-foreground"
-                    : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
-                )}
-              >
-                <span
-                  aria-hidden
-                  title={automation.enabled ? "Enabled" : "Paused"}
+        <ul className="space-y-0.5">
+          {automations.map((automation) => {
+            const active = selectedId === automation.id && draft === null;
+            return (
+              <li key={automation.id}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelectedId(automation.id);
+                    setDraft(null);
+                  }}
                   className={cn(
-                    "size-1.5 shrink-0 rounded-full transition-colors",
-                    automation.enabled ? "bg-success" : "bg-muted-foreground/40",
+                    "group/row flex w-full items-start gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors",
+                    active ? "bg-muted" : "hover:bg-muted/40",
                   )}
-                />
-                <span className="min-w-0 flex-1 truncate">{automation.name}</span>
-                {automation.dirty && (
+                >
                   <span
-                    title="Pending sync"
-                    className="size-1.5 shrink-0 rounded-full bg-warning"
+                    aria-hidden
+                    title={automation.enabled ? "Enabled" : "Paused"}
+                    className={cn(
+                      "mt-[5px] size-1.5 shrink-0 rounded-full transition-colors",
+                      automation.enabled
+                        ? "bg-success"
+                        : "bg-muted-foreground/40",
+                    )}
                   />
-                )}
-              </button>
-            </li>
-          ))}
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-1.5">
+                      <span
+                        className={cn(
+                          "min-w-0 flex-1 truncate text-[13px] transition-colors",
+                          active
+                            ? "text-foreground"
+                            : "text-muted-foreground group-hover/row:text-foreground",
+                        )}
+                      >
+                        {automation.name}
+                      </span>
+                      {automation.dirty && (
+                        <span
+                          title="Pending sync"
+                          className="size-1.5 shrink-0 rounded-full bg-warning"
+                        />
+                      )}
+                    </span>
+                    <span className="mt-0.5 block truncate text-[11px] text-muted-foreground/55">
+                      {describeSchedule(automation.schedule)}
+                    </span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
         </ul>
 
         <div className="mt-4 pt-4 border-t border-border/40">
@@ -490,6 +544,9 @@ function AutomationDetail({
       ? "This machine"
       : (hosts.find((h) => h.id === automation.host_id)?.name ??
         "Removed host");
+  const agentLabel =
+    AGENTS.find((a) => a.value === automation.agent)?.label ??
+    automation.agent;
 
   return (
     <div className="space-y-6">
@@ -515,8 +572,7 @@ function AutomationDetail({
           )}
         </div>
         <p className="text-[12px] text-muted-foreground/85">
-          {describeSchedule(automation.schedule)} · {automation.agent} ·{" "}
-          {hostLabel}
+          {describeSchedule(automation.schedule)} · {agentLabel} · {hostLabel}
         </p>
       </div>
 
@@ -606,13 +662,13 @@ function formatStamp(stamp: string | null): string {
 
 // ── Run history ──
 
-const RUN_STATUS_TONE: Record<string, string> = {
-  scheduled: "bg-muted-foreground/40",
-  running: "bg-warning",
-  succeeded: "bg-success",
-  failed: "bg-destructive",
-  skipped_offline: "bg-muted-foreground/40",
-  skipped_busy: "bg-muted-foreground/40",
+const RUN_STATUS_BADGE: Record<string, string> = {
+  scheduled: "bg-muted text-muted-foreground",
+  running: "bg-warning/15 text-warning",
+  succeeded: "bg-success/15 text-success",
+  failed: "bg-destructive/15 text-destructive",
+  skipped_offline: "bg-muted text-muted-foreground",
+  skipped_busy: "bg-muted text-muted-foreground",
 };
 
 function RunHistory({ automationId }: { automationId: number }) {
@@ -639,33 +695,39 @@ function RunHistory({ automationId }: { automationId: number }) {
 
   return (
     <div className="space-y-1.5">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
-        Run history
-      </p>
+      <div className="flex items-baseline justify-between">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
+          Run history
+        </p>
+        {runs.length > 0 && (
+          <span className="text-[11px] text-muted-foreground/50 tabular-nums">
+            {runs.length}
+          </span>
+        )}
+      </div>
       {loading ? (
-        <p className="text-[12px] text-muted-foreground/70 py-2">Loading…</p>
+        <p className="py-2 text-[12px] text-muted-foreground/70">Loading…</p>
       ) : runs.length === 0 ? (
-        <p className="text-[12px] text-muted-foreground/70 py-2">
+        <p className="rounded-lg border border-dashed border-border/60 px-3 py-3 text-[12px] text-muted-foreground/70">
           No runs yet. The next fire will appear here.
         </p>
       ) : (
-        <ul className="rounded-lg border border-border/60 divide-y divide-border/40">
+        <ul className="overflow-hidden rounded-lg border border-border/60 divide-y divide-border/40">
           {runs.map((run) => (
             <li
               key={run.id}
-              className="flex items-center gap-2.5 px-3 py-2 text-[12px]"
+              title={run.error ?? undefined}
+              className="flex items-center gap-3 px-3 py-2"
             >
-              <span
-                aria-hidden
-                className={cn(
-                  "size-1.5 shrink-0 rounded-full",
-                  RUN_STATUS_TONE[run.status] ?? "bg-muted-foreground/40",
-                )}
-              />
-              <span className="font-mono text-[11.5px] text-muted-foreground/85 tabular-nums">
+              <span className="font-mono text-[11.5px] tabular-nums text-muted-foreground/80">
                 {formatStamp(run.scheduled_for)}
               </span>
-              <span className="ml-auto text-[11px] text-muted-foreground/75">
+              <span
+                className={cn(
+                  "ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+                  RUN_STATUS_BADGE[run.status] ?? "bg-muted text-muted-foreground",
+                )}
+              >
                 {run.status.replace(/_/g, " ")}
               </span>
             </li>

--- a/src/components/automations/automations-section.tsx
+++ b/src/components/automations/automations-section.tsx
@@ -39,13 +39,14 @@ import {
 } from "@/tauri/commands";
 
 /**
- * Settings → Automations.
+ * The Automations management panel — rendered full-screen by
+ * `AutomationsView`, reached from the left sidebar.
  *
  * Scheduled agent runs: a named prompt + agent + recurrence that fires
- * on a chosen host. Mirrors the sidebar-list + detail-pane shape of the
- * Hosts section. The schedule is stored as a complete RFC 5545
- * iCalendar block; the builder below composes the common
- * hourly/daily/weekly cases, and a raw field handles anything else.
+ * on a chosen host. A sidebar-list + detail-pane layout. The schedule
+ * is stored as a complete RFC 5545 iCalendar block; the builder below
+ * composes the common hourly/daily/weekly cases, and a raw field
+ * handles anything else.
  */
 
 type Frequency = "HOURLY" | "DAILY" | "WEEKLY";

--- a/src/components/automations/automations-section.tsx
+++ b/src/components/automations/automations-section.tsx
@@ -31,12 +31,19 @@ import {
   automationsRuns,
   automationsSetEnabled,
   automationsUpdate,
+  dbGetRecentProjects,
   hostsList,
   type AutomationInput,
   type AutomationRunView,
   type AutomationView,
   type HostView,
 } from "@/tauri/commands";
+
+/** A repository the user has opened — the source for the project picker. */
+interface ProjectOption {
+  name: string;
+  path: string;
+}
 
 /**
  * The Automations management panel — rendered full-screen by
@@ -169,6 +176,9 @@ interface FormDraft {
   /** Raw schedule string — used when `rawMode` is on. */
   rawSchedule: string;
   rawMode: boolean;
+  /** True once the user has chosen "Other path…" in the project picker,
+   *  so the manual-path input stays open even while it is still empty. */
+  projectCustom: boolean;
 }
 
 function emptyDraft(): FormDraft {
@@ -183,6 +193,7 @@ function emptyDraft(): FormDraft {
     builder: { frequency: "DAILY", hour: 9, minute: 0, weekday: "MO" },
     rawSchedule: "",
     rawMode: false,
+    projectCustom: false,
   };
 }
 
@@ -199,6 +210,7 @@ function draftFromAutomation(a: AutomationView): FormDraft {
     builder: parsed ?? { frequency: "DAILY", hour: 9, minute: 0, weekday: "MO" },
     rawSchedule: a.schedule,
     rawMode: parsed === null,
+    projectCustom: false,
   };
 }
 
@@ -226,6 +238,8 @@ export function AutomationsSection() {
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+
   // `null` = not editing. A draft with no matching automation = create.
   const [draft, setDraft] = useState<FormDraft | null>(null);
   const [creating, setCreating] = useState(false);
@@ -233,12 +247,16 @@ export function AutomationsSection() {
   const reload = useCallback(async () => {
     setError(null);
     try {
-      const [fresh, freshHosts] = await Promise.all([
+      const [fresh, freshHosts, freshProjects] = await Promise.all([
         automationsList(),
         hostsList(),
+        dbGetRecentProjects(50),
       ]);
       setAutomations(fresh);
       setHosts(freshHosts);
+      setProjects(
+        freshProjects.map((p) => ({ name: p.name, path: p.path })),
+      );
       if (fresh.length > 0 && selectedId === null) {
         setSelectedId(fresh[0].id);
       } else if (fresh.length === 0) {
@@ -491,6 +509,7 @@ export function AutomationsSection() {
             draft={draft}
             setDraft={setDraft}
             hosts={hosts}
+            projects={projects}
             busy={busy}
             creating={creating || selected === null}
             onSave={handleSave}
@@ -744,6 +763,7 @@ function AutomationForm({
   draft,
   setDraft,
   hosts,
+  projects,
   busy,
   creating,
   onSave,
@@ -752,6 +772,7 @@ function AutomationForm({
   draft: FormDraft;
   setDraft: React.Dispatch<React.SetStateAction<FormDraft | null>>;
   hosts: HostView[];
+  projects: ProjectOption[];
   busy: boolean;
   creating: boolean;
   onSave: () => void;
@@ -763,6 +784,11 @@ function AutomationForm({
     setDraft((prev) =>
       prev ? { ...prev, builder: { ...prev.builder, ...next } } : prev,
     );
+
+  const canSave =
+    draft.name.trim() !== "" &&
+    draft.prompt.trim() !== "" &&
+    draft.projectPath.trim() !== "";
 
   return (
     <div className="space-y-5">
@@ -788,6 +814,8 @@ function AutomationForm({
           className="min-h-24 text-[13px]"
         />
       </Field>
+
+      <ProjectField draft={draft} patch={patch} projects={projects} />
 
       <div className="grid grid-cols-2 gap-4">
         <Field label="Agent">
@@ -851,16 +879,12 @@ function AutomationForm({
         </Field>
       </div>
 
-      <Field label="Project path" hint="Repository the run operates in (optional).">
-        <Input
-          value={draft.projectPath}
-          onChange={(e) => patch({ projectPath: e.target.value })}
-          placeholder="/home/you/code/my-repo"
-          className="h-9 text-[13px] font-mono"
-        />
-      </Field>
-
-      <div className="flex justify-end gap-1.5 pt-2 border-t border-border/40">
+      <div className="flex items-center justify-end gap-3 pt-2 border-t border-border/40">
+        {!canSave && (
+          <span className="mr-auto text-[11px] text-muted-foreground/60">
+            Name, prompt and project are required.
+          </span>
+        )}
         <Button
           type="button"
           variant="ghost"
@@ -877,7 +901,7 @@ function AutomationForm({
           variant="secondary"
           size="sm"
           className="h-8 gap-1.5 text-[12px]"
-          disabled={busy}
+          disabled={busy || !canSave}
           onClick={onSave}
         >
           {busy ? (
@@ -975,9 +999,9 @@ function ScheduleField({
       )}
 
       <div className="mt-1.5 flex items-center justify-between gap-3">
-        <code className="min-w-0 truncate text-[10.5px] text-muted-foreground/60 font-mono">
-          {composed.replace(/\n/g, " · ")}
-        </code>
+        <span className="min-w-0 truncate text-[11px] text-muted-foreground/60">
+          Runs {describeSchedule(composed).toLowerCase()}
+        </span>
         <button
           type="button"
           className="shrink-0 text-[11px] text-muted-foreground/70 hover:text-foreground transition-colors"
@@ -992,6 +1016,63 @@ function ScheduleField({
           {draft.rawMode ? "Use builder" : "Edit raw"}
         </button>
       </div>
+    </Field>
+  );
+}
+
+/** The project picker — choose one of your opened repositories, or
+ *  fall back to a manual path. Solves the "why am I typing a path?"
+ *  confusion: you pick a project, the automation handles the worktree. */
+function ProjectField({
+  draft,
+  patch,
+  projects,
+}: {
+  draft: FormDraft;
+  patch: (next: Partial<FormDraft>) => void;
+  projects: ProjectOption[];
+}) {
+  const known = projects.some((p) => p.path === draft.projectPath);
+  // Custom mode: the user explicitly chose "Other path…", or we are
+  // editing an automation whose project is not in the recent list.
+  const custom = draft.projectCustom || (draft.projectPath !== "" && !known);
+  const selectValue = custom ? "__custom__" : known ? draft.projectPath : "";
+
+  return (
+    <Field
+      label="Project"
+      hint="The repository the agent works in. Each run gets a fresh worktree of it automatically — you don't set one up yourself."
+    >
+      <Select
+        value={selectValue || undefined}
+        onValueChange={(value) => {
+          if (value === "__custom__") {
+            patch({ projectCustom: true });
+          } else {
+            patch({ projectCustom: false, projectPath: value });
+          }
+        }}
+      >
+        <SelectTrigger className="h-9 text-[13px]">
+          <SelectValue placeholder="Choose a project…" />
+        </SelectTrigger>
+        <SelectContent>
+          {projects.map((project) => (
+            <SelectItem key={project.path} value={project.path}>
+              {project.name}
+            </SelectItem>
+          ))}
+          <SelectItem value="__custom__">Other path…</SelectItem>
+        </SelectContent>
+      </Select>
+      {custom && (
+        <Input
+          value={draft.projectPath}
+          onChange={(e) => patch({ projectPath: e.target.value })}
+          placeholder="/home/you/code/my-repo"
+          className="mt-1.5 h-9 text-[13px] font-mono"
+        />
+      )}
     </Field>
   );
 }

--- a/src/components/automations/automations-view.tsx
+++ b/src/components/automations/automations-view.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { WindowChrome } from "@/components/layout/window-chrome";
+import { useUIStore } from "@/stores/ui-store";
+import { AutomationsSection } from "./automations-section";
+
+/**
+ * Full-screen Automations view.
+ *
+ * A first-class destination reached from the left sidebar (not a
+ * Settings sub-page) — the same placement Codex and Superset give it.
+ * Mirrors `SettingsView`'s full-screen chrome: a `WindowChrome` drag
+ * strip, a back-button header, then the management panel.
+ */
+export function AutomationsView() {
+  const setShowAutomations = useUIStore((s) => s.setShowAutomations);
+
+  // Escape closes the view, matching the other full-screen overlays.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setShowAutomations(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [setShowAutomations]);
+
+  return (
+    <div className="relative flex h-screen flex-col bg-background">
+      <WindowChrome />
+      {/* `pt-7` (= the 28px WindowChrome drag strip) keeps the back
+          button's hit area entirely below the drag region. */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 pt-7 pb-2">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close automations"
+          className="text-muted-foreground hover:text-foreground hover:bg-muted/50"
+          onClick={() => setShowAutomations(false)}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <span className="text-[13px] font-medium text-foreground">
+          Automations
+        </span>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
+        <div className="mx-auto max-w-3xl">
+          <p className="mb-5 text-[12.5px] text-muted-foreground/85 leading-relaxed">
+            Scheduled agent runs. An automation runs a prompt with an agent
+            on a recurring schedule; each fire records a run you can review
+            here.
+          </p>
+          <AutomationsSection />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/automations/automations-view.tsx
+++ b/src/components/automations/automations-view.tsx
@@ -47,13 +47,8 @@ export function AutomationsView() {
         </span>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
-        <div className="mx-auto max-w-3xl">
-          <p className="mb-5 text-[12.5px] text-muted-foreground/85 leading-relaxed">
-            Scheduled agent runs. An automation runs a prompt with an agent
-            on a recurring schedule; each fire records a run you can review
-            here.
-          </p>
+      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-6">
+        <div className="mx-auto max-w-5xl">
           <AutomationsSection />
         </div>
       </div>

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -11,6 +11,7 @@ import { TitleBar } from "./title-bar";
 import { WorkspaceMain } from "./workspace-main";
 import { EmptyState } from "./empty-state";
 import { SettingsView } from "@/components/settings/settings-view";
+import { AutomationsView } from "@/components/automations/automations-view";
 import { CommandPalette } from "@/components/overlays/command-palette";
 import { NewProjectScreen } from "@/components/overlays/new-project-screen";
 import { FileSearchDialog } from "@/components/search/file-search-dialog";
@@ -30,6 +31,7 @@ export function AppShell() {
   const lazyEnabled = useFeatureFlags((s) => s.enableLazyWorkspaceCreation);
   const hasActiveDraft = useChatDraftStore((s) => s.activeDraftId !== null);
   const showSettings = useUIStore((s) => s.showSettings);
+  const showAutomations = useUIStore((s) => s.showAutomations);
   const showNewProjectScreen = useUIStore((s) => s.showNewProjectScreen);
   const commandPaletteOpen = useUIStore((s) => s.showCommandPalette);
   const setCommandPaletteOpen = useUIStore((s) => s.setShowCommandPalette);
@@ -58,6 +60,11 @@ export function AppShell() {
   // Full-screen settings — replaces entire app including sidebar
   if (showSettings) {
     return <SettingsView />;
+  }
+
+  // Full-screen Automations — a first-class destination, like Settings
+  if (showAutomations) {
+    return <AutomationsView />;
   }
 
   // Full-screen new project — replaces entire app including sidebar

--- a/src/components/layout/sidebar-action-row.tsx
+++ b/src/components/layout/sidebar-action-row.tsx
@@ -14,12 +14,13 @@ import {
 import { useChatDraftStore } from "@/stores/chat-draft-store";
 import { useUIStore } from "@/stores/ui-store";
 import { useFeatureFlags } from "@/stores/feature-flags";
-import { Plus, FolderPlus, FolderOpen } from "lucide-react";
+import { Plus, FolderPlus, FolderOpen, CalendarClock } from "lucide-react";
 import { useProjectActions } from "@/hooks/use-project-actions";
 
 export function SidebarActionRow() {
   const setShowNewWorkspaceDialog = useUIStore((s) => s.setShowNewWorkspaceDialog);
   const setShowNewProjectScreen = useUIStore((s) => s.setShowNewProjectScreen);
+  const setShowAutomations = useUIStore((s) => s.setShowAutomations);
   const enableAgentChat = useFeatureFlags((s) => s.enableAgentChat);
   const enableLazyWorkspaceCreation = useFeatureFlags(
     (s) => s.enableLazyWorkspaceCreation,
@@ -99,6 +100,22 @@ export function SidebarActionRow() {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      {/* Automations — a first-class destination under "New agent",
+          above the project list, matching where Codex and Superset
+          place it. Opens the full-screen Automations view. */}
+      <div className="px-2 pb-1.5">
+        <Button
+          variant="ghost"
+          aria-label="Automations"
+          className="w-full justify-start gap-2 h-8 px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+          onClick={() => setShowAutomations(true)}
+        >
+          <CalendarClock className="size-[18px]" />
+          <span>Automations</span>
+        </Button>
+      </div>
+
       <SidebarSeparator />
     </ShadcnSidebarHeader>
   );

--- a/src/components/settings/automations-section.tsx
+++ b/src/components/settings/automations-section.tsx
@@ -1,0 +1,956 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  CalendarClock,
+  Check,
+  Loader2,
+  Pause,
+  Pencil,
+  Play,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import {
+  automationsCreate,
+  automationsDelete,
+  automationsList,
+  automationsRuns,
+  automationsSetEnabled,
+  automationsUpdate,
+  hostsList,
+  type AutomationInput,
+  type AutomationRunView,
+  type AutomationView,
+  type HostView,
+} from "@/tauri/commands";
+
+/**
+ * Settings → Automations.
+ *
+ * Scheduled agent runs: a named prompt + agent + recurrence that fires
+ * on a chosen host. Mirrors the sidebar-list + detail-pane shape of the
+ * Hosts section. The schedule is stored as a complete RFC 5545
+ * iCalendar block; the builder below composes the common
+ * hourly/daily/weekly cases, and a raw field handles anything else.
+ */
+
+type Frequency = "HOURLY" | "DAILY" | "WEEKLY";
+
+const WEEKDAYS: Array<{ value: string; label: string }> = [
+  { value: "MO", label: "Monday" },
+  { value: "TU", label: "Tuesday" },
+  { value: "WE", label: "Wednesday" },
+  { value: "TH", label: "Thursday" },
+  { value: "FR", label: "Friday" },
+  { value: "SA", label: "Saturday" },
+  { value: "SU", label: "Sunday" },
+];
+
+const AGENTS: Array<{ value: string; label: string }> = [
+  { value: "claude", label: "Claude Code" },
+  { value: "codex", label: "Codex" },
+];
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** Build a complete RFC 5545 schedule from the friendly builder fields. */
+function composeSchedule(opts: {
+  frequency: Frequency;
+  hour: number;
+  minute: number;
+  weekday: string;
+  timezone: string;
+}): string {
+  const now = new Date();
+  const datestamp = `${now.getFullYear()}${pad2(now.getMonth() + 1)}${pad2(
+    now.getDate(),
+  )}`;
+  if (opts.frequency === "HOURLY") {
+    return `DTSTART:${datestamp}T000000Z\nRRULE:FREQ=HOURLY;BYMINUTE=${opts.minute};BYSECOND=0`;
+  }
+  const time = `${pad2(opts.hour)}${pad2(opts.minute)}00`;
+  const dtstart = `DTSTART;TZID=${opts.timezone}:${datestamp}T${time}`;
+  if (opts.frequency === "WEEKLY") {
+    return `${dtstart}\nRRULE:FREQ=WEEKLY;BYDAY=${opts.weekday}`;
+  }
+  return `${dtstart}\nRRULE:FREQ=DAILY`;
+}
+
+interface BuilderState {
+  frequency: Frequency;
+  hour: number;
+  minute: number;
+  weekday: string;
+}
+
+/** Best-effort reverse of `composeSchedule` so editing an automation
+ *  re-opens the builder pre-filled. Returns null for any schedule the
+ *  builder cannot represent — the form then falls back to a raw field. */
+function parseSchedule(schedule: string): BuilderState | null {
+  const freq = schedule.match(/FREQ=(HOURLY|DAILY|WEEKLY)/);
+  if (!freq) return null;
+  const frequency = freq[1] as Frequency;
+  // Reject anything the builder does not emit (intervals, bounds).
+  if (/INTERVAL=|COUNT=|UNTIL=/.test(schedule)) return null;
+
+  if (frequency === "HOURLY") {
+    const minute = schedule.match(/BYMINUTE=(\d{1,2})/);
+    return {
+      frequency,
+      hour: 0,
+      minute: minute ? Number(minute[1]) : 0,
+      weekday: "MO",
+    };
+  }
+  const time = schedule.match(/:\d{8}T(\d{2})(\d{2})\d{2}/);
+  if (!time) return null;
+  const hour = Number(time[1]);
+  const minute = Number(time[2]);
+  if (frequency === "WEEKLY") {
+    const byday = schedule.match(/BYDAY=([A-Z]{2})\b/);
+    if (!byday) return null;
+    return { frequency, hour, minute, weekday: byday[1] };
+  }
+  return { frequency, hour, minute, weekday: "MO" };
+}
+
+/** Human one-liner for the detail pane and list. */
+function describeSchedule(schedule: string): string {
+  const parsed = parseSchedule(schedule);
+  if (!parsed) return "Custom schedule";
+  const time = `${pad2(parsed.hour)}:${pad2(parsed.minute)}`;
+  if (parsed.frequency === "HOURLY") {
+    return `Hourly at :${pad2(parsed.minute)}`;
+  }
+  if (parsed.frequency === "DAILY") return `Daily at ${time}`;
+  const day = WEEKDAYS.find((d) => d.value === parsed.weekday)?.label ?? parsed.weekday;
+  return `Weekly on ${day} at ${time}`;
+}
+
+function byNameInsensitive(a: AutomationView, b: AutomationView): number {
+  return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+}
+
+const browserTimezone = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+};
+
+/** Draft state for the create/edit form. */
+interface FormDraft {
+  name: string;
+  prompt: string;
+  agent: string;
+  timezone: string;
+  hostId: number | null;
+  projectPath: string;
+  retentionLimit: number;
+  builder: BuilderState;
+  /** Raw schedule string — used when `rawMode` is on. */
+  rawSchedule: string;
+  rawMode: boolean;
+}
+
+function emptyDraft(): FormDraft {
+  return {
+    name: "",
+    prompt: "",
+    agent: "claude",
+    timezone: browserTimezone(),
+    hostId: null,
+    projectPath: "",
+    retentionLimit: 10,
+    builder: { frequency: "DAILY", hour: 9, minute: 0, weekday: "MO" },
+    rawSchedule: "",
+    rawMode: false,
+  };
+}
+
+function draftFromAutomation(a: AutomationView): FormDraft {
+  const parsed = parseSchedule(a.schedule);
+  return {
+    name: a.name,
+    prompt: a.prompt,
+    agent: a.agent,
+    timezone: a.timezone,
+    hostId: a.host_id,
+    projectPath: a.project_path ?? "",
+    retentionLimit: a.retention_limit,
+    builder: parsed ?? { frequency: "DAILY", hour: 9, minute: 0, weekday: "MO" },
+    rawSchedule: a.schedule,
+    rawMode: parsed === null,
+  };
+}
+
+function draftToInput(draft: FormDraft): AutomationInput {
+  const schedule = draft.rawMode
+    ? draft.rawSchedule.trim()
+    : composeSchedule({ ...draft.builder, timezone: draft.timezone });
+  return {
+    name: draft.name.trim(),
+    prompt: draft.prompt,
+    agent: draft.agent,
+    schedule,
+    timezone: draft.timezone.trim(),
+    host_id: draft.hostId,
+    project_path: draft.projectPath.trim() || null,
+    retention_limit: draft.retentionLimit,
+  };
+}
+
+export function AutomationsSection() {
+  const [automations, setAutomations] = useState<AutomationView[]>([]);
+  const [hosts, setHosts] = useState<HostView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // `null` = not editing. A draft with no matching automation = create.
+  const [draft, setDraft] = useState<FormDraft | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const reload = useCallback(async () => {
+    setError(null);
+    try {
+      const [fresh, freshHosts] = await Promise.all([
+        automationsList(),
+        hostsList(),
+      ]);
+      setAutomations(fresh);
+      setHosts(freshHosts);
+      if (fresh.length > 0 && selectedId === null) {
+        setSelectedId(fresh[0].id);
+      } else if (fresh.length === 0) {
+        setSelectedId(null);
+      } else if (selectedId !== null && !fresh.find((a) => a.id === selectedId)) {
+        setSelectedId(fresh[0]?.id ?? null);
+      }
+    } catch (err) {
+      setError(typeof err === "string" ? err : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedId]);
+
+  useEffect(() => {
+    void reload();
+    // Mount-only — `reload` closes over `selectedId` but we only want
+    // the initial fetch here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const selected = useMemo(
+    () => automations.find((a) => a.id === selectedId) ?? null,
+    [automations, selectedId],
+  );
+
+  const startCreate = useCallback(() => {
+    setCreating(true);
+    setDraft(emptyDraft());
+    setError(null);
+  }, []);
+
+  const startEdit = useCallback((automation: AutomationView) => {
+    setCreating(false);
+    setDraft(draftFromAutomation(automation));
+    setError(null);
+  }, []);
+
+  const cancelForm = useCallback(() => {
+    setDraft(null);
+    setCreating(false);
+    setError(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!draft) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const input = draftToInput(draft);
+      const saved =
+        creating || selected === null
+          ? await automationsCreate(input)
+          : await automationsUpdate(selected.id, input);
+      setAutomations((prev) => {
+        const without = prev.filter((a) => a.id !== saved.id);
+        return [...without, saved].sort(byNameInsensitive);
+      });
+      setSelectedId(saved.id);
+      setDraft(null);
+      setCreating(false);
+    } catch (err) {
+      setError(typeof err === "string" ? err : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [draft, creating, selected]);
+
+  const handleToggleEnabled = useCallback(async (automation: AutomationView) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await automationsSetEnabled(
+        automation.id,
+        !automation.enabled,
+      );
+      setAutomations((prev) =>
+        prev.map((a) => (a.id === updated.id ? updated : a)),
+      );
+    } catch (err) {
+      setError(typeof err === "string" ? err : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const handleDelete = useCallback(async (automation: AutomationView) => {
+    if (
+      !window.confirm(
+        `Delete the automation "${automation.name}"? Its run history is kept.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await automationsDelete(automation.id);
+      setAutomations((prev) => prev.filter((a) => a.id !== automation.id));
+      if (selectedId === automation.id) setSelectedId(null);
+    } catch (err) {
+      setError(typeof err === "string" ? err : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [selectedId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+        <Loader2 className="mr-2 size-4 animate-spin" />
+        Loading automations…
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-[460px] gap-6">
+      {/* Sidebar */}
+      <div className="w-56 shrink-0 border-r border-border/60 pr-5 flex flex-col">
+        <div className="mb-3 flex items-end justify-between gap-2">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/60">
+            Automations
+          </p>
+          <span className="text-[11px] text-muted-foreground/60 tabular-nums">
+            {automations.length}
+          </span>
+        </div>
+
+        {automations.length === 0 && draft === null && (
+          <div className="rounded-lg border border-dashed border-border/60 p-3 text-[12px] text-muted-foreground/80 leading-relaxed">
+            No automations yet. Create one to run an agent on a schedule.
+          </div>
+        )}
+
+        <ul className="space-y-px">
+          {automations.map((automation) => (
+            <li key={automation.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedId(automation.id);
+                  setDraft(null);
+                }}
+                className={cn(
+                  "group/row flex w-full items-center gap-2.5 rounded-md px-2.5 h-8 text-left text-[13px] transition-colors",
+                  selectedId === automation.id && draft === null
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+                )}
+              >
+                <span
+                  aria-hidden
+                  title={automation.enabled ? "Enabled" : "Paused"}
+                  className={cn(
+                    "size-1.5 shrink-0 rounded-full transition-colors",
+                    automation.enabled ? "bg-success" : "bg-muted-foreground/40",
+                  )}
+                />
+                <span className="min-w-0 flex-1 truncate">{automation.name}</span>
+                {automation.dirty && (
+                  <span
+                    title="Pending sync"
+                    className="size-1.5 shrink-0 rounded-full bg-warning"
+                  />
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-4 pt-4 border-t border-border/40">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="w-full justify-start gap-2 h-8 px-2.5 text-[13px] text-muted-foreground hover:text-foreground hover:bg-muted/40 border border-dashed border-border/60"
+            onClick={startCreate}
+          >
+            <Plus className="size-3.5" />
+            New automation
+          </Button>
+        </div>
+      </div>
+
+      {/* Detail */}
+      <div className="flex-1 min-w-0">
+        {error && (
+          <div className="mb-4 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-[12px] text-destructive leading-relaxed">
+            {error}
+          </div>
+        )}
+
+        {draft !== null ? (
+          <AutomationForm
+            draft={draft}
+            setDraft={setDraft}
+            hosts={hosts}
+            busy={busy}
+            creating={creating || selected === null}
+            onSave={handleSave}
+            onCancel={cancelForm}
+          />
+        ) : !selected ? (
+          <div className="flex h-full items-center justify-center text-center">
+            <div className="space-y-3">
+              <div className="mx-auto size-12 rounded-full bg-muted/40 border border-border/40 flex items-center justify-center">
+                <CalendarClock className="size-5 text-muted-foreground/60" />
+              </div>
+              <p className="text-[13px] text-muted-foreground/80">
+                Select an automation, or create a new one.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <AutomationDetail
+            automation={selected}
+            hosts={hosts}
+            busy={busy}
+            onEdit={() => startEdit(selected)}
+            onToggleEnabled={() => void handleToggleEnabled(selected)}
+            onDelete={() => void handleDelete(selected)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Detail view ──
+
+function AutomationDetail({
+  automation,
+  hosts,
+  busy,
+  onEdit,
+  onToggleEnabled,
+  onDelete,
+}: {
+  automation: AutomationView;
+  hosts: HostView[];
+  busy: boolean;
+  onEdit: () => void;
+  onToggleEnabled: () => void;
+  onDelete: () => void;
+}) {
+  const hostLabel =
+    automation.host_id === null
+      ? "This machine"
+      : (hosts.find((h) => h.id === automation.host_id)?.name ??
+        "Removed host");
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="mb-1 flex items-center gap-2">
+          <h3 className="text-[15px] font-semibold tracking-tight text-foreground">
+            {automation.name}
+          </h3>
+          <span
+            className={cn(
+              "rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider border",
+              automation.enabled
+                ? "bg-success/15 border-success/30 text-success"
+                : "bg-muted border-border/50 text-muted-foreground",
+            )}
+          >
+            {automation.enabled ? "Enabled" : "Paused"}
+          </span>
+          {automation.dirty && (
+            <span className="rounded-full bg-warning/15 border border-warning/30 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-warning">
+              Pending sync
+            </span>
+          )}
+        </div>
+        <p className="text-[12px] text-muted-foreground/85">
+          {describeSchedule(automation.schedule)} · {automation.agent} ·{" "}
+          {hostLabel}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <FactCard label="Next run" value={formatStamp(automation.next_run_at)} />
+        <FactCard label="Last run" value={formatStamp(automation.last_run_at)} />
+      </div>
+
+      <div className="space-y-1.5">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
+          Prompt
+        </p>
+        <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-[12.5px] text-foreground/90 leading-relaxed whitespace-pre-wrap max-h-40 overflow-y-auto">
+          {automation.prompt}
+        </div>
+      </div>
+
+      <RunHistory automationId={automation.id} />
+
+      <div className="flex items-center justify-between pt-4 border-t border-border/40">
+        <div className="flex gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-[12px]"
+            disabled={busy}
+            onClick={onEdit}
+          >
+            <Pencil className="size-3.5" />
+            Edit
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-[12px]"
+            disabled={busy}
+            onClick={onToggleEnabled}
+          >
+            {automation.enabled ? (
+              <>
+                <Pause className="size-3.5" />
+                Pause
+              </>
+            ) : (
+              <>
+                <Play className="size-3.5" />
+                Resume
+              </>
+            )}
+          </Button>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 gap-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
+          disabled={busy}
+          onClick={onDelete}
+        >
+          <Trash2 className="size-3.5" />
+          Delete
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FactCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2.5">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
+        {label}
+      </p>
+      <p className="mt-1 text-[12.5px] text-foreground/90 tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function formatStamp(stamp: string | null): string {
+  if (!stamp) return "—";
+  const date = new Date(stamp);
+  if (Number.isNaN(date.getTime())) return stamp;
+  return date.toLocaleString();
+}
+
+// ── Run history ──
+
+const RUN_STATUS_TONE: Record<string, string> = {
+  scheduled: "bg-muted-foreground/40",
+  running: "bg-warning",
+  succeeded: "bg-success",
+  failed: "bg-destructive",
+  skipped_offline: "bg-muted-foreground/40",
+  skipped_busy: "bg-muted-foreground/40",
+};
+
+function RunHistory({ automationId }: { automationId: number }) {
+  const [runs, setRuns] = useState<AutomationRunView[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    automationsRuns(automationId, 20)
+      .then((fresh) => {
+        if (!cancelled) setRuns(fresh);
+      })
+      .catch(() => {
+        if (!cancelled) setRuns([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [automationId]);
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
+        Run history
+      </p>
+      {loading ? (
+        <p className="text-[12px] text-muted-foreground/70 py-2">Loading…</p>
+      ) : runs.length === 0 ? (
+        <p className="text-[12px] text-muted-foreground/70 py-2">
+          No runs yet. The next fire will appear here.
+        </p>
+      ) : (
+        <ul className="rounded-lg border border-border/60 divide-y divide-border/40">
+          {runs.map((run) => (
+            <li
+              key={run.id}
+              className="flex items-center gap-2.5 px-3 py-2 text-[12px]"
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  "size-1.5 shrink-0 rounded-full",
+                  RUN_STATUS_TONE[run.status] ?? "bg-muted-foreground/40",
+                )}
+              />
+              <span className="font-mono text-[11.5px] text-muted-foreground/85 tabular-nums">
+                {formatStamp(run.scheduled_for)}
+              </span>
+              <span className="ml-auto text-[11px] text-muted-foreground/75">
+                {run.status.replace(/_/g, " ")}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// ── Create / edit form ──
+
+function AutomationForm({
+  draft,
+  setDraft,
+  hosts,
+  busy,
+  creating,
+  onSave,
+  onCancel,
+}: {
+  draft: FormDraft;
+  setDraft: React.Dispatch<React.SetStateAction<FormDraft | null>>;
+  hosts: HostView[];
+  busy: boolean;
+  creating: boolean;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const patch = (next: Partial<FormDraft>) =>
+    setDraft((prev) => (prev ? { ...prev, ...next } : prev));
+  const patchBuilder = (next: Partial<BuilderState>) =>
+    setDraft((prev) =>
+      prev ? { ...prev, builder: { ...prev.builder, ...next } } : prev,
+    );
+
+  return (
+    <div className="space-y-5">
+      <h3 className="text-[15px] font-semibold tracking-tight text-foreground">
+        {creating ? "New automation" : "Edit automation"}
+      </h3>
+
+      <Field label="Name">
+        <Input
+          value={draft.name}
+          onChange={(e) => patch({ name: e.target.value })}
+          placeholder="Daily issue triage"
+          className="h-9 text-[13px]"
+          autoFocus
+        />
+      </Field>
+
+      <Field label="Prompt" hint="What the agent does on every run.">
+        <Textarea
+          value={draft.prompt}
+          onChange={(e) => patch({ prompt: e.target.value })}
+          placeholder="Review newly opened issues and add labels…"
+          className="min-h-24 text-[13px]"
+        />
+      </Field>
+
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Agent">
+          <Select value={draft.agent} onValueChange={(v) => patch({ agent: v })}>
+            <SelectTrigger className="h-9 text-[13px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AGENTS.map((agent) => (
+                <SelectItem key={agent.value} value={agent.value}>
+                  {agent.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+
+        <Field label="Host">
+          <Select
+            value={draft.hostId === null ? "local" : String(draft.hostId)}
+            onValueChange={(v) =>
+              patch({ hostId: v === "local" ? null : Number(v) })
+            }
+          >
+            <SelectTrigger className="h-9 text-[13px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="local">This machine</SelectItem>
+              {hosts.map((host) => (
+                <SelectItem key={host.id} value={String(host.id)}>
+                  {host.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+      </div>
+
+      <ScheduleField draft={draft} patch={patch} patchBuilder={patchBuilder} />
+
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="Timezone">
+          <Input
+            value={draft.timezone}
+            onChange={(e) => patch({ timezone: e.target.value })}
+            className="h-9 text-[13px] font-mono"
+          />
+        </Field>
+        <Field label="Keep last N runs" hint="Older run worktrees are pruned.">
+          <Input
+            type="number"
+            min={1}
+            max={1000}
+            value={draft.retentionLimit}
+            onChange={(e) =>
+              patch({ retentionLimit: Number(e.target.value) || 10 })
+            }
+            className="h-9 text-[13px] tabular-nums"
+          />
+        </Field>
+      </div>
+
+      <Field label="Project path" hint="Repository the run operates in (optional).">
+        <Input
+          value={draft.projectPath}
+          onChange={(e) => patch({ projectPath: e.target.value })}
+          placeholder="/home/you/code/my-repo"
+          className="h-9 text-[13px] font-mono"
+        />
+      </Field>
+
+      <div className="flex justify-end gap-1.5 pt-2 border-t border-border/40">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 gap-1.5 text-[12px]"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          <X className="size-3.5" />
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="h-8 gap-1.5 text-[12px]"
+          disabled={busy}
+          onClick={onSave}
+        >
+          {busy ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Check className="size-3.5" />
+          )}
+          {creating ? "Create" : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ScheduleField({
+  draft,
+  patch,
+  patchBuilder,
+}: {
+  draft: FormDraft;
+  patch: (next: Partial<FormDraft>) => void;
+  patchBuilder: (next: Partial<BuilderState>) => void;
+}) {
+  const composed = draft.rawMode
+    ? draft.rawSchedule
+    : composeSchedule({ ...draft.builder, timezone: draft.timezone });
+
+  return (
+    <Field
+      label="Schedule"
+      hint={
+        draft.rawMode
+          ? "Raw RFC 5545 — a DTSTART line and one RRULE line."
+          : undefined
+      }
+    >
+      {draft.rawMode ? (
+        <Textarea
+          value={draft.rawSchedule}
+          onChange={(e) => patch({ rawSchedule: e.target.value })}
+          className="min-h-20 text-[12px] font-mono"
+          placeholder={"DTSTART:20260101T090000Z\nRRULE:FREQ=DAILY"}
+        />
+      ) : (
+        <div className="flex flex-wrap items-center gap-2">
+          <Select
+            value={draft.builder.frequency}
+            onValueChange={(v) => patchBuilder({ frequency: v as Frequency })}
+          >
+            <SelectTrigger className="h-9 w-32 text-[13px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="HOURLY">Hourly</SelectItem>
+              <SelectItem value="DAILY">Daily</SelectItem>
+              <SelectItem value="WEEKLY">Weekly</SelectItem>
+            </SelectContent>
+          </Select>
+
+          {draft.builder.frequency === "WEEKLY" && (
+            <Select
+              value={draft.builder.weekday}
+              onValueChange={(v) => patchBuilder({ weekday: v })}
+            >
+              <SelectTrigger className="h-9 w-36 text-[13px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {WEEKDAYS.map((day) => (
+                  <SelectItem key={day.value} value={day.value}>
+                    {day.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+
+          <Input
+            type="time"
+            value={`${pad2(
+              draft.builder.frequency === "HOURLY" ? 0 : draft.builder.hour,
+            )}:${pad2(draft.builder.minute)}`}
+            onChange={(e) => {
+              const [h, m] = e.target.value.split(":");
+              patchBuilder({ hour: Number(h) || 0, minute: Number(m) || 0 });
+            }}
+            className="h-9 w-28 text-[13px] tabular-nums"
+          />
+          {draft.builder.frequency === "HOURLY" && (
+            <span className="text-[11.5px] text-muted-foreground/70">
+              past each hour
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="mt-1.5 flex items-center justify-between gap-3">
+        <code className="min-w-0 truncate text-[10.5px] text-muted-foreground/60 font-mono">
+          {composed.replace(/\n/g, " · ")}
+        </code>
+        <button
+          type="button"
+          className="shrink-0 text-[11px] text-muted-foreground/70 hover:text-foreground transition-colors"
+          onClick={() => {
+            if (draft.rawMode) {
+              patch({ rawMode: false });
+            } else {
+              patch({ rawMode: true, rawSchedule: composed });
+            }
+          }}
+        >
+          {draft.rawMode ? "Use builder" : "Edit raw"}
+        </button>
+      </div>
+    </Field>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-[13px] font-medium text-foreground">{label}</Label>
+      {children}
+      {hint && (
+        <p className="text-[11px] text-muted-foreground/70 leading-relaxed">
+          {hint}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -48,7 +48,6 @@ import {
   BookOpen,
   Server,
   Sparkles,
-  CalendarClock,
 } from "lucide-react";
 import { useUIStore } from "@/stores/ui-store";
 import { useAppStore } from "@/stores/app-store";
@@ -113,7 +112,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical } from "lucide-react";
 
-type Section = "beta_features" | "account" | "appearance" | "editor" | "terminal" | "presets" | "projects" | "git" | "agent" | "permissions" | "skills" | "mcp" | "hosts" | "automations" | "browser" | "shortcuts" | "notifications" | "session_restore";
+type Section = "beta_features" | "account" | "appearance" | "editor" | "terminal" | "presets" | "projects" | "git" | "agent" | "permissions" | "skills" | "mcp" | "hosts" | "browser" | "shortcuts" | "notifications" | "session_restore";
 
 interface NavItem { id: Section; label: string; icon: React.ElementType }
 interface NavGroup { label: string; items: NavItem[] }
@@ -151,9 +150,6 @@ function buildNavGroups(agentChatEnabled: boolean): NavGroup[] {
     // not a personal preference. Always visible (no flag gate) since
     // the underlying daemon is now standard built-in behavior.
     { id: "hosts", label: "Hosts", icon: Server },
-    // Automations — scheduled agent runs. Sits next to Hosts because an
-    // automation picks a host to run on; both are workflow decisions.
-    { id: "automations", label: "Automations", icon: CalendarClock },
     { id: "session_restore", label: "Session Restore", icon: RotateCcw },
   ];
 
@@ -186,14 +182,13 @@ function buildNavGroups(agentChatEnabled: boolean): NavGroup[] {
 const ALL_SECTION_IDS: Section[] = [
   "beta_features",
   "account", "appearance", "editor", "terminal", "presets", "projects",
-  "git", "agent", "permissions", "skills", "mcp", "hosts", "automations",
-  "browser", "shortcuts", "notifications", "session_restore",
+  "git", "agent", "permissions", "skills", "mcp", "hosts", "browser",
+  "shortcuts", "notifications", "session_restore",
 ];
 
 import { KeybindEditor } from "./keybind-editor";
 import { BetaFeaturesSection } from "./beta-features-section";
 import { HostsSection } from "./hosts-section";
-import { AutomationsSection } from "./automations-section";
 import { McpSection } from "./mcp-section";
 import { PermissionsSection } from "./permissions-section";
 import { SkillsSection } from "./skills-section";
@@ -1395,17 +1390,6 @@ export function SettingsView() {
               description="Remote machines you can push workspaces to. SSH credentials stay on your device — only the host name and SSH target sync across your devices."
             />
             <HostsSection />
-          </div>
-        );
-
-      case "automations":
-        return (
-          <div>
-            <SectionHeader
-              title="Automations"
-              description="Scheduled agent runs. An automation runs a prompt with an agent on a recurring schedule; each fire records a run you can review here."
-            />
-            <AutomationsSection />
           </div>
         );
 

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -48,6 +48,7 @@ import {
   BookOpen,
   Server,
   Sparkles,
+  CalendarClock,
 } from "lucide-react";
 import { useUIStore } from "@/stores/ui-store";
 import { useAppStore } from "@/stores/app-store";
@@ -112,7 +113,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical } from "lucide-react";
 
-type Section = "beta_features" | "account" | "appearance" | "editor" | "terminal" | "presets" | "projects" | "git" | "agent" | "permissions" | "skills" | "mcp" | "hosts" | "browser" | "shortcuts" | "notifications" | "session_restore";
+type Section = "beta_features" | "account" | "appearance" | "editor" | "terminal" | "presets" | "projects" | "git" | "agent" | "permissions" | "skills" | "mcp" | "hosts" | "automations" | "browser" | "shortcuts" | "notifications" | "session_restore";
 
 interface NavItem { id: Section; label: string; icon: React.ElementType }
 interface NavGroup { label: string; items: NavItem[] }
@@ -150,6 +151,9 @@ function buildNavGroups(agentChatEnabled: boolean): NavGroup[] {
     // not a personal preference. Always visible (no flag gate) since
     // the underlying daemon is now standard built-in behavior.
     { id: "hosts", label: "Hosts", icon: Server },
+    // Automations — scheduled agent runs. Sits next to Hosts because an
+    // automation picks a host to run on; both are workflow decisions.
+    { id: "automations", label: "Automations", icon: CalendarClock },
     { id: "session_restore", label: "Session Restore", icon: RotateCcw },
   ];
 
@@ -182,13 +186,14 @@ function buildNavGroups(agentChatEnabled: boolean): NavGroup[] {
 const ALL_SECTION_IDS: Section[] = [
   "beta_features",
   "account", "appearance", "editor", "terminal", "presets", "projects",
-  "git", "agent", "permissions", "skills", "mcp", "hosts", "browser",
-  "shortcuts", "notifications", "session_restore",
+  "git", "agent", "permissions", "skills", "mcp", "hosts", "automations",
+  "browser", "shortcuts", "notifications", "session_restore",
 ];
 
 import { KeybindEditor } from "./keybind-editor";
 import { BetaFeaturesSection } from "./beta-features-section";
 import { HostsSection } from "./hosts-section";
+import { AutomationsSection } from "./automations-section";
 import { McpSection } from "./mcp-section";
 import { PermissionsSection } from "./permissions-section";
 import { SkillsSection } from "./skills-section";
@@ -1390,6 +1395,17 @@ export function SettingsView() {
               description="Remote machines you can push workspaces to. SSH credentials stay on your device — only the host name and SSH target sync across your devices."
             />
             <HostsSection />
+          </div>
+        );
+
+      case "automations":
+        return (
+          <div>
+            <SectionHeader
+              title="Automations"
+              description="Scheduled agent runs. An automation runs a prompt with an agent on a recurring schedule; each fire records a run you can review here."
+            />
+            <AutomationsSection />
           </div>
         );
 

--- a/src/hooks/use-automation-fire-toast.ts
+++ b/src/hooks/use-automation-fire-toast.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+
+import { useTauriEvent } from "./use-tauri-event";
+import { onAutomationFire } from "@/tauri/events";
+import { automationsGet, type AutomationRunView } from "@/tauri/commands";
+import { toast } from "@/lib/toast";
+
+/**
+ * Surfaces an ambient toast each time the scheduler fires an automation.
+ *
+ * The run row is already persisted by the backend before the
+ * `automations://fire` event is emitted — this hook is purely the
+ * "your automation just ran" signal. The automation name is fetched
+ * lazily so the event payload can stay the lean run row.
+ */
+export function useAutomationFireToast() {
+  const handleFire = useCallback((run: AutomationRunView) => {
+    void automationsGet(run.automation_id)
+      .then((automation) => {
+        toast.info(`Automation "${automation.name}" fired`);
+      })
+      .catch(() => {
+        toast.info("An automation fired");
+      });
+  }, []);
+
+  useTauriEvent(onAutomationFire, handleFire, [handleFire]);
+}

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -11,6 +11,7 @@ interface UIStore {
   newWorkspaceProjectDir: string | null;
   showSettings: boolean;
   settingsSection: string | null;
+  showAutomations: boolean;
   showFileSearch: boolean;
   showContentSearch: boolean;
   pendingWorkspaces: PendingWorkspace[];
@@ -29,6 +30,7 @@ interface UIStore {
   setRightPanelWidth: (width: number) => void;
   setShowNewWorkspaceDialog: (show: boolean, projectDir?: string | null) => void;
   setShowSettings: (show: boolean, section?: string | null) => void;
+  setShowAutomations: (show: boolean) => void;
   setShowFileSearch: (show: boolean) => void;
   setShowContentSearch: (show: boolean) => void;
   addPendingWorkspace: (pw: PendingWorkspace) => void;
@@ -52,6 +54,7 @@ export const useUIStore = create<UIStore>()(
       newWorkspaceProjectDir: null,
       showSettings: false,
       settingsSection: null,
+      showAutomations: false,
       showFileSearch: false,
       showContentSearch: false,
       pendingWorkspaces: [],
@@ -88,6 +91,7 @@ export const useUIStore = create<UIStore>()(
         set({ showNewWorkspaceDialog: show, newWorkspaceProjectDir: show ? (projectDir ?? null) : null }),
 
       setShowSettings: (show, section = null) => set({ showSettings: show, settingsSection: show ? (section ?? null) : null }),
+      setShowAutomations: (show) => set({ showAutomations: show }),
       setShowFileSearch: (show) => set({ showFileSearch: show }),
       setShowContentSearch: (show) => set({ showContentSearch: show }),
 

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1595,6 +1595,79 @@ export const hostsTestConnection = (id: number) =>
 export const hostsBootstrapInstall = (id: number, uname: string) =>
   invoke<HostBootstrapResult>("hosts_bootstrap_install", { id, uname });
 
+// ── Automations (scheduled agent runs) ──
+//
+// An automation is a named prompt + agent + recurrence. `schedule` is a
+// complete RFC 5545 iCalendar block (a DTSTART line plus one RRULE
+// line). `dirty` flags unpushed changes for a future account-sync.
+export interface AutomationView {
+  id: number;
+  server_id: string | null;
+  name: string;
+  prompt: string;
+  agent: string;
+  schedule: string;
+  timezone: string;
+  host_id: number | null;
+  project_path: string | null;
+  enabled: boolean;
+  retention_limit: number;
+  last_run_at: string | null;
+  next_run_at: string | null;
+  created_at: string;
+  updated_at: string;
+  dirty: boolean;
+}
+
+/** One fire of an automation (or a skipped fire). `status` is one of
+ *  `scheduled | running | succeeded | failed | skipped_offline |
+ *  skipped_busy`. */
+export interface AutomationRunView {
+  id: number;
+  automation_id: number;
+  status: string;
+  scheduled_for: string;
+  started_at: string | null;
+  finished_at: string | null;
+  host_id: number | null;
+  workspace_id: string | null;
+  error: string | null;
+  created_at: string;
+}
+
+/** Editable fields of an automation, shared by create and update. */
+export interface AutomationInput {
+  name: string;
+  prompt: string;
+  agent: string;
+  schedule: string;
+  timezone: string;
+  host_id: number | null;
+  project_path: string | null;
+  retention_limit: number;
+}
+
+export const automationsList = () =>
+  invoke<AutomationView[]>("automations_list");
+
+export const automationsGet = (id: number) =>
+  invoke<AutomationView>("automations_get", { id });
+
+export const automationsCreate = (input: AutomationInput) =>
+  invoke<AutomationView>("automations_create", { input });
+
+export const automationsUpdate = (id: number, input: AutomationInput) =>
+  invoke<AutomationView>("automations_update", { id, input });
+
+export const automationsSetEnabled = (id: number, enabled: boolean) =>
+  invoke<AutomationView>("automations_set_enabled", { id, enabled });
+
+export const automationsDelete = (id: number) =>
+  invoke<void>("automations_delete", { id });
+
+export const automationsRuns = (automationId: number, limit?: number) =>
+  invoke<AutomationRunView[]>("automations_runs", { automationId, limit });
+
 export interface WorkspacePushOutcome {
   ok: boolean;
   message: string;

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1610,6 +1610,9 @@ export interface AutomationView {
   timezone: string;
   host_id: number | null;
   project_path: string | null;
+  /** The project's git remote URL — how a remote host clones the repo.
+   *  Resolved server-side from the chosen project. */
+  project_remote: string | null;
   enabled: boolean;
   retention_limit: number;
   last_run_at: string | null;
@@ -1631,11 +1634,17 @@ export interface AutomationRunView {
   finished_at: string | null;
   host_id: number | null;
   workspace_id: string | null;
+  /** The branch the run's worktree was created on. */
+  branch: string | null;
+  /** URL of the pull request the run opened, if any. */
+  pr_url: string | null;
   error: string | null;
   created_at: string;
 }
 
-/** Editable fields of an automation, shared by create and update. */
+/** Editable fields of an automation, shared by create and update.
+ *  `project_remote` is resolved server-side from `project_path`; the
+ *  UI may omit it. */
 export interface AutomationInput {
   name: string;
   prompt: string;
@@ -1644,6 +1653,7 @@ export interface AutomationInput {
   timezone: string;
   host_id: number | null;
   project_path: string | null;
+  project_remote?: string | null;
   retention_limit: number;
 }
 

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1617,9 +1617,18 @@ export interface AutomationView {
   retention_limit: number;
   last_run_at: string | null;
   next_run_at: string | null;
+  /** Status of the most recent run — drives the list health dot.
+   *  `null` until the automation has fired. */
+  last_run_status: string | null;
   created_at: string;
   updated_at: string;
   dirty: boolean;
+}
+
+/** Result of probing whether a host can reach an automation's repo. */
+export interface RepoAccessResult {
+  ok: boolean;
+  message: string;
 }
 
 /** One fire of an automation (or a skipped fire). `status` is one of
@@ -1677,6 +1686,20 @@ export const automationsDelete = (id: number) =>
 
 export const automationsRuns = (automationId: number, limit?: number) =>
   invoke<AutomationRunView[]>("automations_runs", { automationId, limit });
+
+/** Probe whether a host can reach a project's repo (a read-only
+ *  `git ls-remote`). `hostId` null = "This machine" (always reachable).
+ *  Pass `projectRemote` when known, else `projectPath` to resolve it. */
+export const automationsCheckRepoAccess = (
+  hostId: number | null,
+  projectPath: string | null,
+  projectRemote: string | null,
+) =>
+  invoke<RepoAccessResult>("automations_check_repo_access", {
+    hostId,
+    projectPath,
+    projectRemote,
+  });
 
 export interface WorkspacePushOutcome {
   ok: boolean;

--- a/src/tauri/events.ts
+++ b/src/tauri/events.ts
@@ -10,6 +10,7 @@ import type {
   ThemeColors,
   UserSettings,
 } from "./types";
+import type { AutomationRunView } from "./commands";
 
 export type EventCallback<T> = (payload: T) => void;
 
@@ -27,6 +28,11 @@ export const onTerminalStatus = (cb: EventCallback<TerminalStatusPayload>): Prom
 
 export const onSerializeTerminalBuffers = (cb: EventCallback<null>): Promise<UnlistenFn> =>
   listen<null>("serialize-terminal-buffers", () => cb(null));
+
+/** Fired by the automation scheduler each time a due automation
+ *  produces a run. The payload is the freshly-created run row. */
+export const onAutomationFire = (cb: EventCallback<AutomationRunView>): Promise<UnlistenFn> =>
+  listen<AutomationRunView>("automations://fire", (e) => cb(e.payload));
 
 export const emitScrollbackSerializationComplete = () =>
   emit("scrollback-serialization-complete");


### PR DESCRIPTION
## What this is

Adds **Automations** — a named prompt + agent + RFC 5545 recurrence that
runs on a host you pick. Each fire creates a fresh git worktree and runs
the agent headlessly in it. Automations are account-bound, so every
signed-in device sees the same list.

Researched from Superset's Automations feature, then reimplemented for
Codemux's Tauri + Rust + React architecture. The one deliberate
divergence: Codemux schedules on the host itself rather than via a cloud
cron — this gives real completion status, overlap prevention, and local
run retention.

## What's in it

- **Storage** — `automations` + `automation_runs` tables (local SQLite,
  schema v6) and `codemux_automations` on the API (already deployed).
- **Recurrence** — RFC 5545 schedule engine via the `rrule` crate, with
  IANA-timezone / DST correctness.
- **Scheduler** — once-a-minute `tick`: due detection, per-minute
  idempotent fires, overlap serialisation (`skipped_busy`), and a
  stuck-run reconciler that fails runs orphaned by a crash.
- **Executor** — fires the agent in an isolated worktree off a fresh
  branch; records terminal status, branch, and any PR URL.
- **Account sync** — `automations_sync` pushes/pulls the registry
  through the live `/api/automations` endpoints (dirty-flag / tombstone
  model, same as `hosts_sync`).
- **Remote hosts** — `codemux-remote scheduler` subcommand + host
  bootstrap (systemd user service); GitHub-backbone repo transport (a
  host clones the project's git remote with its own credentials).
- **Preflight** — a per-repo `git ls-remote` access check with
  self-healing at-a-glance health dots; non-blocking by design.
- **Surfaces** — a first-class Automations view in the left sidebar,
  eight `automation_*` MCP tools, control-socket handlers, and the
  `automations_*` desktop commands.

## Testing

- 1476 Rust unit tests (recurrence, scheduler + host routing, executor
  incl. real-git clone/fetch, sync, reconciler, preflight, DB CRUD /
  migration).
- 263 server tests for the `/api/automations` endpoints.
- 1698 frontend tests; `tsc` clean.
- Live end-to-end round-trip against the production API (signup → token
  → CRUD → `project_remote`), with cleanup.

The final commit fixes three latent bugs found in a review pass — a
timestamp-format mismatch in the stuck-run reconciler, a runaway
re-fire on an unparseable schedule, and a sync edge case that could run
a remote-host automation on the wrong machine — each with a regression
test.

## Known caveats (non-blocking)

- The live remote-host run path is built and unit-tested but hasn't
  been exercised on real hardware yet — the local ("This machine") path
  is fully exercisable.
- Optional future hardening: per-host scoped tokens, a one-shot
  "run now" action, worktree pruning by `retention_limit`, and a
  `host_server_id` column tidy-up. None block the feature.

37 files changed.