### PR TITLE
fix(hosts): probe ~/.local/bin/codemux-remote when PATH lookup fails

### DIFF
--- a/src-tauri/src/ssh/probe.rs
+++ b/src-tauri/src/ssh/probe.rs
@@ -78,9 +78,22 @@ pub fn build_probe_argv(ssh_target: &str, timeout_secs: u64) -> Vec<String> {
         // `codemux-remote version` if available. The remote-side
         // `printf` separates the two with a sentinel so the laptop
         // can split.
+        //
+        // The `$HOME/.local/bin/codemux-remote` fallback exists because
+        // bootstrap installs there, but a non-interactive SSH shell
+        // (which is what `ssh user@host 'cmd'` runs) typically does NOT
+        // source `~/.profile` — so `~/.local/bin` is missing from PATH
+        // on most distros (Arch, Ubuntu, Debian, Fedora). Without the
+        // fallback, `command -v` returns nothing immediately after a
+        // successful install and the UI re-shows the install button on
+        // every subsequent "Test connection" press. Mirrors the same
+        // fix applied in `commands::hosts::ensure_remote_binary_current`
+        // and the supervisor's tunnel-spawn command.
         "printf 'UNAME: ' ; uname -sm ; \
          if command -v codemux-remote >/dev/null 2>&1 ; then \
            printf 'CMR: ' ; codemux-remote version ; \
+         elif [ -x \"$HOME/.local/bin/codemux-remote\" ] ; then \
+           printf 'CMR: ' ; \"$HOME/.local/bin/codemux-remote\" version ; \
          else \
            printf 'CMR: NOT_INSTALLED\\n' ; \
          fi"
@@ -183,6 +196,37 @@ mod tests {
         // The remote command must be the LAST positional arg.
         assert!(argv.last().unwrap().contains("uname -sm"));
         assert!(argv.last().unwrap().contains("codemux-remote"));
+    }
+
+    #[test]
+    fn build_probe_argv_falls_back_to_home_local_bin() {
+        // Bootstrap installs to ~/.local/bin/codemux-remote, but a
+        // non-interactive ssh shell typically doesn't have that dir on
+        // PATH (it's added by ~/.profile, which only login shells
+        // source). Without an explicit fallback, `command -v` returns
+        // nothing immediately after a successful install and the UI
+        // re-shows the install button on every "Test" press.
+        //
+        // Lock in BOTH the PATH lookup AND the absolute-path fallback
+        // so a future refactor doesn't silently drop either branch.
+        let argv = build_probe_argv("zeus@10.0.0.5", 8);
+        let cmd = argv.last().unwrap();
+        assert!(
+            cmd.contains("command -v codemux-remote"),
+            "PATH lookup must remain (fast path when binary is on PATH)"
+        );
+        assert!(
+            cmd.contains("$HOME/.local/bin/codemux-remote"),
+            "absolute-path fallback must remain (covers the common case \
+             where ~/.local/bin isn't on the non-interactive PATH)"
+        );
+        // The fallback must run the binary, not just stat it — otherwise
+        // we'd report "installed" for a 0-byte file or a half-uploaded
+        // binary that doesn't actually execute.
+        assert!(
+            cmd.contains("\"$HOME/.local/bin/codemux-remote\" version"),
+            "fallback must invoke the binary's version subcommand"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- "Test connection" was reporting `NOT_INSTALLED` immediately after a successful install, causing the UI to re-show the Install button on every press
- Root cause: probe used `command -v codemux-remote` over a non-interactive SSH shell, but bootstrap installs to `~/.local/bin/codemux-remote` — and most distros only put that dir on PATH via `~/.profile` (login shells only)
- Fall back to invoking `\$HOME/.local/bin/codemux-remote` directly when the PATH lookup misses; mirrors the absolute-path pattern already used by `ensure_remote_binary_current` and the tunnel supervisor's spawn command

## Verification
- New unit test `build_probe_argv_falls_back_to_home_local_bin` locks in BOTH the PATH lookup AND the absolute-path fallback so a future refactor can't silently drop either branch
- All 6 `ssh::probe` tests pass
- `cargo check` clean, `tsc --noEmit` clean, vitest 1766/1766 passing
- End-to-end against a real host: with the binary installed at `~/.local/bin/codemux-remote` and `\$PATH=/usr/local/sbin:/usr/local/bin:/usr/bin` (no `~/.local/bin`), the new probe script returns `CMR: {"name":"codemux-remote","protocol_version":1,"version":"0.7.1"}` where the old script returned `CMR: NOT_INSTALLED`

## Test plan
- [ ] Install codemux-remote on a fresh host via the Devices panel
- [ ] Press "Test now" — should report installed/connected instead of re-prompting to install
- [ ] Confirm hosts where `~/.local/bin` IS on the non-interactive PATH still take the fast (PATH lookup) branch
- [ ] Confirm hosts without the binary still show "Reachable, but codemux-remote isn't installed yet"