### PR TITLE
Expand open-in-editor launcher and group by family

### DIFF
--- a/docs/features/ide-integration.md
+++ b/docs/features/ide-integration.md
@@ -20,16 +20,29 @@ Detected editors:
 
 | Command | Display Name | Windows Fallback Paths |
 |---------|-------------|---------------------|
-| `code` | VS Code | `Microsoft VS Code\Code.exe` |
+| `code` | VS Code | `Microsoft VS Code\Code.exe`, `Microsoft VS Code Insiders\Code - Insiders.exe` |
 | `cursor` | Cursor | `cursor\Cursor.exe` |
+| `windsurf` | Windsurf | `Windsurf\Windsurf.exe` |
+| `trae` | Trae | `Trae\Trae.exe` |
 | `codium` | VSCodium | `VSCodium\VSCodium.exe` |
 | `zed` | Zed | `Zed\Zed.exe` |
-| `idea` | IntelliJ IDEA | (PATH only — JetBrains Toolbox shims live on `PATH`) |
-| `goland` | GoLand | (PATH only) |
-| `webstorm` | WebStorm | (PATH only) |
+| `fleet` | Fleet | (PATH only — JetBrains Toolbox shim) |
+| `lapce` | Lapce | `Lapce\lapce.exe` |
+| `idea` | IntelliJ IDEA | (PATH only — JetBrains Toolbox shim) |
+| `pycharm` | PyCharm | (PATH only — JetBrains Toolbox shim) |
+| `phpstorm` | PhpStorm | (PATH only — JetBrains Toolbox shim) |
+| `webstorm` | WebStorm | (PATH only — JetBrains Toolbox shim) |
+| `goland` | GoLand | (PATH only — JetBrains Toolbox shim) |
+| `rubymine` | RubyMine | (PATH only — JetBrains Toolbox shim) |
+| `clion` | CLion | (PATH only — JetBrains Toolbox shim) |
+| `rider` | Rider | (PATH only — JetBrains Toolbox shim) |
+| `datagrip` | DataGrip | (PATH only — JetBrains Toolbox shim) |
+| `studio` | Android Studio | (PATH only — JetBrains Toolbox shim) |
 | `sublime_text` | Sublime Text | (PATH only) |
 
 The `EditorInfo.command` field stores the **full resolved path**, not just the command name, so `open_in_editor` can spawn the exact `.exe` we detected — important on Windows where PATH alone is unreliable for per-user installs.
+
+Editors without a dedicated icon asset (Windsurf, Trae, Fleet, Lapce, JetBrains family) render with a placeholder in the UI: JetBrains-family entries use the IntelliJ icon as a stand-in (consistent JetBrains visual language), other unmapped editors fall back to the generic Code2 lucide glyph. Adding per-product SVGs in `src/assets/editor-icons/` and wiring them into `src/components/icons/editor-icon.tsx` is a drop-in upgrade.
 
 ### Opening
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1436,14 +1436,33 @@ pub struct EditorInfo {
 
 static DETECTED_EDITORS: OnceLock<Vec<EditorInfo>> = OnceLock::new();
 
+// Order matters: this is the order shown in the IDE launcher dropdown when
+// multiple editors are detected, and the first installed entry becomes the
+// auto-picked default on first run. Roughly: VS Code family → AI-first
+// editors → other modern GUI editors → JetBrains family → other GUI.
 const EDITOR_CANDIDATES: &[(&str, &str)] = &[
+    // VS Code family
     ("code", "VS Code"),
     ("cursor", "Cursor"),
+    ("windsurf", "Windsurf"),
+    ("trae", "Trae"),
     ("codium", "VSCodium"),
+    // Modern GUI editors
     ("zed", "Zed"),
+    ("fleet", "Fleet"),
+    ("lapce", "Lapce"),
+    // JetBrains family (shims installed by JetBrains Toolbox land on PATH)
     ("idea", "IntelliJ IDEA"),
-    ("goland", "GoLand"),
+    ("pycharm", "PyCharm"),
+    ("phpstorm", "PhpStorm"),
     ("webstorm", "WebStorm"),
+    ("goland", "GoLand"),
+    ("rubymine", "RubyMine"),
+    ("clion", "CLion"),
+    ("rider", "Rider"),
+    ("datagrip", "DataGrip"),
+    ("studio", "Android Studio"),
+    // Other
     ("sublime_text", "Sublime Text"),
 ];
 
@@ -1462,8 +1481,11 @@ const WINDOWS_EDITOR_FALLBACKS: &[(&str, &[&str])] = &[
         ],
     ),
     ("cursor", &[r"cursor\Cursor.exe"]),
+    ("windsurf", &[r"Windsurf\Windsurf.exe"]),
+    ("trae", &[r"Trae\Trae.exe"]),
     ("codium", &[r"VSCodium\VSCodium.exe"]),
     ("zed", &[r"Zed\Zed.exe"]),
+    ("lapce", &[r"Lapce\lapce.exe"]),
 ];
 
 /// Resolve an editor command to an absolute path:

--- a/src/components/icons/editor-icon.tsx
+++ b/src/components/icons/editor-icon.tsx
@@ -15,6 +15,11 @@ interface EditorIconProps {
   className?: string;
 }
 
+// Editors without dedicated icon assets fall back to the generic Code2
+// lucide glyph (see render below). JetBrains-family editors share the
+// IntelliJ icon as a placeholder until per-product art is added; they
+// all use the same red/gradient JetBrains visual language so this
+// reads as "JetBrains IDE" rather than as a wrong logo.
 const ICON_MAP: Record<string, string> = {
   code: vscodeIcon,
   codium: vscodiumIcon,
@@ -24,6 +29,15 @@ const ICON_MAP: Record<string, string> = {
   goland: golandIcon,
   webstorm: webstormIcon,
   sublime_text: sublimeIcon,
+  // JetBrains family placeholders
+  pycharm: intellijIcon,
+  phpstorm: intellijIcon,
+  rubymine: intellijIcon,
+  clion: intellijIcon,
+  rider: intellijIcon,
+  datagrip: intellijIcon,
+  fleet: intellijIcon,
+  studio: intellijIcon,
 };
 
 export function EditorIcon({ id, className }: EditorIconProps) {

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -3,12 +3,16 @@ import {
   ContextMenu,
   ContextMenuTrigger,
   ContextMenuContent,
+  ContextMenuGroup,
   ContextMenuItem,
+  ContextMenuLabel,
   ContextMenuSeparator,
   ContextMenuSub,
   ContextMenuSubTrigger,
   ContextMenuSubContent,
 } from "@/components/ui/context-menu";
+import { groupEditors } from "@/lib/editor-groups";
+import { EditorIcon } from "@/components/icons/editor-icon";
 import {
   Dialog,
   DialogContent,
@@ -324,19 +328,42 @@ export function WorkspaceContextMenuItems({
       </ContextMenuItem>
       {editors.length === 1 ? (
         <ContextMenuItem onClick={() => handleOpenInEditor(editors[0].id)}>
+          <EditorIcon id={editors[0].id} className="h-4 w-4" />
           Open in {editors[0].name}
         </ContextMenuItem>
       ) : editors.length > 1 ? (
-        <ContextMenuSub>
-          <ContextMenuSubTrigger>Open in editor</ContextMenuSubTrigger>
-          <ContextMenuSubContent>
-            {editors.map((editor) => (
-              <ContextMenuItem key={editor.id} onClick={() => handleOpenInEditor(editor.id)}>
-                {editor.name}
-              </ContextMenuItem>
-            ))}
-          </ContextMenuSubContent>
-        </ContextMenuSub>
+        (() => {
+          const groupedEditors = groupEditors(editors);
+          const showGroupLabels = groupedEditors.length > 1;
+          return (
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>Open in editor</ContextMenuSubTrigger>
+              <ContextMenuSubContent>
+                {groupedEditors.map((group, groupIdx) => (
+                  // Same grouping pattern as the title-bar launcher —
+                  // render section labels between families when more
+                  // than one is installed, skip them when only one
+                  // family is present so a "VS Code family" header
+                  // doesn't dangle over a single entry.
+                  <ContextMenuGroup key={group.id}>
+                    {groupIdx > 0 && <ContextMenuSeparator />}
+                    {showGroupLabels && (
+                      <ContextMenuLabel className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                        {group.label}
+                      </ContextMenuLabel>
+                    )}
+                    {group.editors.map((editor) => (
+                      <ContextMenuItem key={editor.id} onClick={() => handleOpenInEditor(editor.id)}>
+                        <EditorIcon id={editor.id} className="h-4 w-4" />
+                        {editor.name}
+                      </ContextMenuItem>
+                    ))}
+                  </ContextMenuGroup>
+                ))}
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          );
+        })()
       ) : null}
       <ContextMenuItem
         onClick={handleCopyBranch}

--- a/src/components/layout/title-bar.tsx
+++ b/src/components/layout/title-bar.tsx
@@ -9,9 +9,13 @@ import { ResourceMonitor } from "./resource-monitor";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { groupEditors } from "@/lib/editor-groups";
 import {
   Tooltip,
   TooltipContent,
@@ -62,6 +66,8 @@ function IdeLauncher() {
   );
 
   const defaultEditor = editors.find((e) => e.id === defaultEditorId);
+  const groupedEditors = groupEditors(editors);
+  const showGroupLabels = groupedEditors.length > 1;
 
   if (editors.length === 0 || !workspacePath) return null;
 
@@ -109,20 +115,35 @@ function IdeLauncher() {
             <ChevronDown className="h-3 w-3" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-44">
-          {editors.map((editor) => (
-            <DropdownMenuItem
-              key={editor.id}
-              onClick={() => handleOpen(editor.id)}
-            >
-              <EditorIcon id={editor.id} className="h-4 w-4" />
-              <span>{editor.name}</span>
-              {editor.id === defaultEditorId && (
-                <span className="ml-auto text-[10px] text-muted-foreground">
-                  default
-                </span>
+        <DropdownMenuContent align="end" className="w-48">
+          {groupedEditors.map((group, groupIdx) => (
+            // Render each family as a labelled section using
+            // DropdownMenuGroup for proper radix aria semantics. We only
+            // show a header + separator when more than one group is
+            // present — a user with only VS Code installed shouldn't
+            // see a lonely "VS Code family" header above a single item.
+            <DropdownMenuGroup key={group.id}>
+              {groupIdx > 0 && <DropdownMenuSeparator />}
+              {showGroupLabels && (
+                <DropdownMenuLabel className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                  {group.label}
+                </DropdownMenuLabel>
               )}
-            </DropdownMenuItem>
+              {group.editors.map((editor) => (
+                <DropdownMenuItem
+                  key={editor.id}
+                  onClick={() => handleOpen(editor.id)}
+                >
+                  <EditorIcon id={editor.id} className="h-4 w-4" />
+                  <span>{editor.name}</span>
+                  {editor.id === defaultEditorId && (
+                    <span className="ml-auto text-[10px] text-muted-foreground">
+                      default
+                    </span>
+                  )}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
           ))}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/lib/editor-groups.test.ts
+++ b/src/lib/editor-groups.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { groupEditors, groupForEditorId } from "./editor-groups";
+import type { EditorInfo } from "@/tauri/types";
+
+const makeEditor = (id: string, name = id): EditorInfo => ({
+  id,
+  name,
+  command: `/usr/bin/${id}`,
+});
+
+describe("groupForEditorId", () => {
+  it("maps known editors to their family", () => {
+    expect(groupForEditorId("code")).toBe("vscode");
+    expect(groupForEditorId("cursor")).toBe("vscode");
+    expect(groupForEditorId("windsurf")).toBe("vscode");
+    expect(groupForEditorId("zed")).toBe("modern");
+    expect(groupForEditorId("idea")).toBe("jetbrains");
+    expect(groupForEditorId("pycharm")).toBe("jetbrains");
+    expect(groupForEditorId("studio")).toBe("jetbrains");
+    expect(groupForEditorId("sublime_text")).toBe("other");
+  });
+
+  it("falls back to 'other' for unknown ids — keeps the UI working when the backend adds a candidate before the frontend mapping catches up", () => {
+    expect(groupForEditorId("brand-new-editor-9000")).toBe("other");
+  });
+});
+
+describe("groupEditors", () => {
+  it("omits empty groups so the UI doesn't render headers with no items", () => {
+    const result = groupEditors([makeEditor("code"), makeEditor("cursor")]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("vscode");
+    expect(result[0].editors.map((e) => e.id)).toEqual(["code", "cursor"]);
+  });
+
+  it("preserves the order each editor came in within its group", () => {
+    // Simulates the backend returning candidates in its declared order
+    const detected = [
+      makeEditor("code"),
+      makeEditor("cursor"),
+      makeEditor("idea"),
+      makeEditor("pycharm"),
+      makeEditor("sublime_text"),
+    ];
+    const result = groupEditors(detected);
+    expect(result.map((g) => g.id)).toEqual(["vscode", "jetbrains", "other"]);
+    expect(result[0].editors.map((e) => e.id)).toEqual(["code", "cursor"]);
+    expect(result[1].editors.map((e) => e.id)).toEqual(["idea", "pycharm"]);
+    expect(result[2].editors.map((e) => e.id)).toEqual(["sublime_text"]);
+  });
+
+  it("emits groups in the canonical order (vscode → modern → jetbrains → other)", () => {
+    // Provide them out-of-order on input to confirm the function imposes
+    // the canonical group order rather than echoing input order across
+    // groups
+    const detected = [
+      makeEditor("sublime_text"),
+      makeEditor("idea"),
+      makeEditor("zed"),
+      makeEditor("code"),
+    ];
+    const result = groupEditors(detected);
+    expect(result.map((g) => g.id)).toEqual([
+      "vscode",
+      "modern",
+      "jetbrains",
+      "other",
+    ]);
+  });
+
+  it("returns an empty array when no editors are detected", () => {
+    expect(groupEditors([])).toEqual([]);
+  });
+
+  it("routes unknown editor ids into 'other' rather than dropping them", () => {
+    const result = groupEditors([
+      makeEditor("code"),
+      makeEditor("totally-new-thing"),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[1].id).toBe("other");
+    expect(result[1].editors.map((e) => e.id)).toEqual(["totally-new-thing"]);
+  });
+});

--- a/src/lib/editor-groups.ts
+++ b/src/lib/editor-groups.ts
@@ -1,0 +1,79 @@
+import type { EditorInfo } from "@/tauri/types";
+
+/**
+ * Editors are partitioned into families so the launcher dropdown and
+ * workspace context menu can render them as labelled sections (e.g. all
+ * JetBrains products together). The Rust candidate list owns the canonical
+ * order — this module only adds a layer of grouping on top of whatever the
+ * backend returned, preserving relative order within each group.
+ *
+ * If a new editor id is added on the backend without a group mapping here,
+ * it lands in the "Other" bucket — safe default, no UI crash.
+ */
+export type EditorGroupId = "vscode" | "modern" | "jetbrains" | "other";
+
+export interface EditorGroup {
+  id: EditorGroupId;
+  label: string;
+  editors: EditorInfo[];
+}
+
+const GROUP_LABEL: Record<EditorGroupId, string> = {
+  vscode: "VS Code family",
+  modern: "Modern editors",
+  jetbrains: "JetBrains",
+  other: "Other",
+};
+
+const GROUP_ORDER: EditorGroupId[] = ["vscode", "modern", "jetbrains", "other"];
+
+const ID_TO_GROUP: Record<string, EditorGroupId> = {
+  // VS Code family — forks/derivatives that share the VS Code UX
+  code: "vscode",
+  cursor: "vscode",
+  windsurf: "vscode",
+  trae: "vscode",
+  codium: "vscode",
+  // Modern standalone editors
+  zed: "modern",
+  lapce: "modern",
+  // JetBrains family (Fleet included — shares Toolbox + visual language)
+  fleet: "jetbrains",
+  idea: "jetbrains",
+  pycharm: "jetbrains",
+  phpstorm: "jetbrains",
+  webstorm: "jetbrains",
+  goland: "jetbrains",
+  rubymine: "jetbrains",
+  clion: "jetbrains",
+  rider: "jetbrains",
+  datagrip: "jetbrains",
+  studio: "jetbrains",
+  // Other
+  sublime_text: "other",
+};
+
+export function groupForEditorId(id: string): EditorGroupId {
+  return ID_TO_GROUP[id] ?? "other";
+}
+
+/**
+ * Partition the detected editors into ordered groups. Empty groups are
+ * omitted so the UI doesn't render an "JetBrains" header above nothing.
+ */
+export function groupEditors(editors: EditorInfo[]): EditorGroup[] {
+  const buckets: Record<EditorGroupId, EditorInfo[]> = {
+    vscode: [],
+    modern: [],
+    jetbrains: [],
+    other: [],
+  };
+  for (const editor of editors) {
+    buckets[groupForEditorId(editor.id)].push(editor);
+  }
+  return GROUP_ORDER.filter((id) => buckets[id].length > 0).map((id) => ({
+    id,
+    label: GROUP_LABEL[id],
+    editors: buckets[id],
+  }));
+}


### PR DESCRIPTION
## Summary

- The launcher previously detected 8 editors (VS Code, Cursor, VSCodium, Zed, IntelliJ IDEA, GoLand, WebStorm, Sublime Text). Adds 11 more so users on any major stack see their IDE: Windsurf, Trae, Fleet, Lapce, PyCharm, PhpStorm, RubyMine, CLion, Rider, DataGrip, Android Studio.
- Title-bar dropdown and workspace context-menu submenu now partition entries into labelled sections — **VS Code family**, **Modern editors**, **JetBrains**, **Other** — only rendering section headers when more than one family is detected (no lonely headers).
- Cross-platform: detection still goes through `which::which()` so PATHEXT, `.cmd` shims, and JetBrains Toolbox shims work without special casing. Windows install-path fallbacks added for per-user installs (Windsurf, Trae, Lapce).

## Detected editors

| Family | Editors |
|---|---|
| VS Code family | VS Code, Cursor, **Windsurf**, **Trae**, VSCodium |
| Modern editors | Zed, **Lapce** |
| JetBrains | **Fleet**, IntelliJ IDEA, **PyCharm**, **PhpStorm**, WebStorm, GoLand, **RubyMine**, **CLion**, **Rider**, **DataGrip**, **Android Studio** |
| Other | Sublime Text |

**Bold** = new in this PR.

All five UI entry points that call `detectEditors()` automatically inherit the expanded list: title-bar launcher, workspace context menu, empty-workspace-state row, Settings → Editor preference, and Skills panel "Open file".

Icon assets aren't shipped for the new editors yet — JetBrains-family entries reuse the IntelliJ icon as a brand-consistent placeholder, others fall back to the generic `Code2` lucide glyph. Adding per-product SVGs is a drop-in upgrade.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passes
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 1481/1482 pass; one failure (`agent_browser::tests::resolve_binary_finds_native_binary_from_project_root`) reproduces on a clean `main` tree, unrelated to this change
- [x] `npm run check` (tsc --noEmit) passes
- [x] `npm run test` — 1712/1712 vitest pass (1705 prior + 7 new for `editor-groups`)
- [ ] Manual: install a JetBrains IDE alongside Cursor + VS Code, confirm the dropdown groups them under separate section headers
- [ ] Manual: install only one editor, confirm no section header is rendered above the single entry
- [ ] Manual (Windows): install Windsurf/Trae per-user, confirm detection picks them up without PATH entries