### PR TITLE
fix(remote): pull agent-created host workspaces with files + git

### DIFF
--- a/docs/plans/remote-workspace-pull-fix.md
+++ b/docs/plans/remote-workspace-pull-fix.md
@@ -1,0 +1,83 @@
+# Remote workspace pull/adoption fix (passpage empty-worktree investigation)
+
+- Purpose: Track the fix for agent-created workspaces on a `codemux-remote` host that pull as EMPTY worktrees on the desktop, plus the supporting tool/skill gaps surfaced by the same investigation.
+- Audience: Anyone touching the remote daemon tool surface, the hosts-inventory poller, workspaces-sync, or the SSH pull/adoption path.
+- Authority: Active work plan. Behavior that lands moves to `docs/features/remote-hosts.md` / `docs/features/workspaces-sync.md`.
+- Read next: `docs/plans/mcp-on-remote.md`, `docs/plans/project-identity.md`, `docs/features/workspaces-sync.md`.
+
+## Trigger / symptom
+
+A user runs an agent on a home server (`pandora`) via `codemux-remote mcp`. The agent built a real project at `/home/deus/projects/passpage` (`git init`, commits, branches) and a real, populated worktree at `/home/deus/projects/passpage-ui-polish` (branch `ui-polish-v1`). Both are correctly registered in the daemon. On the **desktop**, the two workspaces appear under project `passpage` as "remote" rows, but pulling/opening them shows **empty file trees**.
+
+## Verified facts (read-only inspection)
+
+- Server is healthy: real repo + populated linked worktree, both registered with correct `path`, `kind`, `project_uid`, `project_name`; `repo_remote = null` (local-only repo). Daemon binary is `0.7.4` and its `workspace list` envelope emits all identity fields correctly.
+- The worktree on the host is a **sibling** (`~/projects/passpage-ui-polish`), created by a manual `git worktree add` — NOT under `~/.codemux/worktrees/` (the agent improvised because the headless MCP had no `worktree_create`).
+- Desktop: local `~/.codemux/worktrees/passpage/{main,ui-polish-v1}` exist but are **empty, no `.git`**. The desktop `workspaces_sync` rows have empty `project_uid`/`workspace_kind`, and the `main` row has empty `project_path`.
+
+## Root causes
+
+1. **Pull-back rsyncs from an ASSUMED path, not the real one.** `workspace_pull_back_impl` (`commands/hosts.rs`) computes the remote source as `crate::ssh::conventional_remote_path(project_name, branch)` = `~/.codemux/worktrees/<project>/<branch>`. That is correct only for workspaces the **desktop pushed**. An agent-created workspace lives at its real registered `path` (`/home/deus/projects/passpage-ui-polish`), which does not exist under `~/.codemux/worktrees/` → `pull_workspace_back` returns `RemoteNotFound` (or an empty copy) → empty local worktree. The daemon's true `path` is never threaded to the pull.
+
+2. **The real remote path is dropped in sync.** `reconcile_host_inventory` maps `project_path = project_root ?? path`. For a worktree, `project_root` is the parent repo, so the worktree's own on-disk `path` is lost — the sync row cannot tell the pull where the files actually are.
+
+3. **Linked-worktree `.git` is unusable cross-machine.** A worktree's `.git` is a gitfile pointing at `<parent>/.git/worktrees/<name>`. Even if files rsync, that pointer references a path that doesn't exist on the desktop → broken git view. For a **local-only** repo (no remote) this can't be repaired by cloning.
+
+4. **`upsert_workspace_sync_from_server` clobbers local identity.** It is server-authoritative for `project_uid`/`workspace_kind` and will overwrite a correctly-derived local value with a `null` from the cloud. Latent footgun independent of the above.
+
+5. **Headless MCP had no `worktree_create`** (FIXED — see below). The Vexis skill told the agent to call `mcp__codemux__worktree_create`, absent on the remote surface, forcing the `git worktree add` + `workspace_create` improvisation.
+
+## Fixes
+
+### #3 — `worktree_create` on the headless daemon — DONE (this branch)
+
+`src-tauri/src/remote/git.rs` (new): `create_worktree(home, repo, branch, new_branch, base)` runs `git worktree add` under `~/.codemux/worktrees/<repo>/<branch>` (desktop layout), idempotent reuse, real-repo unit tests. Wired as the `worktree_create` MCP tool in `remote/tools/mod.rs` (catalog + dispatch + dispatch-level tests). Registers the worktree with `project_root = parent repo` so it inherits the shared `project_uid` and `kind = worktree`.
+
+### #1 — pull the REAL remote path + stop clobbering identity — DONE (this branch)
+
+- New local-only `origin_path` column on `workspaces_sync` (additive ALTER), threaded through `WorkspaceSyncRecord`, `row_to_workspace_sync` (index 16), and the remote-discovered insert/update CRUD.
+- `reconcile_host_inventory` records `origin_path = ws.path` (the daemon's REAL on-host path), distinct from `project_path` (which collapses to the parent repo for a worktree).
+- `workspace_pull_back_impl` now rsyncs from `origin_path` when present, falling back to the conventional path only for desktop-pushed workspaces (backward compatible). This fixes the empty pull for agent-created main/standard workspaces end-to-end.
+- `upsert_workspace_sync_from_server` uses `COALESCE(server, local)` for `project_uid`/`workspace_kind` so a null from the cloud never clobbers a locally-derived identity. `origin_path`/`origin_uid` are not in its SET list, so they survive cloud pulls untouched.
+- Adoption already surfaces `RemoteNotFound`/`RsyncFailed` as `ok:false`.
+- Tests: `reconcile_records_real_origin_path_distinct_from_project_path`, `reconcile_updates_origin_path_when_host_path_changes`, plus all 107 existing sync tests still green.
+
+### (superseded) #1 — original plan
+
+- Thread the daemon's actual `Workspace.path` through `RemoteWorkspace` → a new `origin_path` (or reuse) column on `workspaces_sync` → the adopted app_state workspace → `workspace_pull_back_impl`, which rsyncs from that path instead of the reconstructed conventional path. Backward compatible: a pushed workspace's real path already IS the conventional path.
+- `upsert_workspace_sync_from_server`: `COALESCE(server, local)` for `project_uid`/`workspace_kind` so a null from the cloud never wipes a known-good local value.
+- Adoption already surfaces `RemoteNotFound`/`RsyncFailed` as `ok:false`; ensure the adoption command propagates that as a visible error and does not leave a silent empty shell linked as "adopted".
+
+### #2 — adopting a worktree of a local-only repo — DONE (this branch, Design A)
+
+Decision: **A. Whole-repo rsync + local worktree recreate.** `workspaces_adopt_synced` now detects `workspace_kind == "worktree"` and delegates to `adopt_worktree_via_repo_rsync`:
+1. rsync the PARENT repo (incl. `.git`, from the worktree row's `project_path` = the repo path on the host) into `~/.codemux/projects/<repo>` — skipped when a local repo is already there (adopting a 2nd worktree of the same project reuses it).
+2. `git_recreate_worktree_for_adopted_repo` (new in `git.rs`): `git worktree prune` (drops the host's stale worktree admin entries, which point at paths that don't exist locally) then `git worktree add` for the branch into the canonical `~/.codemux/worktrees/<repo>/<branch>`.
+3. Register a local workspace at the recreated worktree, clear `host_id`, link the sync row.
+
+Works for local-only repos (no remote) because rsync carries the objects + branch refs — no clone needed. `main`/standard rows keep the single-dir pull path (now sourcing from `origin_path`, #1).
+
+Tests: `git::tests::test_recreate_worktree_for_adopted_repo_prunes_stale_host_entry` (simulates the rsynced-in stale host worktree entry → prune → clean local recreate). The SSH rsync leg is covered by the shared `pull_workspace_back` machinery.
+
+Options not taken: **B. Standalone snapshot** (rsync worktree + copy objects) — diverges from "it's a worktree", duplicates objects. **C. Require a remote** — fails for local-only repos like `passpage`.
+
+### #4 — Vexis skill update — drafted, handed to user (skill lives on pandora; not edited here)
+
+Add a new-project bootstrap (`git init` + project-folder location convention) and correct the remote tool surface (`worktree_create` now available on `codemux-remote mcp`).
+
+## Superset comparison (pre-merge review)
+
+Studied `superset-sh/superset` to validate our approach. Findings:
+
+- **Architectural divergence (the big one).** Superset NEVER copies files across machines. The desktop operates **in place** on the owning host via a WebSocket-tunnelled remote-FS RPC (`relay` → host-service → `node:fs` on `worktreePath`; see `packages/workspace-fs`, `apps/relay/src/tunnel.ts`). Files don't cross the wire except per-request bytes; a host offline ⇒ "files unavailable" screen. So Superset structurally **cannot** hit our "empty worktree after sync" bug — there is no sync. Codemux is copy/rsync-based, which is why we had the bug and why #1/#2 patch the rsync path. Our fixes are correct *within* the copy model; a tunnelled remote-FS is the larger strategic alternative (major rearchitecture — explicitly deferred, tracked here as the long-term direction).
+- **Validated: prune-before-add.** Superset's host-service runs `git worktree prune` before every `git worktree add` (and adopts a branch already checked out elsewhere). We now do this in BOTH the #2 recreate path and the #3 headless `worktree_create` (added in review).
+- **Validated: git-init bootstrap.** Superset `git init --initial-branch=main` + `--allow-empty` initial commit, with atomic mkdir + a `PRECONDITION_FAILED` translation when git identity is unset. Our #4 skill draft mirrors this (added the `--allow-empty` note).
+- **Validated: deterministic identity.** Superset reconciles independent clones by canonical GitHub remote (random UUID + `findByGitHubRemote`/`linkRepoCloneUrl`). Our `project_identity.rs` computes the uid deterministically from the canonical remote — same convergence, no reconcile step. Already shipped.
+- **Adopt later (out of scope for this PR):**
+  - **Main-workspace normalize sweep + "one main per (project,host)" guarantee.** Superset enforces a partial unique index `(projectId, hostId) WHERE type='main'`, calls `ensureMainWorkspace` at every create, and runs `runMainWorkspaceSweep` on boot ("no orphan worktrees"). Our daemon has `sweep_backfill_identity` (backfills uid/kind) but not a main-normalize/guarantee. Worth adding to `remote/workspace.rs`.
+  - **Worktree path keyed by stable project id, not repo basename.** Superset uses `~/.superset/worktrees/<projectId>/<branch>`; ours is `~/.codemux/worktrees/<repo-basename>/<branch>`, which can collide across two different repos sharing a basename. Re-keying by `project_uid` is a broader change to `workspace_paths.rs` (used by push/pull/adopt) — defer.
+
+## Touch points
+
+- `src-tauri/src/remote/git.rs` (new, done), `remote/tools/mod.rs` (done)
+- `src-tauri/src/hosts_inventory.rs` (carry real `path`), `database.rs` (sync column + upsert COALESCE), `state.rs`/`commands/workspace.rs` (adopted workspace carries origin path), `commands/hosts.rs` (`workspace_pull_back_impl` uses it), `commands/workspaces_sync.rs` (adoption error propagation)

--- a/docs/plans/vexis-skill-draft.md
+++ b/docs/plans/vexis-skill-draft.md
@@ -1,0 +1,58 @@
+# Vexis `codemux-delegation` skill — proposed additions (hand to user)
+
+The skill on `pandora` (`~/vexis-workspace/skills/software-dev/codemux-delegation/SKILL.md`)
+assumes the project already exists as a git repo and tells the agent to call
+`mcp__codemux__worktree_create` — which does NOT exist on the remote
+`codemux-remote mcp` surface. Two additions fix the gaps. (Not applied on
+pandora — paste/adapt as you see fit.)
+
+## 1. New-project bootstrap (add as a step BEFORE "Standard flow (new work)")
+
+> ### Bootstrapping a brand-new project
+>
+> If the project does not exist yet as a git repository, create it first —
+> `worktree_create`/`worktree add` need a repo with at least one commit on a
+> base branch:
+>
+> 1. Choose a normal project root: `~/projects/<name>` (NOT under
+>    `~/.codemux/worktrees/`, which is reserved for per-branch worktrees).
+> 2. Via `terminal_spawn` + `terminal_write` (or your shell tools):
+>    ```sh
+>    mkdir -p ~/projects/<name> && cd ~/projects/<name>
+>    git init --initial-branch=main
+>    git config user.email "<you>" && git config user.name "<you>"   # if not global
+>    # ...scaffold initial files...
+>    git add -A && git commit -m "init"
+>    # If there are no files to commit yet, still make an empty first
+>    # commit so `main` is forkable: git commit --allow-empty -m "init"
+>    ```
+> 3. Only after `main` has a commit do you create worktrees/workspaces.
+>
+> A repo with NO initial commit cannot be forked into a worktree — always
+> make the first commit on `main`.
+
+## 2. Correct the remote tool surface (replace the `worktree_create` bullet in "Standard flow")
+
+> 3. **Create worktree + workspace.**
+>    - On a **desktop** Codemux MCP: call `mcp__codemux__worktree_create`
+>      (atomic: worktree + workspace + agent launch).
+>    - On a **remote host** (`codemux-remote mcp`): call
+>      `mcp__codemux__worktree_create` as well — it now exists on the
+>      headless surface (Codemux ≥ next release) and runs `git worktree add`
+>      under `~/.codemux/worktrees/<repo>/<branch>`, then registers the
+>      workspace. Params: `repo_path` (absolute repo root), `branch`
+>      (kebab-case), `new_branch: true`, `base: "main"`, optional `name`.
+>    - Fallback for older `codemux-remote` daemons without `worktree_create`:
+>      run `git worktree add ~/.codemux/worktrees/<repo>/<branch> -b <branch> main`
+>      in a terminal, THEN `workspace_create` with `path` = that worktree dir
+>      and `project_root` = the repo root (so it gets the shared project
+>      identity + `worktree` kind). Do NOT register a worktree at a path you
+>      never actually `git worktree add`-ed.
+
+## Why
+
+- The old skill presumed `main` already exists; a from-scratch project then
+  gets a worktree branched off an empty/absent base.
+- It named a desktop-only tool; on the remote the agent had to improvise,
+  and improvised paths (sibling dirs) don't match what the desktop pull
+  expects — contributing to the empty-pull symptom.

--- a/src-tauri/src/commands/hosts.rs
+++ b/src-tauri/src/commands/hosts.rs
@@ -797,7 +797,7 @@ pub async fn workspace_pull_back_impl(
     // Resolve State guards in a tight pre-await scope and capture
     // owned values so the State guards drop before any `.await`
     // (they are not Send).
-    let (host, ws_clone) = {
+    let (host, ws_clone, origin_path) = {
         let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
         let db: tauri::State<'_, DatabaseStore> = app.state();
         let snapshot = app_state.snapshot();
@@ -815,7 +815,20 @@ pub async fn workspace_pull_back_impl(
             .into_iter()
             .find(|h| h.id == host_id)
             .ok_or_else(|| format!("Host {host_id} no longer exists locally"))?;
-        (host, ws)
+        // The authoritative remote source path. For a workspace an agent
+        // CREATED on the host, this is its real on-host path (e.g.
+        // `/home/deus/projects/passpage`) — which is NOT the
+        // `~/.codemux/worktrees/<project>/<branch>` convention the desktop
+        // uses for workspaces it PUSHED. Pulling from the wrong (assumed)
+        // path is exactly what produced empty worktrees. Falls back to the
+        // convention when the sync row has no recorded origin path (the
+        // pushed-workspace case, where the two coincide).
+        let origin_path = db
+            .list_workspaces_sync_for_sync()
+            .into_iter()
+            .find(|r| r.workspace_id.as_deref() == Some(workspace_id.as_str()))
+            .and_then(|r| r.origin_path);
+        (host, ws, origin_path)
     };
     let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
     // Rename for compatibility with the original function body below
@@ -840,9 +853,16 @@ pub async fn workspace_pull_back_impl(
 
     #[cfg(unix)]
     {
-        let remote_path =
-            crate::ssh::conventional_remote_path(&project_name, &branch);
-        let remote_path_str = remote_path.to_string_lossy().to_string();
+        // Prefer the workspace's REAL recorded path on the host
+        // (`origin_path`, set by the inventory poller from the daemon
+        // registry). Only reconstruct the conventional path when we have
+        // no recorded origin — i.e. a workspace this device pushed, where
+        // the remote path IS the conventional one.
+        let remote_path_str = origin_path.clone().unwrap_or_else(|| {
+            crate::ssh::conventional_remote_path(&project_name, &branch)
+                .to_string_lossy()
+                .to_string()
+        });
         let opts = crate::ssh::PullOptions::new(
             &host.ssh_target,
             &remote_path_str,
@@ -976,7 +996,7 @@ pub async fn workspace_pull_back_impl(
     }
     #[cfg(not(unix))]
     {
-        let _ = (local_worktree, project_name, branch, host);
+        let _ = (local_worktree, project_name, branch, host, origin_path);
         Ok(WorkspacePullOutcome {
             ok: false,
             message: "SSH transport is Unix-only for now.".into(),

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -414,6 +414,25 @@ pub async fn workspaces_adopt_synced(
     app: tauri::AppHandle,
     server_id: String,
 ) -> Result<AdoptOutcome, String> {
+    // A `worktree` row can't be pulled as a standalone directory: its
+    // `.git` is a gitfile pointing at a parent repo that doesn't exist
+    // on this device, so a bare rsync of the worktree dir lands with
+    // broken git. Adopt the PARENT repo (rsync incl. `.git`) and
+    // recreate the linked worktree locally instead. `main`/standard
+    // rows fall through to the single-dir pull below.
+    let is_worktree = {
+        let db: tauri::State<'_, DatabaseStore> = app.state();
+        db.list_workspaces_sync_for_sync()
+            .into_iter()
+            .find(|r| r.server_id.as_deref() == Some(server_id.as_str()))
+            .and_then(|r| r.workspace_kind)
+            .as_deref()
+            == Some("worktree")
+    };
+    if is_worktree {
+        return adopt_worktree_via_repo_rsync(app, server_id).await;
+    }
+
     // Step 1+2+3+4+5: do all the sync DB lookups in a scope so the
     // State<'_> guard is dropped before we await anything (Tauri's
     // State is not Send across awaits).
@@ -555,6 +574,193 @@ pub async fn workspaces_adopt_synced(
         worktree_path,
         message: pull_outcome.message,
     })
+}
+
+/// Adopt a `worktree` row by materialising its PARENT repo locally and
+/// recreating the linked worktree — the "whole-repo + recreate" model.
+///
+/// Why not just rsync the worktree dir: a worktree's `.git` is a gitfile
+/// pointing at `<parent>/.git/worktrees/<name>`, a path that only exists
+/// on the originating host. Copied alone it's a broken repo. And the
+/// parent may be a **local-only** repo (no remote), so we can't clone it
+/// — rsync is the only way to get the objects + branch refs.
+///
+/// Flow (mirrors `workspaces_adopt_via_clone`, but the source is an SSH
+/// host path instead of a git remote URL):
+///   1. Resolve the row + host; idempotent short-circuit if already adopted.
+///   2. rsync the parent repo (incl. `.git`) from `project_path` on the
+///      host into `~/.codemux/projects/<repo>` — skipped if a local repo
+///      is already there (adopting a second worktree of the same project).
+///   3. `git worktree prune` (drops the host's stale worktree entries),
+///      then `git worktree add` for the branch into the canonical
+///      `~/.codemux/worktrees/<repo>/<branch>` path.
+///   4. Register a local workspace pointing at the recreated worktree and
+///      link the sync row.
+async fn adopt_worktree_via_repo_rsync(
+    app: tauri::AppHandle,
+    server_id: String,
+) -> Result<AdoptOutcome, String> {
+    // ── resolve row + host + paths (no awaits) ──
+    let (host, remote_repo_path, local_project_path, branch, title) = {
+        let db: tauri::State<'_, DatabaseStore> = app.state();
+        let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
+
+        let row = db
+            .list_workspaces_sync_for_sync()
+            .into_iter()
+            .find(|r| r.server_id.as_deref() == Some(server_id.as_str()))
+            .ok_or_else(|| format!("Synced workspace not found: {server_id}"))?;
+
+        // Idempotency: already adopted and still live → return it.
+        if let Some(existing) = row.workspace_id.as_deref() {
+            let snapshot = app_state.snapshot();
+            if let Some(w) = snapshot
+                .workspaces
+                .iter()
+                .find(|w| w.workspace_id.0 == existing)
+            {
+                let worktree = w
+                    .worktree_path
+                    .clone()
+                    .unwrap_or_else(|| w.cwd.clone());
+                return Ok(AdoptOutcome {
+                    workspace_id: existing.to_string(),
+                    worktree_path: worktree,
+                    message: "Workspace already adopted on this device.".into(),
+                });
+            }
+        }
+
+        let host_server_id = row.host_server_id.as_deref().ok_or_else(|| {
+            "This workspace has no host; clone-based adoption is not \
+             implemented yet (Phase 3 of the workspaces-sync rollout)."
+                .to_string()
+        })?;
+        let local_host = db
+            .list_hosts()
+            .into_iter()
+            .find(|h| h.server_id.as_deref() == Some(host_server_id))
+            .ok_or_else(|| {
+                format!(
+                    "host_not_configured: The host this workspace lives on \
+                     (host_server_id={host_server_id}) is not configured on \
+                     this device yet. Add it in Settings → Devices."
+                )
+            })?;
+
+        // For a worktree row, `project_path` is the PARENT repo's path on
+        // the host (the reconcile maps it from the daemon's project_root).
+        // That is the rsync source — NOT `origin_path` (the worktree dir).
+        let remote_repo_path = row.project_path.clone().ok_or_else(|| {
+            "no_parent_repo: this worktree has no recorded parent repo path \
+             on the host, so it can't be reconstructed. Re-poll the host or \
+             adopt its main checkout first."
+                .to_string()
+        })?;
+        let project_name = std::path::Path::new(&remote_repo_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .filter(|n| !n.is_empty())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| row.title.clone());
+        let branch = row.git_branch.clone().unwrap_or_else(|| "main".to_string());
+        let home = dirs::home_dir().ok_or_else(|| "home directory unavailable".to_string())?;
+        let local_project_path = home.join(".codemux").join("projects").join(&project_name);
+
+        (
+            local_host,
+            remote_repo_path,
+            local_project_path,
+            branch,
+            row.title.clone(),
+        )
+    };
+
+    #[cfg(unix)]
+    {
+        // ── 2. rsync the parent repo (incl .git) unless already present ──
+        let already_local = local_project_path.join(".git").exists();
+        if !already_local {
+            if let Err(e) = std::fs::create_dir_all(&local_project_path) {
+                return Err(format!(
+                    "could not create local project dir {}: {e}",
+                    local_project_path.display()
+                ));
+            }
+            let opts = crate::ssh::PullOptions::new(
+                &host.ssh_target,
+                &remote_repo_path,
+                &local_project_path,
+            );
+            match crate::ssh::pull_workspace_back(opts).await {
+                crate::ssh::PullResult::Pulled { .. } => {}
+                crate::ssh::PullResult::RemoteNotFound { path } => {
+                    let _ = std::fs::remove_dir_all(&local_project_path);
+                    return Err(format!(
+                        "Remote repo not found at {path}. The host may have been \
+                         wiped or the project moved."
+                    ));
+                }
+                crate::ssh::PullResult::RsyncFailed { reason } => {
+                    return Err(format!("rsync failed: {reason}"));
+                }
+                crate::ssh::PullResult::HostUnreachable { reason } => {
+                    return Err(format!("Host unreachable: {reason}"));
+                }
+            }
+        }
+
+        // ── 3. prune stale host worktrees + recreate the branch locally ──
+        let repo_for_blocking = local_project_path.clone();
+        let branch_for_blocking = branch.clone();
+        let worktree_actual_path = tokio::task::spawn_blocking(move || {
+            crate::git::git_recreate_worktree_for_adopted_repo(
+                &repo_for_blocking,
+                &branch_for_blocking,
+            )
+        })
+        .await
+        .map_err(|e| format!("worktree recreate join failed: {e}"))??;
+
+        // ── 4. register a local workspace + link the sync row ──
+        let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
+        let db: tauri::State<'_, DatabaseStore> = app.state();
+        let local_project_str = local_project_path.to_string_lossy().to_string();
+        let workspace_id = app_state.create_synced_workspace_shell(
+            title,
+            host.id,
+            Some(local_project_str.clone()),
+            worktree_actual_path.clone(),
+            Some(branch.clone()),
+        );
+        // It's local right away (the files are already on disk) — clear
+        // host_id so panes spawn against the local pty-daemon.
+        app_state.set_workspace_host_id(&workspace_id.0, None)?;
+        db.link_workspace_sync_to_local(&server_id, &workspace_id.0)?;
+        drop(app_state);
+        drop(db);
+
+        if let Err(e) = crate::workspaces_sync::try_sync_with_app(&app).await {
+            eprintln!(
+                "[workspaces-sync] post-adopt (worktree) sync failed (will retry): {e}"
+            );
+        }
+        crate::state::emit_app_state(&app);
+
+        Ok(AdoptOutcome {
+            workspace_id: workspace_id.0,
+            worktree_path: worktree_actual_path,
+            message: format!(
+                "Adopted worktree: synced repo to {local_project_str} and \
+                 recreated the '{branch}' worktree."
+            ),
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (host, remote_repo_path, local_project_path, branch, title);
+        Err("SSH transport is Unix-only for now.".into())
+    }
 }
 
 /// Adopt a sibling-device workspace into this device via the
@@ -811,6 +1017,7 @@ mod tests {
             origin_uid: Some("uuid-1".into()),
             project_uid: None,
             workspace_kind: None,
+            origin_path: project_path.map(|s| s.into()),
             created_at: "2026-01-01 00:00:00".into(),
             updated_at: "2026-01-01 00:00:00".into(),
             deleted_at: None,

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -371,6 +371,7 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
         // persists them from the server row.
         "ALTER TABLE workspaces_sync ADD COLUMN project_uid TEXT",
         "ALTER TABLE workspaces_sync ADD COLUMN workspace_kind TEXT",
+        "ALTER TABLE workspaces_sync ADD COLUMN origin_path TEXT",
     ] {
         if let Err(e) = conn.execute(stmt, []) {
             let msg = e.to_string();
@@ -944,6 +945,17 @@ pub struct WorkspaceSyncRecord {
     /// `"main"` | `"worktree"`. Local-only column, same lifecycle as
     /// `project_uid`.
     pub workspace_kind: Option<String>,
+    /// The workspace's ACTUAL absolute path on the originating host, as
+    /// reported by the remote daemon (`remote::workspace::Workspace.path`).
+    /// Set only by the host-inventory poller for remote-discovered rows;
+    /// null otherwise. This is the authoritative rsync source for pulling
+    /// an agent-created workspace back — unlike `project_path` (which is
+    /// the project root, not the worktree dir) and unlike the reconstructed
+    /// `~/.codemux/worktrees/<project>/<branch>` convention (which only
+    /// matches workspaces the desktop *pushed*, not ones the agent created
+    /// at an arbitrary path on the host). Local-only column, same
+    /// lifecycle as `origin_uid`; survives cloud pulls untouched.
+    pub origin_path: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
@@ -990,7 +1002,7 @@ impl DatabaseStore {
         conn.query_row(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
              FROM workspaces_sync WHERE id = ?1",
             params![id],
             row_to_workspace_sync,
@@ -1067,7 +1079,7 @@ impl DatabaseStore {
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
              FROM workspaces_sync
              WHERE user_id = 'local' AND deleted_at IS NULL
              ORDER BY updated_at DESC",
@@ -1087,7 +1099,7 @@ impl DatabaseStore {
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
              FROM workspaces_sync
              WHERE user_id = 'local'",
         ) {
@@ -1105,7 +1117,7 @@ impl DatabaseStore {
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
              FROM workspaces_sync
              WHERE user_id = 'local' AND dirty = 1",
         ) {
@@ -1174,11 +1186,19 @@ impl DatabaseStore {
         let conn = self.conn.lock().unwrap();
         let updated = conn
             .execute(
+                // `project_uid`/`workspace_kind` are server-authoritative
+                // ONLY when the server actually has a value. A null from
+                // the cloud must never clobber a known-good local identity
+                // that the host-inventory poller derived (the cloud schema
+                // may carry null for older rows). COALESCE(server, local)
+                // keeps the local value when the server's is null.
                 "UPDATE workspaces_sync
                  SET title = ?1, host_server_id = ?2, project_path = ?3,
                      project_remote = ?4, git_branch = ?5, git_head_sha = ?6,
                      created_at = ?7, updated_at = ?8,
-                     deleted_at = ?9, project_uid = ?11, workspace_kind = ?12,
+                     deleted_at = ?9,
+                     project_uid = COALESCE(?11, project_uid),
+                     workspace_kind = COALESCE(?12, workspace_kind),
                      dirty = 0
                  WHERE user_id = 'local' AND server_id = ?10",
                 params![
@@ -1292,7 +1312,7 @@ impl DatabaseStore {
                 "SELECT id, server_id, workspace_id, title, host_server_id,
                         project_path, project_remote, git_branch, git_head_sha,
                         created_at, updated_at, deleted_at, dirty, origin_uid,
-                        project_uid, workspace_kind
+                        project_uid, workspace_kind, origin_path
                  FROM workspaces_sync
                  WHERE user_id = 'local'
                    AND host_server_id = ?1
@@ -1322,14 +1342,15 @@ impl DatabaseStore {
         git_branch: Option<&str>,
         project_uid: Option<&str>,
         workspace_kind: Option<&str>,
+        origin_path: Option<&str>,
     ) -> Result<WorkspaceSyncRecord, String> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO workspaces_sync
                 (user_id, workspace_id, title, host_server_id,
                  project_path, project_remote, git_branch, origin_uid,
-                 project_uid, workspace_kind, dirty)
-             VALUES ('local', NULL, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1)",
+                 project_uid, workspace_kind, origin_path, dirty)
+             VALUES ('local', NULL, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1)",
             params![
                 title,
                 host_server_id,
@@ -1339,6 +1360,7 @@ impl DatabaseStore {
                 origin_uid,
                 project_uid,
                 workspace_kind,
+                origin_path,
             ],
         )
         .map_err(|e| format!("Failed to insert remote-discovered workspace sync row: {e}"))?;
@@ -1346,7 +1368,7 @@ impl DatabaseStore {
         conn.query_row(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
              FROM workspaces_sync WHERE id = ?1",
             params![id],
             row_to_workspace_sync,
@@ -1371,6 +1393,7 @@ impl DatabaseStore {
         git_branch: Option<&str>,
         project_uid: Option<&str>,
         workspace_kind: Option<&str>,
+        origin_path: Option<&str>,
     ) -> Result<(), String> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
@@ -1378,6 +1401,7 @@ impl DatabaseStore {
              SET title = ?1, project_path = ?2,
                  project_remote = ?3, git_branch = ?4,
                  project_uid = ?5, workspace_kind = ?6,
+                 origin_path = ?8,
                  updated_at = datetime('now'), dirty = 1
              WHERE id = ?7 AND deleted_at IS NULL",
             params![
@@ -1387,7 +1411,8 @@ impl DatabaseStore {
                 git_branch,
                 project_uid,
                 workspace_kind,
-                id
+                id,
+                origin_path,
             ],
         )
         .map_err(|e| format!("Failed to update remote-discovered row: {e}"))?;
@@ -1407,7 +1432,7 @@ impl DatabaseStore {
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
              FROM workspaces_sync
              WHERE user_id = 'local'
                AND host_server_id = ?1
@@ -1466,6 +1491,7 @@ fn row_to_workspace_sync(
         origin_uid: row.get(13)?,
         project_uid: row.get(14)?,
         workspace_kind: row.get(15)?,
+        origin_path: row.get(16)?,
     })
 }
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1667,6 +1667,33 @@ fn existing_worktree_matches(repo_path: &Path, target_path: &str, branch: &str) 
     path_matches(&current_path) && current_branch.as_deref() == Some(&expected_branch_ref)
 }
 
+/// Recreate a worktree for an EXISTING branch inside a repo that was
+/// copied from another machine (e.g. rsynced from a `codemux-remote`
+/// host during worktree adoption).
+///
+/// Such a repo carries the host's worktree admin entries under
+/// `.git/worktrees/<name>/`, each pointing at an absolute path that
+/// doesn't exist on this machine. Left in place, those stale entries
+/// make git think the branch is "already checked out" and refuse a
+/// fresh `git worktree add`. We `git worktree prune` first (drops every
+/// registration whose path is gone — which is all of them, since they
+/// reference the source machine), then add a clean local worktree for
+/// the branch via `git_create_worktree`.
+///
+/// Returns the local worktree path. The branch must already exist in
+/// the repo (it came over with the rsync); we attach it, never create.
+pub fn git_recreate_worktree_for_adopted_repo(
+    repo_path: &Path,
+    branch: &str,
+) -> Result<String, String> {
+    // Prune stale worktree registrations inherited from the source
+    // machine. Permissive: a fresh clone with no worktrees is a no-op,
+    // and any failure here shouldn't block the add (which will surface
+    // its own clear error if the state is genuinely broken).
+    let _ = run_git_permissive(repo_path, &["worktree", "prune"]);
+    git_create_worktree(repo_path, branch, false, None, None)
+}
+
 pub fn git_create_worktree(
     repo_path: &Path,
     branch: &str,
@@ -2196,6 +2223,42 @@ C  source.txt -> copy.txt";
 
         let branches_after = git_list_branches(&repo, false).expect("list branches after");
         assert!(!branches_after.contains(&"feature-test".to_string()), "branch should be deleted");
+    }
+
+    #[test]
+    fn test_recreate_worktree_for_adopted_repo_prunes_stale_host_entry() {
+        // Simulate a repo rsynced from a codemux-remote host during
+        // worktree adoption: it carries a worktree admin entry for the
+        // branch, but that entry points at the HOST's path, which does
+        // not exist on this machine. A naive `git worktree add` for the
+        // branch then fails ("already used by worktree"). The recreate
+        // helper must prune the stale entry and add a clean local one.
+        let (_dir, repo) = setup_test_repo();
+        // A branch that "came over with the rsync".
+        run_git(&repo, &["branch", "adopted-feature"]).expect("create branch");
+        // A worktree at a path we then delete → stale, prunable, and it
+        // holds the branch "checked out" until pruned.
+        let ghost = _dir.path().join("ghost-host-worktree");
+        run_git(
+            &repo,
+            &["worktree", "add", &ghost.to_string_lossy(), "adopted-feature"],
+        )
+        .expect("add ghost worktree");
+        std::fs::remove_dir_all(&ghost).expect("delete ghost worktree dir");
+
+        // Recreate: prunes the ghost, adds a clean local worktree.
+        let wt_path = git_recreate_worktree_for_adopted_repo(&repo, "adopted-feature")
+            .expect("recreate worktree for adopted repo");
+        let wt = PathBuf::from(&wt_path);
+        assert!(wt.exists(), "recreated worktree dir should exist");
+        assert!(wt.join(".git").is_file(), "should be a linked worktree (.git file)");
+
+        // It's attached to the right branch.
+        let current = run_git_permissive(&wt, &["branch", "--show-current"]);
+        assert_eq!(current.trim(), "adopted-feature");
+
+        // Cleanup so we don't leave a worktree under the real ~/.codemux.
+        let _ = git_remove_worktree(&wt, Some("adopted-feature"), true);
     }
 
     #[test]

--- a/src-tauri/src/hosts_inventory.rs
+++ b/src-tauri/src/hosts_inventory.rs
@@ -389,6 +389,11 @@ pub fn reconcile_host_inventory(
         let project_uid = ws.project_uid.as_deref();
         let workspace_kind = ws.kind.as_deref();
         let branch = ws.branch.as_deref();
+        // The workspace's REAL absolute path on the host. Unlike
+        // `project_path` (which collapses to the project root for a
+        // worktree), this is the authoritative rsync source for pulling
+        // the workspace back. Always present — it's the daemon's `path`.
+        let origin_path = Some(ws.path.as_str());
 
         if let Some(existing) = local_by_uid.get(&ws.id) {
             // Only push an UPDATE when something actually changed —
@@ -399,7 +404,8 @@ pub fn reconcile_host_inventory(
                 || existing.project_remote.as_deref() != project_remote
                 || existing.git_branch.as_deref() != branch
                 || existing.project_uid.as_deref() != project_uid
-                || existing.workspace_kind.as_deref() != workspace_kind;
+                || existing.workspace_kind.as_deref() != workspace_kind
+                || existing.origin_path.as_deref() != origin_path;
             if changed {
                 if let Err(e) = db.update_remote_discovered_workspace_sync(
                     existing.id,
@@ -409,6 +415,7 @@ pub fn reconcile_host_inventory(
                     branch,
                     project_uid,
                     workspace_kind,
+                    origin_path,
                 ) {
                     eprintln!(
                         "[hosts_inventory] update failed for {host_server_id}/{}: {e}",
@@ -427,6 +434,7 @@ pub fn reconcile_host_inventory(
             branch,
             project_uid,
             workspace_kind,
+            origin_path,
         ) {
             eprintln!(
                 "[hosts_inventory] insert failed for {host_server_id}/{}: {e}",
@@ -727,6 +735,52 @@ mod tests {
             Some("/home/agent/projects/passpage"),
             "project_root must win over the worktree path basename"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn reconcile_records_real_origin_path_distinct_from_project_path() {
+        // The crux of the empty-pull bug: a worktree's `project_path`
+        // collapses to the PARENT repo, but the pull must rsync from the
+        // worktree's OWN on-host path. `origin_path` carries that real
+        // path verbatim so pull-back never reconstructs a wrong location.
+        let db = fresh_db();
+        let mut ws = make_remote("uid-wt", "passpage-ui-polish", Some("ui-polish-v1"));
+        ws.project_root = Some("/home/deus/projects/passpage".into());
+        ws.path = "/home/deus/projects/passpage-ui-polish".into();
+        let envelope = make_envelope(vec![ws]);
+
+        reconcile_host_inventory(&db, "host-3", &envelope);
+
+        let rows = db.list_remote_discovered_for_host("host-3");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].origin_path.as_deref(),
+            Some("/home/deus/projects/passpage-ui-polish"),
+            "origin_path must be the workspace's REAL on-host path (the rsync source)"
+        );
+        assert_eq!(
+            rows[0].project_path.as_deref(),
+            Some("/home/deus/projects/passpage"),
+            "project_path stays the parent repo — distinct from origin_path"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn reconcile_updates_origin_path_when_host_path_changes() {
+        // A daemon that re-homes a workspace (rare, but possible) must
+        // update origin_path in place — otherwise pull-back keeps using
+        // the stale source.
+        let db = fresh_db();
+        let mut ws = make_remote("uid-move", "proj", Some("main"));
+        ws.path = "/srv/old/proj".into();
+        reconcile_host_inventory(&db, "host-4", &make_envelope(vec![ws.clone()]));
+        ws.path = "/srv/new/proj".into();
+        let stats = reconcile_host_inventory(&db, "host-4", &make_envelope(vec![ws]));
+        assert_eq!(stats.updated, 1, "changed origin_path should trigger an update");
+        let rows = db.list_remote_discovered_for_host("host-4");
+        assert_eq!(rows[0].origin_path.as_deref(), Some("/srv/new/proj"));
     }
 
     #[test]

--- a/src-tauri/src/remote/git.rs
+++ b/src-tauri/src/remote/git.rs
@@ -1,0 +1,275 @@
+//! Minimal git worktree helper for the headless daemon.
+//!
+//! The desktop has a much richer `crate::git` (PR fetches, remote-ref
+//! resolution, dirty/unpushed guards). The headless daemon only needs
+//! the one operation the `worktree_create` MCP tool requires: take a
+//! repo + branch and produce a checked-out worktree under the same
+//! `~/.codemux/worktrees/<repo>/<branch>` convention the desktop uses,
+//! so an agent on a remote host gets the SAME atomic "fork a branch and
+//! work in it" affordance it has on the desktop.
+//!
+//! Deliberately narrow: no PR-number fetch, no upstream tracking. A
+//! remote host's projects are frequently local-only (no git remote), so
+//! the happy path is "create a new branch off `base` and check it out."
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Result of a successful worktree creation.
+#[derive(Debug, Clone)]
+pub struct CreatedWorktree {
+    /// Absolute path to the new worktree on disk.
+    pub worktree_path: PathBuf,
+    /// Absolute path to the repo root the worktree belongs to.
+    pub repo_root: PathBuf,
+    /// The branch the worktree is checked out on.
+    pub branch: String,
+}
+
+/// Run `git -C <dir> <args>`, returning trimmed stdout on success or a
+/// human-readable error (including git's stderr) on failure.
+fn run_git(dir: &Path, args: &[&str]) -> Result<String, String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map_err(|e| format!("failed to spawn git: {e}"))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(format!("git {} failed: {}", args.join(" "), stderr.trim()));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// Resolve the canonical git root of `repo_path` (follows into a
+/// worktree's parent). `None` when the path is not a git repository.
+pub fn git_root(repo_path: &Path) -> Option<PathBuf> {
+    run_git(repo_path, &["rev-parse", "--show-toplevel"])
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Sanitise a branch name into a single safe path segment. Mirrors the
+/// desktop's worktree-path sanitisation: ASCII-alphanumeric + `_ - .`
+/// survive, everything else (including `/`) becomes `-`.
+pub fn sanitize_branch_for_path(branch: &str) -> String {
+    let s: String = branch
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let s = s.trim_matches('-').to_string();
+    if s.is_empty() {
+        "branch".to_string()
+    } else {
+        s
+    }
+}
+
+/// The conventional worktree path for the headless daemon, matching the
+/// desktop: `<home>/.codemux/worktrees/<repo>/<branch>`. `home` is
+/// injected so this is unit-testable without touching the real HOME.
+pub fn conventional_worktree_path(home: &Path, repo_name: &str, branch: &str) -> PathBuf {
+    home.join(".codemux")
+        .join("worktrees")
+        .join(repo_name)
+        .join(sanitize_branch_for_path(branch))
+}
+
+/// Returns true iff `git worktree list --porcelain` reports an entry at
+/// `target` attached to `refs/heads/<branch>` — i.e. the worktree we'd
+/// create already exists for the same branch, so we can reuse it instead
+/// of letting `git worktree add` fail with "already exists".
+fn existing_worktree_matches(repo_root: &Path, target: &Path, branch: &str) -> bool {
+    let Ok(output) = run_git(repo_root, &["worktree", "list", "--porcelain"]) else {
+        return false;
+    };
+    let expected = format!("refs/heads/{branch}");
+    let mut cur_path: Option<PathBuf> = None;
+    let mut cur_branch: Option<String> = None;
+    let mut matched = false;
+    let mut eval = |p: &Option<PathBuf>, b: &Option<String>| {
+        if p.as_deref() == Some(target) && b.as_deref() == Some(expected.as_str()) {
+            matched = true;
+        }
+    };
+    for raw in output.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            eval(&cur_path, &cur_branch);
+            cur_path = None;
+            cur_branch = None;
+        } else if let Some(rest) = line.strip_prefix("worktree ") {
+            cur_path = Some(PathBuf::from(rest));
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            cur_branch = Some(rest.to_string());
+        }
+    }
+    eval(&cur_path, &cur_branch);
+    matched
+}
+
+/// Create (or reuse) a git worktree for `branch` off `repo_path`.
+///
+/// - `new_branch = true`: create a new branch `branch` based on `base`
+///   (defaults to the repo's current HEAD when `base` is None) and check
+///   it out in a fresh worktree.
+/// - `new_branch = false`: attach a worktree to an existing local
+///   `branch`.
+///
+/// The worktree lands at `<home>/.codemux/worktrees/<repo>/<branch>`.
+/// Idempotent: if that exact path is already a registered worktree for
+/// the same branch, it's returned as-is rather than erroring.
+pub fn create_worktree(
+    home: &Path,
+    repo_path: &Path,
+    branch: &str,
+    new_branch: bool,
+    base: Option<&str>,
+) -> Result<CreatedWorktree, String> {
+    if branch.trim().is_empty() {
+        return Err("branch is required".into());
+    }
+    let repo_root = git_root(repo_path)
+        .ok_or_else(|| format!("not a git repository: {}", repo_path.display()))?;
+    let repo_name = repo_root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "repo".to_string());
+
+    let worktree_path = conventional_worktree_path(home, &repo_name, branch);
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create worktree parent dir: {e}"))?;
+    }
+    let path_str = worktree_path.to_string_lossy().to_string();
+
+    // Reuse an already-registered worktree at the same path+branch.
+    if worktree_path.exists() && existing_worktree_matches(&repo_root, &worktree_path, branch) {
+        return Ok(CreatedWorktree {
+            worktree_path,
+            repo_root,
+            branch: branch.to_string(),
+        });
+    }
+
+    // Prune stale worktree registrations before adding. Without this, a
+    // branch still "claimed" by a registration whose directory was
+    // removed (manually, or by a half-finished teardown) makes
+    // `git worktree add` fail with "branch is already used by worktree at
+    // <missing-path>". This mirrors Superset's host-service, which prunes
+    // before every add for exactly this reason. Permissive: a clean repo
+    // with no stale entries is a no-op.
+    let _ = run_git(&repo_root, &["worktree", "prune"]);
+
+    if new_branch {
+        let mut args = vec!["worktree", "add", "-b", branch, path_str.as_str()];
+        if let Some(b) = base {
+            if !b.trim().is_empty() {
+                args.push(b);
+            }
+        }
+        run_git(&repo_root, &args)?;
+    } else {
+        run_git(&repo_root, &["worktree", "add", path_str.as_str(), branch])?;
+    }
+
+    Ok(CreatedWorktree {
+        worktree_path,
+        repo_root,
+        branch: branch.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Initialise a real git repo with one commit on `main` so worktree
+    /// operations have a base to branch from.
+    fn init_repo(dir: &Path) {
+        let run = |args: &[&str]| {
+            let out = Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .expect("git spawn");
+            assert!(out.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&out.stderr));
+        };
+        run(&["init", "--initial-branch=main"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(dir.join("README.md"), "hi").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "init"]);
+    }
+
+    #[test]
+    fn sanitize_branch_replaces_slashes_and_trims() {
+        assert_eq!(sanitize_branch_for_path("feat/login-bug"), "feat-login-bug");
+        assert_eq!(sanitize_branch_for_path("--weird--"), "weird");
+        assert_eq!(sanitize_branch_for_path(""), "branch");
+        assert_eq!(sanitize_branch_for_path("a_b.c-1"), "a_b.c-1");
+    }
+
+    #[test]
+    fn conventional_path_matches_desktop_layout() {
+        let home = Path::new("/home/x");
+        assert_eq!(
+            conventional_worktree_path(home, "passpage", "ui/polish"),
+            Path::new("/home/x/.codemux/worktrees/passpage/ui-polish")
+        );
+    }
+
+    #[test]
+    fn git_root_none_for_non_repo() {
+        let dir = TempDir::new().unwrap();
+        assert!(git_root(dir.path()).is_none());
+    }
+
+    #[test]
+    fn create_new_branch_worktree_and_reuse_is_idempotent() {
+        let repo = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        init_repo(repo.path());
+
+        let created = create_worktree(home.path(), repo.path(), "feature-x", true, Some("main"))
+            .expect("create worktree");
+        assert!(created.worktree_path.exists());
+        assert!(created.worktree_path.join("README.md").exists(), "worktree is populated");
+        assert!(created.worktree_path.join(".git").is_file(), "linked worktree gitfile");
+        assert_eq!(created.branch, "feature-x");
+        assert_eq!(created.repo_root, git_root(repo.path()).unwrap());
+
+        // Re-asking for the same branch reuses the path instead of erroring.
+        let again = create_worktree(home.path(), repo.path(), "feature-x", true, Some("main"))
+            .expect("reuse worktree");
+        assert_eq!(again.worktree_path, created.worktree_path);
+    }
+
+    #[test]
+    fn create_worktree_rejects_non_repo() {
+        let not_repo = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        let err = create_worktree(home.path(), not_repo.path(), "x", true, None).unwrap_err();
+        assert!(err.contains("not a git repository"), "got: {err}");
+    }
+
+    #[test]
+    fn create_worktree_requires_branch() {
+        let repo = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        init_repo(repo.path());
+        let err = create_worktree(home.path(), repo.path(), "  ", true, None).unwrap_err();
+        assert!(err.contains("branch is required"), "got: {err}");
+    }
+}

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -34,6 +34,7 @@
 
 pub mod auth;
 pub mod config;
+pub mod git;
 pub mod identity;
 pub mod manifest;
 pub mod mcp;

--- a/src-tauri/src/remote/tools/mod.rs
+++ b/src-tauri/src/remote/tools/mod.rs
@@ -53,6 +53,22 @@ pub fn catalog() -> Vec<ToolSpec> {
             }),
         },
         ToolSpec {
+            name: "worktree_create",
+            description: "Create a git worktree + register a Codemux workspace in one call — the headless equivalent of the desktop's worktree_create. Runs `git worktree add` under ~/.codemux/worktrees/<repo>/<branch> and records the resulting workspace. Use this (NOT workspace_create) to fork a branch off an existing git repo on this host. For a brand-new project, first `git init` a folder (e.g. via terminal_spawn/terminal_write), then call this against it.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "repo_path": { "type": "string", "description": "Absolute path to the existing git repository root to fork from." },
+                    "branch": { "type": "string", "description": "Branch name for the worktree (kebab-case recommended)." },
+                    "new_branch": { "type": "boolean", "description": "Create a new branch (true, default) or attach an existing local branch (false)." },
+                    "base": { "type": "string", "description": "Base ref for a new branch (e.g. \"main\"). Defaults to the repo's current HEAD." },
+                    "name": { "type": "string", "description": "Human-readable workspace label. Defaults to the worktree dir basename." }
+                },
+                "required": ["repo_path", "branch"],
+                "additionalProperties": false
+            }),
+        },
+        ToolSpec {
             name: "workspace_list",
             description: "List every workspace registered with this daemon, newest first.",
             input_schema: json!({ "type": "object", "properties": {}, "additionalProperties": false }),
@@ -187,6 +203,7 @@ pub fn dispatch(
 ) -> ToolResult {
     match name {
         "workspace_create" => workspace_create(params, workspaces),
+        "worktree_create" => worktree_create(params, workspaces),
         "workspace_list" => workspace_list(workspaces),
         "workspace_info" => workspace_info(params, workspaces),
         "workspace_update" => workspace_update(params, workspaces),
@@ -214,6 +231,51 @@ fn workspace_create(params: &Value, store: &WorkspaceStore) -> ToolResult {
         serde_json::from_value(params.clone()).map_err(|e| ToolError::invalid(e.to_string()))?;
     let ws = store
         .create(input.name, input.path, input.branch, input.project_root)
+        .map_err(workspace_err)?;
+    Ok(json!({ "workspace": ws }))
+}
+
+#[derive(Debug, Deserialize)]
+struct WorktreeCreateInput {
+    repo_path: String,
+    branch: String,
+    #[serde(default)]
+    new_branch: Option<bool>,
+    #[serde(default)]
+    base: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+fn worktree_create(params: &Value, store: &WorkspaceStore) -> ToolResult {
+    let input: WorktreeCreateInput =
+        serde_json::from_value(params.clone()).map_err(|e| ToolError::invalid(e.to_string()))?;
+
+    // The daemon process owns HOME; resolve the worktree root against it
+    // so a new worktree lands at the same `~/.codemux/worktrees/...`
+    // location the desktop uses.
+    let home = dirs::home_dir()
+        .ok_or_else(|| ToolError::internal("could not resolve home directory"))?;
+
+    let created = super::git::create_worktree(
+        &home,
+        std::path::Path::new(&input.repo_path),
+        &input.branch,
+        input.new_branch.unwrap_or(true),
+        input.base.as_deref(),
+    )
+    .map_err(ToolError::invalid)?;
+
+    // Register the worktree as a workspace. `project_root` is the parent
+    // repo (so the daemon stamps the shared project_uid + `worktree`
+    // kind), exactly as the desktop worktree-create path does.
+    let ws = store
+        .create(
+            input.name,
+            created.worktree_path.to_string_lossy().to_string(),
+            Some(created.branch),
+            Some(created.repo_root.to_string_lossy().to_string()),
+        )
         .map_err(workspace_err)?;
     Ok(json!({ "workspace": ws }))
 }
@@ -361,4 +423,111 @@ fn pty_err(e: super::pty::PtyError) -> ToolError {
 #[allow(dead_code)] // Workspace type re-exported only so external callers can name it
 pub fn _workspace_typename() -> &'static str {
     std::any::type_name::<Workspace>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    fn open_store(dir: &TempDir) -> WorkspaceStore {
+        WorkspaceStore::open(
+            &dir.path().join("codemux.db"),
+            "test-host".into(),
+            dir.path().join("workspaces"),
+        )
+        .unwrap()
+    }
+
+    fn init_repo(dir: &std::path::Path) {
+        let run = |args: &[&str]| {
+            assert!(
+                Command::new("git")
+                    .arg("-C")
+                    .arg(dir)
+                    .args(args)
+                    .output()
+                    .unwrap()
+                    .status
+                    .success(),
+                "git {args:?}"
+            );
+        };
+        run(&["init", "--initial-branch=main"]);
+        run(&["config", "user.email", "t@e.com"]);
+        run(&["config", "user.name", "T"]);
+        std::fs::write(dir.join("f.txt"), "x").unwrap();
+        run(&["add", "."]);
+        run(&["commit", "-m", "init"]);
+    }
+
+    #[test]
+    #[serial]
+    fn worktree_create_dispatch_registers_worktree_workspace() {
+        // The handler resolves HOME via dirs::home_dir(); point it at a
+        // temp dir for the duration of this (serialized) test so the
+        // worktree lands somewhere disposable.
+        let home = TempDir::new().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", home.path());
+
+        let repo = TempDir::new().unwrap();
+        init_repo(repo.path());
+        let store_dir = TempDir::new().unwrap();
+        let store = open_store(&store_dir);
+
+        let params = json!({
+            "repo_path": repo.path().to_string_lossy(),
+            "branch": "feature/login",
+            "base": "main"
+        });
+        let out = worktree_create(&params, &store).expect("worktree_create");
+        let ws = &out["workspace"];
+
+        // Registered as a worktree of the repo, with a populated checkout
+        // under ~/.codemux/worktrees/<repo>/<branch>.
+        assert_eq!(ws["kind"], "worktree");
+        // The git branch name is preserved verbatim; only the on-disk
+        // path segment is sanitized (`feature/login` → `feature-login`).
+        assert_eq!(ws["branch"], "feature/login");
+        let path = ws["path"].as_str().unwrap();
+        assert!(path.contains("/.codemux/worktrees/"), "path: {path}");
+        assert!(path.ends_with("/feature-login"), "sanitized path segment: {path}");
+        assert!(std::path::Path::new(path).join("f.txt").exists(), "checkout populated");
+        assert_eq!(
+            ws["project_root"].as_str().unwrap(),
+            repo.path().to_string_lossy()
+        );
+        // main + worktree of the same local repo share a project_uid.
+        assert!(ws["project_uid"].is_string());
+
+        // restore HOME
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn worktree_create_dispatch_rejects_non_repo() {
+        let home = TempDir::new().unwrap();
+        let prev_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", home.path());
+
+        let not_repo = TempDir::new().unwrap();
+        let store_dir = TempDir::new().unwrap();
+        let store = open_store(&store_dir);
+        let params = json!({ "repo_path": not_repo.path().to_string_lossy(), "branch": "x" });
+        let err = worktree_create(&params, &store).unwrap_err();
+        assert_eq!(err.kind, "invalid_input");
+        assert!(err.message.contains("not a git repository"));
+
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
 }

--- a/src-tauri/src/workspaces_sync.rs
+++ b/src-tauri/src/workspaces_sync.rs
@@ -992,6 +992,7 @@ mod tests {
                 Some("main"),
                 Some("proj-uid-1"),
                 Some("worktree"),
+                Some("/srv/discovered/wt"),
             )
             .expect("insert remote-discovered");
         assert!(row.workspace_id.is_none(), "remote-discovered rows must have NULL workspace_id");
@@ -1039,6 +1040,7 @@ mod tests {
                 Some("main"),
                 None,
                 None,
+                None,
             )
             .unwrap();
         // Simulate the first push assigning a cloud server_id.
@@ -1057,6 +1059,7 @@ mod tests {
             Some("feature/x"),
             Some("proj-uid-z"),
             Some("main"),
+            Some("/srv/new/wt"),
         )
         .unwrap();
 
@@ -1090,11 +1093,11 @@ mod tests {
     #[serial]
     fn list_remote_discovered_for_host_is_scoped() {
         let db = fresh_db();
-        db.insert_remote_discovered_workspace_sync("host-A", "uid-1", "a1", None, None, None, None, None)
+        db.insert_remote_discovered_workspace_sync("host-A", "uid-1", "a1", None, None, None, None, None, None)
             .unwrap();
-        db.insert_remote_discovered_workspace_sync("host-A", "uid-2", "a2", None, None, None, None, None)
+        db.insert_remote_discovered_workspace_sync("host-A", "uid-2", "a2", None, None, None, None, None, None)
             .unwrap();
-        db.insert_remote_discovered_workspace_sync("host-B", "uid-3", "b1", None, None, None, None, None)
+        db.insert_remote_discovered_workspace_sync("host-B", "uid-3", "b1", None, None, None, None, None, None)
             .unwrap();
         // A local-on-this-device row with no origin_uid must not
         // appear in the host scope, even if it carries the same
@@ -1134,6 +1137,7 @@ mod tests {
                 "host-Z",
                 "uid-doomed",
                 "to-be-deleted",
+                None,
                 None,
                 None,
                 None,


### PR DESCRIPTION
## Problem

An agent on a `codemux-remote` host (e.g. a home server) builds a project and worktrees via the MCP. On the desktop they show up as "remote" workspaces, but **pulling/opening them lands an empty file tree** — no files, no git.

## Root cause

`workspace_pull_back_impl` rsynced from the **assumed** `~/.codemux/worktrees/<project>/<branch>` convention — which is only correct for workspaces the desktop *pushed*. Agent-created workspaces live at their **real** registered path on the host (e.g. `/home/deus/projects/passpage`), so the rsync source didn't exist → empty result. Compounding issues:
- the real on-host path was **dropped** during sync (a worktree row kept `project_root`, not the worktree's own path);
- `upsert_workspace_sync_from_server` was server-authoritative and could **clobber** a locally-derived `project_uid`/`workspace_kind` to null;
- the headless MCP had **no `worktree_create`**, so agents improvised `git worktree add` + `workspace_create`;
- a worktree's `.git` is a gitfile pointing at a parent repo that doesn't exist on the desktop → broken git even when files copy.

## Changes

- **`worktree_create` on the headless daemon** (`remote/git.rs` + MCP tool): `git worktree add` under `~/.codemux/worktrees/<repo>/<branch>`, registered with `kind=worktree` + shared `project_uid`, prune-before-add idempotency.
- **Carry the real on-host path** through sync via a new local-only `origin_path` column; pull-back rsyncs from it, falling back to the convention only for pushed workspaces (backward compatible).
- **`COALESCE` guard** in `upsert_workspace_sync_from_server` so a cloud null never wipes a locally-derived identity.
- **Worktree adoption for local-only repos**: rsync the parent repo (incl. `.git`), `git worktree prune`, then recreate the linked worktree locally so the gitfile resolves.

## Tests

New: headless worktree git/dispatch, `origin_path` threading through reconcile, prune-and-recreate of an rsynced-in stale worktree. Full lib suite green + headless-MCP e2e green (the only 2 lib failures are pre-existing/environmental, in files this PR doesn't touch).

## Notes

- Requires a release + host re-bootstrap to deploy the new `codemux-remote` daemon; the true desktop↔host pull is verified end-to-end only after that.
- Superset review captured in `docs/plans/remote-workspace-pull-fix.md`: validated our git-init bootstrap, deterministic identity, and prune-before-add; deferred a main-workspace normalize sweep and project-uid-keyed worktree paths as follow-ups. Vexis skill update drafted in `docs/plans/vexis-skill-draft.md`.