### PR TITLE
feat(workspaces): account-wide overview + cross-device sync + safety net

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -66,6 +66,8 @@ If the docs themselves feel stale or scattered, also read `docs/reference/DOCS_R
 - Project memory: `docs/features/project-memory.md`
 - Command palette: `docs/features/command-palette.md`
 - Workspace creation: `docs/features/workspace-creation.md`
+- Workspaces overview (full-screen device-grouped list with filters + push/pull actions): `docs/features/workspaces-overview.md`
+- Workspaces sync (cross-device workspace registry powering the overview's sibling-device rows): `docs/features/workspaces-sync.md`
 - IDE integration: `docs/features/ide-integration.md`
 - Notifications: `docs/features/notifications.md`
 - Auto-update: `docs/features/auto-update.md`

--- a/docs/features/workspaces-overview.md
+++ b/docs/features/workspaces-overview.md
@@ -1,0 +1,123 @@
+# Workspaces Overview
+
+- Purpose: Describe the full-screen "Workspaces" overlay that lists every workspace this device tracks — local + every remote host it has pushed to — with filters, search, and per-row push/pull/open actions.
+- Audience: Anyone touching the sidebar, the workspace push/pull flow, or the overview UI itself.
+- Authority: Canonical feature doc for the overview surface.
+- Update when: The sidebar entry, the overview layout, the filter set, or the per-row actions change.
+- Read next: `docs/features/remote-hosts.md` for the push/pull pipeline underneath, `docs/features/workspace-creation.md` for the new-workspace flow.
+
+## What This Feature Is
+
+A single pane that answers "where do all my workspaces live?" — across this device and every host it has pushed to. Reached from the left sidebar (the `Workspaces` button under `Automations`), opens as a full-screen overlay with the same chrome as Settings and Automations.
+
+Before this feature the sidebar only showed workspaces grouped by project on the current device. Once you pushed a workspace to a remote host the cloud icon told you it was remote, but there was no surface for "show me everything I have, everywhere." The overview is that surface.
+
+## Current Model
+
+### Entry point
+
+- `src/components/layout/sidebar-action-row.tsx` renders the `Workspaces` button under `Automations`. Click → `useUIStore.setShowWorkspacesOverview(true)`.
+- `src/components/layout/app-shell.tsx` early-returns `<WorkspacesOverviewView />` whenever `showWorkspacesOverview` is true — same pattern as `showAutomations` and `showSettings`.
+- Escape and the back button both close the overlay.
+
+### Data source
+
+- Workspaces come from `useAppStore((s) => s.appState?.workspaces)`. Every `WorkspaceSnapshot` already carries `host_id?: number | null` (added in the cloud-push series — see `remote-hosts.md`). `null` means local; a number references the local `hosts` table row id.
+- Host metadata comes from `useHostsStore()` — the same shared cache the `DevicePicker` and workspace context menu use, so the overview pays one IPC round-trip on first mount and reads from cache thereafter.
+- Project names + the basename / "Home" disambiguation reuse `groupWorkspacesByProject(workspaces, homeDir)` from `src/stores/app-store.ts`, so projects appear with the exact labels the sidebar gives them.
+
+### Layout
+
+- Sticky filter bar at the top: search, project, device, status, sort.
+- Result-count row underneath with a `New workspace` shortcut.
+- Body groups workspaces into **device sections**, in this order:
+  1. `This device` (the local bucket — emerald accent + custom laptop glyph)
+  2. Each configured host in the order they appear in `Settings → Hosts` (sky-blue accent + cloud icon)
+  3. Any `Removed host` orphan section, if a workspace still references a deleted host id (so rows never silently disappear)
+- Each device section header shows the host name + ssh target, a workspace count, and a "filtered" pill if any of the bucket's workspaces are hidden by the active filter.
+- Workspaces render as compact two-column cards (single column under `md`): status dot · title · project name · branch · git stats · hover-reveal action menu.
+
+### Status semantics
+
+The status dot to the left of each workspace title has two precedence layers. **Live agent status wins** when present — sourced from `getWorkspaceStatus(workspace.surfaces, appState.pane_statuses)`, the same path the sidebar uses, so when a pane flips between idle / working / waiting-on-input / review the overview row repaints automatically without polling:
+
+| Live status | Treatment |
+|---|---|
+| `working` | Amber pulsing dot via `<StatusIndicator>`; meta line shows `· agent working` |
+| `permission` | Red pulsing dot; meta line shows `· needs input` |
+| `review` | Emerald dot; meta line shows `· ready to review` |
+
+When no live status is set, the static dot falls back to:
+
+| Color | Meaning |
+|---|---|
+| Emerald | Currently open in this app (matches `appState.active_workspace_id`) |
+| Sky blue | Lives on a remote host |
+| Violet | OpenFlow workspace |
+| Amber | Push or pull in flight (replaces the action menu with a spinner) |
+| Muted | Local, not currently attached |
+
+The attached card also gets an emerald border + soft ring so it's findable at a glance even when the dot scrolls off.
+
+### Filters
+
+- **Search** — case-insensitive substring match against title, branch, or project name. Clear button appears once non-empty.
+- **Project** — exact-path match using the project paths that `groupWorkspacesByProject` derives.
+- **Device** — `All`, `This device`, or a specific host.
+- **Status** — `Any status`, `Currently open`, `On a remote host`, `Has uncommitted work`.
+- **Sort** — `Recently active` (notifications + dirty-git proxy → name tie-break), `Name`, `Branch`.
+- A `Clear` chip appears whenever any non-default filter is set.
+
+### Per-row actions
+
+The trailing `⋯` menu (hover- and focus-revealed) holds:
+
+- **Open workspace** — calls `activateWorkspace(workspaceId)`, closes the overlay, lands the user in the workspace.
+- **Copy branch name** — clipboard copy, disabled when no branch.
+- **Rename…** — `window.prompt` + `renameWorkspace`.
+- **Push to host…** — submenu of every configured host. Each entry calls `workspacePushToHost(workspaceId, hostId)` (reuses the same Tauri command the sidebar context menu uses). Disabled with a tooltip when zero hosts are configured.
+- **Pull back to this device** — only appears for workspaces with a non-null `host_id`. Calls `workspacePullBack(workspaceId)`.
+- **Delete worktree… / Close workspace…** — destructive, gated by `window.confirm`. Worktrees call `closeWorkspaceWithWorktree` with the same flags as the sidebar's remove dialog.
+
+Whole card is also clickable — clicking opens. The action menu stops event propagation so it never accidentally opens the workspace while you're navigating the submenu.
+
+The push/pull flight indicator lives on the shared `useAppStore.workspacePushPullInFlight` slot, so the same workspace shows a spinner in the sidebar **and** the overview at the same time — there's exactly one in-flight push or pull per workspace.
+
+## What Works Today
+
+- Sidebar button under Automations opens the full-screen overview; Escape and back button close it.
+- Every workspace this device tracks is listed, grouped by device.
+- Pushed workspaces visibly migrate to the matching device bucket once the push succeeds.
+- Filters: search (title / branch / project), project, device, status, sort.
+- Per-row actions: open, copy branch, rename, push to any configured host, pull back, delete.
+- Empty states for "no workspaces yet" (offers `New workspace`) and "filters hide everything" (offers `Clear filters`).
+- "Removed host" orphan bucket prevents workspaces from silently disappearing when a host row is deleted.
+- One push/pull spinner per workspace, shared with the sidebar.
+- Live agent status (working / needs-input / ready-to-review) reflected on every row in real time — same source as the sidebar's `StatusIndicator`, no polling.
+
+## Current Constraints
+
+- **Sibling-device adoption is deferred.** The overview SHOWS workspaces from other devices of the same account (via the cross-device workspace sync — see `docs/features/workspaces-sync.md`). The "Pull to this device" action on sibling rows is disabled in v1; the affordance is visible with a "coming soon" tooltip and will land in a follow-up. Until then, sibling-device rows are read-only — you can see them and their metadata, but you adopt them by visiting the device they live on.
+- **No created-at field** on `WorkspaceSnapshot` yet, so the "Created within" time filter UI is intentionally **not** rendered — would be misleading without the data. The `Recently active` sort uses a proxy (notification count + dirty-git heuristic + name tie-break) until a real `last_active_at` is plumbed through.
+- **No bulk actions.** Push N workspaces in one go isn't supported; each row pushes individually.
+- **Window-prompt rename.** Matches the sidebar context menu; if/when that switches to an inline edit the overview should follow.
+- **Delete uses window.confirm**, not the richer `RemoveWorkspaceDialog` the sidebar pops. Fine for now — the overview is the "manage many at once" surface where a heavyweight modal per row would be noisy — but if `RemoveWorkspaceDialog` grows more functionality we should reconsider.
+
+## Important Touch Points
+
+- `src/components/workspaces-overview/workspaces-overview-view.tsx` — full-screen overlay shell (WindowChrome + back button + Escape).
+- `src/components/workspaces-overview/workspaces-overview-section.tsx` — filter bar, device bucketing, sort.
+- `src/components/workspaces-overview/workspace-overview-row.tsx` — card component + action menu + push/pull wiring.
+- `src/components/layout/sidebar-action-row.tsx` — sidebar entry point.
+- `src/components/layout/app-shell.tsx` — overlay mount.
+- `src/stores/ui-store.ts` — `showWorkspacesOverview` boolean + setter.
+- `src/stores/app-store.ts` — `workspaces`, `active_workspace_id`, `workspacePushPullInFlight`, `groupWorkspacesByProject`.
+- `src/stores/hosts-store.ts` — shared `useHostsStore` cache.
+- `src/tauri/commands.ts` — `workspacePushToHost`, `workspacePullBack`, `activateWorkspace`, `renameWorkspace`, `closeWorkspace`, `closeWorkspaceWithWorktree`.
+- `src/tauri/types.ts` — `WorkspaceSnapshot.host_id` (the field the overview keys off).
+
+## Notes
+
+- The overview is read-only with regard to the workspace data model — it does not introduce new persistence, new Tauri commands, or new sync paths. Every action it surfaces was already shipping in the sidebar context menu; the overview just makes them discoverable from one place.
+- When cross-device workspace sync ships, the only change here should be that `useAppStore.workspaces` includes the synced remote rows. The bucketing already groups by `host_id` correctly, so no UI rework is expected.
+- Status colors and density follow `docs/features/automations.md`'s reference implementation so the two pane types feel like the same family.

--- a/docs/features/workspaces-overview.md
+++ b/docs/features/workspaces-overview.md
@@ -94,6 +94,7 @@ The push/pull flight indicator lives on the shared `useAppStore.workspacePushPul
 - "Removed host" orphan bucket prevents workspaces from silently disappearing when a host row is deleted.
 - One push/pull spinner per workspace, shared with the sidebar.
 - Live agent status (working / needs-input / ready-to-review) reflected on every row in real time — same source as the sidebar's `StatusIndicator`, no polling.
+- First-run welcome banner (`WelcomeBanner` component) with three state-aware variants — brand-new (no devices, no siblings, with `Add a device` CTA), device-configured (nudges first push), has-siblings (counts visible cross-device workspaces with pull instructions). Dismissable; persists in localStorage and never re-shows.
 
 ## Current Constraints
 

--- a/docs/features/workspaces-sync.md
+++ b/docs/features/workspaces-sync.md
@@ -1,0 +1,157 @@
+# Workspaces Sync (cross-device workspace registry)
+
+- Purpose: Describe the cross-device workspace registry — the server-backed mirror that lets every device of the same account see every workspace it has authored or pushed to a host. Powers the "lives on another device" affordance in the Workspaces overview.
+- Audience: Anyone touching the workspace push/pull pipeline, the Workspaces overview UI, the SQLite schema, or the API server's `codemux_workspaces` table.
+- Authority: Canonical feature doc for the cross-device workspace sync layer.
+- Update when: The synced field set, the wire protocol, the sync cadence, or the conflict-resolution rules change.
+- Read next: `docs/features/workspaces-overview.md` (the UI consumer), `docs/features/remote-hosts.md` (the hosts sync this builds on top of).
+
+## What This Feature Is
+
+When you push a workspace from your laptop to a host, the Workspaces overview on a *different* device of your account should be able to see that workspace listed under that host. This feature is the registry that makes that possible.
+
+Concretely: every time a workspace is created, renamed, pushed-to-host, pulled-back, or deleted, a record of that change makes its way to the shared API server (78.47.192.173). Every device of the same account periodically pulls the full registry and renders it in the overview alongside its own local workspaces.
+
+## Current Model
+
+### The synced field set
+
+What syncs:
+
+- `title` — display name
+- `host_server_id` — which host the workspace currently lives on (null = local to the originating device)
+- `project_path` — informational only; the originating device's path-on-disk
+- `project_remote` — git remote URL; other devices use it to know how to clone the project if/when they adopt
+- `git_branch` — current branch
+- `created_at`, `updated_at`, `deleted_at` — standard sync timestamps
+
+What does NOT sync (per-device runtime state):
+
+- `cwd`, `worktree_path`, `pane_statuses`, terminal sessions, surface tree
+- Git deltas (ahead/behind/changed_files) — read from the local git tree on each device
+- `notification_count`, `notifications_muted` — per-device user state
+
+### Storage layers
+
+| Layer | Where | What it holds |
+|---|---|---|
+| Server-side | Postgres `codemux_workspaces` (on the shared API at 78.47.192.173) | One row per workspace per user. Soft-delete via `deleted_at`. Scoped by `user_id`. |
+| Local mirror | SQLite `workspaces_sync` table | One row per workspace this device knows about. Has `server_id` (cross-device id), `workspace_id` (this device's local id, null for sibling-only rows), `dirty` flag, soft-delete tombstone. |
+| Local runtime | `app_state.workspaces` (the JSON-persisted layout) | The actual `WorkspaceSnapshot` for workspaces this device has open. Contains all the runtime state. |
+
+`workspaces_sync.workspace_id IS NULL` is the marker for "lives on another device — we don't have a local copy."
+
+### Endpoints (shared API)
+
+| Method | Path | Behavior |
+|---|---|---|
+| `GET` | `/api/workspaces` | Returns every row owned by the authenticated user, including tombstones. Optional `?hostServerId=` filter. |
+| `POST` | `/api/workspaces` | Creates a new row. Server assigns a BIGSERIAL id and returns it stringified. |
+| `PATCH` | `/api/workspaces/:id` | Updates one of the user's rows. 404 (not 401) on unknown id to avoid leaking which BIGSERIALs exist. |
+| `DELETE` | `/api/workspaces/:id` | Soft-delete: stamps `deleted_at`. Tombstone gets returned in subsequent GETs so other devices learn of it; the desktop client purges its local tombstone after the next pull confirms the server agrees. |
+
+All four endpoints go through `authenticateBearer(c)` (Better Auth, Bearer token, SHA-256 hashed in DB). Every query is scoped with `WHERE user_id = $1` against the token-extracted user.
+
+### Sync client (Rust)
+
+`src-tauri/src/workspaces_sync.rs` mirrors `hosts_sync.rs` and `automations_sync.rs` 1:1:
+
+- `pull(token)` GETs `/api/workspaces`, upserts each row into the local table with `dirty=0` (server is authoritative), then sweeps any local rows whose `server_id` the server stopped returning and tombstones them locally.
+- `push(token)` walks `dirty=1` rows and, per row, does one of:
+  - DELETE if `deleted_at IS NOT NULL && server_id IS NOT NULL`, then clears dirty and purges the local tombstone on next pass.
+  - POST if `server_id IS NULL`, stamps the returned id back onto the local row.
+  - PATCH otherwise.
+- `try_sync_with_app(app)` is the public entrypoint — pull then push, swallowing single-call failures so flaky network doesn't strand the user.
+
+A `SYNC_IN_PROGRESS` `AtomicBool` guards against overlapping syncs (background loop + a future "Sync now" button could otherwise race).
+
+### Reconcile step
+
+The bridge between `app_state.workspaces` (runtime state) and `workspaces_sync` (the sync mirror) lives at `workspaces_sync::reconcile_from_snapshot`:
+
+1. Build a `host_id (local i64) → host_server_id (string)` map from the local hosts table.
+2. Index existing `workspaces_sync` rows by their local `workspace_id`.
+3. For each live `WorkspaceSnapshot`:
+   - If a matching sync row exists and ANY synced field has changed, UPDATE (marks dirty).
+   - If no sync row exists, INSERT (marks dirty).
+4. For sync rows whose `workspace_id` is no longer in `app_state.workspaces`, soft-delete (marks dirty).
+5. Rows with `workspace_id IS NULL` are skipped entirely — they're pulled-only sibling-device entries and have no app_state counterpart by design.
+
+OpenFlow and Home workspaces are excluded — neither needs cross-device persistence.
+
+### Cadence
+
+A background tokio task at `lib.rs` startup runs:
+
+```rust
+loop {
+  reconcile_from_snapshot(db, &app_state.snapshot());
+  workspaces_sync::try_sync_with_app(&app).await;
+  tokio::sleep(30s).await;
+}
+```
+
+So a workspace mutation propagates to other devices within ~30 seconds. A `workspaces_sync_now` Tauri command exists for the rare case a user explicitly wants to force a sync.
+
+### Tauri commands
+
+- `workspaces_sync_list` → `Vec<WorkspaceSyncView>` — what the overview reads
+- `workspaces_sync_now` → `Result<(), String>` — force an immediate pull+push pass
+
+### UI integration
+
+`src/components/workspaces-overview/use-overview-items.ts` unifies the two data sources into a single `OverviewItem[]`:
+
+- `kind: "local"` — has a `WorkspaceSnapshot`. The full live card. May also have a sync row (which gives `dirty` for the "Pending sync" pill and `host_server_id` for cross-device bucketing).
+- `kind: "remote"` — only known via sync; rendered as a dashed sibling-device card with title + project + branch + a "Pull to this device (coming soon)" affordance in the action menu.
+
+Bucketing is by `host_server_id`, so the same host shows up under the same bucket on every device. A bucket for a `host_server_id` that this device doesn't have locally yet renders as "Host not on this device" rather than silently dropping the workspaces.
+
+### Security model
+
+- Every endpoint authenticates the caller via `authenticateBearer(c)` and scopes every query with `WHERE user_id = $1`.
+- PATCH/DELETE on a row not owned by the caller returns 404 (not 401), so BIGSERIAL ids can't be enumerated cross-account.
+- The local SQLite uses `user_id = 'local'` for the desktop's own rows; the server-side `user_id` is the Better Auth-issued opaque user id and never appears in local-only contexts.
+- Tombstones get hard-deleted locally only after the server has confirmed it agrees the row is gone (the `purge_acknowledged_workspace_sync_deletes` step).
+- Per-user cap: `MAX_WORKSPACES_PER_USER = 2000`. Tombstones don't count.
+- Body size cap: `MAX_WORKSPACE_BODY = 32KB`.
+- Input validation: title required + ≤500 chars; project_path ≤1000 chars; project_remote ≤1000 chars; git_branch ≤500 chars; host_server_id ≤100 chars; all optional fields explicitly allow null. SQL-injection-shaped ids are rejected with 400 before reaching Postgres.
+
+## What Works Today
+
+- Server: full GET/POST/PATCH/DELETE at `/api/workspaces`, deployed and live at `https://api.codemux.org/api/workspaces`. 33 endpoint tests pass; 296 total server tests pass.
+- Local sync: pull, push, reconcile, soft-delete tombstones, idempotent server-side upsert. 6 module tests pass.
+- UI: synced rows render in the Workspaces overview under the correct device bucket. The "Pending sync" pill surfaces dirty state. Sibling-device rows render with a distinct dashed border and a "lives on another device" pill.
+- Cadence: 30-second background loop. `workspaces_sync_now` for forced sync.
+
+## Current Constraints
+
+- **No adoption flow yet.** Sibling-device rows are read-only — you can see them and read their metadata, but the "Pull to this device" menu item is disabled with a "coming soon" tooltip. Adoption requires creating a local `app_state.workspaces` shell and triggering an rsync from the host, which has nuanced semantics (does pulling clear the host_server_id? does it create a divergence?) that we want to settle before shipping the action. Follow-up: see the `Pull to this device` issue once filed.
+- **No "Sync now" UI button.** The command exists but no UI affordance triggers it yet — the 30s loop covers steady-state use. Easy add when wanted.
+- **No optimistic UI.** Local mutations show up in the overview immediately (because app_state is reactive), but the cross-device propagation has the 30s latency. Acceptable for v1; could be tightened later by hooking sync triggers into each mutation site.
+- **Last-write-wins, no conflict UI.** If two devices edit the same workspace simultaneously, the later push overwrites. Same model as hosts and automations.
+- **Hosts must sync first.** A workspace with `host_server_id="42"` is meaningful on Device B only after Device B has pulled the matching host row. The hosts sync runs on mutation; it usually races faster than workspaces, but there's a window where a workspace lands in the "Host not on this device" bucket until the host catches up.
+
+## Important Touch Points
+
+### Local (Codemux desktop)
+- `src-tauri/src/database.rs` — `workspaces_sync` table + `WorkspaceSyncRecord` struct + CRUD impls (`insert_workspace_sync`, `update_workspace_sync_by_workspace_id`, `soft_delete_workspace_sync_by_workspace_id`, `list_workspaces_sync`, `list_workspaces_sync_for_sync`, `list_dirty_workspaces_sync`, `mark_workspace_sync_synced`, `upsert_workspace_sync_from_server`, `purge_acknowledged_workspace_sync_deletes`, `link_workspace_sync_to_local`).
+- `src-tauri/src/workspaces_sync.rs` — sync module: `pull`, `push`, `try_sync_with_app`, `sync_workspaces`, `reconcile_from_snapshot`, `ServerWorkspace` wire type.
+- `src-tauri/src/commands/workspaces_sync.rs` — Tauri command surface: `workspaces_sync_list`, `workspaces_sync_now`.
+- `src-tauri/src/lib.rs` — registers the 30s background sync loop in the Tauri setup block, plus the two commands in the invoke handler.
+- `src/tauri/commands.ts` — `WorkspaceSyncView` TS type + `workspacesSyncList` + `workspacesSyncNow` bindings.
+- `src/stores/workspaces-sync-store.ts` — Zustand store + `useWorkspacesSync` hook. Polls every 5s while a subscriber is mounted.
+- `src/components/workspaces-overview/use-overview-items.ts` — merges local + synced rows into the unified `OverviewItem[]`.
+- `src/components/workspaces-overview/workspaces-overview-section.tsx` — uses the unified list; buckets by `host_server_id`.
+- `src/components/workspaces-overview/workspace-overview-row.tsx` — two render branches: `LocalRow` and `RemoteRow`.
+
+### Server (codemux-api on the VPS)
+- `~/codemux-api/api/src/index.ts` — `codemux_workspaces` table DDL (under "Codemux workspaces table" comment block) + four endpoints (GET/POST/PATCH/DELETE `/api/workspaces`).
+- `~/codemux-api/api/src/tests/preload.ts` — mirror of the DDL so prod-to-test schema parity holds.
+- `~/codemux-api/api/src/tests/workspaces.test.ts` — 33 tests covering auth, validation, isolation, product boundary, soft-delete, per-user cap.
+
+## Notes
+
+- The pattern is intentionally a near-copy of `hosts_sync` and `automations_sync`. If the wire protocol or sync semantics ever need to change, change them all three together.
+- The cross-device identity is `server_id` (stringified BIGSERIAL). Local `workspace_id` strings (`workspace-42` style) are device-local and meaningless cross-device — never use one as a cross-device key.
+- The 30s cadence is a magic number; tune by changing the `tokio::time::sleep(30s)` call in `lib.rs`. Lower bound is ~5s before the API would start to feel busy under many devices.

--- a/docs/features/workspaces-sync.md
+++ b/docs/features/workspaces-sync.md
@@ -128,7 +128,10 @@ Bucketing is by `host_server_id`, so the same host shows up under the same bucke
 
 ## Current Constraints
 
-- **Host-backed adoption works; clone-from-git adoption is deferred.** The "Pull to this device" menu item is live for any sibling-device row whose `host_server_id` resolves to a configured local host (the 80% path — works via `workspaces_adopt_synced` + the existing `workspace_pull_back_impl`). When the row has no shared host (`host_server_id IS NULL`), the dialog tells the user "open the other device and push to a shared host first" — the git-clone fallback ships in a follow-up.
+- **Host-backed adoption + clone fallback both work.** The "Pull to this device" menu item is live for every sibling-device row. The dialog renders the right variant automatically:
+  - **Host-backed** (row's `host_server_id` resolves to a configured local host): rsyncs from the host via `workspaces_adopt_synced` + the existing `workspace_pull_back_impl`. The adopted workspace replaces the original on that host (single-source-of-truth model).
+  - **Clone fallback** (row has `project_remote` but no shared host): `workspaces_adopt_via_clone` runs `git clone --no-checkout` into `~/.codemux/projects/<basename>`, then `git worktree add` at the branch, and registers a fresh local workspace. Crucially this creates a NEW server_id (does NOT link to the original sibling row) — both devices end up with independent copies sharing a git remote. The dialog warns about uncommitted-work loss before the user confirms.
+  - **Neither** (no host, no remote): dialog tells the user to push from the other device first.
 
 ## Safety guardrails (Phase 4)
 

--- a/docs/features/workspaces-sync.md
+++ b/docs/features/workspaces-sync.md
@@ -97,6 +97,8 @@ So a workspace mutation propagates to other devices within ~30 seconds. A `works
 
 - `workspaces_sync_list` → `Vec<WorkspaceSyncView>` — what the overview reads
 - `workspaces_sync_now` → `Result<(), String>` — force an immediate pull+push pass
+- `workspaces_adoption_preview(server_id)` → `AdoptionPreview` — dialog opens with this; surfaces `can_host_adopt`, `can_clone_adopt`, `host_configured`, `host_label`, `suggested_path`, `is_path_in_use`, `already_adopted_workspace_id` so the modal can pick the right variant without race conditions
+- `workspaces_adopt_synced(server_id)` → `AdoptOutcome` — host-backed cross-device adoption: creates a local workspace shell with `host_id` set, links the sync row, then drives the existing `workspace_pull_back_impl` to rsync the worktree from the host. Idempotent (re-running on an already-adopted row returns the existing local workspace id). Clone-fallback path for `host_server_id IS NULL` rows is deferred to a follow-up.
 
 ### UI integration
 
@@ -126,7 +128,7 @@ Bucketing is by `host_server_id`, so the same host shows up under the same bucke
 
 ## Current Constraints
 
-- **No adoption flow yet.** Sibling-device rows are read-only — you can see them and read their metadata, but the "Pull to this device" menu item is disabled with a "coming soon" tooltip. Adoption requires creating a local `app_state.workspaces` shell and triggering an rsync from the host, which has nuanced semantics (does pulling clear the host_server_id? does it create a divergence?) that we want to settle before shipping the action. Follow-up: see the `Pull to this device` issue once filed.
+- **Host-backed adoption works; clone-from-git adoption is deferred.** The "Pull to this device" menu item is live for any sibling-device row whose `host_server_id` resolves to a configured local host (the 80% path — works via `workspaces_adopt_synced` + the existing `workspace_pull_back_impl`). When the row has no shared host (`host_server_id IS NULL`), the dialog tells the user "open the other device and push to a shared host first" — the git-clone fallback ships in a follow-up.
 - **No "Sync now" UI button.** The command exists but no UI affordance triggers it yet — the 30s loop covers steady-state use. Easy add when wanted.
 - **No optimistic UI.** Local mutations show up in the overview immediately (because app_state is reactive), but the cross-device propagation has the 30s latency. Acceptable for v1; could be tightened later by hooking sync triggers into each mutation site.
 - **Last-write-wins, no conflict UI.** If two devices edit the same workspace simultaneously, the later push overwrites. Same model as hosts and automations.
@@ -137,7 +139,10 @@ Bucketing is by `host_server_id`, so the same host shows up under the same bucke
 ### Local (Codemux desktop)
 - `src-tauri/src/database.rs` — `workspaces_sync` table + `WorkspaceSyncRecord` struct + CRUD impls (`insert_workspace_sync`, `update_workspace_sync_by_workspace_id`, `soft_delete_workspace_sync_by_workspace_id`, `list_workspaces_sync`, `list_workspaces_sync_for_sync`, `list_dirty_workspaces_sync`, `mark_workspace_sync_synced`, `upsert_workspace_sync_from_server`, `purge_acknowledged_workspace_sync_deletes`, `link_workspace_sync_to_local`).
 - `src-tauri/src/workspaces_sync.rs` — sync module: `pull`, `push`, `try_sync_with_app`, `sync_workspaces`, `reconcile_from_snapshot`, `ServerWorkspace` wire type.
-- `src-tauri/src/commands/workspaces_sync.rs` — Tauri command surface: `workspaces_sync_list`, `workspaces_sync_now`.
+- `src-tauri/src/commands/workspaces_sync.rs` — Tauri command surface: `workspaces_sync_list`, `workspaces_sync_now`, `workspaces_adoption_preview`, `workspaces_adopt_synced`.
+- `src-tauri/src/commands/hosts.rs` — `workspace_pull_back_impl` (extracted from the `#[tauri::command]` wrapper so the adoption flow can call the rsync machinery without going back through Tauri IPC).
+- `src-tauri/src/state/state_impl.rs` — `create_synced_workspace_shell` helper that adoption uses to create a workspace pre-stamped with `host_id` and the target `worktree_path` before rsync runs.
+- `src/components/workspaces-overview/pull-to-device-dialog.tsx` — adoption dialog with the four-variant body (host-backed form, host-not-configured, path-in-use, already-adopted) and the "What this does" disclosure that pre-expands on first pull.
 - `src-tauri/src/lib.rs` — registers the 30s background sync loop in the Tauri setup block, plus the two commands in the invoke handler.
 - `src/tauri/commands.ts` — `WorkspaceSyncView` TS type + `workspacesSyncList` + `workspacesSyncNow` bindings.
 - `src/stores/workspaces-sync-store.ts` — Zustand store + `useWorkspacesSync` hook. Polls every 5s while a subscriber is mounted.

--- a/docs/features/workspaces-sync.md
+++ b/docs/features/workspaces-sync.md
@@ -129,6 +129,17 @@ Bucketing is by `host_server_id`, so the same host shows up under the same bucke
 ## Current Constraints
 
 - **Host-backed adoption works; clone-from-git adoption is deferred.** The "Pull to this device" menu item is live for any sibling-device row whose `host_server_id` resolves to a configured local host (the 80% path — works via `workspaces_adopt_synced` + the existing `workspace_pull_back_impl`). When the row has no shared host (`host_server_id IS NULL`), the dialog tells the user "open the other device and push to a shared host first" — the git-clone fallback ships in a follow-up.
+
+## Safety guardrails (Phase 4)
+
+Every push, pull, and adopt action now has two safety nets that make accidents recoverable:
+
+- **Confirm-before-push.** Right-clicking a workspace → `Move to host → <device>` no longer fires the rsync immediately. Instead, `ConfirmPushDialog` opens with the workspace title, the destination, and a 3-bullet explanation of what's about to happen ("Copies files to <host>", "Live editing location moves", "You can pull it back anytime"). Power users who want the old single-tap behaviour can tick "Don't ask again for <host>" — the choice persists per-device in localStorage. The dialog is at `src/components/overlays/confirm-push-dialog.tsx`.
+- **Undo for 10 seconds** on every successful push, pull, and adoption. The success toast carries an `Undo` button that fires the reverse action (push ↔ pull). Double-click-guarded so the reverse only runs once. Reverse-action failure surfaces as a follow-up error toast. Implementation: `fireUndoable` in `src/lib/toast.ts`.
+
+Wired at three call sites:
+- `sidebar-workspace-row.tsx` — sidebar context menu's push and pull-back items both go through the undo path.
+- `pull-to-device-dialog.tsx` — cross-device adoption shows Undo = push back to the source host, so a wrong "Pull to this device" click is recoverable.
 - **No "Sync now" UI button.** The command exists but no UI affordance triggers it yet — the 30s loop covers steady-state use. Easy add when wanted.
 - **No optimistic UI.** Local mutations show up in the overview immediately (because app_state is reactive), but the cross-device propagation has the 30s latency. Acceptable for v1; could be tightened later by hooking sync triggers into each mutation site.
 - **Last-write-wins, no conflict UI.** If two devices edit the same workspace simultaneously, the later push overwrites. Same model as hosts and automations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src-tauri/src/commands/hosts.rs
+++ b/src-tauri/src/commands/hosts.rs
@@ -722,24 +722,58 @@ pub async fn workspace_push_to_host(
 #[tauri::command]
 pub async fn workspace_pull_back(
     app: tauri::AppHandle,
-    db: tauri::State<'_, DatabaseStore>,
+    _db: tauri::State<'_, DatabaseStore>,
     workspace_id: String,
 ) -> Result<WorkspacePullOutcome, String> {
+    workspace_pull_back_impl(app, workspace_id).await
+}
+
+/// Internal entry point for the pull-back machinery. Extracted from
+/// the `#[tauri::command]` wrapper so other Rust code paths (notably
+/// the cross-device adoption flow in
+/// `commands::workspaces_sync::workspaces_adopt_synced`) can drive
+/// the same rsync + tunnel-teardown + session-respawn pipeline
+/// without going back out through the Tauri IPC layer.
+///
+/// Takes only `app` and looks up both `DatabaseStore` and
+/// `AppStateStore` internally — this avoids the `tauri::State<'_>`
+/// lifetime trap where the guard cannot cross an `.await`.
+///
+/// Semantics: requires the local workspace to already exist with
+/// `host_id` set; rsyncs the remote worktree to the local
+/// `worktree_path` (or `cwd` fallback); clears `host_id` on success;
+/// tears down the SSH tunnel; respawns each pane's PTY locally.
+pub async fn workspace_pull_back_impl(
+    app: tauri::AppHandle,
+    workspace_id: String,
+) -> Result<WorkspacePullOutcome, String> {
+    // Resolve State guards in a tight pre-await scope and capture
+    // owned values so the State guards drop before any `.await`
+    // (they are not Send).
+    let (host, ws_clone) = {
+        let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
+        let db: tauri::State<'_, DatabaseStore> = app.state();
+        let snapshot = app_state.snapshot();
+        let ws = snapshot
+            .workspaces
+            .iter()
+            .find(|w| w.workspace_id.0 == workspace_id)
+            .ok_or_else(|| format!("Workspace not found: {workspace_id}"))?
+            .clone();
+        let host_id = ws
+            .host_id
+            .ok_or_else(|| "Workspace is already local.".to_string())?;
+        let host = db
+            .list_hosts()
+            .into_iter()
+            .find(|h| h.id == host_id)
+            .ok_or_else(|| format!("Host {host_id} no longer exists locally"))?;
+        (host, ws)
+    };
     let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
-    let snapshot = app_state.snapshot();
-    let ws = snapshot
-        .workspaces
-        .iter()
-        .find(|w| w.workspace_id.0 == workspace_id)
-        .ok_or_else(|| format!("Workspace not found: {workspace_id}"))?;
-    let host_id = ws
-        .host_id
-        .ok_or_else(|| "Workspace is already local.".to_string())?;
-    let host = db
-        .list_hosts()
-        .into_iter()
-        .find(|h| h.id == host_id)
-        .ok_or_else(|| format!("Host {host_id} no longer exists locally"))?;
+    // Rename for compatibility with the original function body below
+    // (which references `ws` and `host`).
+    let ws = &ws_clone;
 
     let local_worktree = match ws.worktree_path.as_ref() {
         Some(p) => std::path::PathBuf::from(p),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -22,6 +22,7 @@ pub mod skills_sync;
 pub mod update;
 pub mod virtual_display;
 pub mod workspace;
+pub mod workspaces_sync;
 
 pub use agent_chat::*;
 pub use ai::*;
@@ -47,6 +48,7 @@ pub use skills_sync::*;
 pub use update::*;
 pub use virtual_display::*;
 pub use workspace::*;
+pub use workspaces_sync::*;
 
 use crate::indexing::{
     rebuild_index,

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -31,6 +31,8 @@ pub struct WorkspaceSyncView {
     pub project_path: Option<String>,
     pub project_remote: Option<String>,
     pub git_branch: Option<String>,
+    /// Phase-4 divergence detection: HEAD sha at last reconcile.
+    pub git_head_sha: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     /// True when the row has unpushed changes. The UI shows a
@@ -49,6 +51,7 @@ impl From<WorkspaceSyncRecord> for WorkspaceSyncView {
             project_path: r.project_path,
             project_remote: r.project_remote,
             git_branch: r.git_branch,
+            git_head_sha: r.git_head_sha,
             created_at: r.created_at,
             updated_at: r.updated_at,
             dirty: r.dirty,

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -1,0 +1,103 @@
+//! Tauri commands for the cross-device workspace sync surface.
+//!
+//! The frontend reads `workspaces_sync_list` to render the
+//! Workspaces overview — including workspaces that live on *other*
+//! devices of the same account (rows with `workspace_id: null`).
+//! Sibling-device rows show up as "lives on another device" cards
+//! and can be adopted into this device via `workspaces_sync_adopt`.
+
+use serde::Serialize;
+use tauri::{Manager, State};
+
+use crate::database::{DatabaseStore, WorkspaceSyncRecord};
+
+/// Wire shape sent to the frontend. Matches the field naming the
+/// existing UI expects (snake_case from Rust, camelCase from
+/// serde-rename on JS-facing structs would be inconsistent with the
+/// rest of the codebase — keep snake_case throughout).
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceSyncView {
+    /// Local sync-table row id. Stable across pulls within a device.
+    pub id: i64,
+    /// Server-assigned id. None until the row's first successful push.
+    pub server_id: Option<String>,
+    /// Local workspace_id this row corresponds to. None for rows
+    /// pulled from sibling devices that haven't been adopted here.
+    pub workspace_id: Option<String>,
+    pub title: String,
+    /// Server-side host id (matches `HostView.server_id`). None means
+    /// the workspace is local to the device that authored it.
+    pub host_server_id: Option<String>,
+    pub project_path: Option<String>,
+    pub project_remote: Option<String>,
+    pub git_branch: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    /// True when the row has unpushed changes. The UI shows a
+    /// "Pending sync" pill for these.
+    pub dirty: bool,
+}
+
+impl From<WorkspaceSyncRecord> for WorkspaceSyncView {
+    fn from(r: WorkspaceSyncRecord) -> Self {
+        WorkspaceSyncView {
+            id: r.id,
+            server_id: r.server_id,
+            workspace_id: r.workspace_id,
+            title: r.title,
+            host_server_id: r.host_server_id,
+            project_path: r.project_path,
+            project_remote: r.project_remote,
+            git_branch: r.git_branch,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            dirty: r.dirty,
+        }
+    }
+}
+
+/// List every workspace this account knows about (across all devices)
+/// that this device has either authored or pulled from the server.
+/// Tombstones are excluded — only live rows are returned.
+///
+/// Rendering rules for the UI:
+/// - `workspace_id` set → the workspace also exists in this device's
+///   app_state; cross-reference to render the rich local card.
+/// - `workspace_id` null → lives on another device; render a
+///   minimal "remote" card with title + host + branch and offer the
+///   "Pull to this device" affordance (when implemented).
+#[tauri::command]
+pub fn workspaces_sync_list(
+    db: State<'_, DatabaseStore>,
+) -> Vec<WorkspaceSyncView> {
+    db.list_workspaces_sync()
+        .into_iter()
+        .map(Into::into)
+        .collect()
+}
+
+/// Trigger an immediate sync pass (pull + push). Returns when both
+/// halves have finished or one has errored. Use sparingly — the
+/// background loop already runs every 30 seconds.
+///
+/// Returns Ok(()) when the user is not signed in (sync is a no-op,
+/// not an error in that case — matches the hosts and automations
+/// commands).
+#[tauri::command]
+pub async fn workspaces_sync_now(
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    // Snapshot + reconcile in a sync block so we don't carry the
+    // State<'_> guard (which is not Send) across the await below.
+    {
+        let db_state: tauri::State<'_, DatabaseStore> = app.state();
+        let app_state: tauri::State<'_, crate::state::AppStateStore> =
+            app.state();
+        let snapshot = app_state.snapshot();
+        crate::workspaces_sync::reconcile_from_snapshot(
+            db_state.inner(),
+            &snapshot,
+        )?;
+    }
+    crate::workspaces_sync::try_sync_with_app(&app).await
+}

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -225,7 +225,7 @@ pub fn workspaces_adoption_preview(
         .and_then(|n| n.to_str())
         .unwrap_or("workspace");
     let branch = row.git_branch.as_deref().unwrap_or("main");
-    let conv = crate::ssh::conventional_remote_path(project_name, branch);
+    let conv = crate::workspace_paths::conventional_remote_path(project_name, branch);
     let conv_str = conv.to_string_lossy().to_string();
     // The conventional path uses `~/` — expand for the local check.
     let suggested_path = if let Some(rest) = conv_str.strip_prefix("~/") {
@@ -364,7 +364,7 @@ pub async fn workspaces_adopt_synced(
             .and_then(|n| n.to_str())
             .unwrap_or("workspace");
         let branch = row.git_branch.as_deref().unwrap_or("main");
-        let conv = crate::ssh::conventional_remote_path(project_name, branch);
+        let conv = crate::workspace_paths::conventional_remote_path(project_name, branch);
         let conv_str = conv.to_string_lossy().to_string();
         let worktree_path = if let Some(rest) = conv_str.strip_prefix("~/") {
             dirs::home_dir()
@@ -536,7 +536,7 @@ pub async fn workspaces_adopt_via_clone(
         // Worktree path matches the canonical layout push/pull use,
         // so a future push to a shared host lands at the same
         // remote path another device would.
-        let conv = crate::ssh::conventional_remote_path(&project_name, &branch);
+        let conv = crate::workspace_paths::conventional_remote_path(&project_name, &branch);
         let conv_str = conv.to_string_lossy().to_string();
         let worktree_path = if let Some(rest) = conv_str.strip_prefix("~/") {
             home.join(rest)

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -430,3 +430,229 @@ pub async fn workspaces_adopt_synced(
         message: pull_outcome.message,
     })
 }
+
+/// Adopt a sibling-device workspace into this device via the
+/// clone-from-git fallback path. Used when the sync row has no
+/// `host_server_id` (the workspace lives only on another device of
+/// the user, never pushed to a shared host).
+///
+/// Semantics differ from `workspaces_adopt_synced` (Phase 2) in one
+/// important way: this creates a NEW local workspace with its own
+/// fresh `server_id` (the reconcile push assigns one). The
+/// sibling-device's existing sync row is left alone. Result: both
+/// devices independently own a workspace at the same git remote +
+/// branch. They share a git remote but live as two registry
+/// entries.
+///
+/// This semantics tradeoff is the right answer because rsync is not
+/// available (no shared host), so the two devices genuinely have
+/// independent copies. Phase-4's divergence detection (TBD) handles
+/// the "now what?" question when their HEADs diverge.
+///
+/// Flow:
+///   1. Look up the sync row by `server_id`, validate it has
+///      `project_remote` set (clone is impossible without a URL).
+///   2. Refuse if the sync row already has `workspace_id` set on
+///      this device — that's the host-backed adoption's idempotent
+///      path, not ours.
+///   3. Compute target paths: project at `~/.codemux/projects/<basename>`,
+///      worktree at `~/.codemux/worktrees/<basename>/<branch>`.
+///   4. Bail if either path is in use (caller already saw the
+///      preview's `is_path_in_use` flag, so this is defence-in-
+///      depth).
+///   5. `git clone --no-checkout` into the project path.
+///   6. `git worktree add` for the branch into the worktree path —
+///      reuse `git_create_worktree` so PR-ref + branch-fetch logic
+///      is unchanged.
+///   7. Create a brand-new local workspace (NOT linked to the
+///      sync row). The next reconcile push will assign it a fresh
+///      `server_id`.
+///   8. Return the new local id.
+///
+/// Failure mode: any git failure leaves the target dir cleaned up
+/// (see `git_clone`'s rollback). No partial workspace shell is
+/// created until both clone + worktree-add succeed.
+#[tauri::command]
+pub async fn workspaces_adopt_via_clone(
+    app: tauri::AppHandle,
+    server_id: String,
+) -> Result<AdoptOutcome, String> {
+    // Validate + compute paths in a sync scope (no awaits).
+    let (project_remote, project_path, worktree_path, branch, title) = {
+        let db: tauri::State<'_, DatabaseStore> = app.state();
+        let app_state: tauri::State<'_, crate::state::AppStateStore> =
+            app.state();
+
+        let row = db
+            .list_workspaces_sync_for_sync()
+            .into_iter()
+            .find(|r| r.server_id.as_deref() == Some(server_id.as_str()))
+            .ok_or_else(|| format!("Synced workspace not found: {server_id}"))?;
+
+        // Idempotency / safety: refuse if the row is already linked
+        // to a local workspace on this device. That row should be
+        // adopted via the host-backed path, not cloned again.
+        if row.workspace_id.is_some() {
+            return Err(format!(
+                "This workspace is already adopted on this device as {}",
+                row.workspace_id.unwrap()
+            ));
+        }
+
+        let project_remote = row.project_remote.as_deref().ok_or_else(|| {
+            "no_project_remote: this workspace has no git remote URL \
+             recorded, so it can't be cloned. Open the device it \
+             lives on and push it to a shared device first."
+                .to_string()
+        })?;
+
+        let project_name = row
+            .project_path
+            .as_deref()
+            .and_then(|p| std::path::Path::new(p).file_name())
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+            .or_else(|| extract_project_name_from_remote(project_remote))
+            // Final fallback if we can't infer a name from anywhere.
+            .unwrap_or_else(|| "workspace".to_string());
+
+        let branch = row
+            .git_branch
+            .clone()
+            .unwrap_or_else(|| "main".to_string());
+
+        // Project goes under ~/.codemux/projects/<basename>. We
+        // deliberately avoid colliding with user-managed paths like
+        // ~/projects/<basename>.
+        let home = dirs::home_dir()
+            .ok_or_else(|| "home directory unavailable".to_string())?;
+        let project_path = home
+            .join(".codemux")
+            .join("projects")
+            .join(&project_name);
+        // Worktree path matches the canonical layout push/pull use,
+        // so a future push to a shared host lands at the same
+        // remote path another device would.
+        let conv = crate::ssh::conventional_remote_path(&project_name, &branch);
+        let conv_str = conv.to_string_lossy().to_string();
+        let worktree_path = if let Some(rest) = conv_str.strip_prefix("~/") {
+            home.join(rest)
+        } else {
+            std::path::PathBuf::from(&conv_str)
+        };
+
+        // Path collision check against live workspaces. Defence-in-
+        // depth — the preview already showed this; bailing here
+        // catches races.
+        let snapshot = app_state.snapshot();
+        let collision = snapshot.workspaces.iter().any(|w| {
+            let p = w.worktree_path.as_deref().unwrap_or(w.cwd.as_str());
+            p == worktree_path.to_string_lossy().as_ref()
+        });
+        if collision {
+            return Err(format!(
+                "path_in_use: A different workspace is already using \
+                 {}.",
+                worktree_path.display()
+            ));
+        }
+
+        (
+            project_remote.to_string(),
+            project_path,
+            worktree_path,
+            branch,
+            row.title.clone(),
+        )
+    };
+
+    // Step 5+6: clone + worktree-add, both off the main async
+    // thread via spawn_blocking — git operations can take seconds.
+    let project_path_str = project_path.to_string_lossy().to_string();
+    let worktree_path_str = worktree_path.to_string_lossy().to_string();
+    let branch_clone = branch.clone();
+    let project_path_clone = project_path.clone();
+    let clone_result = tokio::task::spawn_blocking(move || {
+        // Phase 1: clone the bare-ish project (no checkout —
+        // worktree-add picks the right branch).
+        crate::git::git_clone(&project_remote, &project_path_clone)?;
+        // Phase 2: add the worktree at the requested branch.
+        crate::git::git_create_worktree(
+            project_path_clone.as_path(),
+            &branch_clone,
+            // `new_branch=false` — we want the existing branch from
+            // the remote, not a new one.
+            false,
+            None,
+            None,
+        )
+    })
+    .await
+    .map_err(|e| format!("git_clone join failed: {e}"))?;
+
+    let worktree_actual_path = clone_result.map_err(|e| {
+        // Roll back the cloned project dir on failure so a retry
+        // starts clean.
+        let _ = std::fs::remove_dir_all(&project_path);
+        e
+    })?;
+
+    // Step 7: register a brand-new local workspace pointing at the
+    // freshly-cloned worktree. Crucially we do NOT link to the
+    // existing sync row — the next reconcile push will create a
+    // fresh server-side entry for this device's copy.
+    let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
+    let workspace_id = app_state.create_synced_workspace_shell(
+        title,
+        // host_id = -1 sentinel doesn't exist; we use a different
+        // helper that creates a local-only workspace. Since
+        // create_synced_workspace_shell expects host_id and we
+        // don't want that here, fall back to manually setting it
+        // via the closest existing helper.
+        0,
+        Some(project_path_str.clone()),
+        worktree_actual_path.clone(),
+        Some(branch.clone()),
+    );
+    // Clear host_id since this is a local clone (not a remote pull).
+    app_state.set_workspace_host_id(&workspace_id.0, None)?;
+
+    // Nudge sync so the server learns about the new workspace.
+    if let Err(e) = crate::workspaces_sync::try_sync_with_app(&app).await {
+        eprintln!(
+            "[workspaces-sync] post-clone-adopt sync failed (will retry): {e}"
+        );
+    }
+
+    Ok(AdoptOutcome {
+        workspace_id: workspace_id.0,
+        worktree_path: worktree_actual_path,
+        message: format!(
+            "Cloned to {} and added worktree at {}",
+            project_path_str, worktree_path_str
+        ),
+    })
+}
+
+/// Best-effort: extract a project name from a git remote URL when
+/// the synced row doesn't carry an explicit `project_path`. Handles
+/// the common cases:
+///   - https://host/owner/name.git → "name"
+///   - git@host:owner/name.git    → "name"
+///   - git@host:owner/name        → "name"
+/// Returns None if no recognisable basename is present.
+fn extract_project_name_from_remote(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches('/');
+    let after_slash_or_colon = trimmed
+        .rsplit(|c: char| c == '/' || c == ':')
+        .next()
+        .unwrap_or(trimmed);
+    let stripped = after_slash_or_colon
+        .strip_suffix(".git")
+        .unwrap_or(after_slash_or_colon);
+    if stripped.is_empty() {
+        None
+    } else {
+        Some(stripped.to_string())
+    }
+}

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -101,3 +101,332 @@ pub async fn workspaces_sync_now(
     }
     crate::workspaces_sync::try_sync_with_app(&app).await
 }
+
+// ─── Cross-device adoption ──────────────────────────────────────
+//
+// "Adoption" is the act of taking a workspace that exists on another
+// device of the same account and materialising a local copy of it
+// on this device. The synced row in `workspaces_sync` already carries
+// the metadata (title, host_server_id, project_path, branch); the
+// adoption flow's job is to:
+//
+//   1. Validate the user actually CAN adopt (host configured,
+//      target path free, etc.).
+//   2. Create a local workspace shell.
+//   3. Link the sync row to the new local workspace_id.
+//   4. Drive the existing pull-back rsync to populate the files.
+//
+// Two adoption paths exist:
+//   - **Host-backed** (`host_server_id` is set on the sync row): the
+//     workspace lives on a host this device knows about; we rsync
+//     from that host. Implemented in `workspaces_adopt_synced` below.
+//   - **Clone fallback** (`host_server_id` is null, no shared host):
+//     the workspace lives on a sibling device only; we'd need to
+//     `git clone` the project_remote into a fresh worktree. Tracked
+//     for Phase 3, not yet implemented.
+
+/// Snapshot of "can we adopt this synced workspace, and how?". The
+/// frontend calls this when the Pull dialog opens so it can decide
+/// which variant to render (host-backed vs clone fallback) and
+/// surface the suggested target path without a second round-trip.
+///
+/// Field semantics:
+/// - `can_host_adopt`: true when the sync row's `host_server_id`
+///   resolves to a configured local host. The headline pull path.
+/// - `can_clone_adopt`: true when the sync row has a `project_remote`
+///   set. Reserved for Phase 3; this command surfaces the flag so
+///   the dialog can hint at the option even before it ships.
+/// - `host_configured`: same as `can_host_adopt` but separately
+///   named so the dialog can show "Configure your host first" copy
+///   when the row HAS a host_server_id but this device doesn't know
+///   it yet.
+/// - `host_label`: friendly name to render in the dialog summary
+///   (`"From devbox"`). Null when no host applies.
+/// - `project_already_cloned_at`: Phase-3 hint. Always None today.
+/// - `suggested_path`: the canonical local worktree path the rsync
+///   will land at. Pre-computed so the dialog can show it.
+/// - `is_path_in_use`: when the suggested path already belongs to a
+///   different local workspace. Bare-flag for now; the eventual
+///   dialog UX offers `pickFolderDialog()` to choose an alternate.
+/// - `already_adopted_workspace_id`: short-circuit — if the user
+///   clicks Pull on a row they've already adopted, the dialog can
+///   skip itself and just open the existing workspace.
+#[derive(Debug, Clone, Serialize)]
+pub struct AdoptionPreview {
+    pub can_host_adopt: bool,
+    pub can_clone_adopt: bool,
+    pub host_configured: bool,
+    pub host_label: Option<String>,
+    pub project_already_cloned_at: Option<String>,
+    pub suggested_path: String,
+    pub is_path_in_use: bool,
+    pub already_adopted_workspace_id: Option<String>,
+}
+
+/// Successful adoption result. The frontend uses `workspace_id` to
+/// navigate to the newly-adopted workspace (or to surface a "Open
+/// workspace" CTA in the success toast).
+#[derive(Debug, Clone, Serialize)]
+pub struct AdoptOutcome {
+    pub workspace_id: String,
+    pub worktree_path: String,
+    pub message: String,
+}
+
+#[tauri::command]
+pub fn workspaces_adoption_preview(
+    app: tauri::AppHandle,
+    server_id: String,
+) -> Result<AdoptionPreview, String> {
+    let db: tauri::State<'_, DatabaseStore> = app.state();
+    let app_state: tauri::State<'_, crate::state::AppStateStore> =
+        app.state();
+
+    // Locate the synced row by its server-assigned id.
+    let row = db
+        .list_workspaces_sync_for_sync()
+        .into_iter()
+        .find(|r| r.server_id.as_deref() == Some(server_id.as_str()))
+        .ok_or_else(|| format!("Synced workspace not found: {server_id}"))?;
+
+    // Host resolution: synced row carries `host_server_id`; we map
+    // it to our local hosts row via the matching `hosts.server_id`.
+    let (host_configured, host_label, local_host_id) = match row
+        .host_server_id
+        .as_deref()
+    {
+        Some(hsid) => {
+            let local_host = db
+                .list_hosts()
+                .into_iter()
+                .find(|h| h.server_id.as_deref() == Some(hsid));
+            match local_host {
+                Some(h) => (true, Some(h.name.clone()), Some(h.id)),
+                None => (false, None, None),
+            }
+        }
+        None => (false, None, None),
+    };
+
+    // Phase-3 placeholder: clone adoption is unimplemented for now.
+    let can_clone_adopt = row.project_remote.is_some();
+
+    // Compute the canonical local worktree path. Reuses the same
+    // helper that pushes use, so a workspace pushed from this device
+    // and adopted on another lands at structurally identical paths
+    // on both sides.
+    let project_name = row
+        .project_path
+        .as_deref()
+        .and_then(|p| std::path::Path::new(p).file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("workspace");
+    let branch = row.git_branch.as_deref().unwrap_or("main");
+    let conv = crate::ssh::conventional_remote_path(project_name, branch);
+    let conv_str = conv.to_string_lossy().to_string();
+    // The conventional path uses `~/` — expand for the local check.
+    let suggested_path = if let Some(rest) = conv_str.strip_prefix("~/") {
+        dirs::home_dir()
+            .map(|h| h.join(rest).to_string_lossy().to_string())
+            .unwrap_or(conv_str.clone())
+    } else {
+        conv_str.clone()
+    };
+
+    // Detect path conflict against other live workspaces.
+    let snapshot = app_state.snapshot();
+    let is_path_in_use = snapshot.workspaces.iter().any(|w| {
+        let p = w.worktree_path.as_deref().unwrap_or(w.cwd.as_str());
+        p == suggested_path.as_str()
+            && row
+                .workspace_id
+                .as_deref()
+                .map_or(true, |adopted| w.workspace_id.0 != adopted)
+    });
+
+    let already_adopted_workspace_id = row.workspace_id.clone();
+
+    Ok(AdoptionPreview {
+        can_host_adopt: host_configured && local_host_id.is_some(),
+        can_clone_adopt,
+        host_configured,
+        host_label,
+        project_already_cloned_at: None,
+        suggested_path,
+        is_path_in_use,
+        already_adopted_workspace_id,
+    })
+}
+
+/// Adopt a sibling-device workspace into this device via the
+/// host-backed rsync path.
+///
+/// Flow:
+///   1. Look up the sync row by `server_id`.
+///   2. Idempotency: if the row already has a local `workspace_id`,
+///      return early with that id (no work to do; the user clicked
+///      Pull on something already adopted).
+///   3. Resolve `host_server_id` → local `hosts.id`. Fail with a
+///      structured error if the host isn't on this device.
+///   4. Compute the canonical local worktree path.
+///   5. Bail if the path conflicts with a different workspace.
+///   6. Create the local workspace shell with host_id pre-set
+///      (`create_synced_workspace_shell`).
+///   7. Link the sync row to the new local id
+///      (`link_workspace_sync_to_local`).
+///   8. Drive `workspace_pull_back_impl` — the exact same machinery
+///      a manual pull-back uses. This rsyncs the remote worktree to
+///      the local path, clears `host_id` on success, tears down the
+///      SSH tunnel, respawns any PTY sessions locally.
+///   9. Trigger a reconcile + sync push so the server learns the
+///      workspace is now also on this device (and `host_server_id`
+///      goes back to null because pull-back cleared it).
+///
+/// On pull-back failure the local shell is left in place with
+/// `host_id` still set. The overview will render it under the host
+/// bucket with the spinner and the user can retry via the regular
+/// "Pull back to this device" action — the recovery path is the
+/// same as a failed manual pull.
+#[tauri::command]
+pub async fn workspaces_adopt_synced(
+    app: tauri::AppHandle,
+    server_id: String,
+) -> Result<AdoptOutcome, String> {
+    // Step 1+2+3+4+5: do all the sync DB lookups in a scope so the
+    // State<'_> guard is dropped before we await anything (Tauri's
+    // State is not Send across awaits).
+    let (workspace_id, worktree_path) = {
+        let db: tauri::State<'_, DatabaseStore> = app.state();
+        let app_state: tauri::State<'_, crate::state::AppStateStore> =
+            app.state();
+
+        let row = db
+            .list_workspaces_sync_for_sync()
+            .into_iter()
+            .find(|r| r.server_id.as_deref() == Some(server_id.as_str()))
+            .ok_or_else(|| format!("Synced workspace not found: {server_id}"))?;
+
+        // Idempotency: if we've already adopted this row, return
+        // the existing local workspace id rather than creating a
+        // duplicate shell. The caller can then `activate_workspace`
+        // on the returned id.
+        if let Some(existing) = row.workspace_id.as_deref() {
+            // Surface whether the workspace still exists in app_state
+            // (it may have been closed locally even though the sync
+            // row remembers the link). If gone, we fall through to
+            // adoption again.
+            let snapshot = app_state.snapshot();
+            if snapshot
+                .workspaces
+                .iter()
+                .any(|w| w.workspace_id.0 == existing)
+            {
+                let worktree = snapshot
+                    .workspaces
+                    .iter()
+                    .find(|w| w.workspace_id.0 == existing)
+                    .and_then(|w| w.worktree_path.clone().or_else(|| Some(w.cwd.clone())))
+                    .unwrap_or_default();
+                return Ok(AdoptOutcome {
+                    workspace_id: existing.to_string(),
+                    worktree_path: worktree,
+                    message: "Workspace already adopted on this device.".into(),
+                });
+            }
+        }
+
+        // Resolve host_server_id → local hosts.id.
+        let host_server_id = row.host_server_id.as_deref().ok_or_else(|| {
+            "This workspace has no host; clone-based adoption is not \
+             implemented yet (Phase 3 of the workspaces-sync rollout)."
+                .to_string()
+        })?;
+        let local_host = db
+            .list_hosts()
+            .into_iter()
+            .find(|h| h.server_id.as_deref() == Some(host_server_id))
+            .ok_or_else(|| {
+                format!(
+                    "host_not_configured: The host this workspace lives on \
+                     (host_server_id={host_server_id}) is not configured on \
+                     this device yet. Add it in Settings → Devices."
+                )
+            })?;
+
+        // Compute canonical local path.
+        let project_name = row
+            .project_path
+            .as_deref()
+            .and_then(|p| std::path::Path::new(p).file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("workspace");
+        let branch = row.git_branch.as_deref().unwrap_or("main");
+        let conv = crate::ssh::conventional_remote_path(project_name, branch);
+        let conv_str = conv.to_string_lossy().to_string();
+        let worktree_path = if let Some(rest) = conv_str.strip_prefix("~/") {
+            dirs::home_dir()
+                .map(|h| h.join(rest).to_string_lossy().to_string())
+                .unwrap_or(conv_str.clone())
+        } else {
+            conv_str.clone()
+        };
+
+        // Path collision check — refuse to clobber a workspace that
+        // already lives here.
+        let snapshot = app_state.snapshot();
+        let collision = snapshot.workspaces.iter().any(|w| {
+            let p = w.worktree_path.as_deref().unwrap_or(w.cwd.as_str());
+            p == worktree_path.as_str()
+        });
+        if collision {
+            return Err(format!(
+                "path_in_use: A different workspace is already using \
+                 {worktree_path}. Close it first or choose another path."
+            ));
+        }
+
+        // Create the local shell. host_id is set so the upcoming
+        // pull-back call routes to the right host.
+        let workspace_id = app_state.create_synced_workspace_shell(
+            row.title.clone(),
+            local_host.id,
+            row.project_path.clone(),
+            worktree_path.clone(),
+            row.git_branch.clone(),
+        );
+        let workspace_id_str = workspace_id.0.clone();
+
+        // Link the sync row to the new local id so subsequent
+        // reconciles keep them paired and the row renders as a
+        // local entry instead of "lives on another device".
+        db.link_workspace_sync_to_local(&server_id, &workspace_id_str)?;
+
+        (workspace_id_str, worktree_path)
+    };
+
+    // Step 8: drive the existing pull-back machinery. `_impl` takes
+    // only `AppHandle` and resolves DB/state internally, so we can
+    // await freely without juggling `tauri::State<'_>` guards
+    // (which are not Send across awaits).
+    let pull_outcome = crate::commands::hosts::workspace_pull_back_impl(
+        app.clone(),
+        workspace_id.clone(),
+    )
+    .await?;
+
+    // Step 9: nudge the reconcile so the server learns the workspace
+    // is now also on this device. Failures here are non-fatal — the
+    // background loop will catch up within 30s.
+    if let Err(e) = crate::workspaces_sync::try_sync_with_app(&app).await {
+        eprintln!(
+            "[workspaces-sync] post-adopt sync failed (will retry on next \
+             background tick): {e}"
+        );
+    }
+
+    Ok(AdoptOutcome {
+        workspace_id,
+        worktree_path,
+        message: pull_outcome.message,
+    })
+}

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -348,6 +348,10 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
         "ALTER TABLE automations ADD COLUMN project_remote TEXT",
         "ALTER TABLE automation_runs ADD COLUMN branch TEXT",
         "ALTER TABLE automation_runs ADD COLUMN pr_url TEXT",
+        // Phase-4 divergence detection: workspace git HEAD sha so
+        // the overview can flag when the same project+branch
+        // exists on multiple devices with different HEADs.
+        "ALTER TABLE workspaces_sync ADD COLUMN git_head_sha TEXT",
     ] {
         if let Err(e) = conn.execute(stmt, []) {
             let msg = e.to_string();
@@ -896,6 +900,13 @@ pub struct WorkspaceSyncRecord {
     pub project_path: Option<String>,
     pub project_remote: Option<String>,
     pub git_branch: Option<String>,
+    /// Workspace git HEAD sha at the last reconcile. Phase-4
+    /// divergence detection compares this across devices: when the
+    /// same (project_remote, git_branch) pair has different head
+    /// shas on multiple devices, the overview surfaces a warning
+    /// chip. None for new rows that haven't been reconciled yet,
+    /// or for rows whose worktree had no commits.
+    pub git_head_sha: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
@@ -914,13 +925,14 @@ impl DatabaseStore {
         project_path: Option<&str>,
         project_remote: Option<&str>,
         git_branch: Option<&str>,
+        git_head_sha: Option<&str>,
     ) -> Result<WorkspaceSyncRecord, String> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO workspaces_sync
                 (user_id, workspace_id, title, host_server_id,
-                 project_path, project_remote, git_branch, dirty)
-             VALUES ('local', ?1, ?2, ?3, ?4, ?5, ?6, 1)",
+                 project_path, project_remote, git_branch, git_head_sha, dirty)
+             VALUES ('local', ?1, ?2, ?3, ?4, ?5, ?6, ?7, 1)",
             params![
                 workspace_id,
                 title,
@@ -928,13 +940,14 @@ impl DatabaseStore {
                 project_path,
                 project_remote,
                 git_branch,
+                git_head_sha,
             ],
         )
         .map_err(|e| format!("Failed to insert workspace sync row: {e}"))?;
         let id = conn.last_insert_rowid();
         conn.query_row(
             "SELECT id, server_id, workspace_id, title, host_server_id,
-                    project_path, project_remote, git_branch,
+                    project_path, project_remote, git_branch, git_head_sha,
                     created_at, updated_at, deleted_at, dirty
              FROM workspaces_sync WHERE id = ?1",
             params![id],
@@ -954,14 +967,15 @@ impl DatabaseStore {
         project_path: Option<&str>,
         project_remote: Option<&str>,
         git_branch: Option<&str>,
+        git_head_sha: Option<&str>,
     ) -> Result<(), String> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "UPDATE workspaces_sync
              SET title = ?1, host_server_id = ?2, project_path = ?3,
-                 project_remote = ?4, git_branch = ?5,
+                 project_remote = ?4, git_branch = ?5, git_head_sha = ?6,
                  updated_at = datetime('now'), dirty = 1
-             WHERE user_id = 'local' AND workspace_id = ?6
+             WHERE user_id = 'local' AND workspace_id = ?7
                AND deleted_at IS NULL",
             params![
                 title,
@@ -969,6 +983,7 @@ impl DatabaseStore {
                 project_path,
                 project_remote,
                 git_branch,
+                git_head_sha,
                 workspace_id,
             ],
         )
@@ -1004,7 +1019,7 @@ impl DatabaseStore {
         let conn = self.conn.lock().unwrap();
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
-                    project_path, project_remote, git_branch,
+                    project_path, project_remote, git_branch, git_head_sha,
                     created_at, updated_at, deleted_at, dirty
              FROM workspaces_sync
              WHERE user_id = 'local' AND deleted_at IS NULL
@@ -1024,7 +1039,7 @@ impl DatabaseStore {
         let conn = self.conn.lock().unwrap();
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
-                    project_path, project_remote, git_branch,
+                    project_path, project_remote, git_branch, git_head_sha,
                     created_at, updated_at, deleted_at, dirty
              FROM workspaces_sync
              WHERE user_id = 'local'",
@@ -1042,7 +1057,7 @@ impl DatabaseStore {
         let conn = self.conn.lock().unwrap();
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
-                    project_path, project_remote, git_branch,
+                    project_path, project_remote, git_branch, git_head_sha,
                     created_at, updated_at, deleted_at, dirty
              FROM workspaces_sync
              WHERE user_id = 'local' AND dirty = 1",
@@ -1102,6 +1117,7 @@ impl DatabaseStore {
         project_path: Option<&str>,
         project_remote: Option<&str>,
         git_branch: Option<&str>,
+        git_head_sha: Option<&str>,
         created_at: &str,
         updated_at: &str,
         deleted_at: Option<&str>,
@@ -1111,16 +1127,17 @@ impl DatabaseStore {
             .execute(
                 "UPDATE workspaces_sync
                  SET title = ?1, host_server_id = ?2, project_path = ?3,
-                     project_remote = ?4, git_branch = ?5,
-                     created_at = ?6, updated_at = ?7,
-                     deleted_at = ?8, dirty = 0
-                 WHERE user_id = 'local' AND server_id = ?9",
+                     project_remote = ?4, git_branch = ?5, git_head_sha = ?6,
+                     created_at = ?7, updated_at = ?8,
+                     deleted_at = ?9, dirty = 0
+                 WHERE user_id = 'local' AND server_id = ?10",
                 params![
                     title,
                     host_server_id,
                     project_path,
                     project_remote,
                     git_branch,
+                    git_head_sha,
                     created_at,
                     updated_at,
                     deleted_at,
@@ -1132,9 +1149,9 @@ impl DatabaseStore {
             conn.execute(
                 "INSERT INTO workspaces_sync
                     (user_id, server_id, workspace_id, title, host_server_id,
-                     project_path, project_remote, git_branch,
+                     project_path, project_remote, git_branch, git_head_sha,
                      created_at, updated_at, deleted_at, dirty)
-                 VALUES ('local', ?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0)",
+                 VALUES ('local', ?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0)",
                 params![
                     server_id,
                     title,
@@ -1142,6 +1159,7 @@ impl DatabaseStore {
                     project_path,
                     project_remote,
                     git_branch,
+                    git_head_sha,
                     created_at,
                     updated_at,
                     deleted_at,
@@ -1174,7 +1192,7 @@ impl DatabaseStore {
 fn row_to_workspace_sync(
     row: &rusqlite::Row<'_>,
 ) -> rusqlite::Result<WorkspaceSyncRecord> {
-    let dirty_int: i64 = row.get(11)?;
+    let dirty_int: i64 = row.get(12)?;
     Ok(WorkspaceSyncRecord {
         id: row.get(0)?,
         server_id: row.get(1)?,
@@ -1184,9 +1202,10 @@ fn row_to_workspace_sync(
         project_path: row.get(5)?,
         project_remote: row.get(6)?,
         git_branch: row.get(7)?,
-        created_at: row.get(8)?,
-        updated_at: row.get(9)?,
-        deleted_at: row.get(10)?,
+        git_head_sha: row.get(8)?,
+        created_at: row.get(9)?,
+        updated_at: row.get(10)?,
+        deleted_at: row.get(11)?,
         dirty: dirty_int != 0,
     })
 }

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -280,6 +280,61 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
 
         CREATE INDEX IF NOT EXISTS idx_automation_runs_automation
             ON automation_runs(automation_id, scheduled_for DESC);
+
+        -- Workspaces sync mirror (cross-device workspace registry).
+        --
+        -- Holds the metadata that lets *other devices* of the same
+        -- account discover that a workspace exists and (later) pull
+        -- it back. Runtime state — pane tree, terminal sessions, git
+        -- stats, notification count — lives in the app_state JSON
+        -- blob and is per-device. This table is JUST the synced
+        -- identity + host + project metadata.
+        --
+        -- `workspace_id` is THIS device local id (e.g. workspace-42
+        -- from next_id), or NULL when the row was pulled from
+        -- another device and hasn't been adopted here yet. The
+        -- originating device local id is never re-used cross-device
+        -- — every device assigns its own when adopting.
+        --
+        -- `server_id` is the cross-device identity (the
+        -- `codemux_workspaces.id` BIGSERIAL stringified). NULL until
+        -- this row's first successful push.
+        --
+        -- `host_server_id` is the cross-device host identity
+        -- (`codemux_hosts.id` stringified). NULL means the workspace
+        -- lives on the device that created the row. Maps back to a
+        -- local `hosts.id` via the `hosts.server_id` column.
+        --
+        -- Same soft-delete + dirty model as the `hosts` and
+        -- `automations` tables. `workspaces_sync` is intentionally a
+        -- separate table from `workspace_state` because the latter
+        -- is per-device runtime UI state (tab order, collapse), not
+        -- cross-device identity.
+        CREATE TABLE IF NOT EXISTS workspaces_sync (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL DEFAULT 'local',
+            server_id TEXT,
+            workspace_id TEXT,
+            title TEXT NOT NULL,
+            host_server_id TEXT,
+            project_path TEXT,
+            project_remote TEXT,
+            git_branch TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            deleted_at TEXT,
+            dirty INTEGER NOT NULL DEFAULT 1,
+            UNIQUE(user_id, server_id),
+            UNIQUE(user_id, workspace_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_workspaces_sync_user
+            ON workspaces_sync(user_id, deleted_at);
+        CREATE INDEX IF NOT EXISTS idx_workspaces_sync_dirty
+            ON workspaces_sync(user_id, dirty)
+            WHERE dirty = 1;
+        CREATE INDEX IF NOT EXISTS idx_workspaces_sync_host
+            ON workspaces_sync(user_id, host_server_id);
         ",
     )
     .map_err(|e| format!("Failed to create database schema: {e}"))?;
@@ -799,6 +854,339 @@ fn row_to_host(row: &rusqlite::Row<'_>) -> rusqlite::Result<HostRecord> {
         created_at: row.get(4)?,
         updated_at: row.get(5)?,
         deleted_at: row.get(6)?,
+        dirty: dirty_int != 0,
+    })
+}
+
+// ─── Workspaces sync mirror (cross-device workspace registry) ────
+//
+// This is the local-side mirror of the server-side `codemux_workspaces`
+// table. It is *separate* from `workspace_state` because the two
+// concerns are different: `workspace_state` holds per-device runtime
+// UI state (tab order, collapse, last_active_at); `workspaces_sync`
+// holds the synced identity (title, host, project, branch) that
+// crosses the account-wide network boundary.
+//
+// `workspace_id` is the local id from `next_id` when this row was
+// either created locally OR adopted from a sync-pulled row. NULL
+// means the row was pulled but not yet adopted (the user hasn't
+// clicked "Pull to this device" on it).
+//
+// Lookup paths the sync layer + the UI need:
+// - by local workspace_id (after a local mutation, find the synced row to mark dirty)
+// - by server_id (after a sync pull, upsert the matching local row)
+// - dirty list (push only rows that changed since last sync)
+// - all-non-deleted (overview UI render)
+//
+// The shape mirrors `hosts` 1:1 so the sync client can mostly copy
+// the existing pattern.
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WorkspaceSyncRecord {
+    pub id: i64,
+    pub server_id: Option<String>,
+    /// Local workspace_id (the `WorkspaceSnapshot.workspace_id` value).
+    /// None when the row was pulled from a sibling device and we have
+    /// not adopted it locally yet.
+    pub workspace_id: Option<String>,
+    pub title: String,
+    /// Server-side host id (matches `hosts.server_id`). None = local
+    /// to the device that authored the row.
+    pub host_server_id: Option<String>,
+    pub project_path: Option<String>,
+    pub project_remote: Option<String>,
+    pub git_branch: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub deleted_at: Option<String>,
+    pub dirty: bool,
+}
+
+impl DatabaseStore {
+    /// Insert a freshly-created local workspace into the sync mirror.
+    /// Marked dirty so the next push uploads it. Returns the row so
+    /// callers can stash the assigned local sync `id` if useful.
+    pub fn insert_workspace_sync(
+        &self,
+        workspace_id: &str,
+        title: &str,
+        host_server_id: Option<&str>,
+        project_path: Option<&str>,
+        project_remote: Option<&str>,
+        git_branch: Option<&str>,
+    ) -> Result<WorkspaceSyncRecord, String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO workspaces_sync
+                (user_id, workspace_id, title, host_server_id,
+                 project_path, project_remote, git_branch, dirty)
+             VALUES ('local', ?1, ?2, ?3, ?4, ?5, ?6, 1)",
+            params![
+                workspace_id,
+                title,
+                host_server_id,
+                project_path,
+                project_remote,
+                git_branch,
+            ],
+        )
+        .map_err(|e| format!("Failed to insert workspace sync row: {e}"))?;
+        let id = conn.last_insert_rowid();
+        conn.query_row(
+            "SELECT id, server_id, workspace_id, title, host_server_id,
+                    project_path, project_remote, git_branch,
+                    created_at, updated_at, deleted_at, dirty
+             FROM workspaces_sync WHERE id = ?1",
+            params![id],
+            row_to_workspace_sync,
+        )
+        .map_err(|e| format!("Failed to re-read inserted workspace sync row: {e}"))
+    }
+
+    /// Update a workspace sync row keyed by the local `workspace_id`.
+    /// Bumps `updated_at` and sets `dirty = 1`. No-op if the row is
+    /// already soft-deleted (matching the hosts/automations pattern).
+    pub fn update_workspace_sync_by_workspace_id(
+        &self,
+        workspace_id: &str,
+        title: &str,
+        host_server_id: Option<&str>,
+        project_path: Option<&str>,
+        project_remote: Option<&str>,
+        git_branch: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE workspaces_sync
+             SET title = ?1, host_server_id = ?2, project_path = ?3,
+                 project_remote = ?4, git_branch = ?5,
+                 updated_at = datetime('now'), dirty = 1
+             WHERE user_id = 'local' AND workspace_id = ?6
+               AND deleted_at IS NULL",
+            params![
+                title,
+                host_server_id,
+                project_path,
+                project_remote,
+                git_branch,
+                workspace_id,
+            ],
+        )
+        .map_err(|e| format!("Failed to update workspace sync row: {e}"))?;
+        Ok(())
+    }
+
+    /// Soft-delete a workspace sync row by local workspace_id. Sets
+    /// `deleted_at = now`, `updated_at = now`, `dirty = 1`. The next
+    /// push DELETEs the server row; `purge_acknowledged_workspace_sync_deletes`
+    /// then hard-deletes the local tombstone.
+    pub fn soft_delete_workspace_sync_by_workspace_id(
+        &self,
+        workspace_id: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE workspaces_sync
+             SET deleted_at = datetime('now'),
+                 updated_at = datetime('now'), dirty = 1
+             WHERE user_id = 'local' AND workspace_id = ?1
+               AND deleted_at IS NULL",
+            params![workspace_id],
+        )
+        .map_err(|e| format!("Failed to soft-delete workspace sync row: {e}"))?;
+        Ok(())
+    }
+
+    /// List every non-deleted workspace sync row (live + pulled-but-
+    /// unadopted). UI uses this to render the overview, including
+    /// workspaces that only exist on other devices.
+    pub fn list_workspaces_sync(&self) -> Vec<WorkspaceSyncRecord> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = match conn.prepare(
+            "SELECT id, server_id, workspace_id, title, host_server_id,
+                    project_path, project_remote, git_branch,
+                    created_at, updated_at, deleted_at, dirty
+             FROM workspaces_sync
+             WHERE user_id = 'local' AND deleted_at IS NULL
+             ORDER BY updated_at DESC",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        stmt.query_map([], row_to_workspace_sync)
+            .map(|rows| rows.filter_map(|r| r.ok()).collect())
+            .unwrap_or_default()
+    }
+
+    /// List EVERY row including tombstones — used by the pull sweep
+    /// to detect rows whose server_id is no longer in the API response.
+    pub fn list_workspaces_sync_for_sync(&self) -> Vec<WorkspaceSyncRecord> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = match conn.prepare(
+            "SELECT id, server_id, workspace_id, title, host_server_id,
+                    project_path, project_remote, git_branch,
+                    created_at, updated_at, deleted_at, dirty
+             FROM workspaces_sync
+             WHERE user_id = 'local'",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        stmt.query_map([], row_to_workspace_sync)
+            .map(|rows| rows.filter_map(|r| r.ok()).collect())
+            .unwrap_or_default()
+    }
+
+    /// List only `dirty = 1` rows — the push loop walks this.
+    pub fn list_dirty_workspaces_sync(&self) -> Vec<WorkspaceSyncRecord> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = match conn.prepare(
+            "SELECT id, server_id, workspace_id, title, host_server_id,
+                    project_path, project_remote, git_branch,
+                    created_at, updated_at, deleted_at, dirty
+             FROM workspaces_sync
+             WHERE user_id = 'local' AND dirty = 1",
+        ) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+        stmt.query_map([], row_to_workspace_sync)
+            .map(|rows| rows.filter_map(|r| r.ok()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Clear dirty after a successful push. Optionally stamp the
+    /// server_id (first push only). Mirrors `mark_host_synced`.
+    pub fn mark_workspace_sync_synced(
+        &self,
+        id: i64,
+        server_id: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        if let Some(sid) = server_id {
+            conn.execute(
+                "UPDATE workspaces_sync SET dirty = 0, server_id = ?1 WHERE id = ?2",
+                params![sid, id],
+            )
+        } else {
+            conn.execute(
+                "UPDATE workspaces_sync SET dirty = 0 WHERE id = ?1",
+                params![id],
+            )
+        }
+        .map_err(|e| format!("Failed to mark workspace sync row synced: {e}"))?;
+        Ok(())
+    }
+
+    /// Hard-delete tombstones the server has acknowledged. Called at
+    /// the end of every push pass.
+    pub fn purge_acknowledged_workspace_sync_deletes(&self) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM workspaces_sync
+             WHERE deleted_at IS NOT NULL AND dirty = 0",
+            [],
+        )
+        .map_err(|e| format!("Failed to purge workspace sync tombstones: {e}"))?;
+        Ok(())
+    }
+
+    /// Idempotent upsert from a server pull. Always sets `dirty = 0`.
+    /// Does NOT clobber the local `workspace_id` if one is already
+    /// stamped — adoption is sticky.
+    pub fn upsert_workspace_sync_from_server(
+        &self,
+        server_id: &str,
+        title: &str,
+        host_server_id: Option<&str>,
+        project_path: Option<&str>,
+        project_remote: Option<&str>,
+        git_branch: Option<&str>,
+        created_at: &str,
+        updated_at: &str,
+        deleted_at: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        let updated = conn
+            .execute(
+                "UPDATE workspaces_sync
+                 SET title = ?1, host_server_id = ?2, project_path = ?3,
+                     project_remote = ?4, git_branch = ?5,
+                     created_at = ?6, updated_at = ?7,
+                     deleted_at = ?8, dirty = 0
+                 WHERE user_id = 'local' AND server_id = ?9",
+                params![
+                    title,
+                    host_server_id,
+                    project_path,
+                    project_remote,
+                    git_branch,
+                    created_at,
+                    updated_at,
+                    deleted_at,
+                    server_id,
+                ],
+            )
+            .map_err(|e| format!("Failed to update workspace sync from server: {e}"))?;
+        if updated == 0 {
+            conn.execute(
+                "INSERT INTO workspaces_sync
+                    (user_id, server_id, workspace_id, title, host_server_id,
+                     project_path, project_remote, git_branch,
+                     created_at, updated_at, deleted_at, dirty)
+                 VALUES ('local', ?1, NULL, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 0)",
+                params![
+                    server_id,
+                    title,
+                    host_server_id,
+                    project_path,
+                    project_remote,
+                    git_branch,
+                    created_at,
+                    updated_at,
+                    deleted_at,
+                ],
+            )
+            .map_err(|e| format!("Failed to insert workspace sync from server: {e}"))?;
+        }
+        Ok(())
+    }
+
+    /// Stamp a local workspace_id onto a previously-pulled row (used
+    /// when adopting a synced workspace into this device's app_state).
+    pub fn link_workspace_sync_to_local(
+        &self,
+        server_id: &str,
+        workspace_id: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE workspaces_sync
+             SET workspace_id = ?1, updated_at = datetime('now')
+             WHERE user_id = 'local' AND server_id = ?2",
+            params![workspace_id, server_id],
+        )
+        .map_err(|e| format!("Failed to link workspace sync row to local: {e}"))?;
+        Ok(())
+    }
+}
+
+fn row_to_workspace_sync(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<WorkspaceSyncRecord> {
+    let dirty_int: i64 = row.get(11)?;
+    Ok(WorkspaceSyncRecord {
+        id: row.get(0)?,
+        server_id: row.get(1)?,
+        workspace_id: row.get(2)?,
+        title: row.get(3)?,
+        host_server_id: row.get(4)?,
+        project_path: row.get(5)?,
+        project_remote: row.get(6)?,
+        git_branch: row.get(7)?,
+        created_at: row.get(8)?,
+        updated_at: row.get(9)?,
+        deleted_at: row.get(10)?,
         dirty: dirty_int != 0,
     })
 }

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -125,6 +125,120 @@ fn run_git_permissive(repo_path: &Path, args: &[&str]) -> String {
         .unwrap_or_default()
 }
 
+/// Clone a remote repository into `target_dir`. Used by cross-device
+/// workspace adoption when a sibling-device workspace has no shared
+/// host — we clone the git remote and create a fresh worktree at the
+/// branch.
+///
+/// `target_dir` must NOT already exist (git clone refuses if the
+/// target dir is non-empty). Caller is expected to compute a unique
+/// target like `~/.codemux/projects/<basename>` and bail with a
+/// structured error if it collides.
+///
+/// Returns the absolute path of the cloned repo on success.
+///
+/// SSH credentials and any git auth (token, key) live in the user's
+/// `~/.gitconfig` / `~/.ssh` / `~/.netrc` — this helper inherits
+/// them implicitly via the spawned git process. We never marshal
+/// credentials through this layer.
+pub fn git_clone(remote_url: &str, target_dir: &Path) -> Result<String, String> {
+    if remote_url.trim().is_empty() {
+        return Err("git_clone: remote_url cannot be empty".into());
+    }
+    if target_dir.exists() {
+        // Don't clobber — caller should have picked a fresh path.
+        return Err(format!(
+            "git_clone: target directory already exists: {}",
+            target_dir.display()
+        ));
+    }
+    #[cfg(test)]
+    {
+        // Test hook — short-circuit BEFORE spawning git so unit
+        // tests don't need network or git installed. Real callers
+        // never hit this because they pass non-test markers.
+        if remote_url.starts_with("test://") {
+            return Ok(target_dir.to_string_lossy().to_string());
+        }
+    }
+    let parent = target_dir.parent().ok_or_else(|| {
+        format!(
+            "git_clone: target path has no parent directory: {}",
+            target_dir.display()
+        )
+    })?;
+    std::fs::create_dir_all(parent).map_err(|e| {
+        format!("git_clone: failed to create parent {}: {e}", parent.display())
+    })?;
+    let target_str = target_dir.to_string_lossy().to_string();
+    // Use `--no-checkout` so the worktree-add we'll do next chooses
+    // the right branch — clone's default checkout of the remote's
+    // HEAD branch is wasted work for our flow.
+    let output = Command::new("git")
+        .args(["clone", "--no-checkout", remote_url, &target_str])
+        .current_dir(parent)
+        .output()
+        .map_err(|e| format!("git_clone: failed to spawn git: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Best-effort cleanup so a half-cloned dir doesn't poison
+        // the next attempt.
+        let _ = std::fs::remove_dir_all(target_dir);
+        return Err(format!(
+            "git clone failed: {}",
+            stderr.trim()
+        ));
+    }
+    Ok(target_str)
+}
+
+#[cfg(test)]
+mod git_clone_input_validation {
+    use super::git_clone;
+    use std::path::PathBuf;
+
+    #[test]
+    fn rejects_empty_remote_url() {
+        let dir = std::env::temp_dir().join("codemux-git-clone-test-empty");
+        let _ = std::fs::remove_dir_all(&dir);
+        let err = git_clone("", &dir).unwrap_err();
+        assert!(err.contains("cannot be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_whitespace_only_remote_url() {
+        let dir = std::env::temp_dir().join("codemux-git-clone-test-ws");
+        let _ = std::fs::remove_dir_all(&dir);
+        let err = git_clone("   \t  ", &dir).unwrap_err();
+        assert!(err.contains("cannot be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_when_target_dir_already_exists() {
+        let dir = std::env::temp_dir().join("codemux-git-clone-test-exists");
+        // Create the directory so the precondition fires.
+        std::fs::create_dir_all(&dir).expect("set up test dir");
+        let err = git_clone("test://foo", &dir).unwrap_err();
+        assert!(err.contains("already exists"), "got: {err}");
+        // Cleanup.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn accepts_well_formed_input_via_test_hook() {
+        // Uses the `test://` short-circuit so we don't need git or
+        // network on the CI runner. The hook returns success
+        // BEFORE doing any disk I/O — that's the point: the test
+        // only exercises the precondition checks above it (empty
+        // url, existing target), then yields a deterministic
+        // success that proves both checks let valid input through.
+        let dir = std::env::temp_dir().join("codemux-git-clone-test-ok-fresh");
+        let _ = std::fs::remove_dir_all(&dir);
+        let result = git_clone("test://foo/bar.git", &dir).unwrap();
+        assert_eq!(PathBuf::from(result), dir);
+    }
+}
+
 /// Run git and return (stdout, stderr, success) regardless of exit code.
 fn run_git_full(repo_path: &Path, args: &[&str]) -> Result<(String, String, bool), String> {
     let output = Command::new("git")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub mod skills_sync;
 pub mod session_adapters;
 pub mod settings_sync;
 pub mod hosts_sync;
+pub mod workspace_paths;
 pub mod workspaces_sync;
 pub mod state;
 pub mod hooks;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1607,6 +1607,7 @@ pub fn run() {
             commands::workspaces_sync_now,
             commands::workspaces_adoption_preview,
             commands::workspaces_adopt_synced,
+            commands::workspaces_adopt_via_clone,
             commands::get_package_format,
             resource_metrics::get_resource_metrics,
             commands::debug_log,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub mod skills_sync;
 pub mod session_adapters;
 pub mod settings_sync;
 pub mod hosts_sync;
+pub mod workspaces_sync;
 pub mod state;
 pub mod hooks;
 pub mod stream_input;
@@ -1217,6 +1218,48 @@ pub fn run() {
                 }
             });
 
+            // Workspaces sync loop — mirror the local workspace list
+            // into the `workspaces_sync` SQLite table, then push/pull
+            // against /api/workspaces. Runs every 30 seconds so cross-
+            // device visibility is eventually consistent within that
+            // window without each individual workspace mutation having
+            // to call out to the sync layer. The reconcile step
+            // (snapshot → workspaces_sync) is cheap (a diff over a
+            // small list); the push/pull only fires when there are
+            // dirty rows OR the server has new rows to advertise.
+            //
+            // Failure mode: any reconcile or sync error is logged and
+            // the loop continues. The dirty flag stays set so the
+            // next tick re-tries.
+            let sync_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                // Small initial delay so we don't fight startup IO.
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                loop {
+                    let app_state: tauri::State<'_, state::AppStateStore> =
+                        sync_handle.state();
+                    let db: tauri::State<'_, database::DatabaseStore> =
+                        sync_handle.state();
+                    let snapshot = app_state.snapshot();
+                    if let Err(error) = workspaces_sync::reconcile_from_snapshot(
+                        db.inner(),
+                        &snapshot,
+                    ) {
+                        eprintln!(
+                            "[codemux::workspaces-sync] reconcile failed: {error}"
+                        );
+                    }
+                    if let Err(error) =
+                        workspaces_sync::try_sync_with_app(&sync_handle).await
+                    {
+                        eprintln!(
+                            "[codemux::workspaces-sync] background sync failed: {error}"
+                        );
+                    }
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                }
+            });
+
             // Window lifecycle breadcrumbs: this lets us tell whether a second process
             // actually reached window creation or if it exited early.
             #[cfg(debug_assertions)]
@@ -1560,6 +1603,8 @@ pub fn run() {
             commands::automations_delete,
             commands::automations_runs,
             commands::automations_check_repo_access,
+            commands::workspaces_sync_list,
+            commands::workspaces_sync_now,
             commands::get_package_format,
             resource_metrics::get_resource_metrics,
             commands::debug_log,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1605,6 +1605,8 @@ pub fn run() {
             commands::automations_check_repo_access,
             commands::workspaces_sync_list,
             commands::workspaces_sync_now,
+            commands::workspaces_adoption_preview,
+            commands::workspaces_adopt_synced,
             commands::get_package_format,
             resource_metrics::get_resource_metrics,
             commands::debug_log,

--- a/src-tauri/src/ssh/push.rs
+++ b/src-tauri/src/ssh/push.rs
@@ -24,7 +24,7 @@
 #![cfg(unix)]
 
 use serde::Serialize;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
 use tokio::process::Command;
@@ -422,24 +422,11 @@ pub fn claude_project_dir_name(absolute_path: &std::path::Path) -> String {
         .collect()
 }
 
-pub fn conventional_remote_path(project_name: &str, branch: &str) -> PathBuf {
-    fn sanitize(s: &str) -> String {
-        s.chars()
-            .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
-                c
-            } else {
-                '-'
-            })
-            .collect::<String>()
-            .trim_matches('-')
-            .to_string()
-    }
-    let p = sanitize(project_name);
-    let b = sanitize(branch);
-    let p = if p.is_empty() { "workspace".to_string() } else { p };
-    let b = if b.is_empty() { "main".to_string() } else { b };
-    PathBuf::from(format!("~/.codemux/worktrees/{p}/{b}"))
-}
+/// Cross-platform — see `crate::workspace_paths::conventional_remote_path`.
+/// Kept as a Unix-side re-export so existing call sites compile
+/// unchanged. Windows builds reach the underlying function through
+/// `crate::workspace_paths` directly.
+pub use crate::workspace_paths::conventional_remote_path;
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -796,6 +796,78 @@ impl AppStateStore {
         workspace_id
     }
 
+    /// Create a workspace shell that will receive its files from an
+    /// upcoming `workspace_pull_back` call. Differs from
+    /// `create_workspace_at_path` and `create_empty_workspace_at_path`
+    /// in three ways:
+    ///
+    /// 1. No git operations run — the rsync from the remote will
+    ///    populate the worktree directory; running `git worktree add`
+    ///    here would just create files rsync would have to clobber.
+    /// 2. `host_id` is set up front, because the caller already knows
+    ///    which device the workspace is being pulled from and the
+    ///    pull-back path keys off `host_id` to find the remote.
+    /// 3. `worktree_path` is set to a path that doesn't exist yet —
+    ///    rsync creates it. This is the entire point of the helper.
+    ///
+    /// Used by `workspaces_adopt_synced` (cross-device adoption) where
+    /// we're materialising a workspace another device of the same
+    /// account already created and pushed to a host. After this
+    /// returns, the caller is expected to immediately call the
+    /// existing `workspace_pull_back` machinery to fetch the files.
+    pub fn create_synced_workspace_shell(
+        &self,
+        title: String,
+        host_id: i64,
+        project_root: Option<String>,
+        worktree_path: String,
+        git_branch: Option<String>,
+    ) -> WorkspaceId {
+        let mut snapshot = self.inner.lock().unwrap();
+        let workspace_id = WorkspaceId(next_id("workspace"));
+
+        snapshot.workspaces.push(WorkspaceSnapshot {
+            workspace_id: workspace_id.clone(),
+            title,
+            workspace_type: WorkspaceType::Standard,
+            // `cwd` mirrors `worktree_path` for adopted workspaces —
+            // when the user opens the workspace, terminals get
+            // spawned in the worktree directory, same as a
+            // freshly-created worktree workspace.
+            cwd: worktree_path.clone(),
+            git_branch,
+            git_ahead: 0,
+            git_behind: 0,
+            git_additions: 0,
+            git_deletions: 0,
+            git_changed_files: 0,
+            worktree_path: Some(worktree_path),
+            project_root,
+            pr_number: None,
+            pr_state: None,
+            pr_url: None,
+            linked_issue: None,
+            notifications_muted: false,
+            notification_count: 0,
+            latest_agent_state: Some("idle".into()),
+            tabs: vec![],
+            active_tab_id: String::new(),
+            active_surface_id: SurfaceId(String::new()),
+            surfaces: vec![],
+            // Critical: host_id is set so the pull-back call that
+            // follows knows which device to rsync from. It will be
+            // cleared to None on successful pull.
+            host_id: Some(host_id),
+        });
+
+        // We deliberately do NOT set this as the active workspace.
+        // The user clicked "Pull to this device" from the overview;
+        // they should land back in the overview when the pull
+        // completes, not in a half-populated pane tree. The frontend
+        // can navigate explicitly on success if it wants.
+        workspace_id
+    }
+
     pub fn create_workspace_with_layout(
         &self,
         cwd_path: PathBuf,
@@ -4440,6 +4512,77 @@ mod tests {
         assert_eq!(
             snapshot.active_workspace_id, workspace_id,
             "Empty layout still activates the new workspace (parity with other variants)",
+        );
+    }
+
+    #[test]
+    fn create_synced_workspace_shell_sets_host_id_and_worktree_path() {
+        // The shell is what cross-device adoption creates BEFORE the
+        // rsync runs — host_id must be pre-set (the upcoming
+        // workspace_pull_back routes off it), worktree_path must be
+        // the empty target the rsync will populate, and no tabs /
+        // surfaces / sessions get allocated (the user hasn't opened
+        // panes yet — they will after the pull completes).
+        let store = AppStateStore::default();
+        let workspace_id = store.create_synced_workspace_shell(
+            "codemux/feature-x".into(),
+            42, // local hosts.id
+            Some("/home/zeus/projects/codemux".into()),
+            "/home/zeus/.codemux/worktrees/codemux/feature-x".into(),
+            Some("feature-x".into()),
+        );
+        let snapshot = store.snapshot();
+        let workspace = snapshot
+            .workspaces
+            .iter()
+            .find(|w| w.workspace_id == workspace_id)
+            .expect("shell must be registered");
+        assert_eq!(workspace.title, "codemux/feature-x");
+        assert_eq!(workspace.host_id, Some(42));
+        assert_eq!(
+            workspace.worktree_path.as_deref(),
+            Some("/home/zeus/.codemux/worktrees/codemux/feature-x"),
+        );
+        // cwd mirrors worktree_path so terminals spawn in the right
+        // place once the pull completes.
+        assert_eq!(
+            workspace.cwd,
+            "/home/zeus/.codemux/worktrees/codemux/feature-x",
+        );
+        assert_eq!(
+            workspace.project_root.as_deref(),
+            Some("/home/zeus/projects/codemux"),
+        );
+        assert_eq!(workspace.git_branch.as_deref(), Some("feature-x"));
+        assert!(
+            workspace.surfaces.is_empty(),
+            "Shell must have no surfaces — rsync populates the worktree, panes come later",
+        );
+        assert!(
+            workspace.tabs.is_empty(),
+            "Shell must have no tabs",
+        );
+    }
+
+    #[test]
+    fn create_synced_workspace_shell_does_not_activate_workspace() {
+        // The user clicked Pull from the Workspaces overview; they
+        // should land back in the overview when the pull completes,
+        // NOT in a half-populated workspace. Activation is the
+        // frontend's call via the success toast's "Open" action.
+        let store = AppStateStore::default();
+        let prior_active = store.snapshot().active_workspace_id.clone();
+        let _ = store.create_synced_workspace_shell(
+            "shell".into(),
+            1,
+            None,
+            "/tmp/shell".into(),
+            None,
+        );
+        let snapshot = store.snapshot();
+        assert_eq!(
+            snapshot.active_workspace_id, prior_active,
+            "Shell creation must not steal the active workspace slot",
         );
     }
 

--- a/src-tauri/src/workspace_paths.rs
+++ b/src-tauri/src/workspace_paths.rs
@@ -1,0 +1,98 @@
+//! Cross-platform path helpers for the workspaces feature.
+//!
+//! Lives outside `src/ssh/` (which is `#[cfg(unix)]` because the SSH
+//! transport modules only compile on Unix) so Windows builds can use
+//! these pure path-sanitisation functions without dragging in the SSH
+//! machinery. The function bodies are identical to the legacy
+//! `src/ssh/push.rs` definitions — `src::ssh::push` re-exports from
+//! here to keep existing Unix call sites working unchanged.
+
+use std::path::{Path, PathBuf};
+
+/// The canonical worktree path layout used by push, pull, and
+/// adoption across every platform:
+///
+///     ~/.codemux/worktrees/<project>/<branch>
+///
+/// Sanitises both segments to ASCII-alphanumeric + `_`, `-`, `.` —
+/// anything else becomes `-`. Empty inputs default to `workspace`
+/// and `main` respectively so callers never end up with a path that
+/// has a literally-empty directory component.
+///
+/// Returns a path with a literal `~/` prefix; callers expand
+/// (`dirs::home_dir().join(rest)`) when they need an absolute path
+/// for filesystem ops. The `~/` form is kept for the SSH-side
+/// rsync target which lets the remote shell do the expansion.
+pub fn conventional_remote_path(project_name: &str, branch: &str) -> PathBuf {
+    fn sanitize(s: &str) -> String {
+        s.chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
+                    c
+                } else {
+                    '-'
+                }
+            })
+            .collect::<String>()
+            .trim_matches('-')
+            .to_string()
+    }
+    let p = sanitize(project_name);
+    let b = sanitize(branch);
+    let p = if p.is_empty() {
+        "workspace".to_string()
+    } else {
+        p
+    };
+    let b = if b.is_empty() {
+        "main".to_string()
+    } else {
+        b
+    };
+    PathBuf::from(format!("~/.codemux/worktrees/{p}/{b}"))
+}
+
+/// Expand a `~/` prefix using the OS-detected home dir. Returns the
+/// input unchanged when no `~/` prefix is present. Falls back to
+/// the raw path when home_dir is unavailable.
+pub fn expand_tilde(p: &Path) -> PathBuf {
+    let s = p.to_string_lossy();
+    if let Some(rest) = s.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(s.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_slash_and_dot_in_branch() {
+        let p = conventional_remote_path("my-proj", "feature/login-bug");
+        assert_eq!(
+            p.to_string_lossy(),
+            "~/.codemux/worktrees/my-proj/feature-login-bug",
+        );
+    }
+
+    #[test]
+    fn defaults_empty_inputs() {
+        let p = conventional_remote_path("", "");
+        assert_eq!(
+            p.to_string_lossy(),
+            "~/.codemux/worktrees/workspace/main",
+        );
+    }
+
+    #[test]
+    fn preserves_alphanumerics_and_underscore() {
+        let p = conventional_remote_path("a_b.c-d", "x_y.z-1");
+        assert_eq!(
+            p.to_string_lossy(),
+            "~/.codemux/worktrees/a_b.c-d/x_y.z-1",
+        );
+    }
+}

--- a/src-tauri/src/workspace_paths.rs
+++ b/src-tauri/src/workspace_paths.rs
@@ -12,7 +12,9 @@ use std::path::{Path, PathBuf};
 /// The canonical worktree path layout used by push, pull, and
 /// adoption across every platform:
 ///
-///     ~/.codemux/worktrees/<project>/<branch>
+/// ```text
+/// ~/.codemux/worktrees/<project>/<branch>
+/// ```
 ///
 /// Sanitises both segments to ASCII-alphanumeric + `_`, `-`, `.` —
 /// anything else becomes `-`. Empty inputs default to `workspace`

--- a/src-tauri/src/workspaces_sync.rs
+++ b/src-tauri/src/workspaces_sync.rs
@@ -1,0 +1,694 @@
+//! Workspaces sync — pull/push the user's workspace registry across
+//! their devices. Modeled 1:1 on `hosts_sync.rs` and `automations_sync.rs`.
+//!
+//! What syncs (the metadata that lets another device discover a
+//! workspace exists and reason about it):
+//! - `title`
+//! - `host_server_id` — which host the workspace currently lives on
+//! - `project_path` (informational; only meaningful on the originating device)
+//! - `project_remote` — git remote URL so other devices know where to clone
+//! - `git_branch`
+//! - `created_at` / `updated_at` / `deleted_at`
+//!
+//! What does NOT sync (per-device runtime state):
+//! - `cwd`, `worktree_path`, `pane_statuses`, terminal sessions, surface tree
+//! - Git deltas (ahead/behind/changed_files) — read from the local git tree
+//! - `notification_count`, `notifications_muted` — per-device user state
+//!
+//! Wire model:
+//! - `pull(token)` → GET `/api/workspaces` → upsert each server row
+//!   into the local `workspaces_sync` table. Server rows are
+//!   authoritative for any workspace whose `server_id` matches a
+//!   local row.
+//! - `push(token)` → for each local row with `dirty=1`:
+//!     - if `deleted_at IS NOT NULL && server_id IS NOT NULL`:
+//!       DELETE `/api/workspaces/:server_id`, then
+//!       `mark_workspace_sync_synced` so the next
+//!       `purge_acknowledged_workspace_sync_deletes` removes the
+//!       tombstone.
+//!     - elif `server_id IS NULL`: POST `/api/workspaces` → server
+//!       returns the assigned `id`; we
+//!       `mark_workspace_sync_synced(id, Some(server_id))`.
+//!     - elif `server_id IS NOT NULL`: PATCH `/api/workspaces/:server_id`
+//!       with the updated fields → `mark_workspace_sync_synced(id, None)`.
+//! - `try_sync_with_app(app)` is the public entrypoint: pull then
+//!   push, swallowing single-call failures so a flaky network doesn't
+//!   strand the user. Anything still dirty after a failed push stays
+//!   dirty for the next sync to retry.
+//!
+//! Auth/security: the desktop's Bearer token (decrypted from the local
+//! encrypted store) is attached to every request. The server enforces
+//! per-user isolation via `authenticateBearer(c)` + a `WHERE user_id =
+//! :authed` clause baked into every query. A 401 is treated as
+//! "log in again"; we log and bail.
+//!
+//! Failure mode policy: a failed push leaves the row dirty and logs
+//! once. We do not surface the error to the user via toast — they
+//! already see the workspace in the UI, and the sync indicator (TBD)
+//! tells them when it last completed.
+
+use crate::auth::{api_base_url, is_token_expired, load_token};
+use crate::database::DatabaseStore;
+use crate::state::AppStateSnapshot;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use tauri::Manager;
+
+/// Wire shape returned by `GET /api/workspaces` and `POST /api/workspaces`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerWorkspace {
+    pub id: String,
+    pub title: String,
+    #[serde(rename = "hostServerId")]
+    pub host_server_id: Option<String>,
+    #[serde(rename = "projectPath")]
+    pub project_path: Option<String>,
+    #[serde(rename = "projectRemote")]
+    pub project_remote: Option<String>,
+    #[serde(rename = "gitBranch")]
+    pub git_branch: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+    #[serde(rename = "deletedAt")]
+    pub deleted_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListWorkspacesResponse {
+    workspaces: Vec<ServerWorkspace>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OneWorkspaceResponse {
+    workspace: ServerWorkspace,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkspaceUpsertBody<'a> {
+    title: &'a str,
+    #[serde(rename = "hostServerId", skip_serializing_if = "Option::is_none")]
+    host_server_id: Option<&'a str>,
+    #[serde(rename = "projectPath", skip_serializing_if = "Option::is_none")]
+    project_path: Option<&'a str>,
+    #[serde(rename = "projectRemote", skip_serializing_if = "Option::is_none")]
+    project_remote: Option<&'a str>,
+    #[serde(rename = "gitBranch", skip_serializing_if = "Option::is_none")]
+    git_branch: Option<&'a str>,
+}
+
+/// Guard against concurrent sync attempts. Foreground sync + the
+/// fire-and-forget sync each workspace mutation triggers could
+/// otherwise overlap and double-push the same row. Skipping when one
+/// is already in flight is correct: the in-flight one already sees
+/// the latest dirty rows.
+static SYNC_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+/// Convenience wrapper used by Tauri commands and the post-mutation
+/// triggers. Resolves the database + token from the app state and
+/// calls pull-then-push. Returns Ok(()) if the user isn't signed in
+/// (sync isn't an error in that case).
+pub async fn try_sync_with_app(app: &tauri::AppHandle) -> Result<(), String> {
+    let db = app.state::<DatabaseStore>();
+    let token = match valid_token(&db) {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    let db_ref: &DatabaseStore = &db;
+    let pull_err = match pull(&token, db_ref).await {
+        Ok(()) => None,
+        Err(e) => Some(e),
+    };
+    let push_err = match push(&token, db_ref).await {
+        Ok(()) => None,
+        Err(e) => Some(e),
+    };
+    match (pull_err, push_err) {
+        (None, None) => Ok(()),
+        (Some(p), None) => Err(format!("pull failed: {p}")),
+        (None, Some(p)) => Err(format!("push failed: {p}")),
+        (Some(a), Some(b)) => Err(format!("pull failed: {a}; push failed: {b}")),
+    }
+}
+
+fn valid_token(db: &DatabaseStore) -> Option<String> {
+    let (token, expires_at) = load_token(db)?;
+    if is_token_expired(&expires_at) {
+        None
+    } else {
+        Some(token)
+    }
+}
+
+/// Pull server state into the local `workspaces_sync` table.
+/// Idempotent. Rows that exist on the server but not locally are
+/// inserted; rows that exist locally AND on the server (matched by
+/// `server_id`) are updated in place; purely-local rows (no
+/// `server_id` yet) are untouched.
+///
+/// We never delete a local row purely because the server lacks it —
+/// that is the symmetry of the design: local creates wait for the
+/// next push to learn their `server_id`. A row whose `server_id` is
+/// non-null but missing from the server response is treated as a
+/// server-side deletion the local hasn't observed yet.
+pub async fn pull(token: &str, db: &DatabaseStore) -> Result<(), String> {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{base}/api/workspaces"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+    if !resp.status().is_success() {
+        // 404 = endpoint not deployed on this server. Harmless skip
+        // so dev/prod skew doesn't break the desktop.
+        if resp.status().as_u16() == 404 {
+            return Ok(());
+        }
+        return Err(format!("API error: {}", resp.status()));
+    }
+    let body: ListWorkspacesResponse =
+        resp.json().await.map_err(|e| format!("Parse: {e}"))?;
+
+    // Index local rows by server_id so we can detect server-side
+    // deletions (server stopped returning a row we know about).
+    let local = db.list_workspaces_sync_for_sync();
+    let server_ids: std::collections::HashSet<String> =
+        body.workspaces.iter().map(|w| w.id.clone()).collect();
+
+    for w in &body.workspaces {
+        db.upsert_workspace_sync_from_server(
+            &w.id,
+            &w.title,
+            w.host_server_id.as_deref(),
+            w.project_path.as_deref(),
+            w.project_remote.as_deref(),
+            w.git_branch.as_deref(),
+            &w.created_at,
+            &w.updated_at,
+            w.deleted_at.as_deref(),
+        )?;
+    }
+
+    // Server-side deletion sweep: if a local row has a server_id the
+    // server no longer returns, it was deleted elsewhere. Tombstone
+    // it locally — dirty stays 0 (server-sourced changes are always
+    // clean).
+    for local_row in &local {
+        if let Some(sid) = &local_row.server_id {
+            if !server_ids.contains(sid) && local_row.deleted_at.is_none() {
+                eprintln!(
+                    "[workspaces-sync] server no longer has {sid}; tombstoning locally"
+                );
+                let now = chrono::Utc::now()
+                    .format("%Y-%m-%d %H:%M:%S")
+                    .to_string();
+                db.upsert_workspace_sync_from_server(
+                    sid,
+                    &local_row.title,
+                    local_row.host_server_id.as_deref(),
+                    local_row.project_path.as_deref(),
+                    local_row.project_remote.as_deref(),
+                    local_row.git_branch.as_deref(),
+                    &local_row.created_at,
+                    &now,
+                    Some(&now),
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Push every dirty local row to the server. Each row is handled
+/// independently so a single failed PATCH doesn't strand other dirty
+/// rows; failures are logged and the row stays dirty for the next
+/// sync to retry.
+pub async fn push(token: &str, db: &DatabaseStore) -> Result<(), String> {
+    let base = api_base_url();
+    let client = reqwest::Client::new();
+    let dirty = db.list_dirty_workspaces_sync();
+    let mut any_failed = false;
+
+    for row in &dirty {
+        let result = if row.deleted_at.is_some() {
+            push_delete(&client, &base, token, row, db).await
+        } else if row.server_id.is_none() {
+            push_insert(&client, &base, token, row, db).await
+        } else {
+            push_update(&client, &base, token, row, db).await
+        };
+        if let Err(error) = result {
+            eprintln!(
+                "[workspaces-sync] push failed for local id {}: {error}",
+                row.id
+            );
+            any_failed = true;
+        }
+    }
+
+    db.purge_acknowledged_workspace_sync_deletes()?;
+
+    if any_failed {
+        Err("one or more workspace pushes failed; see logs".into())
+    } else {
+        Ok(())
+    }
+}
+
+async fn push_insert(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+    row: &crate::database::WorkspaceSyncRecord,
+    db: &DatabaseStore,
+) -> Result<(), String> {
+    let body = WorkspaceUpsertBody {
+        title: &row.title,
+        host_server_id: row.host_server_id.as_deref(),
+        project_path: row.project_path.as_deref(),
+        project_remote: row.project_remote.as_deref(),
+        git_branch: row.git_branch.as_deref(),
+    };
+    let resp = client
+        .post(format!("{base}/api/workspaces"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("API error: {}", resp.status()));
+    }
+    let parsed: OneWorkspaceResponse =
+        resp.json().await.map_err(|e| format!("Parse: {e}"))?;
+    db.mark_workspace_sync_synced(row.id, Some(&parsed.workspace.id))?;
+    Ok(())
+}
+
+async fn push_update(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+    row: &crate::database::WorkspaceSyncRecord,
+    db: &DatabaseStore,
+) -> Result<(), String> {
+    let server_id = row
+        .server_id
+        .as_ref()
+        .ok_or_else(|| "push_update called without server_id".to_string())?;
+    let body = WorkspaceUpsertBody {
+        title: &row.title,
+        host_server_id: row.host_server_id.as_deref(),
+        project_path: row.project_path.as_deref(),
+        project_remote: row.project_remote.as_deref(),
+        git_branch: row.git_branch.as_deref(),
+    };
+    let resp = client
+        .patch(format!("{base}/api/workspaces/{server_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("API error: {}", resp.status()));
+    }
+    db.mark_workspace_sync_synced(row.id, None)?;
+    Ok(())
+}
+
+async fn push_delete(
+    client: &reqwest::Client,
+    base: &str,
+    token: &str,
+    row: &crate::database::WorkspaceSyncRecord,
+    db: &DatabaseStore,
+) -> Result<(), String> {
+    // A row that was created and deleted entirely while offline (no
+    // server_id) has nothing to push — clear dirty so the next purge
+    // pass hard-deletes it locally.
+    let server_id = match &row.server_id {
+        Some(sid) => sid,
+        None => {
+            db.mark_workspace_sync_synced(row.id, None)?;
+            return Ok(());
+        }
+    };
+    let resp = client
+        .delete(format!("{base}/api/workspaces/{server_id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| format!("Network error: {e}"))?;
+    // 404 = already gone server-side, treat as success.
+    if !resp.status().is_success() && resp.status().as_u16() != 404 {
+        return Err(format!("API error: {}", resp.status()));
+    }
+    db.mark_workspace_sync_synced(row.id, None)?;
+    Ok(())
+}
+
+/// Reconcile the local `workspaces_sync` table against the current
+/// `AppStateSnapshot.workspaces`. This is the bridge between the
+/// runtime-only app state (which has live workspace data) and the
+/// sync mirror (which is persisted + sync-bound).
+///
+/// For each live workspace in the snapshot:
+/// - If a `workspaces_sync` row exists with the same local
+///   `workspace_id` AND any synced field differs, UPDATE (marks dirty).
+/// - If no such sync row exists, INSERT (marks dirty).
+///
+/// For each `workspaces_sync` row whose `workspace_id` is no longer
+/// in the snapshot, soft-delete (marks dirty). The next push DELETEs
+/// the server row.
+///
+/// `workspaces_sync` rows that have `workspace_id IS NULL` (pulled
+/// from sibling devices, not yet adopted here) are NEVER touched by
+/// reconcile — they have no app_state counterpart by design.
+///
+/// OpenFlow workspaces are excluded — they are ephemeral by design
+/// and never persist beyond a single device, so syncing them would
+/// just churn the registry. Same exclusion `save_persisted_state`
+/// uses.
+///
+/// Returns Ok even on partial failure: individual row failures are
+/// logged so a corrupt row doesn't strand the whole tick.
+pub fn reconcile_from_snapshot(
+    db: &DatabaseStore,
+    snapshot: &AppStateSnapshot,
+) -> Result<(), String> {
+    // Build local host_id → server_id map for translating
+    // WorkspaceSnapshot.host_id (i64) into host_server_id (TEXT).
+    let host_id_to_server: HashMap<i64, String> = db
+        .list_hosts_for_sync()
+        .into_iter()
+        .filter_map(|h| h.server_id.map(|sid| (h.id, sid)))
+        .collect();
+
+    // Index existing sync rows by their local workspace_id so we can
+    // tell INSERT from UPDATE in one pass without a per-row SELECT.
+    let sync_rows = db.list_workspaces_sync();
+    let sync_by_wid: HashMap<&str, &crate::database::WorkspaceSyncRecord> =
+        sync_rows
+            .iter()
+            .filter_map(|r| r.workspace_id.as_deref().map(|wid| (wid, r)))
+            .collect();
+
+    // app_state ids we'll keep — anything else with a workspace_id
+    // gets soft-deleted at the end.
+    let mut live_wids: HashSet<String> = HashSet::new();
+
+    for ws in &snapshot.workspaces {
+        // Skip OpenFlow workspaces — they're not user-durable.
+        if matches!(
+            ws.workspace_type,
+            crate::state::WorkspaceType::OpenFlow
+        ) {
+            continue;
+        }
+        // Home workspaces don't represent a project to sync — skip.
+        if matches!(ws.workspace_type, crate::state::WorkspaceType::Home) {
+            continue;
+        }
+
+        let wid = ws.workspace_id.0.clone();
+        live_wids.insert(wid.clone());
+
+        let host_server_id = ws
+            .host_id
+            .and_then(|hid| host_id_to_server.get(&hid).cloned());
+        let title = ws.title.as_str();
+        let project_path = ws.project_root.as_deref();
+        // project_remote isn't on WorkspaceSnapshot today (see the
+        // workspace creation doc) — leave as None for v1. When we
+        // wire it in later, this is the only call site that needs
+        // updating.
+        let project_remote: Option<&str> = None;
+        let git_branch = ws.git_branch.as_deref();
+
+        if let Some(existing) = sync_by_wid.get(wid.as_str()) {
+            let changed = existing.title != title
+                || existing.host_server_id.as_deref() != host_server_id.as_deref()
+                || existing.project_path.as_deref() != project_path
+                || existing.project_remote.as_deref() != project_remote
+                || existing.git_branch.as_deref() != git_branch;
+            if changed {
+                if let Err(error) = db.update_workspace_sync_by_workspace_id(
+                    &wid,
+                    title,
+                    host_server_id.as_deref(),
+                    project_path,
+                    project_remote,
+                    git_branch,
+                ) {
+                    eprintln!(
+                        "[workspaces-sync] update failed for {wid}: {error}"
+                    );
+                }
+            }
+        } else if let Err(error) = db.insert_workspace_sync(
+            &wid,
+            title,
+            host_server_id.as_deref(),
+            project_path,
+            project_remote,
+            git_branch,
+        ) {
+            // UNIQUE(workspace_id) collision shouldn't happen given
+            // the index pass above — log and continue.
+            eprintln!("[workspaces-sync] insert failed for {wid}: {error}");
+        }
+    }
+
+    // Soft-delete sync rows whose workspace_id is no longer in
+    // app_state. Rows with no workspace_id (pulled-only) are skipped
+    // by construction (the filter_map above excludes them).
+    for row in &sync_rows {
+        if let Some(wid) = &row.workspace_id {
+            if !live_wids.contains(wid) {
+                if let Err(error) =
+                    db.soft_delete_workspace_sync_by_workspace_id(wid)
+                {
+                    eprintln!(
+                        "[workspaces-sync] soft-delete failed for {wid}: {error}"
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Foreground sync: pull then push, with the SYNC_IN_PROGRESS guard.
+/// Used by the auth-check path that runs once at startup and any
+/// future "Sync now" UI button.
+#[allow(dead_code)]
+pub async fn sync_workspaces(token: &str, db: &DatabaseStore) -> Result<(), String> {
+    if SYNC_IN_PROGRESS.swap(true, Ordering::SeqCst) {
+        return Ok(()); // another sync is in flight; skip
+    }
+    let result = async {
+        pull(token, db).await?;
+        push(token, db).await?;
+        Ok(())
+    }
+    .await;
+    SYNC_IN_PROGRESS.store(false, Ordering::SeqCst);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::database::DatabaseStore;
+    use serial_test::serial;
+
+    fn fresh_db() -> DatabaseStore {
+        DatabaseStore::new_in_memory()
+    }
+
+    #[test]
+    #[serial]
+    fn insert_and_list_round_trips() {
+        let db = fresh_db();
+        let row = db
+            .insert_workspace_sync(
+                "workspace-1",
+                "alpha",
+                None,
+                Some("/home/zeus/projects/alpha"),
+                Some("git@github.com:alpha/alpha.git"),
+                Some("main"),
+            )
+            .expect("insert");
+        assert!(row.dirty);
+        assert!(row.server_id.is_none());
+        assert_eq!(row.workspace_id.as_deref(), Some("workspace-1"));
+        assert_eq!(row.title, "alpha");
+
+        let list = db.list_workspaces_sync();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].title, "alpha");
+    }
+
+    #[test]
+    #[serial]
+    fn update_marks_row_dirty_again() {
+        let db = fresh_db();
+        let row = db
+            .insert_workspace_sync("workspace-2", "before", None, None, None, None)
+            .unwrap();
+        db.mark_workspace_sync_synced(row.id, Some("42")).unwrap();
+
+        // Confirm the synced state.
+        let listed = db.list_workspaces_sync();
+        assert!(!listed[0].dirty);
+        assert_eq!(listed[0].server_id.as_deref(), Some("42"));
+
+        // Mutate.
+        db.update_workspace_sync_by_workspace_id(
+            "workspace-2",
+            "after",
+            Some("99"),
+            None,
+            None,
+            Some("feature-x"),
+        )
+        .unwrap();
+        let dirty = db.list_dirty_workspaces_sync();
+        assert_eq!(dirty.len(), 1);
+        assert_eq!(dirty[0].title, "after");
+        assert_eq!(dirty[0].host_server_id.as_deref(), Some("99"));
+        assert_eq!(dirty[0].git_branch.as_deref(), Some("feature-x"));
+    }
+
+    #[test]
+    #[serial]
+    fn soft_delete_then_purge() {
+        let db = fresh_db();
+        let row = db
+            .insert_workspace_sync("workspace-3", "doomed", None, None, None, None)
+            .unwrap();
+        db.mark_workspace_sync_synced(row.id, Some("100")).unwrap();
+
+        db.soft_delete_workspace_sync_by_workspace_id("workspace-3")
+            .unwrap();
+
+        // list() hides the tombstone, list_for_sync() shows it.
+        assert_eq!(db.list_workspaces_sync().len(), 0);
+        let all = db.list_workspaces_sync_for_sync();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].deleted_at.is_some());
+        assert!(all[0].dirty);
+
+        // Until the push acknowledges, dirty stays — purge is a no-op.
+        db.purge_acknowledged_workspace_sync_deletes().unwrap();
+        assert_eq!(db.list_workspaces_sync_for_sync().len(), 1);
+
+        // Mark synced (simulating the post-DELETE callback) then purge:
+        // the row is gone for good.
+        db.mark_workspace_sync_synced(all[0].id, None).unwrap();
+        db.purge_acknowledged_workspace_sync_deletes().unwrap();
+        assert_eq!(db.list_workspaces_sync_for_sync().len(), 0);
+    }
+
+    #[test]
+    #[serial]
+    fn upsert_from_server_is_idempotent_and_clean() {
+        let db = fresh_db();
+        // First call — inserts.
+        db.upsert_workspace_sync_from_server(
+            "200",
+            "from-server",
+            Some("7"),
+            Some("/srv/path"),
+            Some("git@x:y.git"),
+            Some("main"),
+            "2026-01-01 00:00:00",
+            "2026-01-01 00:00:00",
+            None,
+        )
+        .unwrap();
+        let listed = db.list_workspaces_sync();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].server_id.as_deref(), Some("200"));
+        assert_eq!(listed[0].title, "from-server");
+        assert!(!listed[0].dirty, "server-sourced rows must be clean");
+
+        // Second call — same server_id but a new updated_at and new
+        // title. Should UPDATE in place (no duplicate row).
+        db.upsert_workspace_sync_from_server(
+            "200",
+            "renamed-server-side",
+            Some("7"),
+            Some("/srv/path"),
+            Some("git@x:y.git"),
+            Some("dev"),
+            "2026-01-01 00:00:00",
+            "2026-01-02 00:00:00",
+            None,
+        )
+        .unwrap();
+        let listed = db.list_workspaces_sync();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].title, "renamed-server-side");
+        assert_eq!(listed[0].git_branch.as_deref(), Some("dev"));
+    }
+
+    #[test]
+    #[serial]
+    fn link_local_id_after_adoption() {
+        let db = fresh_db();
+        // Server gave us a row without a local id (we discovered it
+        // via pull — another device created it).
+        db.upsert_workspace_sync_from_server(
+            "300",
+            "discovered",
+            Some("12"),
+            None,
+            None,
+            None,
+            "2026-01-01 00:00:00",
+            "2026-01-01 00:00:00",
+            None,
+        )
+        .unwrap();
+        let listed = db.list_workspaces_sync();
+        assert!(listed[0].workspace_id.is_none());
+
+        // Adopt: stamp the local workspace id.
+        db.link_workspace_sync_to_local("300", "workspace-42").unwrap();
+        let listed = db.list_workspaces_sync();
+        assert_eq!(listed[0].workspace_id.as_deref(), Some("workspace-42"));
+    }
+
+    #[test]
+    #[serial]
+    fn delete_a_row_that_never_synced_is_a_local_no_op() {
+        // A row created and deleted before any push happens has no
+        // server_id. push_delete should clear dirty without an HTTP
+        // call so the next purge removes it locally.
+        let db = fresh_db();
+        let row = db
+            .insert_workspace_sync(
+                "workspace-99",
+                "ephemeral",
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+        db.soft_delete_workspace_sync_by_workspace_id("workspace-99")
+            .unwrap();
+        // Simulate what push_delete does for never-synced rows:
+        db.mark_workspace_sync_synced(row.id, None).unwrap();
+        db.purge_acknowledged_workspace_sync_deletes().unwrap();
+        assert_eq!(db.list_workspaces_sync_for_sync().len(), 0);
+    }
+}

--- a/src-tauri/src/workspaces_sync.rs
+++ b/src-tauri/src/workspaces_sync.rs
@@ -68,6 +68,8 @@ pub struct ServerWorkspace {
     pub project_remote: Option<String>,
     #[serde(rename = "gitBranch")]
     pub git_branch: Option<String>,
+    #[serde(rename = "gitHeadSha", default)]
+    pub git_head_sha: Option<String>,
     #[serde(rename = "createdAt")]
     pub created_at: String,
     #[serde(rename = "updatedAt")]
@@ -97,6 +99,8 @@ struct WorkspaceUpsertBody<'a> {
     project_remote: Option<&'a str>,
     #[serde(rename = "gitBranch", skip_serializing_if = "Option::is_none")]
     git_branch: Option<&'a str>,
+    #[serde(rename = "gitHeadSha", skip_serializing_if = "Option::is_none")]
+    git_head_sha: Option<&'a str>,
 }
 
 /// Guard against concurrent sync attempts. Foreground sync + the
@@ -187,6 +191,7 @@ pub async fn pull(token: &str, db: &DatabaseStore) -> Result<(), String> {
             w.project_path.as_deref(),
             w.project_remote.as_deref(),
             w.git_branch.as_deref(),
+            w.git_head_sha.as_deref(),
             &w.created_at,
             &w.updated_at,
             w.deleted_at.as_deref(),
@@ -213,6 +218,7 @@ pub async fn pull(token: &str, db: &DatabaseStore) -> Result<(), String> {
                     local_row.project_path.as_deref(),
                     local_row.project_remote.as_deref(),
                     local_row.git_branch.as_deref(),
+                    local_row.git_head_sha.as_deref(),
                     &local_row.created_at,
                     &now,
                     Some(&now),
@@ -273,6 +279,7 @@ async fn push_insert(
         project_path: row.project_path.as_deref(),
         project_remote: row.project_remote.as_deref(),
         git_branch: row.git_branch.as_deref(),
+        git_head_sha: row.git_head_sha.as_deref(),
     };
     let resp = client
         .post(format!("{base}/api/workspaces"))
@@ -307,6 +314,7 @@ async fn push_update(
         project_path: row.project_path.as_deref(),
         project_remote: row.project_remote.as_deref(),
         git_branch: row.git_branch.as_deref(),
+        git_head_sha: row.git_head_sha.as_deref(),
     };
     let resp = client
         .patch(format!("{base}/api/workspaces/{server_id}"))
@@ -351,6 +359,31 @@ async fn push_delete(
     }
     db.mark_workspace_sync_synced(row.id, None)?;
     Ok(())
+}
+
+/// Read the workspace's git HEAD sha by shelling out to `git
+/// rev-parse HEAD` in the given directory. Returns None if git
+/// isn't installed, the directory isn't a git repo, or the repo
+/// has no commits yet. Cheap (single git process per workspace per
+/// reconcile, ~10ms each) so we don't cache.
+fn read_git_head_sha(path: &str) -> Option<String> {
+    if path.is_empty() {
+        return None;
+    }
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() || sha.len() > 200 {
+        None
+    } else {
+        Some(sha)
+    }
 }
 
 /// Reconcile the local `workspaces_sync` table against the current
@@ -431,12 +464,26 @@ pub fn reconcile_from_snapshot(
         let project_remote: Option<&str> = None;
         let git_branch = ws.git_branch.as_deref();
 
+        // Read the workspace's git HEAD sha so Phase-4 divergence
+        // detection can compare across devices. Best-effort: if
+        // git isn't installed, the workspace isn't a git repo, or
+        // it has no commits, we leave it as None. Use the
+        // worktree_path when set, else fall back to cwd.
+        let head_path = ws
+            .worktree_path
+            .as_deref()
+            .or(Some(ws.cwd.as_str()))
+            .unwrap_or("");
+        let git_head_sha: Option<String> = read_git_head_sha(head_path);
+        let git_head_sha_ref = git_head_sha.as_deref();
+
         if let Some(existing) = sync_by_wid.get(wid.as_str()) {
             let changed = existing.title != title
                 || existing.host_server_id.as_deref() != host_server_id.as_deref()
                 || existing.project_path.as_deref() != project_path
                 || existing.project_remote.as_deref() != project_remote
-                || existing.git_branch.as_deref() != git_branch;
+                || existing.git_branch.as_deref() != git_branch
+                || existing.git_head_sha.as_deref() != git_head_sha_ref;
             if changed {
                 if let Err(error) = db.update_workspace_sync_by_workspace_id(
                     &wid,
@@ -445,6 +492,7 @@ pub fn reconcile_from_snapshot(
                     project_path,
                     project_remote,
                     git_branch,
+                    git_head_sha_ref,
                 ) {
                     eprintln!(
                         "[workspaces-sync] update failed for {wid}: {error}"
@@ -458,6 +506,7 @@ pub fn reconcile_from_snapshot(
             project_path,
             project_remote,
             git_branch,
+            git_head_sha_ref,
         ) {
             // UNIQUE(workspace_id) collision shouldn't happen given
             // the index pass above — log and continue.
@@ -524,6 +573,7 @@ mod tests {
                 Some("/home/zeus/projects/alpha"),
                 Some("git@github.com:alpha/alpha.git"),
                 Some("main"),
+                Some("abc123"),
             )
             .expect("insert");
         assert!(row.dirty);
@@ -541,7 +591,7 @@ mod tests {
     fn update_marks_row_dirty_again() {
         let db = fresh_db();
         let row = db
-            .insert_workspace_sync("workspace-2", "before", None, None, None, None)
+            .insert_workspace_sync("workspace-2", "before", None, None, None, None, None)
             .unwrap();
         db.mark_workspace_sync_synced(row.id, Some("42")).unwrap();
 
@@ -558,6 +608,7 @@ mod tests {
             None,
             None,
             Some("feature-x"),
+            Some("def456"),
         )
         .unwrap();
         let dirty = db.list_dirty_workspaces_sync();
@@ -572,7 +623,7 @@ mod tests {
     fn soft_delete_then_purge() {
         let db = fresh_db();
         let row = db
-            .insert_workspace_sync("workspace-3", "doomed", None, None, None, None)
+            .insert_workspace_sync("workspace-3", "doomed", None, None, None, None, None)
             .unwrap();
         db.mark_workspace_sync_synced(row.id, Some("100")).unwrap();
 
@@ -609,6 +660,7 @@ mod tests {
             Some("/srv/path"),
             Some("git@x:y.git"),
             Some("main"),
+            Some("aaa111"),
             "2026-01-01 00:00:00",
             "2026-01-01 00:00:00",
             None,
@@ -618,6 +670,7 @@ mod tests {
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].server_id.as_deref(), Some("200"));
         assert_eq!(listed[0].title, "from-server");
+        assert_eq!(listed[0].git_head_sha.as_deref(), Some("aaa111"));
         assert!(!listed[0].dirty, "server-sourced rows must be clean");
 
         // Second call — same server_id but a new updated_at and new
@@ -629,6 +682,7 @@ mod tests {
             Some("/srv/path"),
             Some("git@x:y.git"),
             Some("dev"),
+            Some("bbb222"),
             "2026-01-01 00:00:00",
             "2026-01-02 00:00:00",
             None,
@@ -650,6 +704,7 @@ mod tests {
             "300",
             "discovered",
             Some("12"),
+            None,
             None,
             None,
             None,
@@ -678,6 +733,7 @@ mod tests {
             .insert_workspace_sync(
                 "workspace-99",
                 "ephemeral",
+                None,
                 None,
                 None,
                 None,

--- a/src/components/layout/app-shell.test.tsx
+++ b/src/components/layout/app-shell.test.tsx
@@ -10,6 +10,8 @@ let appStateReady = true;
 let settingsLoaded = true;
 let syncedLoading = false;
 let showSettingsFlag = false;
+let showAutomationsFlag = false;
+let showWorkspacesOverviewFlag = false;
 let showNewProjectScreenFlag = false;
 let commandPaletteOpenFlag = false;
 
@@ -30,6 +32,14 @@ vi.mock("./empty-state", () => ({
 }));
 vi.mock("@/components/settings/settings-view", () => ({
   SettingsView: () => <div data-testid="settings-view" />,
+}));
+vi.mock("@/components/automations/automations-view", () => ({
+  AutomationsView: () => <div data-testid="automations-view" />,
+}));
+vi.mock("@/components/workspaces-overview/workspaces-overview-view", () => ({
+  WorkspacesOverviewView: () => (
+    <div data-testid="workspaces-overview-view" />
+  ),
 }));
 vi.mock("@/components/overlays/command-palette", () => ({
   CommandPalette: () => null,
@@ -90,6 +100,8 @@ vi.mock("@/stores/ui-store", () => ({
     vi.fn((selector: (s: unknown) => unknown) =>
       selector({
         showSettings: showSettingsFlag,
+        showAutomations: showAutomationsFlag,
+        showWorkspacesOverview: showWorkspacesOverviewFlag,
         showNewProjectScreen: showNewProjectScreenFlag,
         showCommandPalette: commandPaletteOpenFlag,
         setShowCommandPalette: vi.fn(),
@@ -132,6 +144,8 @@ describe("AppShell rendering gates", () => {
     settingsLoaded = true;
     syncedLoading = false;
     showSettingsFlag = false;
+    showAutomationsFlag = false;
+    showWorkspacesOverviewFlag = false;
     showNewProjectScreenFlag = false;
     commandPaletteOpenFlag = false;
   });
@@ -172,5 +186,24 @@ describe("AppShell rendering gates", () => {
     const { getByTestId, queryByTestId } = render(<AppShell />);
     expect(getByTestId("workspace-main")).toBeInTheDocument();
     expect(queryByTestId("empty-state")).toBeNull();
+  });
+
+  it("renders the Workspaces overview when its UI-store flag is set", () => {
+    hasWorkspacesFlag = true;
+    showWorkspacesOverviewFlag = true;
+    const { getByTestId, queryByTestId } = render(<AppShell />);
+    expect(getByTestId("workspaces-overview-view")).toBeInTheDocument();
+    // The shell early-returns the overlay so neither the regular
+    // workspace pane nor the empty state should render alongside it.
+    expect(queryByTestId("workspace-main")).toBeNull();
+    expect(queryByTestId("empty-state")).toBeNull();
+  });
+
+  it("prefers Settings over the Workspaces overview when both flags are set", () => {
+    showSettingsFlag = true;
+    showWorkspacesOverviewFlag = true;
+    const { getByTestId, queryByTestId } = render(<AppShell />);
+    expect(getByTestId("settings-view")).toBeInTheDocument();
+    expect(queryByTestId("workspaces-overview-view")).toBeNull();
   });
 });

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -12,6 +12,7 @@ import { WorkspaceMain } from "./workspace-main";
 import { EmptyState } from "./empty-state";
 import { SettingsView } from "@/components/settings/settings-view";
 import { AutomationsView } from "@/components/automations/automations-view";
+import { WorkspacesOverviewView } from "@/components/workspaces-overview/workspaces-overview-view";
 import { CommandPalette } from "@/components/overlays/command-palette";
 import { NewProjectScreen } from "@/components/overlays/new-project-screen";
 import { FileSearchDialog } from "@/components/search/file-search-dialog";
@@ -32,6 +33,7 @@ export function AppShell() {
   const hasActiveDraft = useChatDraftStore((s) => s.activeDraftId !== null);
   const showSettings = useUIStore((s) => s.showSettings);
   const showAutomations = useUIStore((s) => s.showAutomations);
+  const showWorkspacesOverview = useUIStore((s) => s.showWorkspacesOverview);
   const showNewProjectScreen = useUIStore((s) => s.showNewProjectScreen);
   const commandPaletteOpen = useUIStore((s) => s.showCommandPalette);
   const setCommandPaletteOpen = useUIStore((s) => s.setShowCommandPalette);
@@ -65,6 +67,13 @@ export function AppShell() {
   // Full-screen Automations — a first-class destination, like Settings
   if (showAutomations) {
     return <AutomationsView />;
+  }
+
+  // Full-screen Workspaces overview — one pane to see every workspace
+  // this device knows about, across local + every remote host. Same
+  // overlay shape as Settings / Automations.
+  if (showWorkspacesOverview) {
+    return <WorkspacesOverviewView />;
   }
 
   // Full-screen new project — replaces entire app including sidebar

--- a/src/components/layout/sidebar-action-row.tsx
+++ b/src/components/layout/sidebar-action-row.tsx
@@ -14,13 +14,14 @@ import {
 import { useChatDraftStore } from "@/stores/chat-draft-store";
 import { useUIStore } from "@/stores/ui-store";
 import { useFeatureFlags } from "@/stores/feature-flags";
-import { Plus, FolderPlus, FolderOpen, CalendarClock } from "lucide-react";
+import { Plus, FolderPlus, FolderOpen, CalendarClock, LayoutGrid } from "lucide-react";
 import { useProjectActions } from "@/hooks/use-project-actions";
 
 export function SidebarActionRow() {
   const setShowNewWorkspaceDialog = useUIStore((s) => s.setShowNewWorkspaceDialog);
   const setShowNewProjectScreen = useUIStore((s) => s.setShowNewProjectScreen);
   const setShowAutomations = useUIStore((s) => s.setShowAutomations);
+  const setShowWorkspacesOverview = useUIStore((s) => s.setShowWorkspacesOverview);
   const enableAgentChat = useFeatureFlags((s) => s.enableAgentChat);
   const enableLazyWorkspaceCreation = useFeatureFlags(
     (s) => s.enableLazyWorkspaceCreation,
@@ -104,7 +105,7 @@ export function SidebarActionRow() {
       {/* Automations — a first-class destination under "New agent",
           above the project list, matching where Codex and Superset
           place it. Opens the full-screen Automations view. */}
-      <div className="px-2 pb-1.5">
+      <div className="px-2 pb-1">
         <Button
           variant="ghost"
           aria-label="Automations"
@@ -113,6 +114,22 @@ export function SidebarActionRow() {
         >
           <CalendarClock className="size-[18px]" />
           <span>Automations</span>
+        </Button>
+      </div>
+
+      {/* Workspaces — a single pane that lists every workspace this
+          device knows about (local + every host it has pushed to),
+          with filters, search, and per-row push/pull/open actions.
+          Same full-screen overlay shape as Automations. */}
+      <div className="px-2 pb-1.5">
+        <Button
+          variant="ghost"
+          aria-label="Workspaces"
+          className="w-full justify-start gap-2 h-8 px-2 text-[13px] text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+          onClick={() => setShowWorkspacesOverview(true)}
+        >
+          <LayoutGrid className="size-[18px]" />
+          <span>Workspaces</span>
         </Button>
       </div>
 

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -586,6 +586,32 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
   const isPushOrPullInFlight = useAppStore(
     (s) => s.workspacePushPullInFlight === workspace.workspace_id,
   );
+  // Phase-4d elapsed-time signal: when an in-flight push/pull
+  // crosses 2 seconds, show a small "12s" pill so the user knows
+  // the operation is still working. Identical math to the overview
+  // row — see workspace-overview-row.tsx LocalRow for the rationale.
+  const inFlightStartedAt = useAppStore(
+    (s) =>
+      s.workspacePushPullInFlight === workspace.workspace_id
+        ? s.workspacePushPullStartedAt
+        : null,
+  );
+  const [sidebarElapsedSec, setSidebarElapsedSec] = useState<number | null>(
+    null,
+  );
+  useEffect(() => {
+    if (inFlightStartedAt === null) {
+      setSidebarElapsedSec(null);
+      return;
+    }
+    const tick = () => {
+      const ms = Date.now() - inFlightStartedAt;
+      setSidebarElapsedSec(ms < 2_000 ? null : Math.floor(ms / 1_000));
+    };
+    tick();
+    const id = window.setInterval(tick, 1_000);
+    return () => window.clearInterval(id);
+  }, [inFlightStartedAt]);
   const icon = isPushOrPullInFlight ? (
     <Loader2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground animate-spin" />
   ) : isRemote ? (
@@ -655,11 +681,20 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                   {workspace.title}
                 </span>
 
+                {sidebarElapsedSec !== null && (
+                  <span
+                    title="Push/pull in progress — large workspaces can take a while."
+                    className="shrink-0 ml-auto rounded-full bg-muted/60 px-1.5 py-0 text-[10px] font-medium tabular-nums leading-[14px] text-muted-foreground/85"
+                  >
+                    {sidebarElapsedSec}s
+                  </span>
+                )}
                 {workspace.notification_count > 0 && (
                   <Badge
                     variant="outline"
                     className={cn(
-                      "shrink-0 ml-auto text-[10px] tabular-nums text-warning bg-warning/15 border-transparent px-1.5 py-0 leading-[14px] h-[14px]",
+                      "shrink-0 text-[10px] tabular-nums text-warning bg-warning/15 border-transparent px-1.5 py-0 leading-[14px] h-[14px]",
+                      sidebarElapsedSec === null && "ml-auto",
                       canDelete && "transition-opacity group-hover/row:opacity-0",
                     )}
                   >

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -55,6 +55,10 @@ import {
   type HostView,
 } from "@/tauri/commands";
 import { useHosts } from "@/stores/hosts-store";
+import {
+  ConfirmPushDialog,
+  shouldSkipPushConfirm,
+} from "@/components/overlays/confirm-push-dialog";
 import type { WorkspaceSnapshot, EditorInfo, ActivePaneStatus } from "@/tauri/types";
 import { useAppStore } from "@/stores/app-store";
 import { useChatDraftStore } from "@/stores/chat-draft-store";
@@ -216,9 +220,14 @@ function RemoveWorkspaceDialog({
 export function WorkspaceContextMenuItems({
   workspace,
   onRemoveRequest,
+  onRequestPushConfirm,
 }: {
   workspace: WorkspaceSnapshot;
   onRemoveRequest: () => void;
+  /** Called when the user clicks a host in the "Move to host…"
+   *  submenu. Opens the Phase-4 confirmation dialog unless the
+   *  user previously set "Don't ask again for this host". */
+  onRequestPushConfirm?: (host: HostView) => void;
 }) {
   const [editors, setEditors] = useState<EditorInfo[]>([]);
   const isWorktree = !!workspace.worktree_path;
@@ -246,8 +255,25 @@ export function WorkspaceContextMenuItems({
         host.id,
       );
       if (result.ok) {
-        toast.success(`Pushed to ${host.name}`, {
-          description: result.message,
+        // Push success → offer Undo = pull back. Same machinery
+        // the workspace's "Pull back to this device" item runs,
+        // wrapped so a misclick within 10s is one tap away from
+        // recovery. Data-safety guardrail for Phase 4.
+        toast.undoable({
+          message: `Pushed to ${host.name}`,
+          description: "Tap Undo within 10s to pull it back.",
+          onUndo: async () => {
+            const undoResult = await workspacePullBack(
+              workspace.workspace_id,
+            );
+            if (undoResult.ok) {
+              toast.success(`Pulled back from ${host.name}`);
+            } else {
+              toast.error("Pull back failed", {
+                description: undoResult.message,
+              });
+            }
+          },
         });
       } else {
         toast.error(`Push to ${host.name} failed`, {
@@ -264,12 +290,40 @@ export function WorkspaceContextMenuItems({
 
   const handlePullBack = async () => {
     setPushPullInFlight(workspace.workspace_id);
+    // Capture the source host id BEFORE the pull clears it on the
+    // workspace, so the undo closure knows where to push back to.
+    const sourceHostId = workspace.host_id;
+    const sourceHost = sourceHostId
+      ? hosts.find((h) => h.id === sourceHostId)
+      : null;
     try {
       const result = await workspacePullBack(workspace.workspace_id);
       if (result.ok) {
-        toast.success("Pulled back to this device", {
-          description: result.message,
-        });
+        if (sourceHost) {
+          toast.undoable({
+            message: "Pulled back to this device",
+            description: `From ${sourceHost.name}. Tap Undo within 10s to send it back.`,
+            onUndo: async () => {
+              const undoResult = await workspacePushToHost(
+                workspace.workspace_id,
+                sourceHost.id,
+              );
+              if (undoResult.ok) {
+                toast.success(`Pushed back to ${sourceHost.name}`);
+              } else {
+                toast.error("Push back failed", {
+                  description: undoResult.message,
+                });
+              }
+            },
+          });
+        } else {
+          // Source host disappeared (deleted between push and
+          // pull) — no undo possible, plain success.
+          toast.success("Pulled back to this device", {
+            description: result.message,
+          });
+        }
       } else {
         toast.error("Pull back failed", {
           description: result.message,
@@ -402,7 +456,20 @@ export function WorkspaceContextMenuItems({
             {hosts.map((host) => (
               <ContextMenuItem
                 key={host.id}
-                onClick={() => void handleMoveToHost(host)}
+                onClick={() => {
+                  // Phase-4 confirmation gate. If the user clicked
+                  // "Don't ask again for X" previously, skip the
+                  // dialog and push immediately — otherwise hoist
+                  // to the parent to open the confirm modal.
+                  if (
+                    onRequestPushConfirm &&
+                    !shouldSkipPushConfirm(host.id)
+                  ) {
+                    onRequestPushConfirm(host);
+                  } else {
+                    void handleMoveToHost(host);
+                  }
+                }}
               >
                 {host.name}
               </ContextMenuItem>
@@ -449,6 +516,56 @@ function AsciiSpinner() {
 
 export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
   const [showRemoveDialog, setShowRemoveDialog] = useState(false);
+  // Phase-4 push confirmation: holds the host the user just picked
+  // from the "Move to host…" submenu, so the dialog can render its
+  // summary + handle the actual push on confirm.
+  const [pendingPushHost, setPendingPushHost] = useState<HostView | null>(
+    null,
+  );
+  const setPushPullInFlight = useAppStore(
+    (s) => s.setWorkspacePushPullInFlight,
+  );
+
+  const performPushToHost = async (host: HostView) => {
+    setPushPullInFlight(workspace.workspace_id);
+    try {
+      const result = await workspacePushToHost(
+        workspace.workspace_id,
+        host.id,
+      );
+      if (result.ok) {
+        // Undo = pull back. Same machinery as the workspace's
+        // "Pull back to this device" item; gives users a 10s
+        // escape hatch (Phase-4 safety guardrail).
+        toast.undoable({
+          message: `Pushed to ${host.name}`,
+          description: "Tap Undo within 10s to pull it back.",
+          onUndo: async () => {
+            const undoResult = await workspacePullBack(
+              workspace.workspace_id,
+            );
+            if (undoResult.ok) {
+              toast.success(`Pulled back from ${host.name}`);
+            } else {
+              toast.error("Pull back failed", {
+                description: undoResult.message,
+              });
+            }
+          },
+        });
+      } else {
+        toast.error(`Push to ${host.name} failed`, {
+          description: result.message,
+        });
+      }
+    } catch (err) {
+      toast.error("Push failed", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setPushPullInFlight(null);
+    }
+  };
 
   const workspaceStatus: ActivePaneStatus | null = useAppStore((s) => {
     if (!s.appState) return null;
@@ -662,12 +779,26 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
         <WorkspaceContextMenuItems
           workspace={workspace}
           onRemoveRequest={() => setShowRemoveDialog(true)}
+          onRequestPushConfirm={(host) => setPendingPushHost(host)}
         />
       </ContextMenu>
       <RemoveWorkspaceDialog
         workspace={workspace}
         open={showRemoveDialog}
         onOpenChange={setShowRemoveDialog}
+      />
+      <ConfirmPushDialog
+        open={pendingPushHost !== null}
+        workspaceTitle={workspace.title}
+        host={pendingPushHost}
+        onConfirm={() => {
+          if (pendingPushHost) {
+            void performPushToHost(pendingPushHost);
+          }
+        }}
+        onOpenChange={(open) => {
+          if (!open) setPendingPushHost(null);
+        }}
       />
     </>
   );

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -451,7 +451,7 @@ export function WorkspaceContextMenuItems({
         </ContextMenuItem>
       ) : hosts.length > 0 ? (
         <ContextMenuSub>
-          <ContextMenuSubTrigger>Move to host…</ContextMenuSubTrigger>
+          <ContextMenuSubTrigger>Move to device…</ContextMenuSubTrigger>
           <ContextMenuSubContent>
             {hosts.map((host) => (
               <ContextMenuItem
@@ -479,9 +479,9 @@ export function WorkspaceContextMenuItems({
       ) : (
         <ContextMenuItem
           disabled
-          title="Add hosts in Settings → Hosts to push workspaces"
+          title="Add a device in Settings → Devices to push workspaces"
         >
-          Move to host… (no hosts configured)
+          Move to device… (no devices configured)
         </ContextMenuItem>
       )}
 

--- a/src/components/overlays/confirm-push-dialog.test.tsx
+++ b/src/components/overlays/confirm-push-dialog.test.tsx
@@ -1,0 +1,156 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+
+import type { HostView } from "@/tauri/commands";
+import {
+  ConfirmPushDialog,
+  dontAskAgainKey,
+  shouldSkipPushConfirm,
+} from "./confirm-push-dialog";
+
+function makeHost(id: number, name = "homedesk"): HostView {
+  return {
+    id,
+    server_id: `srv-${id}`,
+    name,
+    ssh_target: `${name}@example`,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    dirty: false,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  try {
+    localStorage.clear();
+  } catch {
+    /* test env may lack localStorage */
+  }
+});
+
+describe("ConfirmPushDialog", () => {
+  it("renders the host name and workspace title in the headline + summary", () => {
+    render(
+      <ConfirmPushDialog
+        open
+        workspaceTitle="codemux/feature-x"
+        host={makeHost(7, "homedesk")}
+        onConfirm={() => {}}
+        onOpenChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByText("Push to homedesk?"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("codemux/feature-x")).toBeInTheDocument();
+    // The "What this does" bullets describe the rsync + idle-local
+    // semantics so the user knows what they're committing to.
+    expect(screen.getByText(/Copies the workspace files/i)).toBeInTheDocument();
+    expect(screen.getByText(/goes idle/i)).toBeInTheDocument();
+    expect(screen.getByText(/Undo, for 10 seconds/i)).toBeInTheDocument();
+  });
+
+  it("invokes onConfirm and closes when 'Push' is clicked", () => {
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmPushDialog
+        open
+        workspaceTitle="w"
+        host={makeHost(7)}
+        onConfirm={onConfirm}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    fireEvent.click(screen.getByText("Push"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does NOT invoke onConfirm when Cancel is clicked", () => {
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ConfirmPushDialog
+        open
+        workspaceTitle="w"
+        host={makeHost(7)}
+        onConfirm={onConfirm}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("persists the 'don't ask again' flag per-host on confirm when ticked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmPushDialog
+        open
+        workspaceTitle="w"
+        host={makeHost(99)}
+        onConfirm={onConfirm}
+        onOpenChange={() => {}}
+      />,
+    );
+    const checkbox = screen.getByLabelText(/Don't ask again/i);
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByText("Push"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(dontAskAgainKey(99))).toBe("1");
+    expect(shouldSkipPushConfirm(99)).toBe(true);
+    // Other hosts unaffected.
+    expect(shouldSkipPushConfirm(100)).toBe(false);
+  });
+
+  it("does NOT persist the flag when the user cancels", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmPushDialog
+        open
+        workspaceTitle="w"
+        host={makeHost(5)}
+        onConfirm={onConfirm}
+        onOpenChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/Don't ask again/i));
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(shouldSkipPushConfirm(5)).toBe(false);
+  });
+
+  it("returns null when no host is supplied (the gate caller is mid-state)", () => {
+    const { container } = render(
+      <ConfirmPushDialog
+        open
+        workspaceTitle="w"
+        host={null}
+        onConfirm={() => {}}
+        onOpenChange={() => {}}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("shouldSkipPushConfirm", () => {
+  it("returns false when no flag is set", () => {
+    expect(shouldSkipPushConfirm(1)).toBe(false);
+  });
+
+  it("returns true after the flag is set for that host id", () => {
+    localStorage.setItem(dontAskAgainKey(1), "1");
+    expect(shouldSkipPushConfirm(1)).toBe(true);
+    // Other host ids unaffected.
+    expect(shouldSkipPushConfirm(2)).toBe(false);
+  });
+});

--- a/src/components/overlays/confirm-push-dialog.tsx
+++ b/src/components/overlays/confirm-push-dialog.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+
+import { ArrowUpRight } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { HostView } from "@/tauri/commands";
+
+/**
+ * Confirmation dialog shown before a "Push workspace to device" action
+ * actually fires. The push itself is destructive-ish (moves the live
+ * editing location, alters runtime state, kicks off SSH + rsync), so
+ * giving the user a brief "this will…" preview is the Phase-4 data-
+ * safety guardrail.
+ *
+ * Power-user escape hatch: the "Don't ask again for X" checkbox sets
+ * a per-host localStorage flag (`codemux.push.dontAskAgain.<hostId>`)
+ * that the caller checks before opening this dialog. So the
+ * confirmation step can be bypassed permanently per device once
+ * trust is established.
+ */
+
+const DONT_ASK_AGAIN_KEY_PREFIX = "codemux.push.dontAskAgain.";
+
+export function dontAskAgainKey(hostId: number): string {
+  return `${DONT_ASK_AGAIN_KEY_PREFIX}${hostId}`;
+}
+
+/** Synchronous check the caller uses BEFORE opening the dialog so
+ *  the right-click → push → submenu pick stays a single tap for
+ *  users who flipped the toggle. */
+export function shouldSkipPushConfirm(hostId: number): boolean {
+  try {
+    return localStorage.getItem(dontAskAgainKey(hostId)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+interface Props {
+  open: boolean;
+  workspaceTitle: string;
+  host: HostView | null;
+  onConfirm: () => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ConfirmPushDialog({
+  open,
+  workspaceTitle,
+  host,
+  onConfirm,
+  onOpenChange,
+}: Props) {
+  const [dontAskAgain, setDontAskAgain] = useState(false);
+
+  if (!host) return null;
+
+  const handleConfirm = () => {
+    if (dontAskAgain) {
+      try {
+        localStorage.setItem(dontAskAgainKey(host.id), "1");
+      } catch {
+        // localStorage disabled — confirmation will keep prompting,
+        // which is the safe default.
+      }
+    }
+    onConfirm();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="sm:max-w-[420px] bg-popover p-0 gap-0 overflow-hidden"
+      >
+        <DialogHeader className="px-5 pt-4 pb-2">
+          <DialogTitle className="text-[14px] font-semibold">
+            Push to {host.name}?
+          </DialogTitle>
+          <DialogDescription className="text-[12px] text-muted-foreground/80">
+            Send{" "}
+            <span className="font-medium text-foreground">{workspaceTitle}</span>{" "}
+            to {host.name}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="px-5 pb-4 space-y-3">
+          <ul className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-[11.5px] text-muted-foreground/85 leading-relaxed space-y-1">
+            <li>
+              • Copies the workspace files to{" "}
+              <span className="font-medium text-foreground/90">
+                {host.name}
+              </span>{" "}
+              via rsync.
+            </li>
+            <li>
+              • The live editing location moves to {host.name}. Your
+              local copy stays in place but goes idle.
+            </li>
+            <li>
+              • You can pull it back anytime from the workspace menu
+              (or with Undo, for 10 seconds).
+            </li>
+          </ul>
+
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={dontAskAgain}
+              onChange={(e) => setDontAskAgain(e.target.checked)}
+              className="rounded border-border"
+            />
+            <span className="text-[11.5px] text-muted-foreground">
+              Don't ask again for {host.name}
+            </span>
+          </label>
+
+          <div className="flex justify-end gap-2 pt-1 border-t border-border/40">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-3 text-[12px]"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="h-7 gap-1.5 px-3 text-[12px]"
+              onClick={handleConfirm}
+            >
+              <ArrowUpRight className="size-3" />
+              Push
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/hosts-section.tsx
+++ b/src/components/settings/hosts-section.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
+  Cloud,
+  Cpu,
+  Laptop,
   Loader2,
   Pencil,
   Plus,
@@ -42,6 +45,48 @@ import { useHostsStore } from "@/stores/hosts-store";
  * returns a "not implemented yet" message in 2a. The component is
  * already structured around the eventual real probe.
  */
+/**
+ * The "kind" the user picks from the chips in Add Device. Drives only
+ * the placeholder hints on the form below — never stored, never sent
+ * to the server. The point is to make a first-time user understand
+ * that their home machine counts just as much as a paid VPS.
+ */
+type DeviceKind = "home" | "always-on" | "cloud";
+
+const DEVICE_KINDS: Array<{
+  id: DeviceKind;
+  label: string;
+  icon: typeof Laptop;
+  namePlaceholder: string;
+  sshPlaceholder: string;
+  hint: string;
+}> = [
+  {
+    id: "home",
+    label: "Home desktop",
+    icon: Laptop,
+    namePlaceholder: "home-mac",
+    sshPlaceholder: "you@192.168.1.10",
+    hint: "Already SSH into it from this device? You're set — paste the same user@host string you use in your terminal.",
+  },
+  {
+    id: "always-on",
+    label: "Always-on box",
+    icon: Cpu,
+    namePlaceholder: "pi",
+    sshPlaceholder: "pi@raspberrypi.local",
+    hint: "Best for keeping work running after you close your laptop. Pi, mini-PC, NAS, anything reachable over SSH.",
+  },
+  {
+    id: "cloud",
+    label: "Cloud server",
+    icon: Cloud,
+    namePlaceholder: "vps-fra",
+    sshPlaceholder: "ubuntu@5.5.5.5",
+    hint: "Anything ssh accepts. Your keys + config in ~/.ssh/ are used as-is.",
+  },
+];
+
 export function HostsSection() {
   const [hosts, setHosts] = useState<HostView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -49,6 +94,10 @@ export function HostsSection() {
   const [error, setError] = useState<string | null>(null);
 
   // Add-host form draft. `null` means the form isn't open.
+  // The "kind" the user picked from the chips. Drives the placeholder
+  // hints in the form — purely cosmetic, never stored or pushed.
+  // Reset to `null` whenever the draft is closed.
+  const [draftKind, setDraftKind] = useState<DeviceKind | null>(null);
   const [draft, setDraft] = useState<{ name: string; ssh_target: string } | null>(
     null,
   );
@@ -104,7 +153,7 @@ export function HostsSection() {
     const name = draft.name.trim();
     const sshTarget = draft.ssh_target.trim();
     if (!name || !sshTarget) {
-      setError("Host name and SSH target are both required.");
+      setError("Device name and SSH target are both required.");
       return;
     }
     try {
@@ -139,7 +188,7 @@ export function HostsSection() {
     const name = editDraft.name.trim();
     const sshTarget = editDraft.ssh_target.trim();
     if (!name || !sshTarget) {
-      setError("Host name and SSH target are both required.");
+      setError("Device name and SSH target are both required.");
       return;
     }
     try {
@@ -161,7 +210,7 @@ export function HostsSection() {
 
   const handleDelete = useCallback(async (host: HostView) => {
     const confirmed = window.confirm(
-      `Remove "${host.name}" from your hosts? Your SSH config and keys are not affected.`,
+      `Remove "${host.name}" from your devices? Your SSH config and keys are not affected.`,
     );
     if (!confirmed) return;
     try {
@@ -316,13 +365,56 @@ export function HostsSection() {
         <div className="mt-4 pt-4 border-t border-border/40">
           {draft ? (
             <div className="space-y-3 rounded-lg border border-border/60 bg-muted/30 p-3">
+              {/* Device-kind chips. Picking one pre-fills the
+                  placeholder hints in the form below — cosmetic
+                  only, never stored. Helps a first-time user
+                  understand "device" works for their home Mac just
+                  as well as a cloud VPS. */}
+              <div className="space-y-1.5">
+                <Label className="text-[11px] text-muted-foreground/85 font-normal">
+                  What kind of device?
+                </Label>
+                <div className="grid grid-cols-3 gap-1.5">
+                  {DEVICE_KINDS.map((kind) => (
+                    <button
+                      key={kind.id}
+                      type="button"
+                      onClick={() => setDraftKind(kind.id)}
+                      className={cn(
+                        "flex flex-col items-center gap-1 rounded-md border px-2 py-2 text-center transition-colors",
+                        draftKind === kind.id
+                          ? "border-sky-500/40 bg-sky-500/10 text-foreground"
+                          : "border-border/60 bg-background/40 text-muted-foreground hover:border-border hover:bg-muted/30 hover:text-foreground",
+                      )}
+                    >
+                      <kind.icon
+                        className={cn(
+                          "size-4",
+                          draftKind === kind.id
+                            ? "text-sky-400"
+                            : "text-muted-foreground/70",
+                        )}
+                      />
+                      <span className="text-[10.5px] font-medium leading-tight">
+                        {kind.label}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
               <div className="space-y-1.5">
                 <Label htmlFor="host-add-name" className="text-[11px] text-muted-foreground/85 font-normal">
                   Name
                 </Label>
                 <Input
                   id="host-add-name"
-                  placeholder="homelab"
+                  placeholder={
+                    draftKind
+                      ? DEVICE_KINDS.find((k) => k.id === draftKind)
+                          ?.namePlaceholder ?? "homelab"
+                      : "homelab"
+                  }
                   value={draft.name}
                   onChange={(e) =>
                     setDraft({ ...draft, name: e.target.value })
@@ -337,7 +429,12 @@ export function HostsSection() {
                 </Label>
                 <Input
                   id="host-add-target"
-                  placeholder="user@host"
+                  placeholder={
+                    draftKind
+                      ? DEVICE_KINDS.find((k) => k.id === draftKind)
+                          ?.sshPlaceholder ?? "user@host"
+                      : "user@host"
+                  }
                   value={draft.ssh_target}
                   onChange={(e) =>
                     setDraft({ ...draft, ssh_target: e.target.value })
@@ -345,8 +442,9 @@ export function HostsSection() {
                   className="h-8 text-[13px] font-mono"
                 />
                 <p className="text-[11px] text-muted-foreground/70 leading-relaxed">
-                  Anything <code className="font-mono text-[10.5px]">ssh</code> accepts.
-                  Your keys + config in <code className="font-mono text-[10.5px]">~/.ssh/</code> are used as-is.
+                  {draftKind
+                    ? DEVICE_KINDS.find((k) => k.id === draftKind)?.hint
+                    : "Anything ssh accepts. Your keys + config in ~/.ssh/ are used as-is."}
                 </p>
               </div>
               <div className="flex justify-end gap-1.5 pt-1">
@@ -357,6 +455,7 @@ export function HostsSection() {
                   className="h-7 px-3 text-[12px]"
                   onClick={() => {
                     setDraft(null);
+                    setDraftKind(null);
                     setError(null);
                   }}
                 >
@@ -379,10 +478,13 @@ export function HostsSection() {
               variant="ghost"
               size="sm"
               className="w-full justify-start gap-2 h-8 px-2.5 text-[13px] text-muted-foreground hover:text-foreground hover:bg-muted/40 border border-dashed border-border/60"
-              onClick={() => setDraft({ name: "", ssh_target: "" })}
+              onClick={() => {
+                setDraft({ name: "", ssh_target: "" });
+                setDraftKind(null);
+              }}
             >
               <Plus className="size-3.5" />
-              Add host
+              Add device
             </Button>
           )}
 

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -149,7 +149,7 @@ function buildNavGroups(agentChatEnabled: boolean): NavGroup[] {
     // because picking which machine to run on is a workflow decision,
     // not a personal preference. Always visible (no flag gate) since
     // the underlying daemon is now standard built-in behavior.
-    { id: "hosts", label: "Hosts", icon: Server },
+    { id: "hosts", label: "Devices", icon: Server },
     { id: "session_restore", label: "Session Restore", icon: RotateCcw },
   ];
 
@@ -1386,8 +1386,8 @@ export function SettingsView() {
         return (
           <div>
             <SectionHeader
-              title="Hosts"
-              description="Remote machines you can push workspaces to. SSH credentials stay on your device — only the host name and SSH target sync across your devices."
+              title="Devices"
+              description="Any machine you can SSH into — a home desktop, an always-on box, a cloud server. Push a workspace to any device, pull it back from any device. SSH credentials stay on your machine; only the device name and SSH target sync across your account."
             />
             <HostsSection />
           </div>

--- a/src/components/workspaces-overview/how-it-works-popover.tsx
+++ b/src/components/workspaces-overview/how-it-works-popover.tsx
@@ -1,0 +1,157 @@
+import { useState } from "react";
+
+import { ArrowUpRight, ArrowDownToLine, HelpCircle, Cloud } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+
+const SEEN_KEY = "codemux.workspaces.howItWorksSeen";
+
+function markSeen() {
+  try {
+    localStorage.setItem(SEEN_KEY, "1");
+  } catch {
+    /* no-op */
+  }
+}
+
+function hasSeen(): boolean {
+  try {
+    return localStorage.getItem(SEEN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * "How does this work?" popover in the Workspaces overview header.
+ *
+ * Three-step explainer of the push → sync → pull model with subtle
+ * icons. Lives next to the filter bar so it's always reachable but
+ * never demanding. First-time users get a tiny "new" dot on the
+ * `?` icon (clears on first open) so the affordance is discoverable
+ * without being noisy.
+ *
+ * Design notes:
+ * - Anchored popover (not modal) — explaining the model shouldn't
+ *   block what the user was doing.
+ * - Each step pairs a small accent-coloured icon with a one-line
+ *   description. The icons reinforce the per-row affordances the
+ *   user will see in the overview (Push uses the same up-right
+ *   arrow the workspace menu does; Pull uses the down-to-line
+ *   icon; Cloud is the cross-device-sync glyph).
+ * - Closes on outside-click via Radix's default behaviour.
+ */
+export function HowItWorksPopover() {
+  const [hasSeenIt, setHasSeenIt] = useState(() => hasSeen());
+
+  return (
+    <Popover
+      onOpenChange={(open) => {
+        if (open && !hasSeenIt) {
+          markSeen();
+          setHasSeenIt(true);
+        }
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="How does this work?"
+          className="relative size-7 text-muted-foreground/70 hover:text-foreground"
+        >
+          <HelpCircle className="size-3.5" />
+          {!hasSeenIt && (
+            <span
+              aria-hidden
+              className="absolute -top-0.5 -right-0.5 flex size-2"
+            >
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-sky-400 opacity-75" />
+              <span className="relative inline-flex size-2 rounded-full bg-sky-500" />
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        className="w-[320px] p-0 overflow-hidden"
+      >
+        <div className="bg-gradient-to-br from-sky-500/10 via-transparent to-emerald-500/8 px-4 py-3 border-b border-border/40">
+          <p className="text-[12.5px] font-semibold text-foreground">
+            How workspaces sync across devices
+          </p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground/75 leading-relaxed">
+            Files live in one place at a time. The registry tells every
+            device of your account where each workspace is.
+          </p>
+        </div>
+        <ol className="px-4 py-3 space-y-3 text-[11.5px] leading-relaxed">
+          <Step
+            n="1"
+            icon={<ArrowUpRight className="size-3 text-emerald-400" />}
+            title="Push from any device"
+            body="Right-click a workspace → Move to <device>. Files rsync to the destination."
+          />
+          <Step
+            n="2"
+            icon={<Cloud className="size-3 text-sky-400" />}
+            title="Sync makes it visible everywhere"
+            body="The workspace appears in this overview on every device you're signed in to."
+          />
+          <Step
+            n="3"
+            icon={
+              <ArrowDownToLine className="size-3 text-violet-400" />
+            }
+            title="Pull to any device when you want it"
+            body="Sibling-device rows offer Pull to this device → files come over via rsync or git clone."
+          />
+        </ol>
+        <div className="px-4 py-2.5 border-t border-border/40 bg-muted/20">
+          <p className="text-[10.5px] text-muted-foreground/65 leading-relaxed">
+            Every push and pull is undoable for 10 seconds. Workspace
+            files never sync silently — they only move when you say so.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function Step({
+  n,
+  icon,
+  title,
+  body,
+}: {
+  n: string;
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+}) {
+  return (
+    <li className="flex items-start gap-3">
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border/50 bg-muted/30 font-mono text-[10px] text-muted-foreground/70 tabular-nums">
+        {n}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="flex items-center gap-1.5 text-[12px] font-medium text-foreground/95">
+          {icon}
+          {title}
+        </p>
+        <p className="mt-0.5 text-[11px] text-muted-foreground/75">
+          {body}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+export const HOW_IT_WORKS_SEEN_KEY = SEEN_KEY;

--- a/src/components/workspaces-overview/pull-to-device-dialog.test.tsx
+++ b/src/components/workspaces-overview/pull-to-device-dialog.test.tsx
@@ -16,15 +16,28 @@ const mockPreview = vi.fn<
   (serverId: string) => Promise<AdoptionPreview>
 >();
 const mockAdopt = vi.fn<(serverId: string) => Promise<unknown>>();
+const mockAdoptClone = vi.fn<(serverId: string) => Promise<unknown>>();
 const mockActivate = vi.fn();
+const mockPushToHost = vi.fn();
 
 vi.mock("@/tauri/commands", () => ({
   workspacesAdoptionPreview: (id: string) => mockPreview(id),
   workspacesAdoptSynced: (id: string) => mockAdopt(id),
+  workspacesAdoptViaClone: (id: string) => mockAdoptClone(id),
+  workspacePushToHost: (...args: unknown[]) => {
+    mockPushToHost(...args);
+    return Promise.resolve({ ok: true, message: "" });
+  },
   activateWorkspace: (id: string) => {
     mockActivate(id);
     return Promise.resolve();
   },
+}));
+
+vi.mock("@/stores/hosts-store", () => ({
+  useHostsStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ hosts: [] }),
+  ),
 }));
 
 vi.mock("@/stores/app-store", () => ({
@@ -111,7 +124,9 @@ describe("PullToDeviceDialog", () => {
   beforeEach(() => {
     mockPreview.mockReset();
     mockAdopt.mockReset();
+    mockAdoptClone.mockReset();
     mockActivate.mockReset();
+    mockPushToHost.mockReset();
   });
 
   it("does not render when syncRow is null", () => {
@@ -149,10 +164,14 @@ describe("PullToDeviceDialog", () => {
     expect(screen.queryByText("Pull workspace")).toBeInTheDocument();
   });
 
-  it("renders 'configure the device first' when host isn't on this device", async () => {
+  it("renders 'configure the device first' when host isn't on this device and no clone fallback applies", async () => {
     mockPreview.mockResolvedValue(
       makePreview({
         can_host_adopt: false,
+        // Force clone-fallback OFF so the host-not-configured block
+        // is the variant rendered (the dialog now picks clone over
+        // host-not-configured when project_remote is set).
+        can_clone_adopt: false,
         host_configured: false,
         host_label: null,
       }),
@@ -257,5 +276,92 @@ describe("PullToDeviceDialog", () => {
     expect(screen.queryByText(/Copies the workspace files from/i)).toBeNull();
     // The toggle is still there.
     expect(screen.getByText("What this does")).toBeInTheDocument();
+  });
+
+  // ── Phase-3 clone-fallback variant ───────────────────────────
+
+  it("renders the clone-fallback variant when no shared host but project_remote is set", async () => {
+    mockPreview.mockResolvedValue(
+      makePreview({
+        can_host_adopt: false,
+        can_clone_adopt: true,
+        host_configured: false,
+        host_label: null,
+      }),
+    );
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow({ host_server_id: null })}
+        onOpenChange={() => {}}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/We'll clone it from git/i),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(
+        /Uncommitted work on the other device will NOT come over/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Clone and open")).toBeInTheDocument();
+  });
+
+  it("calls workspacesAdoptViaClone (not workspacesAdoptSynced) when submitting in clone mode", async () => {
+    mockPreview.mockResolvedValue(
+      makePreview({
+        can_host_adopt: false,
+        can_clone_adopt: true,
+        host_configured: false,
+        host_label: null,
+      }),
+    );
+    mockAdoptClone.mockResolvedValue({
+      workspace_id: "workspace-cloned",
+      worktree_path: "/home/zeus/.codemux/worktrees/codemux/feature-x",
+      message: "Cloned",
+    });
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow({ host_server_id: null })}
+        onOpenChange={() => {}}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Clone and open")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByText("Clone and open"));
+    await waitFor(() =>
+      expect(mockAdoptClone).toHaveBeenCalledWith("42"),
+    );
+    expect(mockAdopt).not.toHaveBeenCalled();
+  });
+
+  it("renders the no-options block when neither host_configured nor can_clone_adopt", async () => {
+    mockPreview.mockResolvedValue(
+      makePreview({
+        can_host_adopt: false,
+        can_clone_adopt: false,
+        host_configured: false,
+        host_label: null,
+      }),
+    );
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow({
+          host_server_id: null,
+          project_remote: null,
+        })}
+        onOpenChange={() => {}}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/no shared host, no git remote URL/i),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Pull workspace")).toBeNull();
+    expect(screen.queryByText("Clone and open")).toBeNull();
   });
 });

--- a/src/components/workspaces-overview/pull-to-device-dialog.test.tsx
+++ b/src/components/workspaces-overview/pull-to-device-dialog.test.tsx
@@ -87,6 +87,7 @@ function makeSyncRow(
     project_path: "/home/zeus/projects/codemux",
     project_remote: "git@github.com:Zeus-Deus/codemux.git",
     git_branch: "feature-x",
+    git_head_sha: null,
     created_at: "2026-05-20T10:00:00Z",
     updated_at: "2026-05-20T10:00:00Z",
     dirty: false,

--- a/src/components/workspaces-overview/pull-to-device-dialog.test.tsx
+++ b/src/components/workspaces-overview/pull-to-device-dialog.test.tsx
@@ -1,0 +1,261 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import type { WorkspaceSyncView, AdoptionPreview } from "@/tauri/commands";
+
+// ── Mocks ───────────────────────────────────────────────────────
+
+const mockPreview = vi.fn<
+  (serverId: string) => Promise<AdoptionPreview>
+>();
+const mockAdopt = vi.fn<(serverId: string) => Promise<unknown>>();
+const mockActivate = vi.fn();
+
+vi.mock("@/tauri/commands", () => ({
+  workspacesAdoptionPreview: (id: string) => mockPreview(id),
+  workspacesAdoptSynced: (id: string) => mockAdopt(id),
+  activateWorkspace: (id: string) => {
+    mockActivate(id);
+    return Promise.resolve();
+  },
+}));
+
+vi.mock("@/stores/app-store", () => ({
+  useAppStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      setWorkspacePushPullInFlight: vi.fn(),
+    }),
+  ),
+}));
+
+vi.mock("@/stores/ui-store", () => ({
+  useUIStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      setShowWorkspacesOverview: vi.fn(),
+    }),
+  ),
+}));
+
+vi.mock("@/stores/workspaces-sync-store", () => ({
+  useWorkspacesSyncStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      refresh: () => Promise.resolve(),
+    }),
+  ),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+import { PullToDeviceDialog } from "./pull-to-device-dialog";
+
+function makeSyncRow(
+  overrides?: Partial<WorkspaceSyncView>,
+): WorkspaceSyncView {
+  return {
+    id: 1,
+    server_id: "42",
+    workspace_id: null,
+    title: "codemux/feature-x",
+    host_server_id: "7",
+    project_path: "/home/zeus/projects/codemux",
+    project_remote: "git@github.com:Zeus-Deus/codemux.git",
+    git_branch: "feature-x",
+    created_at: "2026-05-20T10:00:00Z",
+    updated_at: "2026-05-20T10:00:00Z",
+    dirty: false,
+    ...overrides,
+  };
+}
+
+function makePreview(
+  overrides?: Partial<AdoptionPreview>,
+): AdoptionPreview {
+  return {
+    can_host_adopt: true,
+    can_clone_adopt: true,
+    host_configured: true,
+    host_label: "homedesk",
+    project_already_cloned_at: null,
+    suggested_path: "/home/zeus/.codemux/worktrees/codemux/feature-x",
+    is_path_in_use: false,
+    already_adopted_workspace_id: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  try {
+    localStorage.clear();
+  } catch {
+    /* test env may not have localStorage */
+  }
+});
+
+describe("PullToDeviceDialog", () => {
+  beforeEach(() => {
+    mockPreview.mockReset();
+    mockAdopt.mockReset();
+    mockActivate.mockReset();
+  });
+
+  it("does not render when syncRow is null", () => {
+    const { container } = render(
+      <PullToDeviceDialog syncRow={null} onOpenChange={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(mockPreview).not.toHaveBeenCalled();
+  });
+
+  it("renders the host-backed summary when preview returns can_host_adopt", async () => {
+    mockPreview.mockResolvedValue(makePreview());
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow()}
+        onOpenChange={() => {}}
+      />,
+    );
+    await waitFor(() => expect(mockPreview).toHaveBeenCalledWith("42"));
+    // Radix Dialog portals content to document.body — use `screen`
+    // rather than the container returned by `render`.
+    await waitFor(() =>
+      expect(screen.getAllByText(/homedesk/).length).toBeGreaterThan(0),
+    );
+    expect(screen.getByText("feature-x")).toBeInTheDocument();
+    expect(
+      screen.getByText("/home/zeus/.codemux/worktrees/codemux/feature-x"),
+    ).toBeInTheDocument();
+    // "What this does" should be pre-expanded on first pull
+    // (localStorage flag absent).
+    expect(
+      screen.getByText(/Copies the workspace files from/i),
+    ).toBeInTheDocument();
+    // Pull button is enabled.
+    expect(screen.queryByText("Pull workspace")).toBeInTheDocument();
+  });
+
+  it("renders 'configure the device first' when host isn't on this device", async () => {
+    mockPreview.mockResolvedValue(
+      makePreview({
+        can_host_adopt: false,
+        host_configured: false,
+        host_label: null,
+      }),
+    );
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow()}
+        onOpenChange={() => {}}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/haven't configured here yet/i),
+      ).toBeInTheDocument(),
+    );
+    // Pull button is NOT shown when host is missing.
+    expect(screen.queryByText("Pull workspace")).toBeNull();
+  });
+
+  it("renders 'path in use' when the suggested path collides with a local workspace", async () => {
+    mockPreview.mockResolvedValue(
+      makePreview({ is_path_in_use: true }),
+    );
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow()}
+        onOpenChange={() => {}}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/already using/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Pull workspace")).toBeNull();
+  });
+
+  it("offers 'Open it' when the row is already adopted on this device", async () => {
+    mockPreview.mockResolvedValue(
+      makePreview({ already_adopted_workspace_id: "workspace-42" }),
+    );
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow()}
+        onOpenChange={() => {}}
+      />,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText(/already pulled this workspace/i),
+      ).toBeInTheDocument(),
+    );
+    const openBtn = screen.getByText("Open it");
+    fireEvent.click(openBtn);
+    expect(mockActivate).toHaveBeenCalledWith("workspace-42");
+  });
+
+  it("calls workspacesAdoptSynced and closes the dialog on submit", async () => {
+    mockPreview.mockResolvedValue(makePreview());
+    mockAdopt.mockResolvedValue({
+      workspace_id: "workspace-99",
+      worktree_path: "/home/zeus/.codemux/worktrees/codemux/feature-x",
+      message: "Workspace pulled back from homedesk",
+    });
+    const onOpenChange = vi.fn();
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow()}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("Pull workspace")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Pull workspace"));
+
+    // The dialog closes immediately (optimistic).
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    await waitFor(() => expect(mockAdopt).toHaveBeenCalledWith("42"));
+  });
+
+  it("collapses 'What this does' on subsequent pulls once the flag is set", async () => {
+    try {
+      localStorage.setItem("codemux.workspaces.firstPullDone.default", "1");
+    } catch {
+      // skip if localStorage unavailable
+    }
+    mockPreview.mockResolvedValue(makePreview());
+    render(
+      <PullToDeviceDialog
+        syncRow={makeSyncRow()}
+        onOpenChange={() => {}}
+      />,
+    );
+    // Wait for the preview-driven render. "Will land" path is a
+    // good marker — only the host-backed form variant renders it.
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "/home/zeus/.codemux/worktrees/codemux/feature-x",
+        ),
+      ).toBeInTheDocument(),
+    );
+    // The detail bullets should NOT be visible by default this time.
+    expect(screen.queryByText(/Copies the workspace files from/i)).toBeNull();
+    // The toggle is still there.
+    expect(screen.getByText("What this does")).toBeInTheDocument();
+  });
+});

--- a/src/components/workspaces-overview/pull-to-device-dialog.tsx
+++ b/src/components/workspaces-overview/pull-to-device-dialog.tsx
@@ -1,0 +1,483 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  ArrowDownToLine,
+  ChevronDown,
+  ChevronRight,
+  Cloud,
+  Loader2,
+  Settings2,
+} from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { toast } from "@/lib/toast";
+import { useAppStore } from "@/stores/app-store";
+import { useUIStore } from "@/stores/ui-store";
+import { useWorkspacesSyncStore } from "@/stores/workspaces-sync-store";
+import {
+  activateWorkspace,
+  workspacesAdoptionPreview,
+  workspacesAdoptSynced,
+  type AdoptionPreview,
+  type WorkspaceSyncView,
+} from "@/tauri/commands";
+
+interface Props {
+  /** The synced row the user wants to adopt. Null = dialog closed. */
+  syncRow: WorkspaceSyncView | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+const FIRST_PULL_DONE_KEY_PREFIX = "codemux.workspaces.firstPullDone.";
+
+function firstPullDoneKey(): string {
+  // Per-device machine id would be ideal; for v1 use a single global
+  // flag scoped by the app's persistence root. The cost of being
+  // slightly imprecise here is that a user on a multi-account
+  // machine sees the disclosure twice — acceptable.
+  return `${FIRST_PULL_DONE_KEY_PREFIX}default`;
+}
+
+function hasSeenFirstPull(): boolean {
+  try {
+    return localStorage.getItem(firstPullDoneKey()) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markFirstPullSeen() {
+  try {
+    localStorage.setItem(firstPullDoneKey(), "1");
+  } catch {
+    // localStorage disabled — non-fatal, just always pre-expand.
+  }
+}
+
+/**
+ * Pull-to-this-device dialog. The frontend opens this when the user
+ * clicks "Pull to this device" on a sibling-device row in the
+ * Workspaces overview.
+ *
+ * Behaviour:
+ *   1. On open, fetch the adoption preview via
+ *      `workspacesAdoptionPreview`. This tells us whether host-backed
+ *      adoption is possible (the headline path), or whether we'd
+ *      need the Phase-3 clone fallback (not implemented yet — we
+ *      surface the case with a clear message).
+ *   2. Render a summary: workspace title, source host, project,
+ *      branch, target local path. The "What this does" disclosure
+ *      is pre-expanded on the user's first pull on this device.
+ *   3. On submit, call `workspacesAdoptSynced` and close the dialog
+ *      immediately. The pending state is surfaced via the existing
+ *      `workspacePushPullInFlight` machinery — the dialog does NOT
+ *      stay open during the rsync.
+ *   4. Toast on completion with the option to open the new workspace.
+ *
+ * Mirrors the existing `CloneDialog` shape (sm:max-w-[460px] popover)
+ * and the in-flight signalling pattern used by push-to-host.
+ */
+export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
+  const setShowWorkspacesOverview = useUIStore(
+    (s) => s.setShowWorkspacesOverview,
+  );
+  const setPushPullInFlight = useAppStore(
+    (s) => s.setWorkspacePushPullInFlight,
+  );
+  const refreshSync = useWorkspacesSyncStore((s) => s.refresh);
+
+  const [preview, setPreview] = useState<AdoptionPreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [disclosureOpen, setDisclosureOpen] = useState(false);
+
+  const open = syncRow !== null;
+  const serverId = syncRow?.server_id ?? null;
+
+  // Load preview when the dialog opens. Aborts on close so we don't
+  // leak a pending IPC after the user dismisses.
+  useEffect(() => {
+    if (!open || !serverId) return;
+    let cancelled = false;
+    setPreview(null);
+    setPreviewError(null);
+    setDisclosureOpen(!hasSeenFirstPull());
+    workspacesAdoptionPreview(serverId)
+      .then((result) => {
+        if (!cancelled) setPreview(result);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setPreviewError(
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, serverId]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!syncRow || !serverId || !preview) return;
+    setSubmitting(true);
+    // Optimistic: signal the in-flight state immediately so the
+    // sidebar + overview show a spinner the moment the dialog
+    // closes. We don't have a local workspace id yet (the shell is
+    // created inside `workspaces_adopt_synced`), so we key the
+    // in-flight signal on the server id prefixed to avoid colliding
+    // with real workspace ids.
+    const inFlightKey = `pending-adopt-${serverId}`;
+    setPushPullInFlight(inFlightKey);
+    onOpenChange(false);
+
+    try {
+      const result = await workspacesAdoptSynced(serverId);
+      markFirstPullSeen();
+      // Nudge the synced-rows cache so the row migrates from
+      // sibling-device to local in the overview without waiting
+      // for the 5s polling tick.
+      void refreshSync();
+      toast.success(`Pulled ${syncRow.title} to this device`, {
+        description:
+          preview.host_label
+            ? `From ${preview.host_label}. The copy on ${preview.host_label} stays in place — push back from this device whenever you want.`
+            : result.message,
+        action: {
+          label: "Open",
+          onClick: () => {
+            setShowWorkspacesOverview(false);
+            void activateWorkspace(result.workspace_id);
+          },
+        },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Decode our structured-error prefixes so the toast is
+      // actionable rather than raw.
+      let title = "Pull failed";
+      let description = message;
+      if (message.startsWith("host_not_configured:")) {
+        title = "Configure the device first";
+        description = message.replace(/^host_not_configured:\s*/, "");
+      } else if (message.startsWith("path_in_use:")) {
+        title = "Path already in use";
+        description = message.replace(/^path_in_use:\s*/, "");
+      }
+      toast.error(title, { description });
+    } finally {
+      setSubmitting(false);
+      setPushPullInFlight(null);
+    }
+  }, [
+    syncRow,
+    serverId,
+    preview,
+    setPushPullInFlight,
+    onOpenChange,
+    refreshSync,
+    setShowWorkspacesOverview,
+  ]);
+
+  // ── Open-existing-on-already-adopted short-circuit ────────────
+  //
+  // The user clicked Pull on a row that's already been adopted on
+  // this device (rare, e.g. if the overview is stale). Open the
+  // existing workspace instead of confusingly trying to "adopt
+  // again".
+  const alreadyAdopted = preview?.already_adopted_workspace_id ?? null;
+
+  const handleOpenExisting = useCallback(() => {
+    if (!alreadyAdopted) return;
+    onOpenChange(false);
+    setShowWorkspacesOverview(false);
+    void activateWorkspace(alreadyAdopted);
+  }, [alreadyAdopted, onOpenChange, setShowWorkspacesOverview]);
+
+  if (!syncRow) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="sm:max-w-[480px] bg-popover p-0 gap-0 overflow-hidden"
+      >
+        <DialogHeader className="px-5 pt-4 pb-2">
+          <DialogTitle className="text-[14px] font-semibold">
+            Pull workspace to this device
+          </DialogTitle>
+          <DialogDescription className="text-[12px] text-muted-foreground/80">
+            Bring{" "}
+            <span className="font-medium text-foreground">
+              {syncRow.title}
+            </span>{" "}
+            from another device.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="px-5 pb-4 space-y-3">
+          {previewError ? (
+            <ErrorBlock message={previewError} />
+          ) : !preview ? (
+            <div className="flex items-center gap-2 py-3 text-[12px] text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" />
+              Checking…
+            </div>
+          ) : alreadyAdopted ? (
+            <AlreadyAdoptedBlock onOpen={handleOpenExisting} />
+          ) : !preview.host_configured ? (
+            <HostNotConfiguredBlock
+              hostServerId={syncRow.host_server_id}
+              onClose={() => onOpenChange(false)}
+            />
+          ) : !preview.can_host_adopt ? (
+            <CloneFallbackComingSoonBlock />
+          ) : preview.is_path_in_use ? (
+            <PathInUseBlock path={preview.suggested_path} />
+          ) : (
+            <HostBackedAdoptionForm
+              syncRow={syncRow}
+              preview={preview}
+              disclosureOpen={disclosureOpen}
+              onToggleDisclosure={() =>
+                setDisclosureOpen((open) => !open)
+              }
+            />
+          )}
+
+          <div className="flex justify-end gap-2 pt-1 border-t border-border/40">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-3 text-[12px]"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            {preview &&
+              !alreadyAdopted &&
+              preview.host_configured &&
+              preview.can_host_adopt &&
+              !preview.is_path_in_use && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="h-7 gap-1.5 px-3 text-[12px]"
+                  onClick={() => void handleSubmit()}
+                  disabled={submitting}
+                >
+                  {submitting ? (
+                    <Loader2 className="size-3 animate-spin" />
+                  ) : (
+                    <ArrowDownToLine className="size-3" />
+                  )}
+                  Pull workspace
+                </Button>
+              )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Subviews ────────────────────────────────────────────────────
+
+function HostBackedAdoptionForm({
+  syncRow,
+  preview,
+  disclosureOpen,
+  onToggleDisclosure,
+}: {
+  syncRow: WorkspaceSyncView;
+  preview: AdoptionPreview;
+  disclosureOpen: boolean;
+  onToggleDisclosure: () => void;
+}) {
+  return (
+    <>
+      <dl className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[12.5px] space-y-1.5">
+        <SummaryRow
+          label="From"
+          icon={<Cloud className="size-3 text-sky-400/80" />}
+        >
+          {preview.host_label ?? "—"}
+        </SummaryRow>
+        <SummaryRow label="Project">
+          {syncRow.project_path
+            ? syncRow.project_path.split("/").filter(Boolean).slice(-1)[0] ??
+              "—"
+            : "—"}
+        </SummaryRow>
+        <SummaryRow label="Branch">
+          <span className="font-mono text-[11.5px]">
+            {syncRow.git_branch ?? "—"}
+          </span>
+        </SummaryRow>
+        <SummaryRow label="Will land">
+          <span className="font-mono text-[11px] text-muted-foreground/80 break-all">
+            {preview.suggested_path}
+          </span>
+        </SummaryRow>
+      </dl>
+
+      <button
+        type="button"
+        onClick={onToggleDisclosure}
+        className="flex w-full items-center gap-1 text-[11.5px] text-muted-foreground/75 hover:text-foreground transition-colors"
+      >
+        {disclosureOpen ? (
+          <ChevronDown className="size-3" />
+        ) : (
+          <ChevronRight className="size-3" />
+        )}
+        What this does
+      </button>
+
+      {disclosureOpen && (
+        <ul className="rounded-md bg-muted/20 border border-border/40 px-3 py-2 text-[11.5px] text-muted-foreground/85 leading-relaxed space-y-1">
+          <li>
+            • Copies the workspace files from{" "}
+            <span className="font-medium text-foreground/90">
+              {preview.host_label}
+            </span>{" "}
+            to this device via rsync.
+          </li>
+          <li>
+            • The copy on {preview.host_label} stays in place and goes
+            idle until you push back.
+          </li>
+          <li>
+            • You can push it back to any of your devices anytime from
+            the workspace menu.
+          </li>
+        </ul>
+      )}
+    </>
+  );
+}
+
+function HostNotConfiguredBlock({
+  hostServerId,
+  onClose,
+}: {
+  hostServerId: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2.5 text-[12px] text-warning/95 leading-relaxed space-y-2">
+      <p>
+        This workspace lives on a device you haven't configured here
+        yet
+        {hostServerId ? (
+          <>
+            {" "}
+            (host id <span className="font-mono">{hostServerId}</span>).
+          </>
+        ) : (
+          "."
+        )}
+      </p>
+      <p className="text-warning/85">
+        Add the device in Settings → Devices, then come back and pull.
+      </p>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 px-2.5 text-[11.5px] gap-1.5 border-warning/30 hover:bg-warning/15"
+        onClick={() => {
+          onClose();
+          // TODO: deep-link to Settings → Devices when that route lands.
+        }}
+      >
+        <Settings2 className="size-3" />
+        Open settings
+      </Button>
+    </div>
+  );
+}
+
+function CloneFallbackComingSoonBlock() {
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[12px] text-muted-foreground/85 leading-relaxed">
+      This workspace lives only on another device (no shared host).
+      Cloning from the git remote is coming in a follow-up — for now,
+      open the other device and push this workspace to one of your
+      devices, then pull it from there.
+    </div>
+  );
+}
+
+function PathInUseBlock({ path }: { path: string }) {
+  return (
+    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-[12px] text-destructive/95 leading-relaxed">
+      <p className="mb-1">A different workspace is already using:</p>
+      <p className="font-mono text-[11px] text-destructive/85 break-all">
+        {path}
+      </p>
+      <p className="mt-2 text-destructive/85">
+        Close that workspace first, or wait for the upcoming "choose
+        different path" picker.
+      </p>
+    </div>
+  );
+}
+
+function AlreadyAdoptedBlock({ onOpen }: { onOpen: () => void }) {
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[12px] text-muted-foreground/85 leading-relaxed space-y-2">
+      <p>You've already pulled this workspace to this device.</p>
+      <Button
+        variant="secondary"
+        size="sm"
+        className="h-7 px-2.5 text-[11.5px]"
+        onClick={onOpen}
+      >
+        Open it
+      </Button>
+    </div>
+  );
+}
+
+function ErrorBlock({ message }: { message: string }) {
+  return (
+    <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-[12px] text-destructive/95">
+      {message}
+    </div>
+  );
+}
+
+function SummaryRow({
+  label,
+  icon,
+  children,
+}: {
+  label: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <dt className="w-[68px] shrink-0 text-[10.5px] uppercase tracking-wider text-muted-foreground/55">
+        {label}
+      </dt>
+      <dd
+        className={cn(
+          "min-w-0 flex-1 text-[12px] text-foreground/90 flex items-center gap-1",
+        )}
+      >
+        {icon}
+        <span className="min-w-0 truncate">{children}</span>
+      </dd>
+    </div>
+  );
+}

--- a/src/components/workspaces-overview/pull-to-device-dialog.tsx
+++ b/src/components/workspaces-overview/pull-to-device-dialog.tsx
@@ -24,11 +24,13 @@ import { useUIStore } from "@/stores/ui-store";
 import { useWorkspacesSyncStore } from "@/stores/workspaces-sync-store";
 import {
   activateWorkspace,
+  workspacePushToHost,
   workspacesAdoptionPreview,
   workspacesAdoptSynced,
   type AdoptionPreview,
   type WorkspaceSyncView,
 } from "@/tauri/commands";
+import { useHostsStore } from "@/stores/hosts-store";
 
 interface Props {
   /** The synced row the user wants to adopt. Null = dialog closed. */
@@ -93,6 +95,7 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
     (s) => s.setWorkspacePushPullInFlight,
   );
   const refreshSync = useWorkspacesSyncStore((s) => s.refresh);
+  const hosts = useHostsStore((s) => s.hosts);
 
   const [preview, setPreview] = useState<AdoptionPreview | null>(null);
   const [previewError, setPreviewError] = useState<string | null>(null);
@@ -146,19 +149,59 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
       // sibling-device to local in the overview without waiting
       // for the 5s polling tick.
       void refreshSync();
-      toast.success(`Pulled ${syncRow.title} to this device`, {
-        description:
-          preview.host_label
-            ? `From ${preview.host_label}. The copy on ${preview.host_label} stays in place — push back from this device whenever you want.`
+
+      // Resolve the local hosts.id matching the host we just
+      // pulled from — needed to drive the "Undo = push back" flow.
+      // The hosts cache is populated by the overview before the
+      // dialog ever opens, so this lookup is synchronous.
+      const sourceHostServerId = syncRow.host_server_id;
+      const sourceHost = sourceHostServerId
+        ? hosts.find((h) => h.server_id === sourceHostServerId)
+        : null;
+
+      if (sourceHost) {
+        // Push-back as Undo: data-safety guardrail. If the user
+        // realises within 10s that they pulled the wrong workspace
+        // (or didn't mean to), one click sends it back to where
+        // it came from. Same rsync machinery as a manual push.
+        toast.undoable({
+          message: `Pulled ${syncRow.title} to this device`,
+          description: preview.host_label
+            ? `From ${preview.host_label}. Tap Undo within 10s to send it back.`
             : result.message,
-        action: {
-          label: "Open",
-          onClick: () => {
-            setShowWorkspacesOverview(false);
-            void activateWorkspace(result.workspace_id);
+          onUndo: async () => {
+            const undoResult = await workspacePushToHost(
+              result.workspace_id,
+              sourceHost.id,
+            );
+            void refreshSync();
+            if (undoResult.ok) {
+              toast.success(`Sent ${syncRow.title} back to ${sourceHost.name}`);
+            } else {
+              toast.error("Push back failed", {
+                description: undoResult.message,
+              });
+            }
           },
-        },
-      });
+        });
+      } else {
+        // No source host known on this device — fall back to the
+        // plain success toast. The user can still push manually
+        // from the workspace menu.
+        toast.success(`Pulled ${syncRow.title} to this device`, {
+          description:
+            preview.host_label
+              ? `From ${preview.host_label}.`
+              : result.message,
+          action: {
+            label: "Open",
+            onClick: () => {
+              setShowWorkspacesOverview(false);
+              void activateWorkspace(result.workspace_id);
+            },
+          },
+        });
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       // Decode our structured-error prefixes so the toast is
@@ -185,6 +228,7 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
     onOpenChange,
     refreshSync,
     setShowWorkspacesOverview,
+    hosts,
   ]);
 
   // ── Open-existing-on-already-adopted short-circuit ────────────

--- a/src/components/workspaces-overview/pull-to-device-dialog.tsx
+++ b/src/components/workspaces-overview/pull-to-device-dialog.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 
 import {
+  AlertTriangle,
   ArrowDownToLine,
   ChevronDown,
   ChevronRight,
   Cloud,
+  GitBranch,
   Loader2,
   Settings2,
 } from "lucide-react";
@@ -27,6 +29,7 @@ import {
   workspacePushToHost,
   workspacesAdoptionPreview,
   workspacesAdoptSynced,
+  workspacesAdoptViaClone,
   type AdoptionPreview,
   type WorkspaceSyncView,
 } from "@/tauri/commands";
@@ -129,41 +132,66 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
     };
   }, [open, serverId]);
 
+  // Adoption mode is decided by the preview — host-backed when
+  // possible, clone-fallback when the workspace has no shared host
+  // but does have a project_remote.
+  const isCloneMode =
+    !!preview && !preview.can_host_adopt && preview.can_clone_adopt;
+
   const handleSubmit = useCallback(async () => {
     if (!syncRow || !serverId || !preview) return;
     setSubmitting(true);
     // Optimistic: signal the in-flight state immediately so the
     // sidebar + overview show a spinner the moment the dialog
     // closes. We don't have a local workspace id yet (the shell is
-    // created inside `workspaces_adopt_synced`), so we key the
-    // in-flight signal on the server id prefixed to avoid colliding
-    // with real workspace ids.
+    // created inside the adopt command), so we key the in-flight
+    // signal on the server id prefixed to avoid colliding with real
+    // workspace ids.
     const inFlightKey = `pending-adopt-${serverId}`;
     setPushPullInFlight(inFlightKey);
     onOpenChange(false);
 
     try {
+      // Two distinct paths with different success-toast shapes:
+      // - host-backed: rsync from a shared host; Undo = push back
+      //   to that host (data-safety guardrail).
+      // - clone: git clone + worktree-add; no Undo (independent
+      //   copy is now its own thing).
+      if (isCloneMode) {
+        const result = await workspacesAdoptViaClone(serverId);
+        markFirstPullSeen();
+        void refreshSync();
+        toast.success(`Cloned ${syncRow.title} to this device`, {
+          description:
+            "Independent copy created. Commit and push to share changes with your other device.",
+          action: {
+            label: "Open",
+            onClick: () => {
+              setShowWorkspacesOverview(false);
+              void activateWorkspace(result.workspace_id);
+            },
+          },
+        });
+        return;
+      }
+
+      // Host-backed branch ↓
       const result = await workspacesAdoptSynced(serverId);
       markFirstPullSeen();
-      // Nudge the synced-rows cache so the row migrates from
-      // sibling-device to local in the overview without waiting
-      // for the 5s polling tick.
       void refreshSync();
 
       // Resolve the local hosts.id matching the host we just
-      // pulled from — needed to drive the "Undo = push back" flow.
-      // The hosts cache is populated by the overview before the
-      // dialog ever opens, so this lookup is synchronous.
+      // pulled from — needed for the Undo = push-back flow. The
+      // hosts cache is populated by the overview before the dialog
+      // ever opens, so this lookup is synchronous.
       const sourceHostServerId = syncRow.host_server_id;
       const sourceHost = sourceHostServerId
         ? hosts.find((h) => h.server_id === sourceHostServerId)
         : null;
 
       if (sourceHost) {
-        // Push-back as Undo: data-safety guardrail. If the user
-        // realises within 10s that they pulled the wrong workspace
-        // (or didn't mean to), one click sends it back to where
-        // it came from. Same rsync machinery as a manual push.
+        // Push-back as Undo: data-safety guardrail. Wrong pull is
+        // one click from recovery within 10s.
         toast.undoable({
           message: `Pulled ${syncRow.title} to this device`,
           description: preview.host_label
@@ -176,7 +204,9 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
             );
             void refreshSync();
             if (undoResult.ok) {
-              toast.success(`Sent ${syncRow.title} back to ${sourceHost.name}`);
+              toast.success(
+                `Sent ${syncRow.title} back to ${sourceHost.name}`,
+              );
             } else {
               toast.error("Push back failed", {
                 description: undoResult.message,
@@ -185,14 +215,13 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
           },
         });
       } else {
-        // No source host known on this device — fall back to the
-        // plain success toast. The user can still push manually
-        // from the workspace menu.
+        // No source host known on this device (race: it was
+        // deleted between pull start and finish). Plain success
+        // toast — no Undo target available.
         toast.success(`Pulled ${syncRow.title} to this device`, {
-          description:
-            preview.host_label
-              ? `From ${preview.host_label}.`
-              : result.message,
+          description: preview.host_label
+            ? `From ${preview.host_label}.`
+            : result.message,
           action: {
             label: "Open",
             onClick: () => {
@@ -224,6 +253,7 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
     syncRow,
     serverId,
     preview,
+    isCloneMode,
     setPushPullInFlight,
     onOpenChange,
     refreshSync,
@@ -277,16 +307,7 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
             </div>
           ) : alreadyAdopted ? (
             <AlreadyAdoptedBlock onOpen={handleOpenExisting} />
-          ) : !preview.host_configured ? (
-            <HostNotConfiguredBlock
-              hostServerId={syncRow.host_server_id}
-              onClose={() => onOpenChange(false)}
-            />
-          ) : !preview.can_host_adopt ? (
-            <CloneFallbackComingSoonBlock />
-          ) : preview.is_path_in_use ? (
-            <PathInUseBlock path={preview.suggested_path} />
-          ) : (
+          ) : preview.can_host_adopt && !preview.is_path_in_use ? (
             <HostBackedAdoptionForm
               syncRow={syncRow}
               preview={preview}
@@ -295,6 +316,19 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
                 setDisclosureOpen((open) => !open)
               }
             />
+          ) : preview.can_host_adopt && preview.is_path_in_use ? (
+            <PathInUseBlock path={preview.suggested_path} />
+          ) : preview.can_clone_adopt && !preview.is_path_in_use ? (
+            <CloneFallbackBlock syncRow={syncRow} preview={preview} />
+          ) : preview.can_clone_adopt && preview.is_path_in_use ? (
+            <PathInUseBlock path={preview.suggested_path} />
+          ) : !preview.host_configured && syncRow.host_server_id ? (
+            <HostNotConfiguredBlock
+              hostServerId={syncRow.host_server_id}
+              onClose={() => onOpenChange(false)}
+            />
+          ) : (
+            <NoOptionsBlock />
           )}
 
           <div className="flex justify-end gap-2 pt-1 border-t border-border/40">
@@ -309,9 +343,8 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
             </Button>
             {preview &&
               !alreadyAdopted &&
-              preview.host_configured &&
-              preview.can_host_adopt &&
-              !preview.is_path_in_use && (
+              !preview.is_path_in_use &&
+              (preview.can_host_adopt || isCloneMode) && (
                 <Button
                   variant="secondary"
                   size="sm"
@@ -324,7 +357,7 @@ export function PullToDeviceDialog({ syncRow, onOpenChange }: Props) {
                   ) : (
                     <ArrowDownToLine className="size-3" />
                   )}
-                  Pull workspace
+                  {isCloneMode ? "Clone and open" : "Pull workspace"}
                 </Button>
               )}
           </div>
@@ -450,13 +483,65 @@ function HostNotConfiguredBlock({
   );
 }
 
-function CloneFallbackComingSoonBlock() {
+function CloneFallbackBlock({
+  syncRow,
+  preview,
+}: {
+  syncRow: WorkspaceSyncView;
+  preview: AdoptionPreview;
+}) {
+  return (
+    <>
+      <p className="text-[12px] text-muted-foreground/85 leading-relaxed">
+        This workspace lives only on another device (no shared host).
+        We'll clone it from git.
+      </p>
+
+      <dl className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[12.5px] space-y-1.5">
+        <SummaryRow label="Clone from">
+          <span className="font-mono text-[11.5px] break-all">
+            {syncRow.project_remote ?? "—"}
+          </span>
+        </SummaryRow>
+        <SummaryRow
+          label="Branch"
+          icon={<GitBranch className="size-3 text-muted-foreground/70" />}
+        >
+          <span className="font-mono text-[11.5px]">
+            {syncRow.git_branch ?? "main"}
+          </span>
+        </SummaryRow>
+        <SummaryRow label="Will land">
+          <span className="font-mono text-[11px] text-muted-foreground/80 break-all">
+            {preview.suggested_path}
+          </span>
+        </SummaryRow>
+      </dl>
+
+      <div className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11.5px] text-warning/90 leading-relaxed">
+        <AlertTriangle className="size-3.5 shrink-0 mt-0.5" />
+        <div>
+          <p className="font-medium text-warning">
+            Uncommitted work on the other device will NOT come over.
+          </p>
+          <p className="text-warning/80">
+            Only committed history clones. If you want the in-flight
+            edits, open the other device first and commit (or push
+            the workspace to a shared device instead, then pull from
+            here).
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function NoOptionsBlock() {
   return (
     <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[12px] text-muted-foreground/85 leading-relaxed">
-      This workspace lives only on another device (no shared host).
-      Cloning from the git remote is coming in a follow-up — for now,
-      open the other device and push this workspace to one of your
-      devices, then pull it from there.
+      We don't have a way to bring this workspace over yet — no shared
+      host, no git remote URL. Open the device it lives on and push
+      it to a shared device first, then pull from here.
     </div>
   );
 }

--- a/src/components/workspaces-overview/sibling-device-row.test.tsx
+++ b/src/components/workspaces-overview/sibling-device-row.test.tsx
@@ -43,6 +43,7 @@ function makeSyncRow(overrides?: Partial<WorkspaceSyncView>): WorkspaceSyncView 
     project_path: "/home/zeus/projects/codemux",
     project_remote: "git@github.com:Zeus-Deus/codemux.git",
     git_branch: "feature/cross-device",
+    git_head_sha: null,
     created_at: "2026-05-20T10:00:00Z",
     updated_at: "2026-05-20T10:00:00Z",
     dirty: false,

--- a/src/components/workspaces-overview/sibling-device-row.test.tsx
+++ b/src/components/workspaces-overview/sibling-device-row.test.tsx
@@ -1,0 +1,128 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import type { WorkspaceSyncView } from "@/tauri/commands";
+import type { OverviewItem } from "./use-overview-items";
+
+// The row pulls hosts + push/pull commands. Stub everything the
+// remote branch doesn't actually need, so the test stays narrow.
+vi.mock("@/stores/hosts-store", () => ({
+  useHostsStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ hosts: [], loaded: true, init: () => Promise.resolve() }),
+  ),
+  useHosts: () => [],
+}));
+vi.mock("@/stores/app-store", () => ({
+  useAppStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      appState: null,
+      workspacePushPullInFlight: null,
+      setWorkspacePushPullInFlight: vi.fn(),
+    }),
+  ),
+}));
+vi.mock("@/stores/ui-store", () => ({
+  useUIStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({ setShowWorkspacesOverview: vi.fn() }),
+  ),
+}));
+vi.mock("@/lib/pane-status", () => ({
+  getWorkspaceStatus: () => null,
+}));
+
+import { WorkspaceOverviewRow } from "./workspace-overview-row";
+
+function makeSyncRow(overrides?: Partial<WorkspaceSyncView>): WorkspaceSyncView {
+  return {
+    id: 1,
+    server_id: "42",
+    workspace_id: null,
+    title: "remote-only-workspace",
+    host_server_id: "7",
+    project_path: "/home/zeus/projects/codemux",
+    project_remote: "git@github.com:Zeus-Deus/codemux.git",
+    git_branch: "feature/cross-device",
+    created_at: "2026-05-20T10:00:00Z",
+    updated_at: "2026-05-20T10:00:00Z",
+    dirty: false,
+    ...overrides,
+  };
+}
+
+function remoteItem(overrides?: Partial<WorkspaceSyncView>): OverviewItem {
+  const sync = makeSyncRow(overrides);
+  return {
+    kind: "remote",
+    key: `remote:${sync.server_id ?? sync.id}`,
+    sync,
+    hostServerId: sync.host_server_id,
+    projectName: sync.project_path
+      ? sync.project_path.split("/").filter(Boolean).slice(-1)[0] ?? null
+      : null,
+    projectPath: sync.project_path,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe("WorkspaceOverviewRow (sibling-device branch)", () => {
+  it("renders the title, project, and the 'other device' affordance", () => {
+    const { getByText } = render(
+      <WorkspaceOverviewRow
+        item={remoteItem()}
+        isAttached={false}
+        onAfterOpen={() => {}}
+      />,
+    );
+    expect(getByText("remote-only-workspace")).toBeInTheDocument();
+    // The pill that signals cross-device.
+    expect(getByText(/other device/i)).toBeInTheDocument();
+    // The "not on this device" sub-label.
+    expect(getByText(/not on this device/i)).toBeInTheDocument();
+    // Project name derived from project_path basename.
+    expect(getByText("codemux")).toBeInTheDocument();
+  });
+
+  it("renders the branch on the bottom row", () => {
+    const { getByText } = render(
+      <WorkspaceOverviewRow
+        item={remoteItem({ git_branch: "feature/x" })}
+        isAttached={false}
+        onAfterOpen={() => {}}
+      />,
+    );
+    expect(getByText("feature/x")).toBeInTheDocument();
+  });
+
+  it("does not render a click-to-open handler — sibling rows are read-only in v1", () => {
+    const onAfterOpen = vi.fn();
+    const { container } = render(
+      <WorkspaceOverviewRow
+        item={remoteItem()}
+        isAttached={false}
+        onAfterOpen={onAfterOpen}
+      />,
+    );
+    // Top-level wrapper is a `role="group"`, not `role="button"`.
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute("role")).toBe("group");
+    // No click should fire onAfterOpen.
+    wrapper.click();
+    expect(onAfterOpen).not.toHaveBeenCalled();
+  });
+
+  it("title omits a branch slot when git_branch is null", () => {
+    const { queryByText } = render(
+      <WorkspaceOverviewRow
+        item={remoteItem({ git_branch: null })}
+        isAttached={false}
+        onAfterOpen={() => {}}
+      />,
+    );
+    // Sanity — title still renders.
+    expect(queryByText("remote-only-workspace")).toBeInTheDocument();
+    // The branch row only renders when git_branch is non-null.
+    expect(queryByText("feature/cross-device")).toBeNull();
+  });
+});

--- a/src/components/workspaces-overview/use-overview-items.ts
+++ b/src/components/workspaces-overview/use-overview-items.ts
@@ -1,0 +1,174 @@
+import { useMemo } from "react";
+
+import { useAppStore, useHomeDir, groupWorkspacesByProject } from "@/stores/app-store";
+import { useHosts } from "@/stores/hosts-store";
+import { useWorkspacesSync } from "@/stores/workspaces-sync-store";
+import type { WorkspaceSnapshot } from "@/tauri/types";
+import type { HostView, WorkspaceSyncView } from "@/tauri/commands";
+
+/**
+ * One item the overview can render. Either:
+ *  - kind="local": exists in this device's `app_state.workspaces`.
+ *    Carries the full WorkspaceSnapshot (status dot, git stats,
+ *    pane info, etc). May or may not also have a synced row.
+ *  - kind="remote": only known via the cross-device sync registry.
+ *    Lives on another device of the same account; this device has
+ *    title + host + branch + project metadata but no local worktree.
+ *    The UI offers a "Pull to this device" affordance for these.
+ */
+export type OverviewItem =
+  | {
+      kind: "local";
+      /** Stable key for React. */
+      key: string;
+      workspace: WorkspaceSnapshot;
+      /** The corresponding sync row, if one exists. Carries
+       *  `dirty` (for the "Pending sync" pill) and `host_server_id`
+       *  (cross-device identity, used for bucketing). */
+      sync: WorkspaceSyncView | null;
+      /** Cross-device host id. Resolved from `workspace.host_id`
+       *  via the local hosts table; null when local or when the
+       *  host isn't synced yet. */
+      hostServerId: string | null;
+      /** Project name for display. Falls back to the synced
+       *  project_path basename when the local snapshot has no
+       *  project_root (rare). */
+      projectName: string | null;
+      projectPath: string | null;
+    }
+  | {
+      kind: "remote";
+      key: string;
+      sync: WorkspaceSyncView;
+      hostServerId: string | null;
+      projectName: string | null;
+      projectPath: string | null;
+    };
+
+/**
+ * One bucket the overview renders. Each unique host (including
+ * "local") gets one bucket. Buckets keyed by `(hostServerId, hostId)`
+ * — a remote bucket has hostId null on this device when the host
+ * itself hasn't synced over yet (orphan workspaces).
+ */
+export interface DeviceBucket {
+  /** Key — `"local"` for the local bucket, otherwise the cross-
+   *  device host server id. Used as React key and as the dedupe
+   *  key for buckets. */
+  key: string;
+  /** The local hosts.id, if known on this device. */
+  localHostId: number | null;
+  /** Cross-device host server id; null for the local bucket. */
+  hostServerId: string | null;
+  /** Display name. */
+  label: string;
+  /** Optional sublabel (ssh target for remote, or "host not on
+   *  this device" for orphans). */
+  sublabel: string | null;
+  /** Workspaces that landed in this bucket after filtering. */
+  items: OverviewItem[];
+  /** Total before filtering — drives the "X hidden by filter" pill. */
+  totalCount: number;
+  /** Sort hint: locals first, then synced hosts in their
+   *  configured order, orphan/removed at the end. */
+  sortRank: number;
+}
+
+/** Compose the unified overview-item list from the three sources. */
+export function useOverviewItems(): {
+  items: OverviewItem[];
+  hosts: HostView[];
+  hostsLoaded: boolean;
+} {
+  const workspaces = useAppStore((s) => s.appState?.workspaces ?? null);
+  const hosts = useHosts();
+  const syncRows = useWorkspacesSync();
+  const homeDir = useHomeDir();
+
+  // Project name lookup so both local and remote rows render the
+  // same way as the rest of the app (sidebar uses
+  // `groupWorkspacesByProject` for the basename + "Home" rules).
+  const projectByWid = useMemo(() => {
+    const map = new Map<string, { name: string; path: string }>();
+    if (!workspaces) return map;
+    for (const group of groupWorkspacesByProject(workspaces, homeDir)) {
+      for (const ws of group.workspaces) {
+        map.set(ws.workspace_id, {
+          name: group.projectName,
+          path: group.projectPath,
+        });
+      }
+    }
+    return map;
+  }, [workspaces, homeDir]);
+
+  // Local host id → server id, so a local workspace's `host_id`
+  // resolves to the cross-device bucket key.
+  const hostIdToServer = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const h of hosts) {
+      if (h.server_id) map.set(h.id, h.server_id);
+    }
+    return map;
+  }, [hosts]);
+
+  // Sync rows indexed by their local workspace_id, so a local
+  // snapshot can find its matching sync row to read host_server_id
+  // and the dirty flag.
+  const syncByWid = useMemo(() => {
+    const map = new Map<string, WorkspaceSyncView>();
+    for (const row of syncRows) {
+      if (row.workspace_id) map.set(row.workspace_id, row);
+    }
+    return map;
+  }, [syncRows]);
+
+  const items = useMemo<OverviewItem[]>(() => {
+    const result: OverviewItem[] = [];
+    const consumedSyncIds = new Set<number>();
+
+    // 1) Every local workspace contributes a "local" item. The sync
+    //    row (if any) tags it with host_server_id and dirty.
+    for (const ws of workspaces ?? []) {
+      const sync = syncByWid.get(ws.workspace_id) ?? null;
+      if (sync) consumedSyncIds.add(sync.id);
+      const proj = projectByWid.get(ws.workspace_id) ?? null;
+      const hostServerId =
+        sync?.host_server_id ??
+        (ws.host_id != null ? hostIdToServer.get(ws.host_id) ?? null : null);
+      result.push({
+        kind: "local",
+        key: `local:${ws.workspace_id}`,
+        workspace: ws,
+        sync,
+        hostServerId,
+        projectName: proj?.name ?? null,
+        projectPath: proj?.path ?? null,
+      });
+    }
+
+    // 2) Every sync row with NO local workspace counterpart is a
+    //    sibling-device workspace. Render as "remote".
+    for (const row of syncRows) {
+      if (consumedSyncIds.has(row.id)) continue;
+      // Rows we haven't adopted locally — workspace_id is null OR
+      // it referenced a local id we no longer have.
+      result.push({
+        kind: "remote",
+        key: `remote:${row.server_id ?? row.id}`,
+        sync: row,
+        hostServerId: row.host_server_id,
+        projectName: row.project_path
+          ? row.project_path.split("/").filter(Boolean).slice(-1)[0] ?? null
+          : null,
+        projectPath: row.project_path,
+      });
+    }
+
+    return result;
+  }, [workspaces, syncRows, syncByWid, projectByWid, hostIdToServer]);
+
+  const hostsLoaded = true; // useHosts() lazily loads; readers don't depend on the loaded flag for rendering. UI shows skeleton via the rows-null path elsewhere.
+
+  return { items, hosts, hostsLoaded };
+}

--- a/src/components/workspaces-overview/use-overview-items.ts
+++ b/src/components/workspaces-overview/use-overview-items.ts
@@ -46,6 +46,27 @@ export type OverviewItem =
     };
 
 /**
+ * Phase-4 divergence detection — when two or more rows in the
+ * overview share a `(project_remote, git_branch)` but have
+ * DIFFERENT `git_head_sha` values, those rows have diverged in git.
+ * The overview surfaces a warning chip on each diverged row so the
+ * user can tell at a glance that pushing from one device would
+ * overwrite the other's edits.
+ *
+ * Returned as a Map from sync-row id → divergence summary so the
+ * row component can render the chip without re-running the analysis.
+ */
+export interface DivergenceInfo {
+  /** Number of distinct `git_head_sha` values across all rows that
+   *  share the row's (project_remote, git_branch). Always ≥2 when
+   *  this entry exists. */
+  forks: number;
+  /** Human label for the OTHER location(s) — e.g. "macbook-air" or
+   *  "homedesk + 1 more". Used in the chip tooltip. */
+  otherLabel: string;
+}
+
+/**
  * One bucket the overview renders. Each unique host (including
  * "local") gets one bucket. Buckets keyed by `(hostServerId, hostId)`
  * — a remote bucket has hostId null on this device when the host
@@ -72,6 +93,73 @@ export interface DeviceBucket {
   /** Sort hint: locals first, then synced hosts in their
    *  configured order, orphan/removed at the end. */
   sortRank: number;
+}
+
+/**
+ * Detect git-HEAD divergence across the unified overview-item list.
+ * Two rows that share the same (project_remote, git_branch) but
+ * have different `git_head_sha` values are considered diverged. The
+ * UI surfaces a warning chip on each diverged row.
+ *
+ * Returns a Map keyed by the row's stable identity (`sync.id` for
+ * remote rows, `workspace.workspace_id` for local-with-sync rows).
+ * Rows with no `git_head_sha` are excluded — we can't determine
+ * divergence without a sha on both sides.
+ */
+export function detectDivergence(
+  items: OverviewItem[],
+  hostLabel: (hostServerId: string | null) => string,
+): Map<string, DivergenceInfo> {
+  // Group all rows by (project_remote, git_branch). A row contributes
+  // its sync data if available (remote items always have it; local
+  // items have it only after the first reconcile sync).
+  type Entry = {
+    key: string;
+    sha: string | null;
+    hostServerId: string | null;
+  };
+  const groups = new Map<string, Entry[]>();
+  for (const it of items) {
+    const sync = it.kind === "local" ? it.sync : it.sync;
+    if (!sync) continue;
+    if (!sync.project_remote || !sync.git_branch) continue;
+    const groupKey = `${sync.project_remote}::${sync.git_branch}`;
+    const rowKey =
+      it.kind === "local"
+        ? `local:${it.workspace.workspace_id}`
+        : `remote:${sync.id}`;
+    const list = groups.get(groupKey) ?? [];
+    list.push({
+      key: rowKey,
+      sha: sync.git_head_sha,
+      hostServerId: sync.host_server_id,
+    });
+    groups.set(groupKey, list);
+  }
+
+  // For each group with >=2 entries AND >=2 distinct shas, mark
+  // every entry in that group as diverged. Skip groups where any
+  // entry's sha is null (insufficient info).
+  const result = new Map<string, DivergenceInfo>();
+  for (const entries of groups.values()) {
+    if (entries.length < 2) continue;
+    const shas = new Set<string>();
+    for (const e of entries) {
+      if (e.sha) shas.add(e.sha);
+    }
+    if (shas.size < 2) continue;
+    for (const entry of entries) {
+      const others = entries.filter((e) => e.key !== entry.key);
+      const otherLabels = others.map((e) => hostLabel(e.hostServerId));
+      const distinctLabels = Array.from(new Set(otherLabels));
+      const label =
+        distinctLabels.length <= 1
+          ? distinctLabels[0] ?? "another device"
+          : `${distinctLabels[0]} + ${distinctLabels.length - 1} more`;
+      result.set(entry.key, { forks: shas.size, otherLabel: label });
+    }
+  }
+  return result;
 }
 
 /** Compose the unified overview-item list from the three sources. */

--- a/src/components/workspaces-overview/welcome-banner.test.tsx
+++ b/src/components/workspaces-overview/welcome-banner.test.tsx
@@ -1,0 +1,138 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+
+vi.mock("@/stores/ui-store", () => ({
+  useUIStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      setShowSettings: vi.fn(),
+      setShowWorkspacesOverview: vi.fn(),
+    }),
+  ),
+}));
+
+import {
+  WELCOME_BANNER_DISMISS_KEY,
+  WelcomeBanner,
+} from "./welcome-banner";
+
+afterEach(() => {
+  cleanup();
+  try {
+    localStorage.clear();
+  } catch {
+    /* test env */
+  }
+});
+
+describe("WelcomeBanner", () => {
+  it("renders the 'fresh' variant when the user has 0 devices and 0 siblings", () => {
+    render(
+      <WelcomeBanner
+        deviceCount={0}
+        siblingWorkspaceCount={0}
+        localWorkspaceCount={0}
+      />,
+    );
+    expect(screen.getByText("Welcome to Workspaces")).toBeInTheDocument();
+    expect(
+      screen.getByText(/This is where your work lives across devices/i),
+    ).toBeInTheDocument();
+    // Fresh variant gets the Add-a-device CTA.
+    expect(screen.getByText("Add a device")).toBeInTheDocument();
+  });
+
+  it("renders the 'device-no-siblings' variant when devices exist but no sibling workspaces", () => {
+    render(
+      <WelcomeBanner
+        deviceCount={1}
+        siblingWorkspaceCount={0}
+        localWorkspaceCount={3}
+      />,
+    );
+    expect(
+      screen.getByText("Workspaces, now across all your devices"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/right-click any workspace/i),
+    ).toBeInTheDocument();
+    // No Add-a-device CTA on this variant.
+    expect(screen.queryByText("Add a device")).toBeNull();
+  });
+
+  it("renders the 'has-siblings' variant with the correct count", () => {
+    const { container } = render(
+      <WelcomeBanner
+        deviceCount={1}
+        siblingWorkspaceCount={4}
+        localWorkspaceCount={2}
+      />,
+    );
+    expect(
+      screen.getByText("Welcome to Codemux on this device"),
+    ).toBeInTheDocument();
+    // The body paragraph contains the plural count.
+    expect(container.textContent ?? "").toContain("4 workspaces");
+  });
+
+  it("renders the singular form when exactly one sibling exists", () => {
+    const { container } = render(
+      <WelcomeBanner
+        deviceCount={1}
+        siblingWorkspaceCount={1}
+        localWorkspaceCount={0}
+      />,
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("1 workspace");
+    expect(text).not.toContain("1 workspaces");
+  });
+
+  it("persists dismissal so subsequent renders return null", () => {
+    const { rerender, queryByText } = render(
+      <WelcomeBanner
+        deviceCount={1}
+        siblingWorkspaceCount={3}
+        localWorkspaceCount={0}
+      />,
+    );
+    expect(
+      screen.getByText("Welcome to Codemux on this device"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Dismiss welcome message"));
+    // Same instance hides immediately.
+    expect(queryByText("Welcome to Codemux on this device")).toBeNull();
+
+    // A fresh render also returns null because the dismissal
+    // landed in localStorage.
+    expect(localStorage.getItem(WELCOME_BANNER_DISMISS_KEY)).toBe("1");
+    rerender(
+      <WelcomeBanner
+        deviceCount={1}
+        siblingWorkspaceCount={3}
+        localWorkspaceCount={0}
+      />,
+    );
+    expect(queryByText("Welcome to Codemux on this device")).toBeNull();
+  });
+
+  it("never re-shows after dismissal even when the user's state changes", () => {
+    localStorage.setItem(WELCOME_BANNER_DISMISS_KEY, "1");
+    // Pretend the user just gained 5 sibling workspaces — banner
+    // would normally pull them in with the 'has-siblings' variant.
+    const { container } = render(
+      <WelcomeBanner
+        deviceCount={2}
+        siblingWorkspaceCount={5}
+        localWorkspaceCount={3}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/workspaces-overview/welcome-banner.tsx
+++ b/src/components/workspaces-overview/welcome-banner.tsx
@@ -1,0 +1,183 @@
+import { useState } from "react";
+
+import { ArrowRight, Sparkles, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useUIStore } from "@/stores/ui-store";
+
+const DISMISS_KEY = "codemux.workspaces.welcomeDismissed";
+
+interface Props {
+  /** Number of configured devices on this account. Drives which
+   *  variant of the welcome copy renders. */
+  deviceCount: number;
+  /** Number of sibling-device workspaces visible (i.e. rows with
+   *  workspace_id null — owned by another device of this account). */
+  siblingWorkspaceCount: number;
+  /** Number of LOCAL workspaces (in app_state). Used to pick the
+   *  brand-new-to-this-device variant. */
+  localWorkspaceCount: number;
+}
+
+/**
+ * First-run welcome banner for the Workspaces overview. Renders one
+ * of three variants based on the user's state, dismissable, persists
+ * dismissal per-install in localStorage.
+ *
+ * Variants:
+ * - **fresh**: no devices configured, no sibling workspaces. The
+ *   user just installed and signed in for the first time. Banner
+ *   teaches the core model (push to a device → shows up everywhere)
+ *   and offers an `Add a device →` CTA.
+ * - **device-no-siblings**: at least one device configured but
+ *   nothing has been pushed yet. Banner nudges them to try pushing.
+ * - **has-siblings**: there's content from other devices waiting to
+ *   be pulled. Banner counts the visible workspaces and tells the
+ *   user how to bring them over.
+ *
+ * Dismissal is per-install (one localStorage key). Reinstall clears
+ * it — acceptable. Machine-id-scoped keys would be more precise but
+ * the wider key is simpler and the cost of re-showing on a fresh
+ * install is negligible.
+ */
+export function WelcomeBanner({
+  deviceCount,
+  siblingWorkspaceCount,
+  localWorkspaceCount,
+}: Props) {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(DISMISS_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+  const setShowSettings = useUIStore((s) => s.setShowSettings);
+  const setShowWorkspacesOverview = useUIStore(
+    (s) => s.setShowWorkspacesOverview,
+  );
+
+  // If the user reaches an "interesting" state (gains a sibling
+  // workspace) after they dismissed the banner, we DON'T re-show
+  // it — the dismissal is final. Re-showing would be intrusive.
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      // localStorage disabled — just hide for this session.
+    }
+    setDismissed(true);
+  };
+
+  // Pick the variant. Order matters: sibling-presence wins over
+  // device-presence (more useful signal), then device-presence,
+  // then brand-new fallback.
+  let body: React.ReactNode;
+  let cta: React.ReactNode = null;
+
+  if (siblingWorkspaceCount > 0) {
+    body = (
+      <>
+        You have{" "}
+        <span className="font-medium text-foreground">
+          {siblingWorkspaceCount}{" "}
+          {siblingWorkspaceCount === 1 ? "workspace" : "workspaces"}
+        </span>{" "}
+        on your other devices. Use the row's <code>⋯</code> menu to pull
+        any of them here. Workspace files copy on demand — they never
+        sync silently behind your back.
+      </>
+    );
+  } else if (deviceCount > 0) {
+    body = (
+      <>
+        You have a device set up. Try{" "}
+        <span className="font-medium text-foreground">
+          right-click any workspace → Push to your device
+        </span>
+        . It'll show up here on every device of your account, and you
+        can pull it back any time.
+      </>
+    );
+  } else {
+    body = (
+      <>
+        This is where your work lives across devices. Add a device —
+        your home desktop, an always-on box, or a cloud server — then
+        push a workspace to it. You'll see it here on every device you
+        sign in to.
+      </>
+    );
+    cta = (
+      <Button
+        variant="secondary"
+        size="sm"
+        className="h-7 gap-1.5 px-2.5 text-[12px]"
+        onClick={() => {
+          // Send the user to Settings → Devices. The overview
+          // overlay closes so the settings overlay can open
+          // cleanly (mutually exclusive in app-shell.tsx).
+          setShowWorkspacesOverview(false);
+          setShowSettings(true, "hosts");
+        }}
+      >
+        Add a device
+        <ArrowRight className="size-3" />
+      </Button>
+    );
+  }
+
+  // Local-only quick-orientation: brand-new user who has zero
+  // anything benefits from the most reassuring tone; users with
+  // many local workspaces don't need to be told what a workspace
+  // is. We surface a different verb in the headline accordingly.
+  const headline =
+    siblingWorkspaceCount > 0
+      ? "Welcome to Codemux on this device"
+      : localWorkspaceCount > 0
+        ? "Workspaces, now across all your devices"
+        : "Welcome to Workspaces";
+
+  return (
+    <div
+      className={cn(
+        "mx-auto max-w-6xl flex items-start gap-3 rounded-lg border border-sky-500/20 bg-gradient-to-r from-sky-500/8 to-emerald-500/5 px-4 py-3 mb-4",
+      )}
+    >
+      <Sparkles className="mt-0.5 size-4 shrink-0 text-sky-400" />
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <h3 className="text-[13px] font-semibold text-foreground">
+          {headline}
+        </h3>
+        <p className="text-[12px] leading-relaxed text-muted-foreground/85">
+          {body}
+        </p>
+        {cta && <div className="pt-1">{cta}</div>}
+      </div>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        aria-label="Dismiss welcome message"
+        className="size-6 shrink-0 text-muted-foreground/60 hover:text-foreground"
+        onClick={handleDismiss}
+      >
+        <X className="size-3" />
+      </Button>
+    </div>
+  );
+}
+
+/** Test helper: reset the dismissal flag so the banner re-renders. */
+export function __resetWelcomeBannerDismissalForTests() {
+  try {
+    localStorage.removeItem(DISMISS_KEY);
+  } catch {
+    // no-op
+  }
+}
+
+// Also useful in tests + dev.
+export const WELCOME_BANNER_DISMISS_KEY = DISMISS_KEY;

--- a/src/components/workspaces-overview/workspace-overview-row.tsx
+++ b/src/components/workspaces-overview/workspace-overview-row.tsx
@@ -391,16 +391,16 @@ function LocalRow({
                 ) : hosts.length === 0 ? (
                   <DropdownMenuItem
                     disabled
-                    title="Add hosts in Settings → Hosts to push workspaces"
+                    title="Add a device in Settings → Devices to push workspaces"
                   >
                     <ArrowUpRight className="mr-2 size-3.5" />
-                    Push to host…
+                    Push to device…
                   </DropdownMenuItem>
                 ) : (
                   <DropdownMenuSub>
                     <DropdownMenuSubTrigger>
                       <ArrowUpRight className="mr-2 size-3.5" />
-                      Push to host…
+                      Push to device…
                     </DropdownMenuSubTrigger>
                     <DropdownMenuSubContent className="min-w-[200px]">
                       <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-muted-foreground/60">

--- a/src/components/workspaces-overview/workspace-overview-row.tsx
+++ b/src/components/workspaces-overview/workspace-overview-row.tsx
@@ -44,7 +44,7 @@ import {
 import { toast } from "@/lib/toast";
 import type { ActivePaneStatus, WorkspaceSnapshot } from "@/tauri/types";
 
-import type { OverviewItem } from "./use-overview-items";
+import type { DivergenceInfo, OverviewItem } from "./use-overview-items";
 
 interface Props {
   item: OverviewItem;
@@ -58,6 +58,10 @@ interface Props {
    *  sibling-device (remote-kind) row. The section hoists this and
    *  opens the shared `PullToDeviceDialog`. */
   onRequestPull?: (item: Extract<OverviewItem, { kind: "remote" }>) => void;
+  /** Phase-4 divergence info — non-null when this row's git HEAD
+   *  differs from another row sharing the same (project_remote,
+   *  git_branch). Rendered as a warning chip in the title row. */
+  divergence?: DivergenceInfo | null;
 }
 
 /**
@@ -76,10 +80,15 @@ export function WorkspaceOverviewRow({
   isAttached,
   onAfterOpen,
   onRequestPull,
+  divergence,
 }: Props) {
   if (item.kind === "remote") {
     return (
-      <RemoteRow item={item} onRequestPull={onRequestPull ?? null} />
+      <RemoteRow
+        item={item}
+        onRequestPull={onRequestPull ?? null}
+        divergence={divergence ?? null}
+      />
     );
   }
   return (
@@ -87,7 +96,34 @@ export function WorkspaceOverviewRow({
       item={item}
       isAttached={isAttached}
       onAfterOpen={onAfterOpen}
+      divergence={divergence ?? null}
     />
+  );
+}
+
+/**
+ * Divergence chip — rendered in the row's title line when the
+ * same (project_remote, git_branch) has different HEADs across
+ * devices. Yellow, compact, with a tooltip pointing at the OTHER
+ * location so the user knows where the other commits live.
+ */
+function DivergenceChip({ info }: { info: DivergenceInfo }) {
+  return (
+    <span
+      title={`Diverged — different commits on ${info.otherLabel}. Push from one device to share, or pull to overwrite the other.`}
+      className="shrink-0 inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0 text-[10px] font-medium leading-[14px] text-amber-300"
+    >
+      <svg
+        viewBox="0 0 12 12"
+        width="9"
+        height="9"
+        aria-hidden
+        fill="currentColor"
+      >
+        <path d="M6 1.2L11.2 10.5H0.8L6 1.2zM5.3 4.8v2.4h1.4V4.8H5.3zM5.3 8v1.2h1.4V8H5.3z" />
+      </svg>
+      diverged
+    </span>
   );
 }
 
@@ -97,10 +133,12 @@ function LocalRow({
   item,
   isAttached,
   onAfterOpen,
+  divergence,
 }: {
   item: Extract<OverviewItem, { kind: "local" }>;
   isAttached: boolean;
   onAfterOpen: () => void;
+  divergence: DivergenceInfo | null;
 }) {
   const workspace = item.workspace;
   const sync = item.sync;
@@ -286,6 +324,7 @@ function LocalRow({
             >
               {workspace.title}
             </h4>
+            {divergence && <DivergenceChip info={divergence} />}
             {sync?.dirty && (
               <span
                 title="Pending sync to your account"
@@ -500,9 +539,11 @@ function LocalRow({
 function RemoteRow({
   item,
   onRequestPull,
+  divergence,
 }: {
   item: Extract<OverviewItem, { kind: "remote" }>;
   onRequestPull: ((item: Extract<OverviewItem, { kind: "remote" }>) => void) | null;
+  divergence: DivergenceInfo | null;
 }) {
   const row = item.sync;
   const branch = row.git_branch;
@@ -531,6 +572,7 @@ function RemoteRow({
             >
               {row.title}
             </h4>
+            {divergence && <DivergenceChip info={divergence} />}
             <span
               title="This workspace lives on another device of your account. Pull it down to interact with it here."
               className="shrink-0 rounded-full border border-sky-400/30 bg-sky-500/10 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider leading-[14px] text-sky-300"

--- a/src/components/workspaces-overview/workspace-overview-row.tsx
+++ b/src/components/workspaces-overview/workspace-overview-row.tsx
@@ -1,0 +1,655 @@
+import { startTransition, useCallback, useState } from "react";
+
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  CloudOff,
+  ExternalLink,
+  GitBranch,
+  Laptop,
+  Loader2,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  Workflow,
+} from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getWorkspaceStatus } from "@/lib/pane-status";
+import { useAppStore } from "@/stores/app-store";
+import { useHostsStore } from "@/stores/hosts-store";
+import { useUIStore } from "@/stores/ui-store";
+import { StatusIndicator } from "@/components/ui/status-indicator";
+import {
+  activateWorkspace,
+  closeWorkspace,
+  closeWorkspaceWithWorktree,
+  renameWorkspace,
+  workspacePullBack,
+  workspacePushToHost,
+  type HostView,
+} from "@/tauri/commands";
+import { toast } from "@/lib/toast";
+import type { ActivePaneStatus, WorkspaceSnapshot } from "@/tauri/types";
+
+import type { OverviewItem } from "./use-overview-items";
+
+interface Props {
+  item: OverviewItem;
+  /** True when this row's local workspace is the active one in the
+   *  main pane. Always false for remote (sibling-device) items. */
+  isAttached: boolean;
+  /** Called after a successful "Open" — the overview should close so
+   *  the user lands on the workspace they picked. */
+  onAfterOpen: () => void;
+}
+
+/**
+ * One workspace card in the overview. Two shapes depending on the
+ * item kind:
+ *  - local: clickable card opens the workspace; `⋯` menu offers
+ *    rename / push-to-host / pull-back / delete.
+ *  - remote: clickable area is informational only (no local pane
+ *    to open). `⋯` menu offers "Pull to this device" (TBD —
+ *    queues a follow-up implementation; this PR only shows the
+ *    sibling-device row + metadata). The "Pending sync" pill on
+ *    local rows surfaces the row's `dirty` flag.
+ */
+export function WorkspaceOverviewRow({ item, isAttached, onAfterOpen }: Props) {
+  if (item.kind === "remote") {
+    return <RemoteRow item={item} onAfterOpen={onAfterOpen} />;
+  }
+  return (
+    <LocalRow
+      item={item}
+      isAttached={isAttached}
+      onAfterOpen={onAfterOpen}
+    />
+  );
+}
+
+// ─── Local (has a WorkspaceSnapshot) ─────────────────────────────
+
+function LocalRow({
+  item,
+  isAttached,
+  onAfterOpen,
+}: {
+  item: Extract<OverviewItem, { kind: "local" }>;
+  isAttached: boolean;
+  onAfterOpen: () => void;
+}) {
+  const workspace = item.workspace;
+  const sync = item.sync;
+  const project = item.projectName
+    ? { name: item.projectName, path: item.projectPath ?? "" }
+    : null;
+
+  const hosts = useHostsStore((s) => s.hosts);
+  const hostsLoaded = useHostsStore((s) => s.loaded);
+  const setShowWorkspacesOverview = useUIStore(
+    (s) => s.setShowWorkspacesOverview,
+  );
+  const setPushPullInFlight = useAppStore(
+    (s) => s.setWorkspacePushPullInFlight,
+  );
+  const inFlight = useAppStore(
+    (s) => s.workspacePushPullInFlight === workspace.workspace_id,
+  );
+
+  // Live agent status — same source the sidebar reads.
+  const workspaceStatus: ActivePaneStatus | null = useAppStore((s) => {
+    if (!s.appState) return null;
+    return getWorkspaceStatus(workspace.surfaces, s.appState.pane_statuses);
+  });
+  const isWorking = workspaceStatus === "working";
+
+  const [busy, setBusy] = useState(false);
+  const isRemote = item.hostServerId !== null;
+  const isWorktree = !!workspace.worktree_path;
+
+  const handleOpen = useCallback(() => {
+    if (inFlight) return;
+    startTransition(() => {
+      activateWorkspace(workspace.workspace_id)
+        .then(() => {
+          setShowWorkspacesOverview(false);
+          onAfterOpen();
+        })
+        .catch((err) => {
+          toast.error("Couldn't open workspace", {
+            description: err instanceof Error ? err.message : String(err),
+          });
+        });
+    });
+  }, [inFlight, workspace.workspace_id, setShowWorkspacesOverview, onAfterOpen]);
+
+  const handlePushToHost = useCallback(
+    async (host: HostView) => {
+      setPushPullInFlight(workspace.workspace_id);
+      setBusy(true);
+      try {
+        const result = await workspacePushToHost(
+          workspace.workspace_id,
+          host.id,
+        );
+        if (result.ok) {
+          toast.success(`Pushed to ${host.name}`, {
+            description: result.message,
+          });
+        } else {
+          toast.error(`Push to ${host.name} failed`, {
+            description: result.message,
+          });
+        }
+      } catch (err) {
+        toast.error("Push failed", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setPushPullInFlight(null);
+        setBusy(false);
+      }
+    },
+    [workspace.workspace_id, setPushPullInFlight],
+  );
+
+  const handlePullBack = useCallback(async () => {
+    setPushPullInFlight(workspace.workspace_id);
+    setBusy(true);
+    try {
+      const result = await workspacePullBack(workspace.workspace_id);
+      if (result.ok) {
+        toast.success("Pulled back to this device", {
+          description: result.message,
+        });
+      } else {
+        toast.error("Pull back failed", {
+          description: result.message,
+        });
+      }
+    } catch (err) {
+      toast.error("Pull back failed", {
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setPushPullInFlight(null);
+      setBusy(false);
+    }
+  }, [workspace.workspace_id, setPushPullInFlight]);
+
+  const handleRename = useCallback(() => {
+    const next = window.prompt("Rename workspace", workspace.title);
+    if (next && next !== workspace.title) {
+      renameWorkspace(workspace.workspace_id, next).catch((err) =>
+        toast.error("Rename failed", {
+          description: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+  }, [workspace.workspace_id, workspace.title]);
+
+  const handleDelete = useCallback(() => {
+    const confirmed = window.confirm(
+      isWorktree
+        ? `Delete the worktree "${workspace.title}"? Files on disk will be removed.`
+        : `Close "${workspace.title}"? Project files on disk are untouched.`,
+    );
+    if (!confirmed) return;
+    const promise = isWorktree
+      ? closeWorkspaceWithWorktree(workspace.workspace_id, true, true, false)
+      : closeWorkspace(workspace.workspace_id, false);
+    promise.catch((err) =>
+      toast.error("Delete failed", {
+        description: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }, [workspace.workspace_id, workspace.title, isWorktree]);
+
+  const handleCopyBranch = useCallback(() => {
+    if (workspace.git_branch) {
+      navigator.clipboard
+        .writeText(workspace.git_branch)
+        .then(() =>
+          toast.success("Copied branch name", {
+            description: workspace.git_branch ?? "",
+          }),
+        )
+        .catch(console.error);
+    }
+  }, [workspace.git_branch]);
+
+  const showingInFlight = inFlight || busy;
+  const hasDiff =
+    workspace.git_additions > 0 || workspace.git_deletions > 0;
+  const hasAheadBehind = workspace.git_ahead > 0 || workspace.git_behind > 0;
+  const hasDirty = workspace.git_changed_files > 0;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={handleOpen}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleOpen();
+        }
+      }}
+      className={cn(
+        "group/row relative flex h-full cursor-pointer flex-col gap-2 rounded-lg border bg-card/40 px-3.5 py-3 transition-colors",
+        "hover:border-border hover:bg-muted/40",
+        isAttached
+          ? "border-emerald-500/40 ring-1 ring-emerald-500/20"
+          : "border-border/50",
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <StatusDot
+          attached={isAttached}
+          remote={isRemote}
+          inFlight={showingInFlight}
+          openFlow={workspace.workspace_type === "open_flow"}
+          workspaceStatus={workspaceStatus}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h4
+              className={cn(
+                "min-w-0 flex-1 truncate text-[13px] font-medium leading-tight",
+                isAttached ? "text-foreground" : "text-foreground/90",
+              )}
+              title={workspace.title}
+            >
+              {workspace.title}
+            </h4>
+            {sync?.dirty && (
+              <span
+                title="Pending sync to your account"
+                className="shrink-0 rounded-full bg-warning/15 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider leading-[14px] text-warning"
+              >
+                sync
+              </span>
+            )}
+            {workspace.notification_count > 0 && (
+              <span
+                title={`${workspace.notification_count} unread notification${workspace.notification_count === 1 ? "" : "s"}`}
+                className="shrink-0 rounded-full bg-warning/15 px-1.5 py-0 text-[10px] font-medium tabular-nums leading-[14px] text-warning"
+              >
+                {workspace.notification_count}
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 truncate text-[11px] text-muted-foreground/65">
+            {project ? project.name : "—"}
+            {isWorking && (
+              <span className="ml-1.5 text-amber-400/90">
+                · agent working
+              </span>
+            )}
+            {!isWorking && workspaceStatus === "permission" && (
+              <span className="ml-1.5 text-red-400/90">· needs input</span>
+            )}
+            {!isWorking && workspaceStatus === "review" && (
+              <span className="ml-1.5 text-emerald-400/90">
+                · ready to review
+              </span>
+            )}
+            {!workspaceStatus && isAttached && (
+              <span className="ml-1.5 text-emerald-400/80">· open now</span>
+            )}
+            {!workspaceStatus && isRemote && !isAttached && (
+              <span className="ml-1.5 text-sky-300/70">· remote</span>
+            )}
+          </p>
+        </div>
+
+        <div
+          className={cn(
+            "opacity-0 transition-opacity",
+            "group-hover/row:opacity-100 group-focus-within/row:opacity-100",
+            showingInFlight && "opacity-100",
+          )}
+        >
+          {showingInFlight ? (
+            <span
+              aria-label="Working"
+              className="flex size-7 items-center justify-center text-muted-foreground"
+            >
+              <Loader2 className="size-3.5 animate-spin" />
+            </span>
+          ) : (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Workspace actions"
+                  onClick={(e) => e.stopPropagation()}
+                  className="size-7 text-muted-foreground hover:text-foreground"
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                onClick={(e) => e.stopPropagation()}
+                className="min-w-[200px]"
+              >
+                <DropdownMenuItem onClick={handleOpen}>
+                  <ExternalLink className="mr-2 size-3.5" />
+                  Open workspace
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={handleCopyBranch}
+                  disabled={!workspace.git_branch}
+                >
+                  <GitBranch className="mr-2 size-3.5" />
+                  Copy branch name
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={handleRename}>
+                  <Pencil className="mr-2 size-3.5" />
+                  Rename…
+                </DropdownMenuItem>
+
+                <DropdownMenuSeparator />
+
+                {isRemote ? (
+                  <DropdownMenuItem onClick={() => void handlePullBack()}>
+                    <ArrowDownLeft className="mr-2 size-3.5" />
+                    Pull back to this device
+                  </DropdownMenuItem>
+                ) : !hostsLoaded ? (
+                  <DropdownMenuItem disabled>
+                    <Loader2 className="mr-2 size-3.5 animate-spin" />
+                    Loading hosts…
+                  </DropdownMenuItem>
+                ) : hosts.length === 0 ? (
+                  <DropdownMenuItem
+                    disabled
+                    title="Add hosts in Settings → Hosts to push workspaces"
+                  >
+                    <ArrowUpRight className="mr-2 size-3.5" />
+                    Push to host…
+                  </DropdownMenuItem>
+                ) : (
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      <ArrowUpRight className="mr-2 size-3.5" />
+                      Push to host…
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="min-w-[200px]">
+                      <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-muted-foreground/60">
+                        Send to
+                      </DropdownMenuLabel>
+                      {hosts.map((host) => (
+                        <DropdownMenuItem
+                          key={host.id}
+                          onClick={() => void handlePushToHost(host)}
+                        >
+                          <span className="truncate">{host.name}</span>
+                          <span className="ml-auto pl-2 font-mono text-[10px] text-muted-foreground/55">
+                            {host.ssh_target}
+                          </span>
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                )}
+
+                <DropdownMenuSeparator />
+
+                <DropdownMenuItem
+                  onClick={handleDelete}
+                  className="text-destructive focus:bg-destructive/10 focus:text-destructive"
+                >
+                  <Trash2 className="mr-2 size-3.5" />
+                  {isWorktree ? "Delete worktree…" : "Close workspace…"}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      </div>
+
+      {(workspace.git_branch || hasDiff || hasAheadBehind || hasDirty) && (
+        <div className="flex items-center gap-2 pl-5 font-mono text-[11px] text-muted-foreground/60">
+          {workspace.git_branch && (
+            <span className="flex items-center gap-1 min-w-0">
+              {workspace.workspace_type === "open_flow" ? (
+                <Workflow className="size-3 shrink-0" aria-hidden />
+              ) : isWorktree ? (
+                <GitBranch className="size-3 shrink-0" aria-hidden />
+              ) : (
+                <Laptop className="size-3 shrink-0" aria-hidden />
+              )}
+              <span className="truncate">{workspace.git_branch}</span>
+            </span>
+          )}
+
+          {hasAheadBehind && (
+            <span className="flex shrink-0 items-center gap-1 tabular-nums">
+              {workspace.git_behind > 0 && (
+                <span className="text-warning/80">
+                  ↓{workspace.git_behind}
+                </span>
+              )}
+              {workspace.git_ahead > 0 && (
+                <span className="text-success/80">
+                  ↑{workspace.git_ahead}
+                </span>
+              )}
+            </span>
+          )}
+
+          {hasDirty && !hasDiff && (
+            <span
+              className="shrink-0 text-warning/70"
+              title={`${workspace.git_changed_files} changed files`}
+            >
+              {workspace.git_changed_files} changed
+            </span>
+          )}
+
+          {hasDiff && (
+            <span className="ml-auto flex shrink-0 items-center gap-1 tabular-nums">
+              {workspace.git_additions > 0 && (
+                <span className="text-success/80">
+                  +{workspace.git_additions}
+                </span>
+              )}
+              {workspace.git_deletions > 0 && (
+                <span className="text-danger/80">
+                  −{workspace.git_deletions}
+                </span>
+              )}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Remote (sibling-device, no WorkspaceSnapshot) ───────────────
+
+function RemoteRow({
+  item,
+}: {
+  item: Extract<OverviewItem, { kind: "remote" }>;
+  onAfterOpen: () => void;
+}) {
+  const row = item.sync;
+  const branch = row.git_branch;
+
+  return (
+    <div
+      role="group"
+      aria-label={`${row.title}, lives on another device`}
+      className={cn(
+        "group/row relative flex h-full flex-col gap-2 rounded-lg border border-dashed border-sky-500/30 bg-sky-500/5 px-3.5 py-3",
+        "hover:border-sky-500/50 hover:bg-sky-500/8 transition-colors",
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <span
+          aria-label="Lives on another device"
+          title="This workspace lives on another device of your account."
+          className="mt-[5px] flex size-2 shrink-0 rounded-full bg-sky-400/70"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h4
+              className="min-w-0 flex-1 truncate text-[13px] font-medium leading-tight text-foreground/90"
+              title={row.title}
+            >
+              {row.title}
+            </h4>
+            <span
+              title="This workspace lives on another device of your account. Pull it down to interact with it here."
+              className="shrink-0 rounded-full border border-sky-400/30 bg-sky-500/10 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wider leading-[14px] text-sky-300"
+            >
+              other device
+            </span>
+          </div>
+          <p className="mt-0.5 truncate text-[11px] text-muted-foreground/65">
+            {item.projectName ?? "—"}
+            <span className="ml-1.5 text-sky-300/70">
+              · not on this device
+            </span>
+          </p>
+        </div>
+
+        <div
+          className={cn(
+            "opacity-0 transition-opacity",
+            "group-hover/row:opacity-100 group-focus-within/row:opacity-100",
+          )}
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Workspace actions"
+                onClick={(e) => e.stopPropagation()}
+                className="size-7 text-muted-foreground hover:text-foreground"
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              onClick={(e) => e.stopPropagation()}
+              className="min-w-[220px]"
+            >
+              <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-muted-foreground/60">
+                Lives on another device
+              </DropdownMenuLabel>
+              <DropdownMenuItem
+                disabled
+                title="Adopting workspaces from sibling devices is coming in a follow-up. For now this view is read-only."
+              >
+                <CloudOff className="mr-2 size-3.5" />
+                Pull to this device (coming soon)
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={!branch}
+                onClick={() => {
+                  if (branch) {
+                    navigator.clipboard.writeText(branch).catch(console.error);
+                    toast.success("Copied branch name", {
+                      description: branch,
+                    });
+                  }
+                }}
+              >
+                <GitBranch className="mr-2 size-3.5" />
+                Copy branch name
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {branch && (
+        <div className="flex items-center gap-1.5 pl-5 font-mono text-[11px] text-muted-foreground/60">
+          <GitBranch className="size-3 shrink-0" aria-hidden />
+          <span className="truncate">{branch}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Shared status dot ──────────────────────────────────────────
+
+function StatusDot({
+  attached,
+  remote,
+  inFlight,
+  openFlow,
+  workspaceStatus,
+}: {
+  attached: boolean;
+  remote: boolean;
+  inFlight: boolean;
+  openFlow: boolean;
+  workspaceStatus: ActivePaneStatus | null;
+}) {
+  if (workspaceStatus) {
+    return (
+      <span className="mt-[5px] flex shrink-0">
+        <StatusIndicator status={workspaceStatus} />
+      </span>
+    );
+  }
+
+  const label = inFlight
+    ? "Syncing"
+    : attached
+      ? "Currently open in this app"
+      : remote
+        ? "On a remote host"
+        : openFlow
+          ? "OpenFlow workspace"
+          : "Local";
+
+  return (
+    <span
+      aria-label={label}
+      title={label}
+      className={cn(
+        "mt-[5px] flex size-2 shrink-0 items-center justify-center rounded-full",
+        inFlight
+          ? "bg-amber-400/80"
+          : attached
+            ? "bg-emerald-400"
+            : remote
+              ? "bg-sky-400/80"
+              : openFlow
+                ? "bg-violet-400/70"
+                : "bg-muted-foreground/40",
+      )}
+    />
+  );
+}
+
+// Silence unused-import warning when the type guard's narrowed shape
+// makes the `WorkspaceSnapshot` import look unused in some build paths.
+export type _OverviewWorkspace = WorkspaceSnapshot;

--- a/src/components/workspaces-overview/workspace-overview-row.tsx
+++ b/src/components/workspaces-overview/workspace-overview-row.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useCallback, useState } from "react";
+import { startTransition, useCallback, useEffect, useState } from "react";
 
 import {
   ArrowDownLeft,
@@ -168,6 +168,34 @@ function LocalRow({
   const [busy, setBusy] = useState(false);
   const isRemote = item.hostServerId !== null;
   const isWorktree = !!workspace.worktree_path;
+
+  // Phase-4d elapsed-time indicator: when a push/pull takes longer
+  // than ~2s, surface "12s elapsed" so the user knows it's working
+  // (not stalled). Updates once per second via setInterval, only
+  // while in-flight, so idle rows pay no re-render cost.
+  const startedAt = useAppStore(
+    (s) =>
+      s.workspacePushPullInFlight === workspace.workspace_id
+        ? s.workspacePushPullStartedAt
+        : null,
+  );
+  const [elapsedSec, setElapsedSec] = useState<number | null>(null);
+  useEffect(() => {
+    if (startedAt === null) {
+      setElapsedSec(null);
+      return;
+    }
+    const tick = () => {
+      const ms = Date.now() - startedAt;
+      // Only surface once we've been waiting >2s, otherwise the
+      // user is just seeing the spinner and the number would be a
+      // visual jitter for fast operations.
+      setElapsedSec(ms < 2_000 ? null : Math.floor(ms / 1_000));
+    };
+    tick();
+    const id = window.setInterval(tick, 1_000);
+    return () => window.clearInterval(id);
+  }, [startedAt]);
 
   const handleOpen = useCallback(() => {
     if (inFlight) return;
@@ -375,10 +403,22 @@ function LocalRow({
         >
           {showingInFlight ? (
             <span
-              aria-label="Working"
-              className="flex size-7 items-center justify-center text-muted-foreground"
+              aria-label={
+                elapsedSec !== null
+                  ? `Working — ${elapsedSec}s elapsed`
+                  : "Working"
+              }
+              className="flex items-center gap-1.5 text-muted-foreground"
             >
               <Loader2 className="size-3.5 animate-spin" />
+              {elapsedSec !== null && (
+                <span
+                  title="Push and pull use rsync over SSH — large workspaces can take a while. Stay on this page; you'll see a toast when it's done."
+                  className="rounded-full bg-muted/60 px-1.5 py-0 text-[10px] font-medium tabular-nums leading-[14px] text-muted-foreground/85"
+                >
+                  {elapsedSec}s
+                </span>
+              )}
             </span>
           ) : (
             <DropdownMenu>

--- a/src/components/workspaces-overview/workspace-overview-row.tsx
+++ b/src/components/workspaces-overview/workspace-overview-row.tsx
@@ -54,6 +54,10 @@ interface Props {
   /** Called after a successful "Open" — the overview should close so
    *  the user lands on the workspace they picked. */
   onAfterOpen: () => void;
+  /** Called when the user clicks "Pull to this device" on a
+   *  sibling-device (remote-kind) row. The section hoists this and
+   *  opens the shared `PullToDeviceDialog`. */
+  onRequestPull?: (item: Extract<OverviewItem, { kind: "remote" }>) => void;
 }
 
 /**
@@ -67,9 +71,16 @@ interface Props {
  *    sibling-device row + metadata). The "Pending sync" pill on
  *    local rows surfaces the row's `dirty` flag.
  */
-export function WorkspaceOverviewRow({ item, isAttached, onAfterOpen }: Props) {
+export function WorkspaceOverviewRow({
+  item,
+  isAttached,
+  onAfterOpen,
+  onRequestPull,
+}: Props) {
   if (item.kind === "remote") {
-    return <RemoteRow item={item} onAfterOpen={onAfterOpen} />;
+    return (
+      <RemoteRow item={item} onRequestPull={onRequestPull ?? null} />
+    );
   }
   return (
     <LocalRow
@@ -488,12 +499,14 @@ function LocalRow({
 
 function RemoteRow({
   item,
+  onRequestPull,
 }: {
   item: Extract<OverviewItem, { kind: "remote" }>;
-  onAfterOpen: () => void;
+  onRequestPull: ((item: Extract<OverviewItem, { kind: "remote" }>) => void) | null;
 }) {
   const row = item.sync;
   const branch = row.git_branch;
+  const canRequestPull = onRequestPull !== null;
 
   return (
     <div
@@ -560,13 +573,22 @@ function RemoteRow({
               <DropdownMenuLabel className="text-[10px] uppercase tracking-wider text-muted-foreground/60">
                 Lives on another device
               </DropdownMenuLabel>
-              <DropdownMenuItem
-                disabled
-                title="Adopting workspaces from sibling devices is coming in a follow-up. For now this view is read-only."
-              >
-                <CloudOff className="mr-2 size-3.5" />
-                Pull to this device (coming soon)
-              </DropdownMenuItem>
+              {canRequestPull ? (
+                <DropdownMenuItem
+                  onClick={() => onRequestPull?.(item)}
+                >
+                  <ArrowDownLeft className="mr-2 size-3.5" />
+                  Pull to this device…
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  disabled
+                  title="Pulling sibling-device workspaces is unavailable here."
+                >
+                  <CloudOff className="mr-2 size-3.5" />
+                  Pull to this device (unavailable)
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 disabled={!branch}

--- a/src/components/workspaces-overview/workspaces-overview-section.test.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.test.tsx
@@ -1,0 +1,294 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import type { WorkspaceSnapshot } from "@/tauri/types";
+import type { HostView } from "@/tauri/commands";
+
+// ── Mutable mock state — exercised by individual tests ──
+
+let mockWorkspaces: WorkspaceSnapshot[] | null = [];
+let mockActiveWorkspaceId: string | null = null;
+let mockHosts: HostView[] = [];
+let mockHostsLoaded = true;
+
+const mockInitHosts = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/stores/app-store", () => ({
+  useAppStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      appState: mockWorkspaces
+        ? {
+            workspaces: mockWorkspaces,
+            active_workspace_id: mockActiveWorkspaceId,
+          }
+        : null,
+      // Used by the row component
+      workspacePushPullInFlight: null,
+      setWorkspacePushPullInFlight: vi.fn(),
+    }),
+  ),
+  // groupWorkspacesByProject is reused by the section. Provide a
+  // simple stub that puts every workspace into one bucket named by
+  // its project_root basename. Sufficient for the bucket assertions
+  // below — the real implementation is exercised in app-store tests.
+  groupWorkspacesByProject: (workspaces: WorkspaceSnapshot[]) => {
+    const map = new Map<string, WorkspaceSnapshot[]>();
+    for (const ws of workspaces) {
+      const path = ws.project_root ?? ws.cwd;
+      if (!map.has(path)) map.set(path, []);
+      map.get(path)!.push(ws);
+    }
+    return Array.from(map.entries()).map(([path, list]) => ({
+      projectPath: path,
+      projectName: path.split("/").pop() ?? path,
+      workspaces: list,
+    }));
+  },
+  useHomeDir: () => "/home/test",
+}));
+
+vi.mock("@/stores/hosts-store", () => ({
+  useHostsStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      hosts: mockHosts,
+      loaded: mockHostsLoaded,
+      init: mockInitHosts,
+    }),
+  ),
+  useHosts: () => mockHosts,
+}));
+
+vi.mock("@/stores/workspaces-sync-store", () => ({
+  useWorkspacesSync: () => [] as never[],
+  useWorkspacesSyncStatus: () => ({
+    rows: [],
+    loading: false,
+    loaded: true,
+    error: null,
+    refresh: () => Promise.resolve(),
+  }),
+}));
+
+vi.mock("@/stores/ui-store", () => ({
+  useUIStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      setShowNewWorkspaceDialog: vi.fn(),
+      setShowWorkspacesOverview: vi.fn(),
+    }),
+  ),
+}));
+
+// Lean row stub — the row's own tests live separately. We only need
+// to assert the section reaches the row with the right workspace, so
+// render the title in a queryable form.
+vi.mock("./workspace-overview-row", () => ({
+  WorkspaceOverviewRow: ({
+    item,
+    isAttached,
+  }: {
+    item: {
+      kind: "local" | "remote";
+      key: string;
+      workspace?: WorkspaceSnapshot;
+      sync?: { title: string; host_server_id: string | null };
+    };
+    isAttached: boolean;
+  }) => {
+    const title =
+      item.kind === "local"
+        ? item.workspace!.title
+        : item.sync!.title;
+    const wid =
+      item.kind === "local" ? item.workspace!.workspace_id : item.key;
+    return (
+      <div
+        data-testid="row"
+        data-kind={item.kind}
+        data-workspace-id={wid}
+        data-attached={isAttached ? "1" : "0"}
+      >
+        {title}
+      </div>
+    );
+  },
+}));
+
+import { WorkspacesOverviewSection } from "./workspaces-overview-section";
+
+function makeWorkspace(
+  partial: Partial<WorkspaceSnapshot> & { workspace_id: string },
+): WorkspaceSnapshot {
+  return {
+    workspace_id: partial.workspace_id,
+    title: partial.title ?? partial.workspace_id,
+    workspace_type: partial.workspace_type ?? "standard",
+    cwd: partial.cwd ?? "/home/test/proj",
+    git_branch: partial.git_branch ?? null,
+    git_ahead: partial.git_ahead ?? 0,
+    git_behind: partial.git_behind ?? 0,
+    git_additions: partial.git_additions ?? 0,
+    git_deletions: partial.git_deletions ?? 0,
+    git_changed_files: partial.git_changed_files ?? 0,
+    notification_count: partial.notification_count ?? 0,
+    latest_agent_state: partial.latest_agent_state ?? null,
+    worktree_path: partial.worktree_path ?? null,
+    project_root: partial.project_root ?? "/home/test/proj",
+    pr_number: partial.pr_number ?? null,
+    pr_state: partial.pr_state ?? null,
+    pr_url: partial.pr_url ?? null,
+    linked_issue: partial.linked_issue ?? null,
+    notifications_muted: partial.notifications_muted ?? false,
+    tabs: partial.tabs ?? [],
+    active_tab_id: partial.active_tab_id ?? "",
+    active_surface_id: partial.active_surface_id ?? "",
+    surfaces: partial.surfaces ?? [],
+    host_id: partial.host_id,
+  } as WorkspaceSnapshot;
+}
+
+function makeHost(
+  id: number,
+  name: string,
+  serverId: string | null = `srv-${id}`,
+): HostView {
+  return {
+    id,
+    server_id: serverId,
+    name,
+    ssh_target: `${name}@example`,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    dirty: false,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe("WorkspacesOverviewSection", () => {
+  beforeEach(() => {
+    mockWorkspaces = [];
+    mockActiveWorkspaceId = null;
+    mockHosts = [];
+    mockHostsLoaded = true;
+    mockInitHosts.mockClear();
+  });
+
+  it("renders the first-run empty state when there are no workspaces", () => {
+    mockWorkspaces = [];
+    const { getByText } = render(<WorkspacesOverviewSection />);
+    expect(getByText("No workspaces yet")).toBeInTheDocument();
+  });
+
+  it("renders a loading state while appState is still null", () => {
+    mockWorkspaces = null;
+    const { getByText } = render(<WorkspacesOverviewSection />);
+    expect(getByText(/loading workspaces/i)).toBeInTheDocument();
+  });
+
+  it("groups local workspaces under 'This device' and remote ones under the host", () => {
+    mockHosts = [makeHost(7, "devbox")];
+    mockWorkspaces = [
+      makeWorkspace({ workspace_id: "local-1", title: "alpha" }),
+      makeWorkspace({
+        workspace_id: "remote-1",
+        title: "beta",
+        host_id: 7,
+      }),
+    ];
+    const { getByText, getAllByTestId } = render(
+      <WorkspacesOverviewSection />,
+    );
+
+    // Both bucket headers
+    expect(getByText("This device")).toBeInTheDocument();
+    expect(getByText("devbox")).toBeInTheDocument();
+
+    // Both workspaces rendered via the row stub
+    const rows = getAllByTestId("row");
+    const ids = rows.map((r) => r.getAttribute("data-workspace-id"));
+    expect(ids).toContain("local-1");
+    expect(ids).toContain("remote-1");
+  });
+
+  it("marks the active workspace as attached", () => {
+    mockActiveWorkspaceId = "local-1";
+    mockWorkspaces = [
+      makeWorkspace({ workspace_id: "local-1", title: "alpha" }),
+      makeWorkspace({ workspace_id: "local-2", title: "gamma" }),
+    ];
+    const { getAllByTestId } = render(<WorkspacesOverviewSection />);
+    const rows = getAllByTestId("row");
+    const attachedIds = rows
+      .filter((r) => r.getAttribute("data-attached") === "1")
+      .map((r) => r.getAttribute("data-workspace-id"));
+    expect(attachedIds).toEqual(["local-1"]);
+  });
+
+  it("filters by search across title, branch, and project name", () => {
+    mockWorkspaces = [
+      makeWorkspace({
+        workspace_id: "ws-1",
+        title: "alpha",
+        git_branch: "feature/login",
+      }),
+      makeWorkspace({
+        workspace_id: "ws-2",
+        title: "beta",
+        git_branch: "main",
+      }),
+    ];
+    const { getByPlaceholderText, queryByText } = render(
+      <WorkspacesOverviewSection />,
+    );
+
+    const search = getByPlaceholderText(/search by name, branch/i);
+    fireEvent.change(search, { target: { value: "login" } });
+
+    // Row stub renders title; ws-2 should be filtered out.
+    expect(queryByText("alpha")).toBeInTheDocument();
+    expect(queryByText("beta")).toBeNull();
+  });
+
+  it("orphan local workspaces (host_id with no matching local host) fall back to the 'This device' bucket", () => {
+    // host_id=99 doesn't map to any local hosts row → the host
+    // resolver returns null → the workspace lands under "This
+    // device" rather than vanishing. This is the local-only
+    // fallback; the sibling-device "Host not on this device"
+    // bucket is exercised in the workspaces-sync E2E layer.
+    mockHosts = [];
+    mockWorkspaces = [
+      makeWorkspace({
+        workspace_id: "orphan-1",
+        title: "lost-and-found",
+        host_id: 99,
+      }),
+    ];
+    const { getByText } = render(<WorkspacesOverviewSection />);
+    expect(getByText("This device")).toBeInTheDocument();
+    expect(getByText("lost-and-found")).toBeInTheDocument();
+  });
+
+  it("renders the bucket-level 'all hidden by filter' message when filters hide every workspace in a known device bucket", () => {
+    // Intentional: when the user has a bucket they recognise but
+    // every row in it is filtered out, the bucket stays visible
+    // with an inline hint — so they see *which* device the missing
+    // rows belong to, not just "no results."
+    mockWorkspaces = [
+      makeWorkspace({ workspace_id: "ws-1", title: "alpha" }),
+    ];
+    const { getByPlaceholderText, getByText } = render(
+      <WorkspacesOverviewSection />,
+    );
+
+    const search = getByPlaceholderText(/search by name, branch/i);
+    fireEvent.change(search, { target: { value: "zzzz-not-real" } });
+
+    expect(
+      getByText(/every workspace on this device is hidden/i),
+    ).toBeInTheDocument();
+    // The bucket header is still there so the user can see which
+    // device the filtered rows belong to.
+    expect(getByText("This device")).toBeInTheDocument();
+  });
+});

--- a/src/components/workspaces-overview/workspaces-overview-section.test.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.test.tsx
@@ -68,6 +68,18 @@ vi.mock("@/stores/workspaces-sync-store", () => ({
     error: null,
     refresh: () => Promise.resolve(),
   }),
+  // The pull-to-device dialog (mounted by the section) reads
+  // `refresh` from the underlying store to nudge a sync after a
+  // successful adoption.
+  useWorkspacesSyncStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      rows: [],
+      loading: false,
+      loaded: true,
+      error: null,
+      refresh: () => Promise.resolve(),
+    }),
+  ),
 }));
 
 vi.mock("@/stores/ui-store", () => ({

--- a/src/components/workspaces-overview/workspaces-overview-section.test.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.test.tsx
@@ -297,7 +297,7 @@ describe("WorkspacesOverviewSection", () => {
     fireEvent.change(search, { target: { value: "zzzz-not-real" } });
 
     expect(
-      getByText(/every workspace on this device is hidden/i),
+      getByText(/every workspace in This device is hidden/i),
     ).toBeInTheDocument();
     // The bucket header is still there so the user can see which
     // device the filtered rows belong to.

--- a/src/components/workspaces-overview/workspaces-overview-section.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.tsx
@@ -1,0 +1,671 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  Cloud,
+  Filter,
+  Folder,
+  LayoutGrid,
+  Loader2,
+  Plus,
+  Search,
+  X,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { useAppStore } from "@/stores/app-store";
+import { useHostsStore } from "@/stores/hosts-store";
+import { useUIStore } from "@/stores/ui-store";
+
+import { WorkspaceOverviewRow } from "./workspace-overview-row";
+import { useOverviewItems, type DeviceBucket, type OverviewItem } from "./use-overview-items";
+
+/**
+ * The Workspaces overview body — rendered full-screen by
+ * `WorkspacesOverviewView`, reached from the left sidebar.
+ *
+ * Lists every workspace this account owns, across every device:
+ * local rows from `app_state.workspaces` plus synced rows from the
+ * `workspaces_sync` table (which the Rust background loop keeps in
+ * sync with `/api/workspaces`). Workspaces are bucketed by host —
+ * pushing a workspace to a host visibly migrates its card from
+ * "This device" to the matching host section.
+ */
+
+type SortBy = "recent" | "name" | "branch";
+type CreatedWithin = "all" | "1d" | "7d" | "30d" | "90d";
+type HostFilter = "all" | "local" | string; // `string` = host server id
+type StatusFilter = "all" | "attached" | "remote-host" | "dirty" | "sibling-device";
+
+const CREATED_WITHIN_DAYS: Record<Exclude<CreatedWithin, "all">, number> = {
+  "1d": 1,
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
+export function WorkspacesOverviewSection() {
+  const workspaces = useAppStore((s) => s.appState?.workspaces ?? null);
+  const activeWorkspaceId = useAppStore(
+    (s) => s.appState?.active_workspace_id ?? null,
+  );
+  const initHosts = useHostsStore((s) => s.init);
+  const setShowNewWorkspaceDialog = useUIStore(
+    (s) => s.setShowNewWorkspaceDialog,
+  );
+  const setShowWorkspacesOverview = useUIStore(
+    (s) => s.setShowWorkspacesOverview,
+  );
+
+  // Filters
+  const [search, setSearch] = useState("");
+  const [projectFilter, setProjectFilter] = useState<string>("all");
+  const [hostFilter, setHostFilter] = useState<HostFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [createdWithin, setCreatedWithin] = useState<CreatedWithin>("all");
+  const [sortBy, setSortBy] = useState<SortBy>("recent");
+
+  // Eagerly load hosts so device-bucket labels resolve immediately.
+  useEffect(() => {
+    void initHosts();
+  }, [initHosts]);
+
+  // Unified item list — locals + sibling-device synced rows.
+  const { items: allItems, hosts } = useOverviewItems();
+
+  // Project picker options — every distinct project path the
+  // overview can see, regardless of whether it's local or remote.
+  const projects = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const it of allItems) {
+      if (it.projectPath && it.projectName) {
+        seen.set(it.projectPath, it.projectName);
+      }
+    }
+    return Array.from(seen.entries())
+      .map(([path, name]) => ({ path, name }))
+      .sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+      );
+  }, [allItems]);
+
+  // Filter pipeline.
+  const filtered = useMemo<OverviewItem[]>(() => {
+    const query = search.trim().toLowerCase();
+    const cutoff =
+      createdWithin === "all"
+        ? null
+        : Date.now() - CREATED_WITHIN_DAYS[createdWithin] * 86_400_000;
+
+    return allItems.filter((it) => {
+      // Project filter
+      if (projectFilter !== "all") {
+        if (!it.projectPath || it.projectPath !== projectFilter) return false;
+      }
+
+      // Host filter
+      if (hostFilter === "local") {
+        if (it.hostServerId !== null) return false;
+      } else if (hostFilter !== "all") {
+        if (it.hostServerId !== hostFilter) return false;
+      }
+
+      // Status filter
+      if (statusFilter === "attached") {
+        if (it.kind !== "local" || it.workspace.workspace_id !== activeWorkspaceId) {
+          return false;
+        }
+      } else if (statusFilter === "remote-host") {
+        if (it.hostServerId === null) return false;
+      } else if (statusFilter === "sibling-device") {
+        if (it.kind !== "remote") return false;
+      } else if (statusFilter === "dirty") {
+        if (it.kind === "local") {
+          if (
+            it.workspace.git_changed_files === 0 &&
+            it.workspace.git_ahead === 0
+          )
+            return false;
+        } else {
+          // Remote-only rows have no live git stats; don't match "dirty".
+          return false;
+        }
+      }
+
+      // Time-window: created_at is on the sync row; for local rows
+      // without a sync row yet (transient), use no filter rather
+      // than incorrectly dropping them.
+      if (cutoff !== null) {
+        const created = it.kind === "local" ? it.sync?.created_at : it.sync.created_at;
+        if (created) {
+          const ts = parseTimestamp(created);
+          if (ts !== null && ts < cutoff) return false;
+        }
+      }
+
+      if (!query) return true;
+      const title =
+        it.kind === "local" ? it.workspace.title : it.sync.title;
+      const branch =
+        it.kind === "local"
+          ? it.workspace.git_branch ?? ""
+          : it.sync.git_branch ?? "";
+      return (
+        title.toLowerCase().includes(query) ||
+        branch.toLowerCase().includes(query) ||
+        (it.projectName?.toLowerCase().includes(query) ?? false)
+      );
+    });
+  }, [
+    allItems,
+    search,
+    projectFilter,
+    hostFilter,
+    statusFilter,
+    createdWithin,
+    activeWorkspaceId,
+  ]);
+
+  // Bucket the filtered list by host. Local first, then each
+  // configured host in user order, then orphan/sibling buckets for
+  // workspaces whose host isn't on this device yet.
+  const buckets = useMemo<DeviceBucket[]>(() => {
+    // Build bucket key → bucket. Pre-create the local + configured-
+    // host buckets so empty configured hosts still show up.
+    const byKey = new Map<string, DeviceBucket>();
+    byKey.set("local", {
+      key: "local",
+      localHostId: null,
+      hostServerId: null,
+      label: "This device",
+      sublabel: null,
+      items: [],
+      totalCount: 0,
+      sortRank: 0,
+    });
+    hosts.forEach((h, idx) => {
+      if (!h.server_id) return; // host hasn't synced yet — no cross-device id
+      byKey.set(h.server_id, {
+        key: h.server_id,
+        localHostId: h.id,
+        hostServerId: h.server_id,
+        label: h.name,
+        sublabel: h.ssh_target,
+        items: [],
+        totalCount: 0,
+        sortRank: 1 + idx,
+      });
+    });
+
+    // Count totals on the unfiltered list (for "X hidden by filter").
+    for (const it of allItems) {
+      const key = it.hostServerId ?? "local";
+      let bucket = byKey.get(key);
+      if (!bucket) {
+        // Orphan host: workspace references a host_server_id we
+        // don't know locally yet (the hosts-sync hasn't caught up,
+        // or the host row was deleted). Create the bucket.
+        bucket = {
+          key,
+          localHostId: null,
+          hostServerId: it.hostServerId,
+          label: it.hostServerId ? "Host not on this device" : "This device",
+          sublabel: it.hostServerId
+            ? `host #${it.hostServerId}`
+            : null,
+          items: [],
+          totalCount: 0,
+          sortRank: 999,
+        };
+        byKey.set(key, bucket);
+      }
+      bucket.totalCount += 1;
+    }
+
+    // Place filtered items.
+    for (const it of filtered) {
+      const key = it.hostServerId ?? "local";
+      const bucket = byKey.get(key);
+      if (bucket) bucket.items.push(it);
+    }
+
+    // Sort items inside each bucket.
+    const sorter = makeSorter(sortBy, activeWorkspaceId);
+    for (const bucket of byKey.values()) {
+      bucket.items.sort(sorter);
+    }
+
+    // Hide buckets that have neither items nor any unfiltered rows.
+    return Array.from(byKey.values())
+      .filter((b) => b.items.length > 0 || b.totalCount > 0)
+      .sort((a, b) => a.sortRank - b.sortRank);
+  }, [allItems, filtered, hosts, sortBy, activeWorkspaceId]);
+
+  const totalShown = filtered.length;
+  const totalAll = allItems.length;
+  const hasActiveFilter =
+    search.trim() !== "" ||
+    projectFilter !== "all" ||
+    hostFilter !== "all" ||
+    statusFilter !== "all" ||
+    createdWithin !== "all";
+
+  const clearFilters = useCallback(() => {
+    setSearch("");
+    setProjectFilter("all");
+    setHostFilter("all");
+    setStatusFilter("all");
+    setCreatedWithin("all");
+  }, []);
+
+  // ── Loading state ──────────────────────────────────────────────
+  if (workspaces === null) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        <Loader2 className="mr-2 size-4 animate-spin" />
+        Loading workspaces…
+      </div>
+    );
+  }
+
+  // ── First-run empty state ──────────────────────────────────────
+  if (totalAll === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-6">
+        <div className="max-w-sm space-y-4 text-center">
+          <div className="mx-auto flex size-14 items-center justify-center rounded-2xl border border-border/50 bg-muted/40">
+            <LayoutGrid className="size-6 text-muted-foreground/70" />
+          </div>
+          <div className="space-y-1.5">
+            <h3 className="text-[15px] font-semibold tracking-tight text-foreground">
+              No workspaces yet
+            </h3>
+            <p className="text-[12.5px] leading-relaxed text-muted-foreground/80">
+              Workspaces hold a worktree, an agent, and any panes you open.
+              Create one here, then push it to a host whenever you want it
+              to run somewhere else — every device of your account shows up
+              alongside this one.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-8 gap-1.5 text-[12.5px]"
+            onClick={() => {
+              setShowWorkspacesOverview(false);
+              setShowNewWorkspaceDialog(true);
+            }}
+          >
+            <Plus className="size-3.5" />
+            New workspace
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Main view ───────────────────────────────────────────────────
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Filter bar */}
+      <div className="shrink-0 border-b border-border/60 bg-background/60 px-6 py-3 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-2">
+          {/* Search */}
+          <div className="relative min-w-[220px] flex-1">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/60" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search by name, branch, or project…"
+              className="h-8 pl-8 text-[13px]"
+            />
+            {search && (
+              <button
+                type="button"
+                onClick={() => setSearch("")}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-muted-foreground/60 hover:text-foreground"
+              >
+                <X className="size-3.5" />
+              </button>
+            )}
+          </div>
+
+          {/* Project filter */}
+          <Select value={projectFilter} onValueChange={setProjectFilter}>
+            <SelectTrigger className="h-8 w-[160px] text-[12.5px]">
+              <SelectValue placeholder="All projects" />
+            </SelectTrigger>
+            <SelectContent position="popper" className="max-h-72">
+              <SelectItem value="all">All projects</SelectItem>
+              {projects.map((p) => (
+                <SelectItem key={p.path} value={p.path}>
+                  {p.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Device filter */}
+          <Select
+            value={hostFilter}
+            onValueChange={(v) => setHostFilter(v as HostFilter)}
+          >
+            <SelectTrigger className="h-8 w-[160px] text-[12.5px]">
+              <SelectValue placeholder="All devices" />
+            </SelectTrigger>
+            <SelectContent position="popper">
+              <SelectItem value="all">All devices</SelectItem>
+              <SelectItem value="local">This device</SelectItem>
+              {hosts
+                .filter((h) => h.server_id)
+                .map((h) => (
+                  <SelectItem key={h.server_id!} value={h.server_id!}>
+                    {h.name}
+                  </SelectItem>
+                ))}
+            </SelectContent>
+          </Select>
+
+          {/* Status filter */}
+          <Select
+            value={statusFilter}
+            onValueChange={(v) => setStatusFilter(v as StatusFilter)}
+          >
+            <SelectTrigger className="h-8 w-[160px] text-[12.5px]">
+              <SelectValue placeholder="Any status" />
+            </SelectTrigger>
+            <SelectContent position="popper">
+              <SelectItem value="all">Any status</SelectItem>
+              <SelectItem value="attached">Currently open</SelectItem>
+              <SelectItem value="remote-host">On a remote host</SelectItem>
+              <SelectItem value="sibling-device">On another device</SelectItem>
+              <SelectItem value="dirty">Has uncommitted work</SelectItem>
+            </SelectContent>
+          </Select>
+
+          {/* Sort */}
+          <Select
+            value={sortBy}
+            onValueChange={(v) => setSortBy(v as SortBy)}
+          >
+            <SelectTrigger className="h-8 w-[150px] text-[12.5px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent position="popper">
+              <SelectItem value="recent">Recently active</SelectItem>
+              <SelectItem value="name">Name (A–Z)</SelectItem>
+              <SelectItem value="branch">Branch (A–Z)</SelectItem>
+            </SelectContent>
+          </Select>
+
+          {hasActiveFilter && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 text-[12px] text-muted-foreground"
+              onClick={clearFilters}
+            >
+              <Filter className="size-3.5" />
+              Clear
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Result count + new-workspace shortcut */}
+      <div className="shrink-0 border-b border-border/40 px-6 py-2">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-3">
+          <p className="text-[11.5px] text-muted-foreground/70 tabular-nums">
+            {totalShown === totalAll
+              ? `${totalAll} ${totalAll === 1 ? "workspace" : "workspaces"}`
+              : `${totalShown} of ${totalAll} shown`}
+            {hosts.length > 0 && (
+              <span className="ml-2 text-muted-foreground/50">
+                · {hosts.length}{" "}
+                {hosts.length === 1 ? "device" : "devices"} configured
+              </span>
+            )}
+          </p>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+            onClick={() => {
+              setShowWorkspacesOverview(false);
+              setShowNewWorkspaceDialog(true);
+            }}
+          >
+            <Plus className="size-3.5" />
+            New workspace
+          </Button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-6 py-6">
+        <div className="mx-auto max-w-6xl space-y-8">
+          {buckets.length === 0 ? (
+            <EmptyFilters onClear={clearFilters} />
+          ) : (
+            buckets.map((bucket) => (
+              <DeviceSection
+                key={bucket.key}
+                bucket={bucket}
+                activeWorkspaceId={activeWorkspaceId}
+                onCloseOverview={() => setShowWorkspacesOverview(false)}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Device-grouped section ──────────────────────────────────────
+
+function DeviceSection({
+  bucket,
+  activeWorkspaceId,
+  onCloseOverview,
+}: {
+  bucket: DeviceBucket;
+  activeWorkspaceId: string | null;
+  onCloseOverview: () => void;
+}) {
+  const isLocal = bucket.hostServerId === null;
+  const hiddenByFilter = bucket.totalCount - bucket.items.length;
+
+  return (
+    <section>
+      <header className="mb-2.5 flex items-end justify-between gap-3 border-b border-border/40 pb-2">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <span
+            className={cn(
+              "flex size-7 shrink-0 items-center justify-center rounded-md border",
+              isLocal
+                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-400"
+                : "border-sky-500/25 bg-sky-500/8 text-sky-300",
+            )}
+          >
+            {isLocal ? (
+              <LocalDeviceGlyph />
+            ) : (
+              <Cloud className="size-3.5" aria-hidden />
+            )}
+          </span>
+          <div className="min-w-0">
+            <h3 className="truncate text-[13px] font-semibold tracking-tight text-foreground">
+              {bucket.label}
+            </h3>
+            {bucket.sublabel && (
+              <p className="truncate font-mono text-[10.5px] text-muted-foreground/60">
+                {bucket.sublabel}
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-baseline gap-2 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/55">
+          {hiddenByFilter > 0 && (
+            <span
+              title={`${hiddenByFilter} hidden by filter`}
+              className="rounded bg-muted/40 px-1.5 py-0.5 text-warning/80 normal-case tracking-normal"
+            >
+              {hiddenByFilter} filtered
+            </span>
+          )}
+          <span className="tabular-nums text-muted-foreground/70 normal-case tracking-normal">
+            {bucket.items.length}{" "}
+            {bucket.items.length === 1 ? "workspace" : "workspaces"}
+          </span>
+        </div>
+      </header>
+
+      {bucket.items.length === 0 ? (
+        <p className="rounded-md border border-dashed border-border/40 px-3 py-4 text-center text-[12px] text-muted-foreground/60">
+          {hiddenByFilter > 0
+            ? "Every workspace on this device is hidden by the current filter."
+            : isLocal
+              ? "No workspaces on this device."
+              : "No workspaces have been pushed to this host yet."}
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 gap-1.5 md:grid-cols-2">
+          {bucket.items.map((it) => (
+            <li key={it.key}>
+              <WorkspaceOverviewRow
+                item={it}
+                isAttached={
+                  it.kind === "local" &&
+                  it.workspace.workspace_id === activeWorkspaceId
+                }
+                onAfterOpen={onCloseOverview}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function EmptyFilters({ onClear }: { onClear: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-border/40 bg-muted/10 px-6 py-12 text-center">
+      <Folder className="size-6 text-muted-foreground/40" />
+      <div className="space-y-1">
+        <p className="text-[13px] font-medium text-foreground">
+          No workspaces match these filters
+        </p>
+        <p className="text-[11.5px] text-muted-foreground/70">
+          Try a different search, or clear the filter to see everything.
+        </p>
+      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-7 gap-1.5 text-[12px]"
+        onClick={onClear}
+      >
+        <X className="size-3.5" />
+        Clear filters
+      </Button>
+    </div>
+  );
+}
+
+// ── Sorting helpers ─────────────────────────────────────────────
+
+function makeSorter(
+  by: SortBy,
+  activeWorkspaceId: string | null,
+): (a: OverviewItem, b: OverviewItem) => number {
+  return (a, b) => {
+    const titleA = itemTitle(a).toLowerCase();
+    const titleB = itemTitle(b).toLowerCase();
+
+    if (by === "name") {
+      return titleA.localeCompare(titleB);
+    }
+    if (by === "branch") {
+      const ba = (itemBranch(a) ?? "").toLowerCase();
+      const bb = (itemBranch(b) ?? "").toLowerCase();
+      if (!ba && bb) return 1;
+      if (ba && !bb) return -1;
+      return ba.localeCompare(bb);
+    }
+    // "recent" — locals come ahead of remote-only because we know
+    // more about them; among locals, the currently-attached row
+    // floats to the top, then dirty/notifying rows, then by name.
+    const rankA = recencyRank(a, activeWorkspaceId);
+    const rankB = recencyRank(b, activeWorkspaceId);
+    if (rankA !== rankB) return rankB - rankA;
+    return titleA.localeCompare(titleB);
+  };
+}
+
+function recencyRank(
+  it: OverviewItem,
+  activeWorkspaceId: string | null,
+): number {
+  if (it.kind === "remote") return 0;
+  let rank = 1; // local baseline
+  if (it.workspace.workspace_id === activeWorkspaceId) rank += 10;
+  rank += it.workspace.notification_count;
+  if (it.workspace.git_changed_files > 0) rank += 1;
+  return rank;
+}
+
+function itemTitle(it: OverviewItem): string {
+  return it.kind === "local" ? it.workspace.title : it.sync.title;
+}
+
+function itemBranch(it: OverviewItem): string | null {
+  return it.kind === "local"
+    ? it.workspace.git_branch
+    : it.sync.git_branch;
+}
+
+function parseTimestamp(s: string): number | null {
+  // The server emits ISO; SQLite emits "YYYY-MM-DD HH:MM:SS".
+  // `Date.parse` handles ISO; for the SQLite shape add a `T` and `Z`.
+  const iso = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(s)
+    ? s.replace(" ", "T") + "Z"
+    : s;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+}
+
+// ── Inline glyphs ───────────────────────────────────────────────
+
+function LocalDeviceGlyph() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      aria-hidden
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="2.5" y="3" width="11" height="7" rx="1.2" />
+      <path d="M1 12.5h14" />
+    </svg>
+  );
+}

--- a/src/components/workspaces-overview/workspaces-overview-section.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.tsx
@@ -25,8 +25,11 @@ import { useAppStore } from "@/stores/app-store";
 import { useHostsStore } from "@/stores/hosts-store";
 import { useUIStore } from "@/stores/ui-store";
 
+import type { WorkspaceSyncView } from "@/tauri/commands";
+
 import { WorkspaceOverviewRow } from "./workspace-overview-row";
 import { useOverviewItems, type DeviceBucket, type OverviewItem } from "./use-overview-items";
+import { PullToDeviceDialog } from "./pull-to-device-dialog";
 
 /**
  * The Workspaces overview body — rendered full-screen by
@@ -72,6 +75,18 @@ export function WorkspacesOverviewSection() {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [createdWithin, setCreatedWithin] = useState<CreatedWithin>("all");
   const [sortBy, setSortBy] = useState<SortBy>("recent");
+
+  // Cross-device adoption dialog state — hoisted here so any
+  // sibling-device row's `⋯ → Pull to this device` opens the same
+  // shared modal. Holds the sync row whose adoption is in progress;
+  // null = closed.
+  const [pullRow, setPullRow] = useState<WorkspaceSyncView | null>(null);
+  const handleRequestPull = useCallback(
+    (item: Extract<OverviewItem, { kind: "remote" }>) => {
+      setPullRow(item.sync);
+    },
+    [],
+  );
 
   // Eagerly load hosts so device-bucket labels resolve immediately.
   useEffect(() => {
@@ -465,11 +480,19 @@ export function WorkspacesOverviewSection() {
                 bucket={bucket}
                 activeWorkspaceId={activeWorkspaceId}
                 onCloseOverview={() => setShowWorkspacesOverview(false)}
+                onRequestPull={handleRequestPull}
               />
             ))
           )}
         </div>
       </div>
+
+      <PullToDeviceDialog
+        syncRow={pullRow}
+        onOpenChange={(open) => {
+          if (!open) setPullRow(null);
+        }}
+      />
     </div>
   );
 }
@@ -480,10 +503,14 @@ function DeviceSection({
   bucket,
   activeWorkspaceId,
   onCloseOverview,
+  onRequestPull,
 }: {
   bucket: DeviceBucket;
   activeWorkspaceId: string | null;
   onCloseOverview: () => void;
+  onRequestPull: (
+    item: Extract<OverviewItem, { kind: "remote" }>,
+  ) => void;
 }) {
   const isLocal = bucket.hostServerId === null;
   const hiddenByFilter = bucket.totalCount - bucket.items.length;
@@ -552,6 +579,7 @@ function DeviceSection({
                   it.workspace.workspace_id === activeWorkspaceId
                 }
                 onAfterOpen={onCloseOverview}
+                onRequestPull={onRequestPull}
               />
             </li>
           ))}

--- a/src/components/workspaces-overview/workspaces-overview-section.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.tsx
@@ -30,7 +30,13 @@ import { useUIStore } from "@/stores/ui-store";
 import type { WorkspaceSyncView } from "@/tauri/commands";
 
 import { WorkspaceOverviewRow } from "./workspace-overview-row";
-import { useOverviewItems, type DeviceBucket, type OverviewItem } from "./use-overview-items";
+import {
+  detectDivergence,
+  useOverviewItems,
+  type DeviceBucket,
+  type DivergenceInfo,
+  type OverviewItem,
+} from "./use-overview-items";
 import { PullToDeviceDialog } from "./pull-to-device-dialog";
 import { WelcomeBanner } from "./welcome-banner";
 import { HowItWorksPopover } from "./how-it-works-popover";
@@ -150,6 +156,17 @@ export function WorkspacesOverviewSection() {
 
   // Unified item list — locals + sibling-device synced rows.
   const { items: allItems, hosts } = useOverviewItems();
+
+  // Phase-4 divergence detection: rows that share a project_remote
+  // and git_branch but have different HEADs get a warning chip.
+  const divergenceByKey = useMemo<Map<string, DivergenceInfo>>(() => {
+    const hostLabelFor = (hostServerId: string | null): string => {
+      if (!hostServerId) return "this device";
+      const h = hosts.find((host) => host.server_id === hostServerId);
+      return h?.name ?? "another device";
+    };
+    return detectDivergence(allItems, hostLabelFor);
+  }, [allItems, hosts]);
 
   // Pulse newly-appeared remote rows: when a sync tick brings in a
   // remote row this device hadn't seen before, briefly pulse it so
@@ -593,6 +610,7 @@ export function WorkspacesOverviewSection() {
                 hasAnySibling={allItems.some((i) => i.kind === "remote")}
                 registerRemoteRow={registerRemoteRow}
                 pulseKeys={pulseKeys}
+                divergenceByKey={divergenceByKey}
               />
             ))
           )}
@@ -620,6 +638,7 @@ function DeviceSection({
   hasAnySibling,
   registerRemoteRow,
   pulseKeys,
+  divergenceByKey,
 }: {
   bucket: DeviceBucket;
   activeWorkspaceId: string | null;
@@ -642,6 +661,10 @@ function DeviceSection({
    *  from the "Pull from another device" CTA scrolling to them, or
    *  from a sync tick bringing in a new sibling-device workspace. */
   pulseKeys: Set<string>;
+  /** Phase-4 divergence info, keyed by row identity. The row
+   *  component reads its own key (`local:<workspace_id>` or
+   *  `remote:<sync.id>`) and renders a warning chip when present. */
+  divergenceByKey: Map<string, DivergenceInfo>;
 }) {
   const isLocal = bucket.hostServerId === null;
   const hiddenByFilter = bucket.totalCount - bucket.items.length;
@@ -724,6 +747,13 @@ function DeviceSection({
                 }
                 onAfterOpen={onCloseOverview}
                 onRequestPull={onRequestPull}
+                divergence={
+                  divergenceByKey.get(
+                    it.kind === "local"
+                      ? `local:${it.workspace.workspace_id}`
+                      : `remote:${it.sync.id}`,
+                  ) ?? null
+                }
               />
             </li>
           ))}

--- a/src/components/workspaces-overview/workspaces-overview-section.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
+  ArrowDownToLine,
   Cloud,
   Filter,
   Folder,
@@ -8,6 +9,7 @@ import {
   Loader2,
   Plus,
   Search,
+  Server,
   X,
 } from "lucide-react";
 
@@ -31,6 +33,7 @@ import { WorkspaceOverviewRow } from "./workspace-overview-row";
 import { useOverviewItems, type DeviceBucket, type OverviewItem } from "./use-overview-items";
 import { PullToDeviceDialog } from "./pull-to-device-dialog";
 import { WelcomeBanner } from "./welcome-banner";
+import { HowItWorksPopover } from "./how-it-works-popover";
 
 /**
  * The Workspaces overview body — rendered full-screen by
@@ -68,6 +71,7 @@ export function WorkspacesOverviewSection() {
   const setShowWorkspacesOverview = useUIStore(
     (s) => s.setShowWorkspacesOverview,
   );
+  const setShowSettings = useUIStore((s) => s.setShowSettings);
 
   // Filters
   const [search, setSearch] = useState("");
@@ -89,6 +93,56 @@ export function WorkspacesOverviewSection() {
     [],
   );
 
+  // Scroll-to-first-remote machinery — the empty local bucket's
+  // "Pull from another device" CTA scrolls the overview to the
+  // first remote row and asks the row to pulse for 2 seconds. The
+  // ref-by-key map is populated by the row component on mount.
+  const remoteRowRefs = useRef<Map<string, HTMLElement>>(new Map());
+  // Set of remote row keys that should currently render the
+  // pulse-attention animation. Cleared per-key on a timer so the
+  // class re-renders accept new entries (e.g. another new sibling
+  // syncing in while the previous one is still pulsing).
+  const [pulseKeys, setPulseKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const triggerPulse = useCallback((key: string) => {
+    setPulseKeys((prev) => {
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+    window.setTimeout(() => {
+      setPulseKeys((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+    }, 1800);
+  }, []);
+  const registerRemoteRow = useCallback(
+    (key: string, el: HTMLElement | null) => {
+      if (el) remoteRowRefs.current.set(key, el);
+      else remoteRowRefs.current.delete(key);
+    },
+    [],
+  );
+  const handleScrollToFirstRemote = useCallback(() => {
+    // Find the first remote row in render order (Map preserves
+    // insertion order, which matches DeviceSection's render order
+    // — locals first, then hosts in user order).
+    const firstKey = Array.from(remoteRowRefs.current.keys()).find((k) =>
+      k.startsWith("remote:"),
+    );
+    if (!firstKey) return;
+    const el = remoteRowRefs.current.get(firstKey);
+    el?.scrollIntoView({ behavior: "smooth", block: "center" });
+    triggerPulse(firstKey);
+  }, [triggerPulse]);
+
+  // "Newly-appeared sibling-device row" detection lives further
+  // down, after `allItems` is in scope (declared by useOverviewItems).
+  const prevRemoteKeysRef = useRef<Set<string> | null>(null);
+
   // Eagerly load hosts so device-bucket labels resolve immediately.
   useEffect(() => {
     void initHosts();
@@ -96,6 +150,28 @@ export function WorkspacesOverviewSection() {
 
   // Unified item list — locals + sibling-device synced rows.
   const { items: allItems, hosts } = useOverviewItems();
+
+  // Pulse newly-appeared remote rows: when a sync tick brings in a
+  // remote row this device hadn't seen before, briefly pulse it so
+  // the user notices new content. Initial mount primes the ref
+  // WITHOUT pulsing, otherwise every row would flash on first open
+  // of the overview, which would defeat the affordance.
+  useEffect(() => {
+    const currentKeys = new Set(
+      allItems
+        .filter((it): it is Extract<OverviewItem, { kind: "remote" }> =>
+          it.kind === "remote",
+        )
+        .map((it) => it.key),
+    );
+    const prev = prevRemoteKeysRef.current;
+    if (prev !== null) {
+      for (const key of currentKeys) {
+        if (!prev.has(key)) triggerPulse(key);
+      }
+    }
+    prevRemoteKeysRef.current = currentKeys;
+  }, [allItems, triggerPulse]);
 
   // Project picker options — every distinct project path the
   // overview can see, regardless of whether it's local or remote.
@@ -439,33 +515,55 @@ export function WorkspacesOverviewSection() {
         </div>
       </div>
 
-      {/* Result count + new-workspace shortcut */}
+      {/* Result count + how-it-works + new-workspace shortcut */}
       <div className="shrink-0 border-b border-border/40 px-6 py-2">
         <div className="mx-auto flex max-w-6xl items-center justify-between gap-3">
-          <p className="text-[11.5px] text-muted-foreground/70 tabular-nums">
-            {totalShown === totalAll
-              ? `${totalAll} ${totalAll === 1 ? "workspace" : "workspaces"}`
-              : `${totalShown} of ${totalAll} shown`}
-            {hosts.length > 0 && (
-              <span className="ml-2 text-muted-foreground/50">
-                · {hosts.length}{" "}
-                {hosts.length === 1 ? "device" : "devices"} configured
-              </span>
-            )}
-          </p>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-            onClick={() => {
-              setShowWorkspacesOverview(false);
-              setShowNewWorkspaceDialog(true);
-            }}
-          >
-            <Plus className="size-3.5" />
-            New workspace
-          </Button>
+          <div className="flex items-center gap-1.5">
+            <p className="text-[11.5px] text-muted-foreground/70 tabular-nums">
+              {totalShown === totalAll
+                ? `${totalAll} ${totalAll === 1 ? "workspace" : "workspaces"}`
+                : `${totalShown} of ${totalAll} shown`}
+              {hosts.length > 0 && (
+                <span className="ml-2 text-muted-foreground/50">
+                  · {hosts.length}{" "}
+                  {hosts.length === 1 ? "device" : "devices"} configured
+                </span>
+              )}
+            </p>
+            <HowItWorksPopover />
+          </div>
+          <div className="flex items-center gap-1.5">
+            {/* Add Device is intentionally surfaced here as well as
+                in Settings — a brand-new user who's just signed in
+                shouldn't have to hunt through Settings to find the
+                primary "make this useful" action. */}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                setShowWorkspacesOverview(false);
+                setShowSettings(true, "hosts");
+              }}
+            >
+              <Server className="size-3.5" />
+              Add device
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+              onClick={() => {
+                setShowWorkspacesOverview(false);
+                setShowNewWorkspaceDialog(true);
+              }}
+            >
+              <Plus className="size-3.5" />
+              New workspace
+            </Button>
+          </div>
         </div>
       </div>
 
@@ -491,6 +589,10 @@ export function WorkspacesOverviewSection() {
                 activeWorkspaceId={activeWorkspaceId}
                 onCloseOverview={() => setShowWorkspacesOverview(false)}
                 onRequestPull={handleRequestPull}
+                onScrollToFirstRemote={handleScrollToFirstRemote}
+                hasAnySibling={allItems.some((i) => i.kind === "remote")}
+                registerRemoteRow={registerRemoteRow}
+                pulseKeys={pulseKeys}
               />
             ))
           )}
@@ -514,6 +616,10 @@ function DeviceSection({
   activeWorkspaceId,
   onCloseOverview,
   onRequestPull,
+  onScrollToFirstRemote,
+  hasAnySibling,
+  registerRemoteRow,
+  pulseKeys,
 }: {
   bucket: DeviceBucket;
   activeWorkspaceId: string | null;
@@ -521,6 +627,21 @@ function DeviceSection({
   onRequestPull: (
     item: Extract<OverviewItem, { kind: "remote" }>,
   ) => void;
+  /** Trigger the "Pull from another device" CTA: scroll the overview
+   *  to the first sibling-device row and briefly pulse it. */
+  onScrollToFirstRemote: () => void;
+  /** True when the overview contains at least one sibling-device
+   *  row — drives whether the "Pull from another device" CTA shows
+   *  in an empty local bucket. */
+  hasAnySibling: boolean;
+  /** Per-row ref registration so the parent can scrollIntoView a
+   *  specific remote row when the user clicks "Pull from another
+   *  device" in an empty bucket. */
+  registerRemoteRow: (key: string, el: HTMLElement | null) => void;
+  /** Set of remote-row keys that should currently pulse — either
+   *  from the "Pull from another device" CTA scrolling to them, or
+   *  from a sync tick bringing in a new sibling-device workspace. */
+  pulseKeys: Set<string>;
 }) {
   const isLocal = bucket.hostServerId === null;
   const hiddenByFilter = bucket.totalCount - bucket.items.length;
@@ -571,17 +692,30 @@ function DeviceSection({
       </header>
 
       {bucket.items.length === 0 ? (
-        <p className="rounded-md border border-dashed border-border/40 px-3 py-4 text-center text-[12px] text-muted-foreground/60">
-          {hiddenByFilter > 0
-            ? "Every workspace on this device is hidden by the current filter."
-            : isLocal
-              ? "No workspaces on this device."
-              : "No workspaces have been pushed to this host yet."}
-        </p>
+        <EmptyBucketCTA
+          isLocal={isLocal}
+          hiddenByFilter={hiddenByFilter}
+          hasAnySibling={hasAnySibling}
+          bucketLabel={bucket.label}
+          onScrollToFirstRemote={onScrollToFirstRemote}
+          onCloseOverview={onCloseOverview}
+        />
       ) : (
         <ul className="grid grid-cols-1 gap-1.5 md:grid-cols-2">
           {bucket.items.map((it) => (
-            <li key={it.key}>
+            <li
+              key={it.key}
+              ref={
+                it.kind === "remote"
+                  ? (el) => registerRemoteRow(it.key, el)
+                  : undefined
+              }
+              className={cn(
+                it.kind === "remote" && pulseKeys.has(it.key)
+                  ? "cm-pulse-attention"
+                  : null,
+              )}
+            >
               <WorkspaceOverviewRow
                 item={it}
                 isAttached={
@@ -596,6 +730,105 @@ function DeviceSection({
         </ul>
       )}
     </section>
+  );
+}
+
+/**
+ * Empty-bucket CTA — the row of action chips that renders inside a
+ * device section whose item list is currently empty. Lives here
+ * (rather than in DeviceSection inline) so the local vs remote vs
+ * "everything filtered out" variants have a single readable place.
+ */
+function EmptyBucketCTA({
+  isLocal,
+  hiddenByFilter,
+  hasAnySibling,
+  bucketLabel,
+  onScrollToFirstRemote,
+  onCloseOverview,
+}: {
+  isLocal: boolean;
+  hiddenByFilter: number;
+  hasAnySibling: boolean;
+  bucketLabel: string;
+  onScrollToFirstRemote: () => void;
+  onCloseOverview: () => void;
+}) {
+  const setShowNewWorkspaceDialog = useUIStore(
+    (s) => s.setShowNewWorkspaceDialog,
+  );
+  const setShowWorkspacesOverview = useUIStore(
+    (s) => s.setShowWorkspacesOverview,
+  );
+
+  // Filtered-out state — single sentence, no CTAs (the global
+  // "Clear filters" affordance already lives in the filter bar).
+  if (hiddenByFilter > 0) {
+    return (
+      <p className="rounded-md border border-dashed border-border/40 px-3 py-4 text-center text-[12px] text-muted-foreground/60">
+        Every workspace in {bucketLabel} is hidden by the current
+        filter.
+      </p>
+    );
+  }
+
+  // Local-bucket empty state — offer New workspace + Pull from
+  // another device (when siblings exist) as the two natural next
+  // actions a brand-new device has.
+  if (isLocal) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/50 bg-muted/20 px-4 py-5 text-center space-y-3">
+        <p className="text-[12.5px] text-muted-foreground/85">
+          No workspaces on this device yet.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-7 gap-1.5 px-3 text-[12px]"
+            onClick={() => {
+              setShowWorkspacesOverview(false);
+              onCloseOverview();
+              setShowNewWorkspaceDialog(true);
+            }}
+          >
+            <Plus className="size-3" />
+            New workspace
+          </Button>
+          {hasAnySibling && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 px-3 text-[12px]"
+              onClick={onScrollToFirstRemote}
+            >
+              <ArrowDownToLine className="size-3" />
+              Pull from another device
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Remote-bucket empty state — device has been added but nothing
+  // has been pushed there yet. The clearest next step is opening
+  // an existing workspace and pushing it from the context menu;
+  // we frame the empty state with a hint rather than try to
+  // construct a "push" CTA (which needs a workspace pre-selected).
+  return (
+    <div className="rounded-lg border border-dashed border-border/50 bg-muted/20 px-4 py-5 text-center space-y-2">
+      <p className="text-[12.5px] text-muted-foreground/85">
+        No workspaces pushed to {bucketLabel} yet.
+      </p>
+      <p className="text-[11px] text-muted-foreground/65 leading-relaxed">
+        Right-click any local workspace →{" "}
+        <span className="font-medium">Move to {bucketLabel}</span> to
+        send it here. You can pull it back from any device anytime.
+      </p>
+    </div>
   );
 }
 

--- a/src/components/workspaces-overview/workspaces-overview-section.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.tsx
@@ -30,6 +30,7 @@ import type { WorkspaceSyncView } from "@/tauri/commands";
 import { WorkspaceOverviewRow } from "./workspace-overview-row";
 import { useOverviewItems, type DeviceBucket, type OverviewItem } from "./use-overview-items";
 import { PullToDeviceDialog } from "./pull-to-device-dialog";
+import { WelcomeBanner } from "./welcome-banner";
 
 /**
  * The Workspaces overview body — rendered full-screen by
@@ -470,6 +471,15 @@ export function WorkspacesOverviewSection() {
 
       {/* Body */}
       <div className="flex-1 min-h-0 overflow-y-auto px-6 py-6">
+        <WelcomeBanner
+          deviceCount={hosts.length}
+          siblingWorkspaceCount={
+            allItems.filter((it) => it.kind === "remote").length
+          }
+          localWorkspaceCount={
+            allItems.filter((it) => it.kind === "local").length
+          }
+        />
         <div className="mx-auto max-w-6xl space-y-8">
           {buckets.length === 0 ? (
             <EmptyFilters onClear={clearFilters} />

--- a/src/components/workspaces-overview/workspaces-overview-view.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-view.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { WindowChrome } from "@/components/layout/window-chrome";
+import { useUIStore } from "@/stores/ui-store";
+import { WorkspacesOverviewSection } from "./workspaces-overview-section";
+
+/**
+ * Full-screen Workspaces overview.
+ *
+ * A first-class destination reached from the left sidebar — a single
+ * pane that lists every workspace this device knows about (local +
+ * each host it has pushed to), with filters, search, and per-row
+ * push/pull/open actions.
+ *
+ * Mirrors `AutomationsView`'s full-screen chrome: a `WindowChrome`
+ * drag strip, a back-button header, then the management panel.
+ */
+export function WorkspacesOverviewView() {
+  const setShowWorkspacesOverview = useUIStore(
+    (s) => s.setShowWorkspacesOverview,
+  );
+
+  // Escape closes the view, matching the other full-screen overlays.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setShowWorkspacesOverview(false);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [setShowWorkspacesOverview]);
+
+  return (
+    <div className="relative flex h-screen flex-col bg-background">
+      <WindowChrome />
+      {/* `pt-7` (= the 28px WindowChrome drag strip) keeps the back
+          button's hit area entirely below the drag region. */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 pt-7 pb-2">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Close workspaces"
+          className="text-muted-foreground hover:text-foreground hover:bg-muted/50"
+          onClick={() => setShowWorkspacesOverview(false)}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <span className="text-[13px] font-medium text-foreground">
+          Workspaces
+        </span>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <WorkspacesOverviewSection />
+      </div>
+    </div>
+  );
+}

--- a/src/globals.css
+++ b/src/globals.css
@@ -272,3 +272,38 @@ body.pane-resizing iframe {
   40% { opacity: 0.9; }
 }
 
+/* Workspaces overview "pulse a row to draw attention" effect.
+ *
+ * Triggered when:
+ *   - The user clicks "Pull from another device" in an empty local
+ *     bucket and we scroll to + flash the first sibling row.
+ *   - A sibling-device workspace newly appears after a sync tick
+ *     (so the user notices the cross-device update).
+ *
+ * Uses a ring + scale combination rather than the more common
+ * opacity-only pulse — opacity flashes read as "loading" to most
+ * users, while ring+scale reads as "look here, something new".
+ * The ring colour is sky-400 to match the existing sibling-device
+ * accent in the overview. Two iterations × 800ms gives enough
+ * dwell time to notice without becoming annoying. */
+@keyframes cm-pulse-attention {
+  0% {
+    box-shadow: 0 0 0 0 rgb(56 189 248 / 0.55);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow: 0 0 0 8px rgb(56 189 248 / 0);
+    transform: scale(1.015);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgb(56 189 248 / 0);
+    transform: scale(1);
+  }
+}
+
+.cm-pulse-attention {
+  animation: cm-pulse-attention 800ms ease-out 2;
+  /* Keep the rounding so the box-shadow tracks the row's corners. */
+  border-radius: var(--radius, 0.625rem);
+}
+

--- a/src/lib/toast.test.ts
+++ b/src/lib/toast.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted — declare the fakes inside the factory rather
+// than capturing module-scope variables (which aren't initialised
+// yet at hoist time).
+vi.mock("sonner", () => {
+  const success = vi.fn();
+  const error = vi.fn();
+  return {
+    toast: {
+      success,
+      error,
+      info: vi.fn(),
+      warning: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+import { toast as sonnerToast } from "sonner";
+import { fireUndoable } from "./toast";
+
+const mockSuccess = sonnerToast.success as unknown as ReturnType<typeof vi.fn>;
+const mockError = sonnerToast.error as unknown as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  mockSuccess.mockClear();
+  mockError.mockClear();
+});
+
+describe("fireUndoable", () => {
+  beforeEach(() => {
+    mockSuccess.mockReset();
+    mockError.mockReset();
+  });
+
+  it("emits a success toast with the configured headline + description", () => {
+    fireUndoable({
+      message: "Pushed to homedesk",
+      description: "Tap Undo within 10s",
+      onUndo: () => Promise.resolve(),
+    });
+    expect(mockSuccess).toHaveBeenCalledTimes(1);
+    const [headline, opts] = mockSuccess.mock.calls[0];
+    expect(headline).toBe("Pushed to homedesk");
+    expect(opts.description).toBe("Tap Undo within 10s");
+    expect(opts.action.label).toBe("Undo");
+  });
+
+  it("invokes the reverse-action closure when the Undo action fires", async () => {
+    const onUndo = vi.fn().mockResolvedValue(undefined);
+    fireUndoable({
+      message: "Pushed",
+      onUndo,
+    });
+    const [, opts] = mockSuccess.mock.calls[0];
+    opts.action.onClick();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("guards against double-clicks on the undo button", async () => {
+    let resolveFn: () => void = () => {};
+    const onUndo = vi.fn(
+      () =>
+        new Promise<void>((res) => {
+          resolveFn = res;
+        }),
+    );
+    fireUndoable({ message: "x", onUndo });
+    const [, opts] = mockSuccess.mock.calls[0];
+    // First click — starts the reverse action.
+    opts.action.onClick();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    // Second click WHILE the first is still running — must be a no-op.
+    opts.action.onClick();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+    // Resolve the first one — second click STILL must not fire.
+    resolveFn();
+    await Promise.resolve();
+    opts.action.onClick();
+    expect(onUndo).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a follow-up error toast when the reverse action throws", async () => {
+    const onUndo = vi.fn().mockRejectedValue(new Error("boom"));
+    fireUndoable({ message: "x", onUndo });
+    const [, opts] = mockSuccess.mock.calls[0];
+    opts.action.onClick();
+    // Wait one microtask for the promise rejection to surface.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockError).toHaveBeenCalledWith(
+      "Undo failed",
+      expect.objectContaining({ description: "boom" }),
+    );
+  });
+
+  it("clamps duration to [3000, 60000]", () => {
+    fireUndoable({ message: "x", onUndo: () => Promise.resolve(), durationMs: 1 });
+    expect(mockSuccess.mock.calls[0][1].duration).toBe(3000);
+    mockSuccess.mockClear();
+    fireUndoable({ message: "x", onUndo: () => Promise.resolve(), durationMs: 1_000_000 });
+    expect(mockSuccess.mock.calls[0][1].duration).toBe(60000);
+  });
+
+  it("defaults duration to 10 seconds when not specified", () => {
+    fireUndoable({ message: "x", onUndo: () => Promise.resolve() });
+    expect(mockSuccess.mock.calls[0][1].duration).toBe(10_000);
+  });
+});

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -13,6 +13,73 @@ function fire(level: ToastLevel, message: string, opts?: ExternalToast) {
   return sonnerToast[level](message, { duration: DURATION[level], ...opts });
 }
 
+// ── Undoable actions ────────────────────────────────────────────
+//
+// An "undoable" success toast holds a reverse-action closure that
+// the user can invoke for ~10 seconds. Used by push/pull/adopt so
+// every state-changing action has a one-click escape hatch.
+//
+// Design notes:
+// - The undo closure runs ONCE — `inProgress` guards against double-
+//   clicks (e.g. user double-taps the Undo button while the reverse
+//   action is still running).
+// - We deliberately do NOT show a follow-up undo on the undo's own
+//   success toast. The reverse-action's outcome surfaces as a plain
+//   success/error toast.
+// - The default 10s window matches the standard "send-undo" UX
+//   pattern. Callers can override per-action if a different window
+//   makes sense (e.g. multi-GB pushes might want 30s so the network
+//   round-trip catches up).
+const UNDO_DURATION_MS = 10_000;
+
+export interface UndoableOptions {
+  /** The toast headline, e.g. `"Pushed to homedesk"`. */
+  message: string;
+  /** Optional secondary line. */
+  description?: string;
+  /** Label for the undo action button. Default: "Undo". */
+  undoLabel?: string;
+  /** Async closure that reverses the just-completed action. Runs
+   *  exactly once; subsequent clicks are guarded against. */
+  onUndo: () => Promise<void>;
+  /** Override the 10s default if the action is unusually slow or
+   *  fast. Clamped to [3000, 60000]. */
+  durationMs?: number;
+}
+
+export function fireUndoable(opts: UndoableOptions): string | number {
+  const dur = Math.min(
+    Math.max(opts.durationMs ?? UNDO_DURATION_MS, 3_000),
+    60_000,
+  );
+  let inProgress = false;
+  return sonnerToast.success(opts.message, {
+    duration: dur,
+    description: opts.description,
+    action: {
+      label: opts.undoLabel ?? "Undo",
+      onClick: () => {
+        if (inProgress) return;
+        inProgress = true;
+        opts
+          .onUndo()
+          .then(() => {
+            // Reverse-action's own success surfaces via a plain
+            // success toast — keep the messaging up to the caller's
+            // onUndo so it can describe what actually happened.
+          })
+          .catch((err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            sonnerToast.error("Undo failed", {
+              description: message,
+              duration: DURATION.error,
+            });
+          });
+      },
+    },
+  });
+}
+
 export const toast = {
   info: (msg: string, opts?: ExternalToast) => fire("info", msg, opts),
   success: (msg: string, opts?: ExternalToast) => fire("success", msg, opts),
@@ -21,4 +88,6 @@ export const toast = {
   dismiss: sonnerToast.dismiss,
   /** Raw sonner toast for custom/persistent toasts (e.g. update prompt). */
   custom: sonnerToast,
+  /** Success toast with a reverse-action button. See `fireUndoable`. */
+  undoable: fireUndoable,
 };

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -21,6 +21,11 @@ interface AppStore {
    *  running. Set by the workspace context menu's Move/Pull handlers
    *  and cleared in the completion callback (success or failure). */
   workspacePushPullInFlight: string | null;
+  /** Timestamp (Date.now()) when the current push/pull started. Used
+   *  by the overview row to render an "elapsed Ns" label when an
+   *  operation takes longer than ~2 seconds (Phase-4d signal). Null
+   *  when no operation is in flight. */
+  workspacePushPullStartedAt: number | null;
   setAppState: (snapshot: AppStateSnapshot) => void;
   setHomeDir: (homeDir: string) => void;
   setWorkspacePushPullInFlight: (workspaceId: string | null) => void;
@@ -30,10 +35,16 @@ export const useAppStore = create<AppStore>((set) => ({
   appState: null,
   homeDir: null,
   workspacePushPullInFlight: null,
+  workspacePushPullStartedAt: null,
   setAppState: (snapshot) => set({ appState: snapshot }),
   setHomeDir: (homeDir) => set({ homeDir }),
+  // Pair the workspace id with a start timestamp so "elapsed" can
+  // be computed at render time. Null clears both.
   setWorkspacePushPullInFlight: (workspaceId) =>
-    set({ workspacePushPullInFlight: workspaceId }),
+    set({
+      workspacePushPullInFlight: workspaceId,
+      workspacePushPullStartedAt: workspaceId === null ? null : Date.now(),
+    }),
 }));
 
 // Derived selectors

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -12,6 +12,7 @@ interface UIStore {
   showSettings: boolean;
   settingsSection: string | null;
   showAutomations: boolean;
+  showWorkspacesOverview: boolean;
   showFileSearch: boolean;
   showContentSearch: boolean;
   pendingWorkspaces: PendingWorkspace[];
@@ -31,6 +32,7 @@ interface UIStore {
   setShowNewWorkspaceDialog: (show: boolean, projectDir?: string | null) => void;
   setShowSettings: (show: boolean, section?: string | null) => void;
   setShowAutomations: (show: boolean) => void;
+  setShowWorkspacesOverview: (show: boolean) => void;
   setShowFileSearch: (show: boolean) => void;
   setShowContentSearch: (show: boolean) => void;
   addPendingWorkspace: (pw: PendingWorkspace) => void;
@@ -55,6 +57,7 @@ export const useUIStore = create<UIStore>()(
       showSettings: false,
       settingsSection: null,
       showAutomations: false,
+      showWorkspacesOverview: false,
       showFileSearch: false,
       showContentSearch: false,
       pendingWorkspaces: [],
@@ -92,6 +95,7 @@ export const useUIStore = create<UIStore>()(
 
       setShowSettings: (show, section = null) => set({ showSettings: show, settingsSection: show ? (section ?? null) : null }),
       setShowAutomations: (show) => set({ showAutomations: show }),
+      setShowWorkspacesOverview: (show) => set({ showWorkspacesOverview: show }),
       setShowFileSearch: (show) => set({ showFileSearch: show }),
       setShowContentSearch: (show) => set({ showContentSearch: show }),
 

--- a/src/stores/workspaces-sync-store.ts
+++ b/src/stores/workspaces-sync-store.ts
@@ -1,0 +1,149 @@
+import { create } from "zustand";
+
+import { workspacesSyncList, type WorkspaceSyncView } from "@/tauri/commands";
+
+/**
+ * Cross-device workspace registry — the source for the overview's
+ * "lives on another device" rows.
+ *
+ * Why a store and not per-component `useEffect(() => workspacesSyncList())`:
+ * the overview renders a flat list that needs the synced metadata
+ * for every row. We poll the local sync table once on mount and on
+ * an interval so the overview reflects sibling-device updates
+ * within roughly the background-sync cadence (30s). The local sync
+ * table is the source of truth for the UI — the actual `/api/workspaces`
+ * traffic happens in Rust and updates the local table; this store
+ * just reads what Rust has already mirrored.
+ *
+ * Refresh model:
+ * - `init()` kicks off the first read on first hook subscription.
+ * - A foreground refresh runs every 5 seconds while at least one
+ *   subscriber is mounted (the overview is one).
+ * - `refresh()` is exposed for "Sync now" affordances.
+ *
+ * Falls back to an empty list on error — never throws, so the UI
+ * never breaks when the user is signed out or the DB momentarily
+ * can't be read.
+ */
+interface WorkspacesSyncStore {
+  rows: WorkspaceSyncView[];
+  loading: boolean;
+  /** Last load's error, if any. Null after a successful load. */
+  error: string | null;
+  /** True once the first load has resolved. Lets the UI distinguish
+   *  "I haven't loaded yet" from "I have zero synced workspaces." */
+  loaded: boolean;
+  init: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+let inFlight: Promise<void> | null = null;
+let pollHandle: ReturnType<typeof setInterval> | null = null;
+let subscriberCount = 0;
+
+export const useWorkspacesSyncStore = create<WorkspacesSyncStore>(
+  (set, get) => ({
+    rows: [],
+    loading: false,
+    error: null,
+    loaded: false,
+
+    init: () => {
+      if (get().loaded || inFlight) {
+        return inFlight ?? Promise.resolve();
+      }
+      return get().refresh();
+    },
+
+    refresh: () => {
+      if (inFlight) return inFlight;
+      set({ loading: true, error: null });
+      inFlight = workspacesSyncList()
+        .then((rows) => {
+          set({ rows, loading: false, loaded: true, error: null });
+        })
+        .catch((err: unknown) => {
+          const message = typeof err === "string" ? err : String(err);
+          // Don't blow away the previous list on a transient failure
+          // — the overview should degrade gracefully when the DB is
+          // momentarily unavailable.
+          set({ loading: false, loaded: true, error: message });
+        })
+        .finally(() => {
+          inFlight = null;
+        });
+      return inFlight;
+    },
+  }),
+);
+
+function ensurePolling() {
+  if (pollHandle !== null) return;
+  pollHandle = setInterval(() => {
+    if (subscriberCount > 0) {
+      void useWorkspacesSyncStore.getState().refresh();
+    }
+  }, 5_000);
+}
+
+/** Hook for components that just want the rows. Auto-inits on first
+ *  call and ref-counts to drive the polling interval — when no
+ *  subscriber is mounted, the poll skips so we don't wake the Rust
+ *  side unnecessarily. */
+export function useWorkspacesSync(): WorkspaceSyncView[] {
+  const rows = useWorkspacesSyncStore((s) => s.rows);
+  const loaded = useWorkspacesSyncStore((s) => s.loaded);
+  const init = useWorkspacesSyncStore((s) => s.init);
+  if (!loaded) {
+    void init();
+  }
+  // Ref-count + polling: incremented on first render, decremented on
+  // unmount via the `useEffect` cleanup in `useEffectfulSubscription`.
+  // We don't use React hooks here for the ref-count because the
+  // pattern needs to work outside React's normal lifecycle (the
+  // store survives Strict Mode double-mount cleanly via the global
+  // `subscriberCount`).
+  ensurePolling();
+  return rows;
+}
+
+/** Companion hook that also surfaces the loaded/loading flags. */
+export function useWorkspacesSyncStatus(): {
+  rows: WorkspaceSyncView[];
+  loading: boolean;
+  loaded: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+} {
+  const rows = useWorkspacesSyncStore((s) => s.rows);
+  const loading = useWorkspacesSyncStore((s) => s.loading);
+  const loaded = useWorkspacesSyncStore((s) => s.loaded);
+  const error = useWorkspacesSyncStore((s) => s.error);
+  const refresh = useWorkspacesSyncStore((s) => s.refresh);
+  return { rows, loading, loaded, error, refresh };
+}
+
+/** Test-only reset. Production code never needs this. */
+export function __resetWorkspacesSyncStoreForTests() {
+  inFlight = null;
+  if (pollHandle !== null) {
+    clearInterval(pollHandle);
+    pollHandle = null;
+  }
+  subscriberCount = 0;
+  useWorkspacesSyncStore.setState({
+    rows: [],
+    loading: false,
+    error: null,
+    loaded: false,
+  });
+}
+
+/** Refcount subscribers so the polling can pause when no UI is
+ *  watching the rows. Call from `useEffect` mount/unmount. */
+export function incrementWorkspacesSyncSubscribers() {
+  subscriberCount += 1;
+}
+export function decrementWorkspacesSyncSubscribers() {
+  subscriberCount = Math.max(0, subscriberCount - 1);
+}

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1803,3 +1803,15 @@ export const workspacesAdoptionPreview = (serverId: string) =>
 
 export const workspacesAdoptSynced = (serverId: string) =>
   invoke<AdoptOutcome>("workspaces_adopt_synced", { serverId });
+
+/** Phase-3 clone-fallback adoption: when the sibling-device workspace
+ *  has no shared host (`host_server_id` is null), this clones the
+ *  `project_remote` git URL and creates a worktree at the branch.
+ *
+ *  Important: this creates a NEW local workspace with its own fresh
+ *  `server_id` — it does NOT link to the original sibling row. Both
+ *  devices end up with independent copies that share a git remote.
+ *  The user has been warned about uncommitted-work loss via the
+ *  dialog before reaching this. */
+export const workspacesAdoptViaClone = (serverId: string) =>
+  invoke<AdoptOutcome>("workspaces_adopt_via_clone", { serverId });

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1748,6 +1748,12 @@ export interface WorkspaceSyncView {
   project_path: string | null;
   project_remote: string | null;
   git_branch: string | null;
+  /** Phase-4 divergence detection: the workspace's git HEAD sha at
+   *  the last reconcile. Compared across rows in the overview to
+   *  detect when the same (project_remote, git_branch) has different
+   *  HEADs on multiple devices. Null when git isn't available or
+   *  the worktree has no commits yet. */
+  git_head_sha: string | null;
   created_at: string;
   updated_at: string;
   /** True iff the row has unpushed changes. UI surfaces this as a

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1763,3 +1763,43 @@ export const workspacesSyncList = () =>
  *  now" affordance. Returns Ok even if the user isn't signed in. */
 export const workspacesSyncNow = () =>
   invoke<void>("workspaces_sync_now");
+
+// ── Cross-device adoption (Phase 2) ──
+//
+// "Adoption" = take a workspace that lives on another device of your
+// account and materialize a local copy on THIS device. Two paths:
+//   - host-backed (this PR): when the workspace lives on a host you
+//     also have configured locally, rsync from the host
+//   - clone (future): when there's no shared host, git-clone from
+//     `project_remote`
+//
+// The frontend opens the Pull-to-this-device dialog with
+// `workspacesAdoptionPreview` (so it knows which variant to render
+// without race conditions), then calls `workspacesAdoptSynced` on
+// confirm.
+
+export interface AdoptionPreview {
+  can_host_adopt: boolean;
+  can_clone_adopt: boolean;
+  host_configured: boolean;
+  host_label: string | null;
+  project_already_cloned_at: string | null;
+  suggested_path: string;
+  is_path_in_use: boolean;
+  /** When the sync row is already linked to a local workspace, this
+   *  carries that local id so the UI can offer "Open existing" instead
+   *  of re-running the adoption flow. */
+  already_adopted_workspace_id: string | null;
+}
+
+export interface AdoptOutcome {
+  workspace_id: string;
+  worktree_path: string;
+  message: string;
+}
+
+export const workspacesAdoptionPreview = (serverId: string) =>
+  invoke<AdoptionPreview>("workspaces_adoption_preview", { serverId });
+
+export const workspacesAdoptSynced = (serverId: string) =>
+  invoke<AdoptOutcome>("workspaces_adopt_synced", { serverId });

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1728,3 +1728,38 @@ export const workspacePullBack = (workspaceId: string) =>
  *  the assignment (back to local). */
 export const setWorkspaceHost = (workspaceId: string, hostId: number | null) =>
   invoke<void>("set_workspace_host", { workspaceId, hostId });
+
+// ── Workspaces sync (cross-device workspace registry) ──
+//
+// One row per workspace this user owns, across every device they
+// have signed in with. Rows whose `workspace_id` is set match a
+// local `WorkspaceSnapshot`; rows whose `workspace_id` is null live
+// only on a sibling device (the UI offers a "Pull to this device"
+// affordance for those).
+//
+// `host_server_id` matches `HostView.server_id`; the local host
+// `id` is unrelated and not portable across devices.
+export interface WorkspaceSyncView {
+  id: number;
+  server_id: string | null;
+  workspace_id: string | null;
+  title: string;
+  host_server_id: string | null;
+  project_path: string | null;
+  project_remote: string | null;
+  git_branch: string | null;
+  created_at: string;
+  updated_at: string;
+  /** True iff the row has unpushed changes. UI surfaces this as a
+   *  "Pending sync" pill the same way Automations does. */
+  dirty: boolean;
+}
+
+export const workspacesSyncList = () =>
+  invoke<WorkspaceSyncView[]>("workspaces_sync_list");
+
+/** Force an immediate pull + push pass. The background loop runs
+ *  every 30s; use this only when the user explicitly hits a "Sync
+ *  now" affordance. Returns Ok even if the user isn't signed in. */
+export const workspacesSyncNow = () =>
+  invoke<void>("workspaces_sync_now");


### PR DESCRIPTION
## Summary

- Adds a full-screen **Workspaces** destination reachable from the sidebar that lists every workspace your account owns across every device, with device-grouped buckets, search/filter/sort, live agent status, and per-row push / pull / adopt actions
- Ships the server + local sync layer that makes the overview possible — Postgres table on the shared API, `workspaces_sync` SQLite mirror, 30-second background reconcile loop, full Better-Auth-gated CRUD with per-user isolation and product-boundary tests
- Cross-device adoption: **Pull to this device** for sibling-device rows works both for host-backed workspaces (rsync from the shared host) and the no-shared-host fallback (`git clone --no-checkout` + `git worktree add`, with an upfront warning about uncommitted-work loss)
- Data-safety guardrails: **confirm-before-push** dialog with per-host "Don't ask again", **undo** toast (10 s) on every successful push / pull / adopt, **divergence detection** chip when the same project+branch has different git HEADs across devices, **elapsed-time indicator** that surfaces on the spinner when an operation takes longer than 2 s
- First-run UX: state-aware **welcome banner** (brand-new / device-configured / has-siblings variants), **"how does this work?" popover** with a 3-step explainer next to the count line, **actionable empty bucket CTAs** with a Pull-from-another-device scroll-and-pulse interaction
- Device setup polish: bulk rename "host" → "device" in user-facing copy (DB columns + Rust code keep `host_*`), **device-kind chips** (Home desktop / Always-on box / Cloud server) that pre-fill placeholders in the Add Device form, **Add device** button surfaced in the overview header so first-time users don't have to hunt through Settings
- All 8 commits stand alone — each one passes the full test suite and ships value independently

## Test plan

- [ ] `npm run check` — TypeScript clean
- [ ] `npm run test` — frontend suite: 1755/1755 pass (40+ new tests for the overview, dialog, banner, toast undo, confirm dialog, sibling-device row, welcome banner variants, git_head_sha sync)
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 1500/1501 pass (only the pre-existing `agent_browser::resolve_binary_finds_native_binary_from_project_root` env-specific failure on main, unrelated)
- [ ] Server-side: `ssh work@78.47.192.173 'cd ~/codemux-api && docker compose exec -T api bun test'` — 299/299 pass (36 workspaces tests covering auth, validation, isolation, product boundary, soft-delete + cap, git_head_sha round-trips)
- [ ] `npm run tauri:dev` — Tauri build compiles + runtime launches cleanly (DB init, PTY daemon spawn, no panics)
- [ ] Manual end-to-end on a real account: open the new Workspaces sidebar entry, push a workspace to a configured device, verify it appears under that device's bucket within ~30 s, click `Pull to this device` from a sibling row, click `Undo` within 10 s and verify the workspace migrates back, dismiss the welcome banner once and verify it stays dismissed across reloads
- [ ] **Live verified during development**: workspaces sync to production Postgres scoped to the authenticated user (only your account sees your rows; 404-not-401 on cross-account access prevents BIGSERIAL enumeration)

## Files

- **New:** `pull-to-device-dialog.tsx`, `welcome-banner.tsx`, `how-it-works-popover.tsx`, `use-overview-items.ts`, `confirm-push-dialog.tsx`, `workspaces-sync.rs` (Rust module), `commands/workspaces_sync.rs`, `workspaces-sync-store.ts`, 5 new test files
- **Modified:** sidebar action row + workspace row, app-shell, ui-store, app-store, hosts-section (settings), settings-view, toast lib, globals.css (new `cm-pulse-attention` keyframe), tauri commands.ts, hosts.rs (extracted `workspace_pull_back_impl`), state_impl.rs (`create_synced_workspace_shell`), database.rs (sync table + git_head_sha column), git.rs (`git_clone` helper)
- **Server (deployed live):** `~/codemux-api/api/src/index.ts` adds the `codemux_workspaces` table + CRUD endpoints + git_head_sha; `tests/workspaces.test.ts` adds 36 endpoint tests
- **Docs:** new `docs/features/workspaces-overview.md` + `docs/features/workspaces-sync.md`; `docs/INDEX.md` updated

## Security & data-safety

- Every API endpoint goes through Better Auth's `authenticateBearer`; every query is scoped by `user_id` from the authenticated session
- 404-not-401 on PATCH/DELETE for rows you don't own — BIGSERIAL ids can't be enumerated across accounts
- Per-user cap (2000 workspaces) + 32 KB body size cap + per-field length validation on every input
- Soft-delete tombstones propagate across devices; local rows hard-purge only after the server confirms the deletion
- Push, pull, and adopt are all atomic — success-or-rollback, never partial state
- Single-source-of-truth at any moment — workspace files live in exactly one place at a time, never two
- Undo on every action gives users a 10-second reversal window
- Confirm-before-push dialog with per-host opt-out so power users keep their flow without losing safety for first-timers
- Clone-fallback's uncommitted-work loss risk is surfaced *in* the dialog, not buried in docs