### PR TITLE
Fix Linux preset launch: prompt leak, intermittence, phantom prompt

### DIFF
--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -536,19 +536,60 @@ const PTY_COMMAND_TERMINATOR: &[u8] = b"\r";
 /// Only the raw command text + a carriage return are written — no
 /// serialization. See `PTY_COMMAND_TERMINATOR` for the rationale on
 /// why CR is used rather than LF.
+///
+/// IMPORTANT: command bytes and the terminator are combined into a
+/// SINGLE `write_all` call. See `build_pty_command_payload` for the
+/// "Linux phantom-prompt" regression this prevents.
 fn write_command_to_pty(
     sessions: &Arc<std::sync::Mutex<std::collections::HashMap<String, terminal::SessionRuntime>>>,
     session_id: &str,
     command: &str,
 ) {
+    let payload = build_pty_command_payload(command);
     let mut guard = sessions.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(runtime) = guard.get_mut(session_id) {
         if let Some(writer) = runtime.writer.as_mut() {
-            let _ = writer.write_all(command.as_bytes());
-            let _ = writer.write_all(PTY_COMMAND_TERMINATOR);
+            let _ = writer.write_all(&payload);
             let _ = writer.flush();
         }
     }
+}
+
+/// Concatenate `command` + the PTY command terminator into a single
+/// byte buffer suitable for one `write_all` call.
+///
+/// Why this exists as a discrete helper: the daemon-backed `Writer`
+/// implementation (`DaemonWriter` in `terminal/daemon_backed.rs`) is
+/// fire-and-forget. Each call to `Write::write` spawns its own Tokio
+/// task that round-trips a separate `Write` RPC to the PTY daemon —
+/// there is no FIFO between successive writes on the same handle.
+///
+/// The previous code wrote command bytes and the terminator in two
+/// separate `write_all` calls. On the daemon path, those became two
+/// independent async tasks that could land at the daemon's master fd
+/// in either order:
+///
+///   1. Command first, CR second → shell echoes `claude ...`, then
+///      receives CR → readline submits → preset launches. Correct.
+///   2. CR first, command second → shell receives CR on an empty
+///      line → submits nothing, redraws prompt → THEN the command
+///      bytes arrive and sit at the new prompt with no terminator.
+///      User sees the command text typed in the input but never
+///      executed; pressing Enter manually launches the preset. This
+///      was the "sometimes does nothing" bug after the writer-poll
+///      fix (the writer-poll fix uncovered it by removing the
+///      synthesis path's duplicate write that happened to fire later
+///      in lock-step order).
+///
+/// Combining into one buffer means a single `write_all` → single
+/// `Write::write` call → single spawn → single daemon RPC. The
+/// command and its terminator are atomic from the daemon's
+/// perspective; nothing can race them apart.
+fn build_pty_command_payload(command: &str) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(command.len() + PTY_COMMAND_TERMINATOR.len());
+    payload.extend_from_slice(command.as_bytes());
+    payload.extend_from_slice(PTY_COMMAND_TERMINATOR);
+    payload
 }
 
 /// Write a command to a newly-spawned PTY after the shell is ready.
@@ -577,14 +618,37 @@ fn wait_and_write_command(
     command: &str,
     settle_ms: u64,
 ) {
-    let overall_start = std::time::Instant::now();
-    let overall_timeout = std::time::Duration::from_secs(5);
-
-    // Phase 1: Poll until the PTY writer is available (shell process spawned).
+    // Phase 1: poll until the PTY writer is available (shell process spawned).
+    //
+    // This used to share a single 5-second budget with Phase 2's quiet-
+    // detection. That was fine for the in-process Windows spawn path
+    // (writer is set within milliseconds), but the Linux daemon-backed
+    // spawn can take longer: cold pty_daemon start, the SSH-tunneled
+    // round-trip for remote workspaces, the daemon's own list/spawn/
+    // attach handshake. When apply_preset called us right after
+    // `spawn_pty_for_session` returned (which only kicks off the
+    // async spawn — the writer isn't set until the spawn task lands),
+    // a slow spawn would starve Phase 1, the poll would hit the 5s
+    // wall before the writer appeared, and we'd return without
+    // writing anything. The user-visible symptom was "clicking a
+    // preset on Linux sometimes does nothing." Pre-fix, the bug was
+    // masked because the daemon-backed spawn ALSO synthesized a
+    // duplicate write that fired after the writer was set — every
+    // launch had a backup. With the Linux preset-leak fix gating
+    // that synthesis off for fresh preset launches (see
+    // daemon_backed.rs::should_synthesize_agent_relaunch), the
+    // apply_preset write is the only one, so its budget has to
+    // actually cover daemon spawn time.
+    //
+    // 15s comfortably covers a cold local daemon start (~1-3s
+    // observed) and a first-time SSH-tunneled remote spawn (~5-10s
+    // observed). Phase 2 keeps its own independent 5s budget below.
+    let writer_ready_timeout = std::time::Duration::from_secs(15);
+    let writer_poll_start = std::time::Instant::now();
     let mut writer_found = false;
     loop {
         std::thread::sleep(std::time::Duration::from_millis(50));
-        if overall_start.elapsed() >= overall_timeout {
+        if writer_poll_start.elapsed() >= writer_ready_timeout {
             break;
         }
         let ready = {
@@ -601,7 +665,11 @@ fn wait_and_write_command(
     }
 
     if !writer_found {
-        eprintln!("[codemux::presets] Timeout waiting for PTY writer for session {session_id}");
+        eprintln!(
+            "[codemux::presets] Timeout waiting for PTY writer for session {session_id} \
+             after {:?}",
+            writer_poll_start.elapsed()
+        );
         return;
     }
 
@@ -632,7 +700,16 @@ fn wait_and_write_command(
         return;
     }
 
-    // Phase 2: Wait for shell output to arrive and then go quiet.
+    // Phase 2: wait for shell output to arrive and then go quiet.
+    //
+    // Independent 5s budget — does NOT share with Phase 1's writer
+    // timeout. A slow daemon spawn that ate most of a shared budget
+    // used to leave this phase with no time to detect quiet,
+    // forcing the writer to fire while the shell was still painting
+    // its prompt. Splitting the budgets means each phase gets its
+    // documented headroom regardless of the other's wall-clock.
+    let quiet_phase_timeout = std::time::Duration::from_secs(5);
+    let quiet_phase_start = std::time::Instant::now();
     let quiet_threshold = std::time::Duration::from_millis(settle_ms);
     let poll_interval = std::time::Duration::from_millis(30);
 
@@ -653,7 +730,7 @@ fn wait_and_write_command(
     loop {
         std::thread::sleep(poll_interval);
 
-        if overall_start.elapsed() >= overall_timeout {
+        if quiet_phase_start.elapsed() >= quiet_phase_timeout {
             break;
         }
 
@@ -679,28 +756,33 @@ fn wait_and_write_command(
 
     eprintln!(
         "[codemux::presets] Shell readiness for {session_id}: {detection_method} \
-         (output_chunks={snapshot_len}, elapsed={:?})",
-        overall_start.elapsed()
+         (output_chunks={snapshot_len}, quiet_phase_elapsed={:?}, \
+          total_elapsed={:?})",
+        quiet_phase_start.elapsed(),
+        writer_poll_start.elapsed()
     );
 
     // Write the plain command text followed by the PTY command
-    // terminator. See `PTY_COMMAND_TERMINATOR` for why this is CR
-    // (0x0D) and not LF (0x0A) — short version: PSReadLine on Windows
-    // only recognizes CR as the Enter keystroke, and Linux readline
-    // accepts CR too via its `C-m` → `accept-line` binding, so CR is
-    // the right byte on both platforms.
+    // terminator in a SINGLE `write_all` call. See
+    // `build_pty_command_payload` for why this MUST be one call (and
+    // not two): on the daemon-backed Linux path, separate `write_all`s
+    // race each other and can land the terminator before the command
+    // bytes, leaving the shell with the command typed at a fresh
+    // prompt waiting for a manual Enter. See `PTY_COMMAND_TERMINATOR`
+    // for why CR is the right terminator byte on both Linux and
+    // Windows.
+    let payload = build_pty_command_payload(&command_to_write);
     let mut guard = sessions.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(runtime) = guard.get_mut(session_id) {
         if let Some(writer) = runtime.writer.as_mut() {
-            let result_a = writer.write_all(command_to_write.as_bytes());
-            let result_b = writer.write_all(PTY_COMMAND_TERMINATOR);
-            let result_c = writer.flush();
+            let write_result = writer.write_all(&payload);
+            let flush_result = writer.flush();
             eprintln!(
                 "[codemux::presets] wrote preset/resume command to {session_id} \
-                 (write_ok={}, terminator_ok={}, flush_ok={}, cmd={command_to_write:?})",
-                result_a.is_ok(),
-                result_b.is_ok(),
-                result_c.is_ok(),
+                 (write_ok={}, flush_ok={}, payload_len={}, cmd={command_to_write:?})",
+                write_result.is_ok(),
+                flush_result.is_ok(),
+                payload.len(),
             );
         } else {
             eprintln!(
@@ -849,6 +931,78 @@ mod tests {
         assert_eq!(written, b"echo hello\r");
     }
 
+    /// `Write` impl that records every individual `write` call as a
+    /// separate byte vec. Lets tests assert how many syscalls happened
+    /// and what bytes each one carried — important for the daemon-
+    /// backed path where each `write` becomes its own async task and
+    /// the payload from a single `write` is what travels as one
+    /// network RPC.
+    struct RecordingWriter {
+        calls: std::sync::Arc<std::sync::Mutex<Vec<Vec<u8>>>>,
+    }
+
+    impl Write for RecordingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.calls.lock().unwrap().push(buf.to_vec());
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn build_payload_concatenates_command_and_cr() {
+        let payload = build_pty_command_payload("claude --dangerously-skip-permissions");
+        assert_eq!(
+            payload,
+            b"claude --dangerously-skip-permissions\r",
+            "payload must be `<command>\\r` so a single write_all \
+             call carries both atomically — see helper doc comment \
+             for why this prevents the Linux phantom-prompt race"
+        );
+    }
+
+    #[test]
+    fn write_command_to_pty_uses_single_write_call() {
+        // Regression test for the "preset launches sometimes, sometimes
+        // shows command typed but not executed" Linux bug. The fix
+        // routes the command + terminator through one buffer so the
+        // daemon-backed writer's per-call spawn dispatches a single
+        // RPC, preserving byte order at the daemon's master fd. If
+        // someone later "refactors" this back to two write_all calls,
+        // this test breaks loudly.
+        let sessions = make_sessions();
+        let calls: std::sync::Arc<std::sync::Mutex<Vec<Vec<u8>>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        {
+            let mut guard = sessions.lock().unwrap();
+            let mut runtime = crate::terminal::SessionRuntime::new("sess");
+            runtime.writer = Some(Box::new(RecordingWriter {
+                calls: calls.clone(),
+            }));
+            guard.insert("sess".into(), runtime);
+        }
+
+        write_command_to_pty(&sessions, "sess", "claude --dangerously-skip-permissions");
+
+        let recorded = calls.lock().unwrap();
+        assert_eq!(
+            recorded.len(),
+            1,
+            "command + terminator must reach the writer in exactly ONE \
+             write() call. Two calls would let the daemon-backed path's \
+             fire-and-forget Tokio spawn race them apart, producing the \
+             'command typed but not submitted' Linux bug. Got {} calls: {:?}",
+            recorded.len(),
+            recorded
+        );
+        assert_eq!(
+            &recorded[0][..],
+            b"claude --dangerously-skip-permissions\r"
+        );
+    }
+
     #[test]
     fn test_pty_command_terminator_is_carriage_return() {
         // Regression guard: the programmatic preset-injection path
@@ -900,29 +1054,39 @@ mod tests {
 
     #[test]
     fn test_hard_timeout() {
+        // Writer is present, so Phase 1 passes immediately. No output
+        // ever arrives, so Phase 2 must run its quiet-detection budget
+        // to completion. That budget is independent of Phase 1's
+        // writer-poll budget — Phase 2 alone should take ~5s here.
         let sessions = make_sessions();
         insert_session_with_writer(&sessions, "sess");
-        // No output will ever be produced — should hit the hard timeout
 
         let start = std::time::Instant::now();
         wait_and_write_command(&sessions, "sess", "timeout-cmd", 120);
         let elapsed = start.elapsed();
 
-        // Should have taken approximately 5s (the hard timeout)
         assert!(
             elapsed >= std::time::Duration::from_secs(4),
-            "should wait near full timeout, took {elapsed:?}"
+            "Phase 2 quiet-detection should run its full 5s budget, took {elapsed:?}"
         );
         assert!(
             elapsed < std::time::Duration::from_secs(7),
-            "should not exceed timeout significantly"
+            "Phase 2 budget is 5s independent of Phase 1; should NOT \
+             leak Phase 1's 15s window into total wall-clock here. \
+             Took {elapsed:?}"
         );
     }
 
     #[test]
     fn test_writer_not_found_timeout() {
+        // No writer ever appears — Phase 1 must wait its full
+        // writer-ready budget (15s) before bailing. Phase 2 is never
+        // reached. This test takes ~15s; the long wait is what gives
+        // a real daemon-backed Linux spawn (cold pty_daemon, remote
+        // SSH tunnel) enough room to land the writer before
+        // apply_preset gives up. See `wait_and_write_command` Phase 1
+        // comment for the regression history.
         let sessions = make_sessions();
-        // Session exists but with NO writer (simulates spawn failure)
         {
             let mut guard = sessions.lock().unwrap();
             guard.insert("no-writer".to_string(), SessionRuntime::new("no-writer"));
@@ -932,10 +1096,87 @@ mod tests {
         wait_and_write_command(&sessions, "no-writer", "cmd", 120);
         let elapsed = start.elapsed();
 
-        // Should timeout waiting for writer (~5s)
         assert!(
-            elapsed >= std::time::Duration::from_secs(4),
-            "should wait for writer timeout"
+            elapsed >= std::time::Duration::from_secs(14),
+            "Phase 1 should wait its full 15s writer-ready budget so \
+             slow daemon spawns aren't starved; took {elapsed:?}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(20),
+            "Phase 1 budget is 15s; should NOT exceed significantly. \
+             Took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn test_slow_writer_then_quiet_detected() {
+        // Regression test for the Linux preset-launch intermittence
+        // ("sometimes the preset launches, sometimes it doesn't").
+        // Simulates the daemon-backed spawn race: apply_preset spawns
+        // this poll thread immediately, but the writer doesn't land
+        // until well after the OLD 5s shared budget would have
+        // expired. With split per-phase budgets, Phase 1's 15s window
+        // covers the slow spawn, then Phase 2 detects shell quiet and
+        // the command actually gets written. Pre-fix this would hit
+        // the shared 5s wall, return without writing, and the preset
+        // would silently fail to launch.
+        let sessions = make_sessions();
+        // Insert the runtime stub the apply_preset path would see
+        // *before* the daemon spawn lands the writer.
+        {
+            let mut guard = sessions.lock().unwrap();
+            guard.insert(
+                "slow-spawn".to_string(),
+                SessionRuntime::new("slow-spawn"),
+            );
+        }
+
+        let sessions_for_producer = sessions.clone();
+        // Producer thread: after 7 seconds (well past the old 5s
+        // shared budget) install the writer + a bit of pending output
+        // (shell prompt) so Phase 2 can detect quiet and complete the
+        // write.
+        let producer = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(7));
+            let mut guard = sessions_for_producer.lock().unwrap();
+            let runtime = guard.get_mut("slow-spawn").unwrap();
+            runtime.writer =
+                Some(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>);
+            runtime.pending_output.push_back(vec![b'$', b' ']);
+        });
+
+        let start = std::time::Instant::now();
+        // settle_ms = 80 so Phase 2's quiet detection fires quickly.
+        wait_and_write_command(&sessions, "slow-spawn", "echo hi", 80);
+        let elapsed = start.elapsed();
+        producer.join().unwrap();
+
+        // Must have waited for the writer (≥7s) but not the full
+        // 20s upper bound (Phase 1 15s + Phase 2 5s).
+        assert!(
+            elapsed >= std::time::Duration::from_secs(7),
+            "should have waited for the slow writer to land, took {elapsed:?}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(12),
+            "Phase 2 should fire shortly after writer lands; total \
+             elapsed should be writer-land-time + a brief quiet \
+             window. Took {elapsed:?}"
+        );
+
+        // The write must have actually happened — that's the user-
+        // visible thing the regression broke.
+        let guard = sessions.lock().unwrap();
+        let runtime = guard.get("slow-spawn").unwrap();
+        let writer = runtime.writer.as_ref().unwrap();
+        let writer_ptr = writer.as_ref() as *const dyn Write as *const Vec<u8>;
+        let written = unsafe { &*writer_ptr };
+        assert_eq!(
+            written, b"echo hi\r",
+            "command must have been written after the writer became \
+             available — pre-fix the shared 5s budget timed out first \
+             and nothing was written, manifesting as 'preset click \
+             did nothing' on Linux"
         );
     }
 

--- a/src-tauri/src/terminal/daemon_backed.rs
+++ b/src-tauri/src/terminal/daemon_backed.rs
@@ -26,6 +26,25 @@ use crate::state::AppStateStore;
 use std::sync::Arc;
 use tauri::{AppHandle, Manager, State};
 
+/// Should `spawn_pty_for_session_via_daemon` synthesize a "relaunch this
+/// agent" command from the in-memory `original_command`?
+///
+/// True only when there's positive evidence the shell already had a prior
+/// agent run — either persisted scrollback metadata (`disk_meta_present`)
+/// or a captured agent session UUID (`claude_uuid_present`). Without one
+/// of those, this codepath is racing a fresh `apply_preset` call: the
+/// preset handler will write the exact same command via its own
+/// `write_command_when_ready`, so synthesizing here produces a duplicate
+/// write. The second write lands inside the just-started agent's input
+/// box — the Linux preset-leak bug. Windows isn't affected because the
+/// whole daemon path is `#[cfg(unix)]`-gated.
+pub(crate) fn should_synthesize_agent_relaunch(
+    disk_meta_present: bool,
+    claude_uuid_present: bool,
+) -> bool {
+    disk_meta_present || claude_uuid_present
+}
+
 /// Public entrypoint. Called from `spawn_pty_for_agent` when the
 /// `persistent_agents.enabled` setting is on. Returns an error if the
 /// daemon can't be reached, the spawn failed, or the attach failed —
@@ -527,17 +546,32 @@ pub async fn spawn_pty_for_session_via_daemon(
                 .find(|s| s.session_id.0 == session_id)
                 .and_then(|s| s.adapter_captures.get("claude_session_id"))
                 .cloned();
-            let cmd_opt = agent_binary.map(|bin| {
-                let mut parts = vec![bin];
-                if had_skip_perms {
-                    parts.push("--dangerously-skip-permissions".to_string());
-                }
-                if let Some(uuid) = claude_uuid.as_ref() {
-                    parts.push("--resume".to_string());
-                    parts.push(uuid.clone());
-                }
-                parts.join(" ")
-            });
+            // GATE: only synthesize a relaunch command when there's
+            // evidence this is genuinely a relaunch (persisted disk
+            // meta or a captured agent UUID). If neither is set we're
+            // racing a fresh `apply_preset` call that will write the
+            // command itself — synthesizing here would duplicate the
+            // write and leak the command into the agent's input box
+            // (the Linux preset-leak bug). See the local branch below
+            // for the full rationale.
+            let cmd_opt = if should_synthesize_agent_relaunch(
+                disk_meta.is_some(),
+                claude_uuid.is_some(),
+            ) {
+                agent_binary.map(|bin| {
+                    let mut parts = vec![bin];
+                    if had_skip_perms {
+                        parts.push("--dangerously-skip-permissions".to_string());
+                    }
+                    if let Some(uuid) = claude_uuid.as_ref() {
+                        parts.push("--resume".to_string());
+                        parts.push(uuid.clone());
+                    }
+                    parts.join(" ")
+                })
+            } else {
+                None
+            };
             if let Some(cmd) = cmd_opt {
                 eprintln!(
                     "[codemux::terminal::daemon_backed] remote relaunch for {session_id}: \
@@ -548,11 +582,20 @@ pub async fn spawn_pty_for_session_via_daemon(
                     disk_meta.is_some(),
                 );
                 auto_resume_command = Some(cmd);
-            } else {
+            } else if should_synthesize_agent_relaunch(
+                disk_meta.is_some(),
+                claude_uuid.is_some(),
+            ) {
                 eprintln!(
                     "[codemux::terminal::daemon_backed] remote respawn for {session_id} \
                      has no original_command (was a plain shell, or preset wasn't yet \
                      applied) — spawning bare bash"
+                );
+            } else {
+                eprintln!(
+                    "[codemux::terminal::daemon_backed] skipping remote in-memory synthesis \
+                     for {session_id}: no disk_meta and no captured agent UUID — treating as \
+                     a fresh preset launch (apply_preset owns the PTY write)"
                 );
             }
         } else {
@@ -612,25 +655,55 @@ pub async fn spawn_pty_for_session_via_daemon(
                     auto_resume_command = Some(resume_command);
                 }
             } else if let Some(bin) = agent_binary {
-                // No disk_meta (pull-back, fresh-after-preset, etc.)
-                // — synthesize from in-memory exactly like the remote
-                // path. This is what makes pull-back actually relaunch
-                // Claude with the just-synced conversation history.
-                let mut parts = vec![bin];
-                if had_skip_perms {
-                    parts.push("--dangerously-skip-permissions".to_string());
+                // No disk_meta + adapter pair — this branch is for
+                // pull-back (workspace migrated remote → local while
+                // an agent was running). We synthesize `<binary>
+                // [--dangerously-skip-permissions] [--resume <uuid>]`
+                // from in-memory state so the agent picks up where it
+                // left off on the local host.
+                //
+                // GATE: only synthesize when there is real evidence
+                // this is a *relaunch* — either a captured agent
+                // session UUID (claude_uuid) or persisted scrollback
+                // metadata (disk_meta). Otherwise this is a *fresh
+                // preset launch*, and `apply_preset` is about to
+                // write the exact same command via its own
+                // `write_command_when_ready` call (see
+                // commands/presets.rs::apply_preset → "new_tab"
+                // branch). Without this gate, both writes fire and
+                // the second one lands inside the just-started
+                // agent's input box — the user reported seeing
+                // `claude --dangerously-skip-permissions` typed into
+                // Claude Code's prompt right after launching the
+                // preset on Linux. Windows isn't affected because
+                // the entire daemon-backed path is `#[cfg(unix)]`
+                // and the in-process spawn has no synthesis logic.
+                if should_synthesize_agent_relaunch(
+                    disk_meta.is_some(),
+                    claude_uuid.is_some(),
+                ) {
+                    let mut parts = vec![bin];
+                    if had_skip_perms {
+                        parts.push("--dangerously-skip-permissions".to_string());
+                    }
+                    if let Some(uuid) = claude_uuid.as_ref() {
+                        parts.push("--resume".to_string());
+                        parts.push(uuid.clone());
+                    }
+                    let cmd = parts.join(" ");
+                    eprintln!(
+                        "[codemux::terminal::daemon_backed] local relaunch via in-memory for \
+                         {session_id}: {cmd} (skip_perms={had_skip_perms}, has_uuid={})",
+                        claude_uuid.is_some()
+                    );
+                    auto_resume_command = Some(cmd);
+                } else {
+                    eprintln!(
+                        "[codemux::terminal::daemon_backed] skipping in-memory synthesis for \
+                         {session_id}: no disk_meta and no captured agent UUID — treating as \
+                         a fresh preset launch (apply_preset owns the PTY write)"
+                    );
                 }
-                if let Some(uuid) = claude_uuid.as_ref() {
-                    parts.push("--resume".to_string());
-                    parts.push(uuid.clone());
-                }
-                let cmd = parts.join(" ");
-                eprintln!(
-                    "[codemux::terminal::daemon_backed] local relaunch via in-memory for \
-                     {session_id}: {cmd} (skip_perms={had_skip_perms}, has_uuid={})",
-                    claude_uuid.is_some()
-                );
-                auto_resume_command = Some(cmd);
             }
         }
     }
@@ -1148,4 +1221,74 @@ fn build_agent_env(
     }
 
     env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_synthesize_agent_relaunch;
+
+    // These tests pin the gate that prevents the Linux preset-leak bug.
+    //
+    // Bug shape: clicking a CLI preset on Linux wrote the preset's
+    // command twice — once submitted to the shell (which launched the
+    // agent) and once typed into the just-started agent's input box.
+    // Root cause was that the daemon-backed spawn task synthesized a
+    // "relaunch the agent" command whenever the in-memory
+    // `original_command` was set, racing the `apply_preset` handler's
+    // own write_command_when_ready call. The gate below restricts that
+    // synthesis to genuine relaunches (pull-back, restart) where one of
+    // (disk_meta, captured agent UUID) is present. A fresh preset
+    // launch has neither, so it falls through to apply_preset's single
+    // write.
+    //
+    // Windows was unaffected because the entire daemon-backed path is
+    // `#[cfg(unix)]`-gated — the in-process spawn has no synthesis
+    // logic. So this is specifically a Linux/macOS regression.
+
+    #[test]
+    fn fresh_preset_launch_does_not_synthesize() {
+        // The exact case from the user's bug report: clicking the
+        // Claude Code preset in a fresh workspace. No prior session
+        // ever ran on this PTY → no disk_meta, no captured UUID.
+        // Synthesizing here would duplicate apply_preset's write.
+        assert!(
+            !should_synthesize_agent_relaunch(false, false),
+            "fresh preset launch (no disk meta, no UUID) must NOT \
+             synthesize — apply_preset owns the single write"
+        );
+    }
+
+    #[test]
+    fn restart_with_disk_meta_synthesizes() {
+        // App restart: scrollback meta was flushed to disk in a prior
+        // session. apply_preset is NOT being invoked — the daemon spawn
+        // task is the only thing that will write a command. Must
+        // synthesize so the agent relaunches.
+        assert!(
+            should_synthesize_agent_relaunch(true, false),
+            "respawn with disk meta but no UUID must synthesize so the \
+             agent restarts (e.g. non-Claude agents on app restart)"
+        );
+    }
+
+    #[test]
+    fn pullback_with_captured_uuid_synthesizes() {
+        // Pull-back from remote: scrollback meta hasn't flushed yet
+        // (user never closed), but the in-memory adapter captures hold
+        // Claude's session UUID. We want `claude --resume <uuid>` to
+        // fire on the local host so the conversation continues.
+        assert!(
+            should_synthesize_agent_relaunch(false, true),
+            "pull-back with captured Claude UUID must synthesize the \
+             --resume relaunch command"
+        );
+    }
+
+    #[test]
+    fn both_present_still_synthesizes() {
+        // Belt-and-suspenders: long-running session that's been used
+        // through both an app restart (disk meta) and a remote round-trip
+        // (UUID). Both signals say "this is a real relaunch."
+        assert!(should_synthesize_agent_relaunch(true, true));
+    }
 }


### PR DESCRIPTION
## Summary

Three races on the `#[cfg(unix)]` daemon-backed PTY spawn path that combined to make preset launches on Linux feel broken (Windows uses the in-process spawn and was unaffected throughout).

- **Prompt leak** — clicking a preset typed the command into the just-launched agent's input box after starting it.
- **Intermittent launch** — sometimes the click did nothing at all.
- **Phantom prompt** — sometimes the command appeared at the shell prompt but wasn't submitted (manual Enter required).

## Root causes

1. **Synthesis duplicated apply_preset's write.** `spawn_pty_for_session_via_daemon` synthesized a "relaunch this agent" command from in-memory `original_command` and fired its own `write_command_when_ready`, racing the one `apply_preset` already spawned. Two writes → the second landed in the now-running agent's TUI input.
2. **5s shared writer/quiet budget.** Removing the duplicate (fix #1) exposed a starvation race in `wait_and_write_command`: a slow daemon spawn (cold `pty_daemon`, SSH-tunnelled remote, first-connect) ate most of the shared 5s budget, so Phase 1 (writer ready) timed out before the writer ever appeared and the click silently dropped.
3. **`DaemonWriter` is fire-and-forget.** Each `Write::write` call `tauri::async_runtime::spawn`s its own task that round-trips a separate `Write` RPC to the daemon — there is no FIFO between successive writes on the same handle. Writing command bytes and the CR terminator in two `write_all` calls let the CR land before the command: empty line submitted, prompt redrawn, command bytes then arrived at the new prompt with no terminator.

## Fixes

- `should_synthesize_agent_relaunch(disk_meta_present, claude_uuid_present)` gates the synthesis fallback to genuine relaunches (pull-back / restart). Fresh preset launches have neither signal and skip the synthesis, leaving `apply_preset` as the sole writer.
- Split `wait_and_write_command`'s budget: Phase 1 (writer ready) = 15s, Phase 2 (shell quiet) = 5s, independent timers.
- `build_pty_command_payload` concatenates command bytes + CR into one buffer. One `write_all` → one `Write::write` → one Tokio spawn → one daemon RPC. Command and terminator are atomic at the daemon's master fd.

## Untouched on purpose

Close-app/reopen Claude-resume goes through `resolve_resume_command` (disk_meta + adapter-state pair), not the synthesis fallback this PR gates. That path was deliberately not modified and still produces `claude --resume <uuid>` on restart as before.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — all 1485+ Rust tests pass, including 7 new regression tests:
  - `should_synthesize_agent_relaunch` truth table (4 cases: fresh, disk-meta-only, uuid-only, both)
  - `test_slow_writer_then_quiet_detected` — writer lands at 7s (past old 5s budget); command still gets written
  - `build_payload_concatenates_command_and_cr` — payload shape
  - `write_command_to_pty_uses_single_write_call` — exactly one `Write::write` syscall; breaks loudly if anyone refactors back to two
- [x] `npm run verify` — 110 test files / 1712 tests pass
- [x] Manual: clicking the Claude Code preset on Linux launches cleanly with no command echoed into Claude's input box and no manual-Enter required
- [ ] Smoke-test close-app / reopen on Linux to confirm Claude resume still produces `claude --resume <uuid>`