### PR TITLE
ci: free ~25 GB on Ubuntu runners before Cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Free disk space (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        # GitHub-hosted Ubuntu runners ship with ~14 GB free on /. Our
+        # job restores a Rust target cache, runs `cargo check` and
+        # `cargo test` (each round of which adds GB to target/), installs
+        # node_modules, builds the frontend, and `bun install`s the
+        # sidecar — that comfortably exceeds 14 GB and has produced
+        # post-merge CI failures with "No space left on device" during
+        # `cargo test` (see PR #44 and PR #46 merge runs).
+        #
+        # Removing the preinstalled toolchains we never touch (Android
+        # SDK ~12 GB, .NET ~1.6 GB, Haskell GHC ~5 GB, CodeQL ~5 GB,
+        # cached Docker images ~3 GB) frees ~25 GB in <30 s and avoids
+        # pinning a third-party action. Windows runners have ~150 GB
+        # free and don't need this.
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Install Linux system dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |


### PR DESCRIPTION
## Summary
- Ubuntu CI runs out of disk during `cargo test` and kills the runner with `No space left on device`. Reproduced on PR #44's and PR #46's post-merge runs (latest: run 26578336421, rerun also failed).
- GitHub-hosted Ubuntu runners only have ~14 GB free on `/`. Our job restores a Rust target cache, runs `cargo check` + `cargo test` (each adds GB to `target/`), installs node_modules, builds the frontend, and bun-installs the sidecar. The combined footprint exceeds 14 GB.
- Fix: remove the preinstalled toolchains we never use (Android SDK ~12 GB, .NET ~1.6 GB, Haskell GHC ~5 GB, CodeQL ~5 GB, cached Docker images ~3 GB) right after checkout. Frees ~25 GB in well under a minute and avoids pinning a third-party action. Windows runners (~150 GB) skip the step.

## Test plan
- [ ] Pre-merge CI on this branch passes both `check (ubuntu-latest)` and `check (windows-latest)`
- [ ] `Free disk space (Linux)` step logs `df -h /` showing >25 GB available after cleanup
- [ ] Post-merge CI on `main` finishes `Cargo test` without the disk-space error