### PR TITLE
refactor(diff): drop redundant standalone Diff Viewer new-tab entry points

### DIFF
--- a/src/components/layout/tab-bar.tsx
+++ b/src/components/layout/tab-bar.tsx
@@ -354,14 +354,6 @@ export function TabBar({ workspace }: Props) {
                 Terminal
               </DropdownMenuItem>
               <DropdownMenuItem
-                onClick={() =>
-                  createTab(workspace.workspace_id, "diff").catch(console.error)
-                }
-              >
-                <GitCompare className="h-3.5 w-3.5 mr-2" />
-                Diff Viewer
-              </DropdownMenuItem>
-              <DropdownMenuItem
                 onClick={() => {
                   const surface = workspace.surfaces.find((s) => s.surface_id === workspace.active_surface_id);
                   if (surface) createBrowserPane(surface.active_pane_id).catch(console.error);

--- a/src/components/overlays/command-palette.tsx
+++ b/src/components/overlays/command-palette.tsx
@@ -173,16 +173,6 @@ export function CommandPalette({ open, onOpenChange }: Props) {
           >
             Open Browser
           </CommandItem>
-          <CommandItem
-            onSelect={() =>
-              run(() =>
-                ws &&
-                createTab(ws.workspace_id, "diff").catch(console.error),
-              )
-            }
-          >
-            Open Diff Viewer
-          </CommandItem>
         </CommandGroup>
 
         <CommandGroup heading="Search">


### PR DESCRIPTION
## What

Removes two entry points that opened a **standalone diff tab with no file selected**:

- The **Diff Viewer** item in the `+` new-tab dropdown (`tab-bar.tsx`)
- The **Open Diff Viewer** action in the command palette (`command-palette.tsx`)

## Why

Both created a `kind: "diff"` tab with no `filePath`, so they opened straight to the empty `"Select a file to view changes"` placeholder. There's no file list *inside* the diff tab (only prev/next arrows in the toolbar), so it was a dead-end on open.

The flow users actually use — clicking a changed file in the right-sidebar **Changes panel** — already creates (or reuses) a diff tab and pre-selects that file via `openDiff`. So the standalone entries were redundant.

This also matches **superset**, whose new-tab menu is only Terminal / Chat / Browser; diffs there always open from the Changes sidebar, never as a blank tab.

## Scope

Deletion-only (18 lines across 2 files). All diff infrastructure stays:
- `kind: "diff"` tab type, `DiffPane`, `diff-store`, toolbar, etc. are untouched
- Clicking a file in the Changes panel still opens the diff exactly as before
- `GitCompare` (tab icon) and `createTab` (terminal tab) remain in use in both files — no dangling imports