### PR TITLE
fix(workspaces-overview): show configured-host buckets even when empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src/components/workspaces-overview/workspaces-overview-section.test.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.test.tsx
@@ -281,6 +281,23 @@ describe("WorkspacesOverviewSection", () => {
     expect(getByText("lost-and-found")).toBeInTheDocument();
   });
 
+  it("shows a configured host's bucket even when no workspaces live on it yet", () => {
+    // Regression for the "I added a device, it doesn't show up in the
+    // overview until I push a workspace" bug. The host has a server_id
+    // (i.e. it's synced cross-device), there are no workspaces on it,
+    // and there's a local workspace so the local bucket is non-empty.
+    // The configured-host bucket must still render — otherwise the
+    // user has no way to discover the device from the overview, nor
+    // any obvious target to push to.
+    mockHosts = [makeHost(7, "pandora")];
+    mockWorkspaces = [
+      makeWorkspace({ workspace_id: "local-1", title: "alpha" }),
+    ];
+    const { getByText } = render(<WorkspacesOverviewSection />);
+    expect(getByText("This device")).toBeInTheDocument();
+    expect(getByText("pandora")).toBeInTheDocument();
+  });
+
   it("renders the bucket-level 'all hidden by filter' message when filters hide every workspace in a known device bucket", () => {
     // Intentional: when the user has a bucket they recognise but
     // every row in it is filtered out, the bucket stays visible

--- a/src/components/workspaces-overview/workspaces-overview-section.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.tsx
@@ -352,9 +352,23 @@ export function WorkspacesOverviewSection() {
       bucket.items.sort(sorter);
     }
 
-    // Hide buckets that have neither items nor any unfiltered rows.
+    // Keep configured-host buckets (localHostId != null) even when
+    // empty — matches the intent stated above at the pre-create step:
+    // a device the user has set up should be visible in the overview
+    // the moment it's configured, not only after the first workspace
+    // lands on it. Without this, an empty pandora bucket gets created
+    // and then immediately stripped here, which is why the user only
+    // ever saw "This device" until they pushed a workspace.
+    //
+    // Orphan buckets (localHostId == null, hostServerId != null) and
+    // the special "local" bucket still follow the items/totalCount
+    // rule so the overview doesn't render a dangling "This device"
+    // row when the user has zero workspaces and zero remote rows.
     return Array.from(byKey.values())
-      .filter((b) => b.items.length > 0 || b.totalCount > 0)
+      .filter(
+        (b) =>
+          b.localHostId !== null || b.items.length > 0 || b.totalCount > 0,
+      )
       .sort((a, b) => a.sortRank - b.sortRank);
   }, [allItems, filtered, hosts, sortBy, activeWorkspaceId]);
 


### PR DESCRIPTION
## Summary
- Empty configured-host buckets were getting stripped by the final filter pass, contradicting the comment on the bucket-build step that said *"Pre-create the local + configured-host buckets so empty configured hosts still show up."* A device the user had configured but never landed a workspace on stayed invisible — pushing any workspace to it was the only known workaround.
- The fix carves out configured-host buckets (those carrying a local host-row id) from the empty-bucket filter. The local *This device* bucket and orphan buckets still follow the items/totalCount rule, so the overview won't render a dangling *This device* row on a brand-new account.
- Adds a regression test that fails on the old filter and passes on the new one (verified by stashing the fix).

## Why this bug existed
The bucket pipeline pre-creates a bucket for every configured host (lines 303–315) — the comment there explicitly states this is so empty configured hosts still show up. But the final `.filter()` six lines later required a non-zero items.length OR totalCount, silently undoing the intent. The push-workspace flow worked around it because pushing made totalCount non-zero.

## Test plan
- [x] `npm run test` — 1767 tests pass (was 1766; +1 regression test)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` — clean
- [x] Regression test (`shows a configured host's bucket even when no workspaces live on it yet`) fails on the unfixed component, passes on the fixed one — verified by `git stash`-ing the fix and re-running
- [ ] Visual sanity check in dev/prod: add a host, don't push any workspace, confirm its card appears in Workspaces

## What's *not* in this PR
While investigating I noticed `hosts_bootstrap_install` is the only host-write command that doesn't trigger a hosts sync. That's a real but unrelated edge case (host added while signed out → row stays dirty + server_id null → device hidden for a different reason). Worth fixing in a follow-up, but not the cause of the reported issue, so it's out of scope here.