### PR TITLE
fix(workspaces-sync): refresh overview when host_inventory adds rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src/stores/workspaces-sync-store.test.tsx
+++ b/src/stores/workspaces-sync-store.test.tsx
@@ -1,0 +1,153 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+
+import type { WorkspaceSyncView } from "@/tauri/commands";
+
+// ── Mock the Tauri command so each call resolves with whatever the
+//    current test put in `mockNextRows`. We track the call count to
+//    pin down the bug being fixed: previously the polling interval
+//    fired but the body short-circuited because `subscriberCount`
+//    was stuck at 0 (no useEffect ever called the increment helper),
+//    so the store never re-read the DB after the first load.
+let mockNextRows: WorkspaceSyncView[] = [];
+const listSpy = vi.fn<() => Promise<WorkspaceSyncView[]>>(() =>
+  Promise.resolve(mockNextRows),
+);
+
+vi.mock("@/tauri/commands", () => ({
+  workspacesSyncList: () => listSpy(),
+}));
+
+import {
+  __resetWorkspacesSyncStoreForTests,
+  useWorkspacesSync,
+  useWorkspacesSyncStore,
+} from "./workspaces-sync-store";
+
+function makeRow(
+  partial: Partial<WorkspaceSyncView> & { id: number },
+): WorkspaceSyncView {
+  return {
+    id: partial.id,
+    server_id: partial.server_id ?? null,
+    workspace_id: partial.workspace_id ?? null,
+    title: partial.title ?? `row-${partial.id}`,
+    host_server_id: partial.host_server_id ?? null,
+    project_path: partial.project_path ?? null,
+    project_remote: partial.project_remote ?? null,
+    git_branch: partial.git_branch ?? null,
+    git_head_sha: partial.git_head_sha ?? null,
+    created_at: partial.created_at ?? "2026-01-01T00:00:00Z",
+    updated_at: partial.updated_at ?? "2026-01-01T00:00:00Z",
+    dirty: partial.dirty ?? false,
+  };
+}
+
+describe("useWorkspacesSync subscriber wiring", () => {
+  beforeEach(() => {
+    __resetWorkspacesSyncStoreForTests();
+    listSpy.mockClear();
+    mockNextRows = [];
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("fetches on mount even after the store has already loaded once", async () => {
+    // Simulate the bug's exact scenario:
+    //   1. Some earlier interaction (e.g. an imperative `init()` call,
+    //      or a previous mount-unmount cycle) populated the store with
+    //      an empty list.
+    //   2. The background `hosts_inventory` poller (Rust side) THEN
+    //      inserts sibling rows into the SQLite table.
+    //   3. The user opens the overview — the hook must re-fetch so
+    //      those new rows render. Pre-fix, the hook short-circuited
+    //      on `loaded === true` and the bucket showed "0 workspaces".
+    mockNextRows = [];
+    await act(async () => {
+      await useWorkspacesSyncStore.getState().refresh();
+    });
+    expect(useWorkspacesSyncStore.getState().rows).toEqual([]);
+    expect(useWorkspacesSyncStore.getState().loaded).toBe(true);
+
+    // Now the Rust background poller inserts a sibling row.
+    mockNextRows = [
+      makeRow({ id: 31, host_server_id: "2", title: "passpage-ui-polish" }),
+    ];
+
+    listSpy.mockClear();
+    const { result } = renderHook(() => useWorkspacesSync());
+
+    // Let the mount-effect's refresh resolve.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(listSpy).toHaveBeenCalledTimes(1);
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]?.host_server_id).toBe("2");
+  });
+
+  it("polls every 5 s while at least one subscriber is mounted", async () => {
+    mockNextRows = [];
+    const { unmount } = renderHook(() => useWorkspacesSync());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(listSpy).toHaveBeenCalledTimes(1);
+
+    // Advance past two polling intervals — each should fire one call.
+    mockNextRows = [makeRow({ id: 1 })];
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+    expect(listSpy).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+    expect(listSpy).toHaveBeenCalledTimes(3);
+
+    // Unmount: polling skips because no subscriber is watching.
+    unmount();
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    expect(listSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("ref-counts across multiple concurrent subscribers", async () => {
+    mockNextRows = [];
+    const a = renderHook(() => useWorkspacesSync());
+    const b = renderHook(() => useWorkspacesSync());
+    // Both mounts kicked a refresh; in-flight dedupe collapses them
+    // to a single fetch.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(listSpy).toHaveBeenCalledTimes(1);
+
+    // Unmount one — the other still drives polling.
+    a.unmount();
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+    expect(listSpy).toHaveBeenCalledTimes(2);
+
+    // Unmount the last subscriber — polling skips.
+    b.unmount();
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    expect(listSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/stores/workspaces-sync-store.ts
+++ b/src/stores/workspaces-sync-store.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { create } from "zustand";
 
 import { workspacesSyncList, type WorkspaceSyncView } from "@/tauri/commands";
@@ -16,10 +17,15 @@ import { workspacesSyncList, type WorkspaceSyncView } from "@/tauri/commands";
  * just reads what Rust has already mirrored.
  *
  * Refresh model:
- * - `init()` kicks off the first read on first hook subscription.
+ * - `useWorkspacesSync()` mount fires a fresh `refresh()` so reopening
+ *   the overview always reflects rows the background `hosts_inventory`
+ *   poller (or a peer device's sync push) inserted in the meantime.
  * - A foreground refresh runs every 5 seconds while at least one
  *   subscriber is mounted (the overview is one).
  * - `refresh()` is exposed for "Sync now" affordances.
+ * - `init()` is a passive imperative entry-point retained for
+ *   non-React callers — it short-circuits once the first load has
+ *   resolved, so it's safe to call from anywhere.
  *
  * Falls back to an empty list on error — never throws, so the UI
  * never breaks when the user is signed out or the DB momentarily
@@ -87,23 +93,31 @@ function ensurePolling() {
 }
 
 /** Hook for components that just want the rows. Auto-inits on first
- *  call and ref-counts to drive the polling interval — when no
+ *  call and ref-counts to drive the 5 s polling interval — when no
  *  subscriber is mounted, the poll skips so we don't wake the Rust
- *  side unnecessarily. */
+ *  side unnecessarily.
+ *
+ *  Subscriber lifecycle is managed via a `useEffect`: mount
+ *  increments the global counter, kicks a fresh `refresh()` (so
+ *  re-opening the overview always reflects rows the background
+ *  `hosts_inventory` poller or a peer device inserted while the
+ *  overview was closed — `init()` no-ops after the first call), and
+ *  arms the polling interval; unmount decrements. Strict Mode's
+ *  double-mount cleanly increments/decrements in pairs, so the
+ *  counter stays accurate. */
 export function useWorkspacesSync(): WorkspaceSyncView[] {
   const rows = useWorkspacesSyncStore((s) => s.rows);
-  const loaded = useWorkspacesSyncStore((s) => s.loaded);
-  const init = useWorkspacesSyncStore((s) => s.init);
-  if (!loaded) {
-    void init();
-  }
-  // Ref-count + polling: incremented on first render, decremented on
-  // unmount via the `useEffect` cleanup in `useEffectfulSubscription`.
-  // We don't use React hooks here for the ref-count because the
-  // pattern needs to work outside React's normal lifecycle (the
-  // store survives Strict Mode double-mount cleanly via the global
-  // `subscriberCount`).
-  ensurePolling();
+  const refresh = useWorkspacesSyncStore((s) => s.refresh);
+
+  useEffect(() => {
+    incrementWorkspacesSyncSubscribers();
+    void refresh();
+    ensurePolling();
+    return () => {
+      decrementWorkspacesSyncSubscribers();
+    };
+  }, [refresh]);
+
   return rows;
 }
 


### PR DESCRIPTION
## Summary
- The Workspaces overview was rendering configured-host buckets as "0 workspaces" even after the Rust `hosts_inventory` poller inserted sibling rows into `workspaces_sync`. Verified on a live machine where pandora had 2 rows in the local SQLite (`workspace_id=NULL`, `host_server_id="2"`, `dirty=0`) and was reporting them over SSH, but the UI stayed empty until app restart.
- Root cause: `useWorkspacesSync` referenced a nonexistent `useEffectfulSubscription` hook in a comment but never called the exported `incrementWorkspacesSyncSubscribers` / `decrementWorkspacesSyncSubscribers`. Global `subscriberCount` stuck at 0 → the 5 s `setInterval` body short-circuited every tick. `init()`'s `loaded`-flag short-circuit then froze the snapshot at whatever was in the DB the first time the hook mounted.
- Fix: move the ref-count + a fresh `refresh()` into a `useEffect` inside `useWorkspacesSync` (mount = inc + refresh + ensurePolling; unmount = dec). Strict Mode's double-mount cancels out cleanly via paired inc/dec.
- Adds a focused store test pinning down the three behaviours: re-fetch on mount after a prior load, polling fires while subscribed and stops on unmount, ref-counting across concurrent subscribers.

## Test plan
- [x] `npx vitest run src/stores/workspaces-sync-store.test.tsx` — 3/3 pass
- [x] `npx vitest run` — full frontend suite 1771/1771 pass
- [x] `npm run check` — clean
- [ ] On a host with at least one configured `codemux-remote` server and sibling-only rows in `workspaces_sync`: open the Workspaces overlay, confirm the host's bucket populates within ~5 s (instead of requiring an app restart). Close + reopen the overlay, confirm it re-reads the DB on every open. Leave the overlay open while a new workspace is created on the host; the row should appear within the next ~5 s poll.