### PR TITLE
fix(workspaces): clear sync row on close so overview doesn't tag closed workspaces as "other device"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -696,12 +696,44 @@ pub(crate) async fn close_workspace_with_worktree_impl(
         .close_workspace(&workspace_id)
         .map_err(|e| format!("Failed to close workspace: {e}"))?;
 
+    // Reconcile the sync mirror BEFORE the optimistic emit so the
+    // workspaces overview sees the soft-delete in the same tick that
+    // app_state loses the workspace. Without this, the orphan
+    // `workspaces_sync` row (whose `workspace_id` no longer maps to a
+    // live snapshot) is classified as a sibling-device workspace by
+    // `useOverviewItems` and renders with the "other device" badge for
+    // up to ~30 s, until the background reconcile loop catches up.
+    // Errors here are non-fatal: the close itself already succeeded,
+    // and the background tick will retry the reconcile + push.
+    {
+        let snapshot = state.snapshot();
+        if let Err(error) = crate::workspaces_sync::reconcile_from_snapshot(
+            db,
+            &snapshot,
+        ) {
+            eprintln!(
+                "[workspaces-sync] reconcile after close failed (will \
+                 retry on next background tick): {error}"
+            );
+        }
+    }
+
     // Optimistic emit: the workspace is gone from in-memory state. Push the
     // update to the frontend NOW so the sidebar row disappears immediately,
     // even when the filesystem cleanup below takes seconds (large worktrees,
     // slow disk). A second emit at the end of the command picks up any
     // session/agent-chat fan-out the cleanup triggers.
     crate::state::emit_app_state(&app);
+
+    // Best-effort push of the soft-delete to the server so sibling
+    // devices learn the workspace is gone immediately instead of
+    // waiting for the 30 s background tick. Non-fatal on failure.
+    if let Err(error) = crate::workspaces_sync::try_sync_with_app(&app).await {
+        eprintln!(
+            "[workspaces-sync] sync after close failed (will retry on \
+             next background tick): {error}"
+        );
+    }
 
     // Kill the PTY child process trees for every session that used to belong
     // to this workspace. Sessions are returned atomically from the same lock
@@ -968,11 +1000,40 @@ pub async fn close_workspace(
 
     let result = state.close_workspace(&workspace_id)?;
 
+    // Reconcile the sync mirror BEFORE the optimistic emit — see the
+    // matching block in `close_workspace_with_worktree_impl` for the
+    // full reasoning. In short: without this, the orphan
+    // `workspaces_sync` row mis-renders as a sibling-device workspace
+    // in the overview until the 30 s background tick. Non-fatal on
+    // failure.
+    {
+        let snapshot = state.snapshot();
+        if let Err(error) = crate::workspaces_sync::reconcile_from_snapshot(
+            db.inner(),
+            &snapshot,
+        ) {
+            eprintln!(
+                "[workspaces-sync] reconcile after close failed (will \
+                 retry on next background tick): {error}"
+            );
+        }
+    }
+
     // Optimistic emit: the workspace is gone from in-memory state. Push the
     // update to the frontend NOW so the sidebar row disappears immediately,
     // even if a PTY shutdown or agent-chat thread takes a moment to wind
     // down. A second emit at the end of the command picks up any fan-out.
     crate::state::emit_app_state(&app);
+
+    // Best-effort push of the soft-delete to the server so sibling
+    // devices learn the workspace is gone immediately instead of
+    // waiting for the 30 s background tick. Non-fatal on failure.
+    if let Err(error) = crate::workspaces_sync::try_sync_with_app(&app).await {
+        eprintln!(
+            "[workspaces-sync] sync after close failed (will retry on \
+             next background tick): {error}"
+        );
+    }
 
     // Kill the PTY child process trees for every session that used to belong
     // to this workspace. Sessions are returned atomically from the same lock

--- a/src-tauri/src/workspaces_sync.rs
+++ b/src-tauri/src/workspaces_sync.rs
@@ -722,6 +722,168 @@ mod tests {
         assert_eq!(listed[0].workspace_id.as_deref(), Some("workspace-42"));
     }
 
+    // ── reconcile_from_snapshot regression guards ───────────────
+    //
+    // These exercise the full reconcile bridge, not just the DB
+    // mutations underneath. The motivating regression is the close
+    // path: when a workspace is closed locally, the `workspaces_sync`
+    // row MUST be soft-deleted in the same tick so the overview
+    // doesn't briefly render the closed workspace as "lives on
+    // another device" (see use-overview-items.ts step 2).
+
+    fn make_ws(id: &str, title: &str) -> crate::state::WorkspaceSnapshot {
+        use crate::state::*;
+        WorkspaceSnapshot {
+            workspace_id: WorkspaceId(id.to_string()),
+            title: title.to_string(),
+            workspace_type: WorkspaceType::Standard,
+            cwd: "/tmp".into(),
+            git_branch: None,
+            git_ahead: 0,
+            git_behind: 0,
+            git_additions: 0,
+            git_deletions: 0,
+            git_changed_files: 0,
+            notification_count: 0,
+            latest_agent_state: None,
+            worktree_path: None,
+            project_root: None,
+            pr_number: None,
+            pr_state: None,
+            pr_url: None,
+            linked_issue: None,
+            notifications_muted: false,
+            tabs: Vec::new(),
+            active_tab_id: String::new(),
+            active_surface_id: SurfaceId(String::new()),
+            surfaces: Vec::new(),
+            host_id: None,
+        }
+    }
+
+    fn make_snapshot(
+        workspaces: Vec<crate::state::WorkspaceSnapshot>,
+    ) -> crate::state::AppStateSnapshot {
+        use crate::state::*;
+        let active = workspaces
+            .first()
+            .map(|w| w.workspace_id.clone())
+            .unwrap_or_else(|| WorkspaceId(String::new()));
+        AppStateSnapshot {
+            schema_version: 1,
+            active_workspace_id: active,
+            workspaces,
+            terminal_sessions: Vec::new(),
+            browser_sessions: Vec::new(),
+            agent_browser_sessions: Vec::new(),
+            notifications: Vec::new(),
+            detected_ports: Vec::new(),
+            pane_statuses: std::collections::HashMap::new(),
+            persistence: PersistenceSchema {
+                schema_version: 1,
+                stores_layout_metadata: true,
+                stores_terminal_metadata: true,
+                stores_live_process_state: false,
+            },
+            config: CodemuxConfigSnapshot {
+                config_version: 1,
+                default_shell: None,
+                theme_source: "system".into(),
+                linux_first: false,
+                notification_sound_enabled: false,
+                ai_commit_message_enabled: false,
+                ai_commit_message_cli: None,
+                ai_commit_message_model: None,
+                ai_resolver_enabled: false,
+                ai_resolver_cli: None,
+                ai_resolver_model: None,
+                ai_resolver_strategy: "smart_merge".into(),
+            },
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn reconcile_inserts_row_for_new_workspace() {
+        let db = fresh_db();
+        let snapshot = make_snapshot(vec![make_ws("workspace-A", "alpha")]);
+
+        super::reconcile_from_snapshot(&db, &snapshot).unwrap();
+
+        let list = db.list_workspaces_sync();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].workspace_id.as_deref(), Some("workspace-A"));
+        assert_eq!(list[0].title, "alpha");
+        assert!(list[0].dirty, "freshly inserted row must be dirty");
+    }
+
+    #[test]
+    #[serial]
+    fn reconcile_soft_deletes_row_when_workspace_closed() {
+        // The regression guard for the "closed workspace briefly appears
+        // as 'lives on another device'" bug. When a local workspace is
+        // closed, the close path now calls reconcile_from_snapshot
+        // immediately, which must soft-delete the orphan sync row so
+        // the overview no longer treats it as a sibling-device row.
+        let db = fresh_db();
+
+        // First reconcile: workspace exists, row gets inserted.
+        let with_ws =
+            make_snapshot(vec![make_ws("workspace-doomed", "to-be-closed")]);
+        super::reconcile_from_snapshot(&db, &with_ws).unwrap();
+        assert_eq!(db.list_workspaces_sync().len(), 1);
+
+        // Simulate close: snapshot no longer contains the workspace.
+        let empty = make_snapshot(Vec::new());
+        super::reconcile_from_snapshot(&db, &empty).unwrap();
+
+        // The sync row must be soft-deleted: invisible to list(),
+        // visible (with deleted_at + dirty) to list_for_sync() so the
+        // next push can DELETE it on the server.
+        assert_eq!(
+            db.list_workspaces_sync().len(),
+            0,
+            "list_workspaces_sync must hide the soft-deleted row so \
+             useOverviewItems can't classify it as a sibling-device row"
+        );
+        let all = db.list_workspaces_sync_for_sync();
+        assert_eq!(all.len(), 1);
+        assert!(all[0].deleted_at.is_some());
+        assert!(all[0].dirty, "soft-delete must mark the row dirty for push");
+    }
+
+    #[test]
+    #[serial]
+    fn reconcile_preserves_pulled_only_rows() {
+        // Sibling-device rows arrive via pull and have `workspace_id IS
+        // NULL`. Reconcile must NEVER touch them — they have no
+        // app_state counterpart by design. Otherwise closing a local
+        // workspace could accidentally soft-delete a sibling row.
+        let db = fresh_db();
+        db.upsert_workspace_sync_from_server(
+            "srv-99",
+            "from-sibling",
+            Some("host-7"),
+            Some("/sibling/path"),
+            None,
+            Some("main"),
+            None,
+            "2026-01-01 00:00:00",
+            "2026-01-01 00:00:00",
+            None,
+        )
+        .unwrap();
+        assert_eq!(db.list_workspaces_sync().len(), 1);
+
+        let empty = make_snapshot(Vec::new());
+        super::reconcile_from_snapshot(&db, &empty).unwrap();
+
+        let after = db.list_workspaces_sync();
+        assert_eq!(after.len(), 1, "pulled-only sibling row must survive");
+        assert!(after[0].workspace_id.is_none());
+        assert_eq!(after[0].title, "from-sibling");
+    }
+
     #[test]
     #[serial]
     fn delete_a_row_that_never_synced_is_a_local_no_op() {

--- a/src/components/workspaces-overview/use-overview-items.test.ts
+++ b/src/components/workspaces-overview/use-overview-items.test.ts
@@ -1,0 +1,242 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, cleanup } from "@testing-library/react";
+
+import type { WorkspaceSnapshot } from "@/tauri/types";
+import type { HostView, WorkspaceSyncView } from "@/tauri/commands";
+
+// ── Mutable mock state ────────────────────────────────────────────
+
+let mockWorkspaces: WorkspaceSnapshot[] | null = [];
+let mockHosts: HostView[] = [];
+let mockSyncRows: WorkspaceSyncView[] = [];
+
+vi.mock("@/stores/app-store", () => ({
+  useAppStore: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      appState: mockWorkspaces
+        ? { workspaces: mockWorkspaces, active_workspace_id: null }
+        : null,
+    }),
+  ),
+  useHomeDir: () => "/home/test",
+  // The hook calls `groupWorkspacesByProject` purely for the
+  // workspace_id → projectName mapping. A minimal stub that buckets
+  // by project_root (or cwd) is sufficient — the real impl is
+  // exercised in app-store tests.
+  groupWorkspacesByProject: (workspaces: WorkspaceSnapshot[]) => {
+    const map = new Map<string, WorkspaceSnapshot[]>();
+    for (const ws of workspaces) {
+      const path = ws.project_root ?? ws.cwd;
+      if (!map.has(path)) map.set(path, []);
+      map.get(path)!.push(ws);
+    }
+    return Array.from(map.entries()).map(([path, list]) => ({
+      projectPath: path,
+      projectName: path.split("/").pop() ?? path,
+      workspaces: list,
+    }));
+  },
+}));
+
+vi.mock("@/stores/hosts-store", () => ({
+  useHosts: () => mockHosts,
+}));
+
+vi.mock("@/stores/workspaces-sync-store", () => ({
+  useWorkspacesSync: () => mockSyncRows,
+}));
+
+import { useOverviewItems } from "./use-overview-items";
+
+// ── Factories ─────────────────────────────────────────────────────
+
+function makeWorkspace(
+  partial: Partial<WorkspaceSnapshot> & { workspace_id: string },
+): WorkspaceSnapshot {
+  return {
+    workspace_id: partial.workspace_id,
+    title: partial.title ?? partial.workspace_id,
+    workspace_type: partial.workspace_type ?? "standard",
+    cwd: partial.cwd ?? "/home/test/proj",
+    git_branch: partial.git_branch ?? null,
+    git_ahead: partial.git_ahead ?? 0,
+    git_behind: partial.git_behind ?? 0,
+    git_additions: partial.git_additions ?? 0,
+    git_deletions: partial.git_deletions ?? 0,
+    git_changed_files: partial.git_changed_files ?? 0,
+    notification_count: partial.notification_count ?? 0,
+    latest_agent_state: partial.latest_agent_state ?? null,
+    worktree_path: partial.worktree_path ?? null,
+    project_root: partial.project_root ?? "/home/test/proj",
+    pr_number: partial.pr_number ?? null,
+    pr_state: partial.pr_state ?? null,
+    pr_url: partial.pr_url ?? null,
+    linked_issue: partial.linked_issue ?? null,
+    notifications_muted: partial.notifications_muted ?? false,
+    tabs: partial.tabs ?? [],
+    active_tab_id: partial.active_tab_id ?? "",
+    active_surface_id: partial.active_surface_id ?? "",
+    surfaces: partial.surfaces ?? [],
+    host_id: partial.host_id,
+  } as WorkspaceSnapshot;
+}
+
+function makeSync(
+  partial: Partial<WorkspaceSyncView> & { id: number },
+): WorkspaceSyncView {
+  return {
+    id: partial.id,
+    server_id: partial.server_id ?? `srv-${partial.id}`,
+    workspace_id: partial.workspace_id ?? null,
+    title: partial.title ?? `sync-${partial.id}`,
+    host_server_id: partial.host_server_id ?? null,
+    project_path: partial.project_path ?? "/home/test/proj",
+    project_remote: partial.project_remote ?? null,
+    git_branch: partial.git_branch ?? null,
+    git_head_sha: partial.git_head_sha ?? null,
+    created_at: partial.created_at ?? "2026-01-01T00:00:00Z",
+    updated_at: partial.updated_at ?? "2026-01-01T00:00:00Z",
+    dirty: partial.dirty ?? false,
+  };
+}
+
+function makeHost(
+  id: number,
+  name: string,
+  serverId: string | null = `srv-host-${id}`,
+): HostView {
+  return {
+    id,
+    server_id: serverId,
+    name,
+    ssh_target: `${name}@example`,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    dirty: false,
+  };
+}
+
+afterEach(() => cleanup());
+
+describe("useOverviewItems", () => {
+  beforeEach(() => {
+    mockWorkspaces = [];
+    mockHosts = [];
+    mockSyncRows = [];
+  });
+
+  it("renders a local workspace as kind:local and consumes its sync row", () => {
+    mockWorkspaces = [
+      makeWorkspace({ workspace_id: "ws-1", title: "alpha" }),
+    ];
+    mockSyncRows = [makeSync({ id: 10, workspace_id: "ws-1" })];
+
+    const { result } = renderHook(() => useOverviewItems());
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0]?.kind).toBe("local");
+    if (result.current.items[0]?.kind === "local") {
+      expect(result.current.items[0].workspace.workspace_id).toBe("ws-1");
+      expect(result.current.items[0].sync?.id).toBe(10);
+    }
+  });
+
+  it("renders a sync row whose workspace_id is null as kind:remote (sibling-device)", () => {
+    mockSyncRows = [
+      makeSync({
+        id: 11,
+        workspace_id: null,
+        title: "lives on devbox",
+        host_server_id: "srv-host-7",
+      }),
+    ];
+
+    const { result } = renderHook(() => useOverviewItems());
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0]?.kind).toBe("remote");
+    if (result.current.items[0]?.kind === "remote") {
+      expect(result.current.items[0].sync.title).toBe("lives on devbox");
+    }
+  });
+
+  it("DOES NOT render a sync row whose workspace_id is set but app_state no longer has it", () => {
+    // Regression guard for the "closed workspace briefly appears as
+    // 'lives on another device'" bug. When the close path's reconcile
+    // hasn't pruned the `workspaces_sync` row yet (or the row is stale
+    // for any other reason), `workspace_id` is still set to a local id
+    // that no longer exists in `app_state.workspaces`. This is a
+    // self-orphan — NOT a sibling-device workspace. The overview must
+    // skip it rather than tagging it as "other device".
+    mockWorkspaces = []; // workspace "ws-closed" has been closed
+    mockSyncRows = [
+      makeSync({
+        id: 12,
+        workspace_id: "ws-closed",
+        title: "just-closed",
+        host_server_id: null,
+      }),
+    ];
+
+    const { result } = renderHook(() => useOverviewItems());
+
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it("self-orphan filter does not hide true sibling-device rows in mixed state", () => {
+    // Mix: one live local workspace, one orphan from a recent close,
+    // one true sibling-device row. Only the local and the sibling
+    // should appear.
+    mockWorkspaces = [
+      makeWorkspace({ workspace_id: "ws-live", title: "still-here" }),
+    ];
+    mockSyncRows = [
+      makeSync({ id: 20, workspace_id: "ws-live", title: "still-here" }),
+      makeSync({
+        id: 21,
+        workspace_id: "ws-closed",
+        title: "stale-orphan",
+      }),
+      makeSync({
+        id: 22,
+        workspace_id: null,
+        title: "on-sibling",
+        host_server_id: "srv-host-7",
+      }),
+    ];
+
+    const { result } = renderHook(() => useOverviewItems());
+
+    const kinds = result.current.items.map((i) => i.kind);
+    const titles = result.current.items.map((i) =>
+      i.kind === "local" ? i.workspace.title : i.sync.title,
+    );
+
+    expect(result.current.items).toHaveLength(2);
+    expect(kinds).toContain("local");
+    expect(kinds).toContain("remote");
+    expect(titles).toContain("still-here");
+    expect(titles).toContain("on-sibling");
+    expect(titles).not.toContain("stale-orphan");
+  });
+
+  it("resolves hostServerId on a local item via the hosts table when no sync row exists yet", () => {
+    mockHosts = [makeHost(7, "devbox", "srv-host-7")];
+    mockWorkspaces = [
+      makeWorkspace({
+        workspace_id: "ws-remote",
+        title: "on-devbox",
+        host_id: 7,
+      }),
+    ];
+    mockSyncRows = []; // first reconcile hasn't run yet
+
+    const { result } = renderHook(() => useOverviewItems());
+
+    expect(result.current.items).toHaveLength(1);
+    if (result.current.items[0]?.kind === "local") {
+      expect(result.current.items[0].hostServerId).toBe("srv-host-7");
+    }
+  });
+});

--- a/src/components/workspaces-overview/use-overview-items.ts
+++ b/src/components/workspaces-overview/use-overview-items.ts
@@ -237,10 +237,20 @@ export function useOverviewItems(): {
 
     // 2) Every sync row with NO local workspace counterpart is a
     //    sibling-device workspace. Render as "remote".
+    //
+    //    Defense in depth: a row whose `workspace_id` IS set (non-null)
+    //    used to map to a local workspace on this device — it's not a
+    //    sibling-device row, it's a self-orphan from a workspace that
+    //    was just closed and whose `workspaces_sync` soft-delete hasn't
+    //    reached this snapshot yet (the close path's reconcile + sync
+    //    runs before the next emit, but if it ever fails, the
+    //    background tick is still ~30 s away). Skipping these rows here
+    //    keeps the closed workspace from briefly appearing as
+    //    "lives on another device" in the overview. True sibling-device
+    //    rows always have `workspace_id === null` until adopted.
     for (const row of syncRows) {
       if (consumedSyncIds.has(row.id)) continue;
-      // Rows we haven't adopted locally — workspace_id is null OR
-      // it referenced a local id we no longer have.
+      if (row.workspace_id !== null) continue;
       result.push({
         kind: "remote",
         key: `remote:${row.server_id ?? row.id}`,


### PR DESCRIPTION
## Summary

- After closing a workspace, the Workspaces overview briefly rendered the just-closed workspace as **"lives on another device"** until the 30 s background reconcile loop caught up.
- Root cause: both close paths in `commands/workspace.rs` removed the workspace from `app_state` and emitted to the frontend, but never reconciled `workspaces_sync`. The orphan sync row (now with a `workspace_id` that no longer matched any live workspace) was then classified as `kind: "remote"` by `useOverviewItems` and rendered with the "other device" badge.
- Fix:
  1. **Backend (root cause)** — `close_workspace_with_worktree_impl` and `close_workspace` now `reconcile_from_snapshot` immediately after `state.close_workspace(...)` so the orphan row is soft-deleted in the same tick the frontend re-renders, then best-effort `try_sync_with_app` so sibling devices learn about the close without waiting for the 30 s tick. Failures are non-fatal (logged) — the close itself already succeeded.
  2. **Frontend (defense in depth)** — `useOverviewItems` step 2 now skips sync rows whose `workspace_id` is non-null. True sibling-device rows always have `workspace_id === null` until adoption, so a non-null `workspace_id` with no matching local workspace can only be a self-orphan, never an actual sibling-device row.

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib workspaces_sync::tests::` — 9/9 pass, including 3 new ones:
  - `reconcile_inserts_row_for_new_workspace`
  - `reconcile_soft_deletes_row_when_workspace_closed` (regression guard)
  - `reconcile_preserves_pulled_only_rows`
- [x] `npm run check` (tsc) — clean
- [x] `npm run test` — 1766 tests pass, including 5 new ones in `use-overview-items.test.ts` covering kind:local / kind:remote classification and the self-orphan skip
- [x] Manual reproduction: closing a workspace no longer shows it as "other device" in the overview

Pre-existing failing test on `origin/main` not introduced by this PR: `commands::mcp::tests::project_codemux_entry_is_filtered_out` (reproduces on a clean checkout of `main`).

## Incidental

`package-lock.json` picks up the 0.6.1 → 0.7.0 version follow-on from commit `20f539a chore: bump version to 0.7.0`.