### PR TITLE
feat(terminal): PTY output flow control (backpressure)

### DIFF
--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -36,6 +36,7 @@ Disposal is driven by `useTerminalCacheGc` in `src/hooks/use-terminal-cache-gc.t
 - working directory set to workspace root on creation
 - comm log support for OpenFlow agent communication tracking
 - ANSI code stripping for log capture
+- **output flow control (backpressure)**: a fast producer (`yes`, `cat huge-file`, a verbose build, a runaway agent) can outrun xterm's parser. The renderer drains PTY bytes through `pumpWrites` one chunk per macrotask (so the main thread stays responsive — see `terminal-cache.ts`), but under a *sustained* visible flood the un-drained `writeQueue` would grow without bound. Flow control caps it: when the queued byte count crosses a HIGH watermark (16 MiB) the renderer calls `pause_pty_output`, which (on the daemon spawn path) tells the daemon to stop draining the PTY master fd — the kernel PTY buffer fills and the child blocks on `write()`, real backpressure to the producer. It resumes (`resume_pty_output`) once the queue drains below LOW (4 MiB). Without this, the daemon's broadcast channel would silently drop frames under lag, corrupting the rendered terminal until a redraw. **In-process (non-daemon) sessions treat pause/resume as a no-op** and keep their prior behavior. **Fail-safes** (so a dropped resume can never wedge a PTY): the daemon clears the paused flag on every `Attach` and on `Close`, plus a 10 s max-park backstop in the read loop; the renderer also resumes on detach/park so a backgrounded daemon agent is never left blocked. Wire protocol bumped to v2 (`SetFlowPaused`)
 - session close kills the PTY child and its entire process group via a single `killpg(pid, SIGKILL)` through the central `terminate_pty_session` helper, so closing a pane/tab/workspace also tears down any Claude CLI, MCP server, or rust-analyzer the shell spawned. `portable-pty`'s Unix spawn path calls `setsid()`, so the shell is a process-group leader and `killpg` reaches its children. A previous version did SIGTERM → 200ms grace → SIGKILL; that grace window is exactly the adversarial case for PID recycling (the shell handles SIGTERM and exits in ~50ms, the kernel reuses the PID for an unrelated process, our SIGKILL lands on the wrong process group), so the current code goes straight to SIGKILL and collapses the race to microseconds. `impl Drop for SessionRuntime` is a safety net that kills the tree with a warning if the normal close path is ever skipped.
 
 ## Windows-Specific Notes
@@ -54,7 +55,9 @@ Note: terminal scrollback is saved and restored across app restarts. See `docs/f
 
 ## Important Touch Points
 
-- `src-tauri/src/terminal/mod.rs` — PTY spawning, read/write, session management, comm log locks, dropped-chunk observability counter
+- `src-tauri/src/terminal/mod.rs` — PTY spawning, read/write, session management, comm log locks, dropped-chunk observability counter, `pause_pty_output` / `resume_pty_output` flow-control commands
+- `src-tauri/src/pty_daemon/{protocol,client,server}.rs` — `SetFlowPaused` wire request + per-session `flow_paused` flag gating the daemon read loop (with `Attach`/`Close`/max-park fail-safes)
+- `src/components/terminal/terminal-cache.ts` — `writeQueueBytes` accounting + HIGH/LOW watermark pause/resume in the channel callback and `pumpWrites`
 - `src-tauri/src/commands/workspace.rs` — `create_terminal_session`, `write_to_pty`, `resize_pty`, `attach_pty_output`
 - `src/components/terminal/TerminalPane.tsx` — DOM-attach wrapper, ResizeObserver, focus, status overlay, custom key handler
 - `src/components/terminal/terminal-cache.ts` — module-level Terminal cache, parking node, attach/detach/dispose API

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1500,6 +1500,8 @@ pub fn run() {
             terminal::get_terminal_status,
             terminal::attach_pty_output,
             terminal::detach_pty_output,
+            terminal::pause_pty_output,
+            terminal::resume_pty_output,
             terminal::write_to_pty,
             terminal::resize_pty,
             terminal::clear_agent_status,

--- a/src-tauri/src/pty_daemon/client.rs
+++ b/src-tauri/src/pty_daemon/client.rs
@@ -421,6 +421,35 @@ impl PtyDaemonClient {
         }
     }
 
+    /// Pause or resume the daemon's read loop for a session (terminal output
+    /// flow control — see `ClientRequest::SetFlowPaused`). Best-effort: an
+    /// unknown session id (the session may have just exited) surfaces as a
+    /// `Daemon` error the caller is expected to log-and-ignore.
+    pub async fn set_flow_paused(
+        &self,
+        session_id: String,
+        paused: bool,
+    ) -> Result<(), PtyDaemonError> {
+        let id = self.next_id();
+        match self
+            .send_request(
+                ClientRequest::SetFlowPaused {
+                    request_id: id,
+                    session_id,
+                    paused,
+                },
+                id,
+            )
+            .await?
+        {
+            ServerResponse::FlowPaused { .. } => Ok(()),
+            ServerResponse::Error { message, .. } => Err(PtyDaemonError::Daemon(message)),
+            other => Err(PtyDaemonError::Daemon(format!(
+                "unexpected response to SetFlowPaused: {other:?}"
+            ))),
+        }
+    }
+
     pub async fn shutdown(&self) -> Result<(), PtyDaemonError> {
         let id = self.next_id();
         match self
@@ -447,6 +476,7 @@ fn response_request_id(resp: &ServerResponse) -> u64 {
         | ServerResponse::Closed { request_id }
         | ServerResponse::Listed { request_id, .. }
         | ServerResponse::ShuttingDown { request_id }
+        | ServerResponse::FlowPaused { request_id }
         | ServerResponse::Error { request_id, .. } => *request_id,
     }
 }

--- a/src-tauri/src/pty_daemon/protocol.rs
+++ b/src-tauri/src/pty_daemon/protocol.rs
@@ -22,9 +22,12 @@ use serde::{Deserialize, Serialize};
 
 /// Daemon wire-protocol version. Bumped when the message shape changes in a
 /// backwards-incompatible way. Adoption on startup compares this against the
-/// running daemon's reported version and force-restarts on mismatch — the
-/// same pattern superset uses for their `EXPECTED_DAEMON_VERSION`.
-pub const PROTOCOL_VERSION: u32 = 1;
+/// running daemon's reported version and force-restarts on mismatch.
+///
+/// v2: added `SetFlowPaused` request + `FlowPaused` response (terminal
+/// output flow control). A v1 daemon doesn't understand the pause frame, so
+/// the supervisor must respawn it rather than silently no-op backpressure.
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Request from the Tauri app to the daemon. Every request carries a
 /// `request_id` so the client can correlate responses without ordering
@@ -102,6 +105,24 @@ pub enum ClientRequest {
     /// Ask the daemon to exit cleanly. All PTYs are killed first. Mostly
     /// used by tests; production code lets the daemon stay alive.
     Shutdown { request_id: u64 },
+
+    /// Pause or resume the daemon's read loop for a session (terminal output
+    /// flow control). When `paused=true` the daemon stops draining the PTY
+    /// master fd, so the child's `write()` blocks once the kernel PTY buffer
+    /// fills — real, kernel-level backpressure all the way to the producer.
+    ///
+    /// The Tauri app sends `paused=true` when its renderer-side xterm write
+    /// queue is backed up (a fast producer is outrunning the terminal's
+    /// parser) and `paused=false` once that queue drains. Idempotent.
+    ///
+    /// Fail-safe: the daemon auto-clears the paused flag on the next `Attach`
+    /// and on `Close`, plus a max-park backstop in the read loop, so a
+    /// crashed or wedged client can never leave a PTY paused forever.
+    SetFlowPaused {
+        request_id: u64,
+        session_id: String,
+        paused: bool,
+    },
 }
 
 /// One-shot reply to a `ClientRequest`. Always carries the originating
@@ -142,6 +163,12 @@ pub enum ServerResponse {
         sessions: Vec<DaemonSessionInfo>,
     },
     ShuttingDown {
+        request_id: u64,
+    },
+    /// Reply to `SetFlowPaused`. The flag is applied best-effort; an unknown
+    /// session id returns `Error` instead (the session may have just exited,
+    /// which the client treats as benign).
+    FlowPaused {
         request_id: u64,
     },
     /// Generic error reply. Used for any request that fails — unknown

--- a/src-tauri/src/pty_daemon/server.rs
+++ b/src-tauri/src/pty_daemon/server.rs
@@ -26,8 +26,9 @@ use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use std::collections::HashMap;
 use std::io::Read;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{broadcast, Mutex};
 
@@ -44,6 +45,18 @@ const OUTPUT_CHANNEL_CAPACITY: usize = 512;
 /// alt-screen TUI; for shell scrollback we rely on the existing
 /// `scrollback.rs` system.
 const REPLAY_BUFFER_BYTES: usize = 256 * 1024;
+
+/// Flow-control backstop: the maximum time the read loop will honour a
+/// `flow_paused` flag before force-resuming. A healthy client clears the
+/// flag within milliseconds (as soon as its xterm write queue drains), so
+/// this only ever fires when the client crashed, wedged, or lost the resume
+/// frame. Force-resuming bounds the worst case to "a stuck pane self-heals
+/// in ~this long" instead of "the child is blocked on write forever".
+const FLOW_MAX_PARK: Duration = Duration::from_secs(10);
+
+/// Poll interval for the read loop's pause gate. Small enough that a resume
+/// is observed promptly, large enough that a parked thread costs ~nothing.
+const FLOW_PARK_POLL: Duration = Duration::from_millis(10);
 
 /// Frames pushed through a session's broadcast channel. The reader thread
 /// emits `Output` for every PTY chunk; the waiter thread emits `Exited`
@@ -81,6 +94,12 @@ struct DaemonSession {
     /// by late attachers who connect after the child exited: they see this
     /// value in the `Listed` response instead of getting silence.
     exit_code: Arc<Mutex<Option<i32>>>,
+    /// Terminal output flow control. When `true`, the per-session read
+    /// thread stops draining the master fd, so the child blocks on write
+    /// once the kernel PTY buffer fills. Set/cleared by `SetFlowPaused`;
+    /// force-cleared on `Attach` and `Close` and by the read loop's
+    /// `FLOW_MAX_PARK` backstop. Shared (Arc) with the read thread.
+    flow_paused: Arc<AtomicBool>,
 }
 
 #[derive(Default)]
@@ -349,6 +368,13 @@ async fn handle_request(
                 }
             };
             drop(guard);
+            // Fail-safe: a fresh attach always resumes the read loop. If a
+            // previous client paused this session and then crashed or
+            // dropped its connection without resuming, the new client would
+            // otherwise inherit a wedged (paused) PTY. Clearing here means a
+            // stuck pause self-heals on the next attach (e.g. app restart,
+            // reopening the pane).
+            session.flow_paused.store(false, Ordering::Relaxed);
             // Subscribe to live output (after replay so we don't drop
             // anything in the gap).
             let rx = session.frame_tx.subscribe();
@@ -458,6 +484,11 @@ async fn handle_request(
                 guard.sessions.remove(&session_id)
             };
             if let Some(session) = session {
+                // Clear any pause first so a read thread parked in the
+                // flow-control gate wakes, reads EOF on the now-killed
+                // master, and exits — otherwise it would leak (parked
+                // forever holding the broadcast sender).
+                session.flow_paused.store(false, Ordering::Relaxed);
                 kill_session_pid(session.pid);
             }
             ServerResponse::Closed { request_id }
@@ -498,6 +529,26 @@ async fn handle_request(
                 std::process::exit(0);
             });
             ServerResponse::ShuttingDown { request_id }
+        }
+        ClientRequest::SetFlowPaused {
+            request_id,
+            session_id,
+            paused,
+        } => {
+            let session = {
+                let guard = state.lock().await;
+                guard.sessions.get(&session_id).cloned()
+            };
+            match session {
+                Some(session) => {
+                    session.flow_paused.store(paused, Ordering::Relaxed);
+                    ServerResponse::FlowPaused { request_id }
+                }
+                None => ServerResponse::Error {
+                    request_id,
+                    message: format!("unknown session {session_id}"),
+                },
+            }
         }
     }
 }
@@ -588,6 +639,7 @@ async fn spawn_pty(
     let (tx, _rx) = broadcast::channel::<SessionFrame>(OUTPUT_CHANNEL_CAPACITY);
     let replay = Arc::new(Mutex::new(Vec::with_capacity(REPLAY_BUFFER_BYTES)));
     let exit_code = Arc::new(Mutex::new(None));
+    let flow_paused = Arc::new(AtomicBool::new(false));
 
     let session = Arc::new(DaemonSession {
         session_id: session_id.clone(),
@@ -606,6 +658,7 @@ async fn spawn_pty(
         frame_tx: tx.clone(),
         replay: replay.clone(),
         exit_code: exit_code.clone(),
+        flow_paused: flow_paused.clone(),
     });
 
     {
@@ -617,10 +670,42 @@ async fn spawn_pty(
     let read_session_id = session_id.clone();
     let read_tx = tx.clone();
     let read_replay = replay;
+    let read_flow_paused = flow_paused;
     std::thread::spawn(move || {
         let mut reader = reader;
         let mut buf = [0u8; 8192];
+        // Tracks how long we've been continuously parked, for the
+        // `FLOW_MAX_PARK` backstop.
+        let mut paused_since: Option<Instant> = None;
         loop {
+            // Flow-control gate. While the attached client signals it's
+            // behind (its xterm parser can't keep up), we stop draining the
+            // master fd. The kernel PTY buffer then fills and the child's
+            // next `write()` blocks — backpressure straight to the producer,
+            // instead of us overflowing the broadcast channel and dropping
+            // frames (which corrupts the rendered terminal until a redraw).
+            //
+            // We poll the flag rather than block on a condvar: it guarantees
+            // we re-check even if a wake is somehow missed, and it lets the
+            // `FLOW_MAX_PARK` backstop fire so a wedged/crashed client can
+            // never block the child forever. Exit detection is unaffected —
+            // the waiter thread reaps the child and emits `Exited`
+            // independently of this loop.
+            while read_flow_paused.load(Ordering::Relaxed) {
+                let since = *paused_since.get_or_insert_with(Instant::now);
+                if since.elapsed() >= FLOW_MAX_PARK {
+                    eprintln!(
+                        "[codemux::pty_daemon] session {read_session_id} flow-paused for \
+                         >{}s — force-resuming (client wedged or resume frame lost)",
+                        FLOW_MAX_PARK.as_secs()
+                    );
+                    read_flow_paused.store(false, Ordering::Relaxed);
+                    break;
+                }
+                std::thread::sleep(FLOW_PARK_POLL);
+            }
+            paused_since = None;
+
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -2084,6 +2084,70 @@ pub fn detach_pty_output(
     Ok(())
 }
 
+/// Pause the daemon's PTY read loop for a session (terminal output flow
+/// control). The renderer calls this when a fast producer outruns its xterm
+/// write queue; pausing makes the child block on `write()` once the kernel
+/// PTY buffer fills — real backpressure instead of an ever-growing renderer
+/// queue.
+///
+/// In-process (non-daemon) sessions are a deliberate no-op: they keep
+/// today's behavior exactly, so this can never regress the fallback path.
+/// The daemon side fail-safes (resume on attach/close + a max-park backstop)
+/// guarantee a paused PTY always self-heals even if the matching resume is
+/// never delivered.
+#[tauri::command]
+pub fn pause_pty_output(
+    terminal_state: State<'_, PtyState>,
+    session_id: String,
+) -> Result<(), String> {
+    set_pty_flow_paused(&terminal_state.sessions, &session_id, true);
+    Ok(())
+}
+
+/// Resume the daemon's PTY read loop for a session. See `pause_pty_output`.
+/// Idempotent and a no-op for in-process sessions.
+#[tauri::command]
+pub fn resume_pty_output(
+    terminal_state: State<'_, PtyState>,
+    session_id: String,
+) -> Result<(), String> {
+    set_pty_flow_paused(&terminal_state.sessions, &session_id, false);
+    Ok(())
+}
+
+/// Route a flow-control pause/resume to the daemon that owns `session_id`.
+/// Fire-and-forget (mirrors `DaemonWriter`): flow control is advisory and
+/// not latency-sensitive, and a failure (e.g. the session just exited) is
+/// benign. No-op when the session has no daemon client (in-process path).
+fn set_pty_flow_paused(
+    sessions: &Arc<Mutex<HashMap<String, SessionRuntime>>>,
+    session_id: &str,
+    paused: bool,
+) {
+    #[cfg(unix)]
+    {
+        let client = with_existing_session_runtime(sessions, session_id, |runtime| {
+            runtime.daemon_client.clone()
+        })
+        .flatten();
+        if let Some(client) = client {
+            let session_id = session_id.to_string();
+            tauri::async_runtime::spawn(async move {
+                if let Err(error) = client.set_flow_paused(session_id.clone(), paused).await {
+                    eprintln!(
+                        "[codemux::terminal] flow-control set_flow_paused(paused={paused}) \
+                         for {session_id} failed (benign if the session just exited): {error}"
+                    );
+                }
+            });
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (sessions, session_id, paused);
+    }
+}
+
 #[tauri::command]
 pub fn write_to_pty(
     terminal_state: State<'_, PtyState>,

--- a/src-tauri/tests/pty_daemon_persistence.rs
+++ b/src-tauri/tests/pty_daemon_persistence.rs
@@ -349,3 +349,169 @@ async fn second_client_sees_session_from_first() {
     sleep(Duration::from_millis(100)).await;
     let _ = unsafe { libc::kill(pid_from_first as i32, libc::SIGKILL) };
 }
+
+// ── Terminal output flow control ──
+
+/// Drain everything currently buffered on `rx` until it goes quiet for
+/// `quiet` (no new bytes), or `max` elapses. Used to flush in-flight output
+/// (broadcast channel + socket + client mpsc) before measuring a steady
+/// state.
+async fn drain_until_quiet(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+    quiet: Duration,
+    max: Duration,
+) {
+    let hard_deadline = tokio::time::Instant::now() + max;
+    loop {
+        if tokio::time::Instant::now() >= hard_deadline {
+            break;
+        }
+        match tokio::time::timeout(quiet, rx.recv()).await {
+            Ok(Some(_)) => continue, // got bytes — keep draining
+            Ok(None) => break,       // channel closed
+            Err(_) => break,         // quiet window with no bytes
+        }
+    }
+}
+
+/// Count bytes received on `rx` over `dur`.
+async fn count_bytes_for(
+    rx: &mut tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+    dur: Duration,
+) -> usize {
+    let deadline = tokio::time::Instant::now() + dur;
+    let mut total = 0usize;
+    loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            break;
+        }
+        match tokio::time::timeout(deadline - now, rx.recv()).await {
+            Ok(Some(chunk)) => total += chunk.len(),
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+    total
+}
+
+/// The headline flow-control test: pausing a session stops the daemon from
+/// draining the PTY (so a flooding child blocks on write), and resuming lets
+/// output flow again. `yes` is the flood source — it writes "y\n" forever and
+/// blocks once the kernel PTY buffer fills behind a paused reader.
+#[tokio::test(flavor = "multi_thread")]
+async fn set_flow_paused_stops_and_resumes_output() {
+    let tmp = TempDir::new().unwrap();
+    let (_socket, client) = boot_daemon(&tmp).await;
+
+    let session_id = "flow-control-test".to_string();
+    client
+        .spawn(
+            session_id.clone(),
+            "ws-flow".to_string(),
+            vec!["yes".to_string()],
+            std::env::temp_dir().to_string_lossy().to_string(),
+            vec![],
+            24,
+            80,
+        )
+        .await
+        .expect("spawn yes");
+
+    let mut rx = client.attach(session_id.clone()).await.expect("attach");
+
+    // Phase 1 — flowing. `yes` floods; we should see plenty quickly.
+    let flowing = count_bytes_for(&mut rx, Duration::from_millis(300)).await;
+    assert!(
+        flowing > 50_000,
+        "expected a flood of output while flowing, got only {flowing} bytes"
+    );
+
+    // Pause, then flush whatever was already in flight (broadcast + socket +
+    // client mpsc) so we measure the steady paused state, not the backlog.
+    client
+        .set_flow_paused(session_id.clone(), true)
+        .await
+        .expect("pause");
+    drain_until_quiet(
+        &mut rx,
+        Duration::from_millis(250),
+        Duration::from_secs(4),
+    )
+    .await;
+
+    // Phase 2 — paused. The read thread is parked, the kernel PTY buffer is
+    // full, and `yes` is blocked on write, so essentially nothing new arrives.
+    // (FLOW_MAX_PARK is 10s, well beyond this window, so the backstop can't
+    // fire and mask a broken pause.)
+    let while_paused = count_bytes_for(&mut rx, Duration::from_millis(500)).await;
+    assert!(
+        while_paused < 8192,
+        "expected ~no output while paused, got {while_paused} bytes (pause not honoured?)"
+    );
+
+    // Phase 3 — resumed. Output must flow again.
+    client
+        .set_flow_paused(session_id.clone(), false)
+        .await
+        .expect("resume");
+    let after_resume = count_bytes_for(&mut rx, Duration::from_millis(300)).await;
+    assert!(
+        after_resume > 50_000,
+        "expected output to resume flooding, got only {after_resume} bytes"
+    );
+
+    client.close(session_id).await.expect("close");
+}
+
+/// A fresh `Attach` must clear a stale pause — the fail-safe that prevents a
+/// crashed client from leaving a PTY wedged forever. We pause, drop the
+/// client (simulating a crash without a resume), reconnect, re-attach, and
+/// confirm output flows again.
+#[tokio::test(flavor = "multi_thread")]
+async fn attach_clears_a_stale_flow_pause() {
+    let tmp = TempDir::new().unwrap();
+    let (socket_path, client) = boot_daemon(&tmp).await;
+
+    let session_id = "flow-attach-reset".to_string();
+    client
+        .spawn(
+            session_id.clone(),
+            "ws-flow2".to_string(),
+            vec!["yes".to_string()],
+            std::env::temp_dir().to_string_lossy().to_string(),
+            vec![],
+            24,
+            80,
+        )
+        .await
+        .expect("spawn yes");
+
+    {
+        let mut rx = client.attach(session_id.clone()).await.expect("attach 1");
+        // Confirm it's flowing, then pause and abandon the connection.
+        let flowing = count_bytes_for(&mut rx, Duration::from_millis(200)).await;
+        assert!(flowing > 0, "expected output before pause");
+        client
+            .set_flow_paused(session_id.clone(), true)
+            .await
+            .expect("pause");
+    }
+    // Drop the first client entirely — a crashed app that never resumed.
+    drop(client);
+    sleep(Duration::from_millis(150)).await;
+
+    // Reconnect and re-attach. The daemon clears flow_paused on Attach, so
+    // output must flow despite the earlier pause never being released.
+    let client2 = PtyDaemonClient::connect(&socket_path)
+        .await
+        .expect("reconnect");
+    let mut rx2 = client2.attach(session_id.clone()).await.expect("attach 2");
+    let after_reattach = count_bytes_for(&mut rx2, Duration::from_millis(400)).await;
+    assert!(
+        after_reattach > 50_000,
+        "attach must clear a stale pause; got only {after_reattach} bytes"
+    );
+
+    client2.close(session_id).await.expect("close");
+}

--- a/src/components/terminal/terminal-cache.test.ts
+++ b/src/components/terminal/terminal-cache.test.ts
@@ -46,6 +46,8 @@ vi.mock("@/tauri/commands", () => {
     detachPtyOutput: vi.fn().mockImplementation(async (sid: string) => {
       handlers.delete(sid);
     }),
+    pausePtyOutput: vi.fn().mockResolvedValue(undefined),
+    resumePtyOutput: vi.fn().mockResolvedValue(undefined),
     getTerminalScrollback: vi.fn().mockResolvedValue(null),
     cacheTerminalScrollback: vi.fn().mockResolvedValue(undefined),
     uncacheTerminalScrollback: vi.fn().mockResolvedValue(undefined),
@@ -129,6 +131,9 @@ const emitChannelBytes = (commands as unknown as {
 const resetChannels = (commands as unknown as {
   __test_resetChannels: () => void;
 }).__test_resetChannels;
+
+const pausePtyOutput = vi.mocked(commands.pausePtyOutput);
+const resumePtyOutput = vi.mocked(commands.resumePtyOutput);
 
 const baseOptions = {
   paneId: "pane-1",
@@ -562,6 +567,90 @@ describe("terminal-cache", () => {
     expect(entry.writePumpRunning).toBe(false);
 
     writeSpy.mockRestore();
+  });
+
+  // ── Flow control (terminal output backpressure) ──
+  //
+  // A fast producer can queue PTY bytes faster than the throttled pump
+  // drains them. When the queued byte count crosses the HIGH watermark we
+  // ask the backend to pause the PTY read loop; once it drains below LOW we
+  // resume. The 9 MiB chunks below are zero-filled (NUL is a no-op in the
+  // xterm parser) and terminal.write is stubbed, so these exercise the
+  // accounting + pause/resume wiring without parsing tens of MiB.
+  const NINE_MIB = 9 * 1024 * 1024;
+
+  it("pauses the PTY when the write queue exceeds the high watermark, resumes when it drains", async () => {
+    const sid = "session-flow-pause-resume";
+    pausePtyOutput.mockClear();
+    resumePtyOutput.mockClear();
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    const writeSpy = vi
+      .spyOn(entry.terminal, "write")
+      .mockImplementation(() => true);
+
+    // Three 9 MiB chunks emitted synchronously. The pump drains exactly one
+    // chunk synchronously (up to its first `await`), leaving ~18 MiB queued —
+    // past the 16 MiB HIGH watermark — so a pause is requested.
+    for (let i = 0; i < 3; i++) {
+      emitChannelBytes(sid, new Uint8Array(NINE_MIB));
+    }
+
+    expect(pausePtyOutput).toHaveBeenCalledWith(sid);
+    expect(pausePtyOutput).toHaveBeenCalledTimes(1);
+    expect(entry.flowPaused).toBe(true);
+    expect(resumePtyOutput).not.toHaveBeenCalled();
+
+    // Drain everything; once the queue falls below the 4 MiB LOW watermark we
+    // resume exactly once.
+    await waitForPumpDrain();
+
+    expect(resumePtyOutput).toHaveBeenCalledWith(sid);
+    expect(resumePtyOutput).toHaveBeenCalledTimes(1);
+    expect(entry.flowPaused).toBe(false);
+    expect(entry.writeQueueBytes).toBe(0);
+
+    writeSpy.mockRestore();
+    disposeTerminal(sid);
+  });
+
+  it("resumes the PTY on detach if it was paused (so a parked agent isn't left blocked)", async () => {
+    const sid = "session-flow-detach-resume";
+    pausePtyOutput.mockClear();
+    resumePtyOutput.mockClear();
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const { entry } = await getOrCreateTerminal(sid, baseOptions);
+    attachToContainer(sid, container);
+
+    const writeSpy = vi
+      .spyOn(entry.terminal, "write")
+      .mockImplementation(() => true);
+
+    for (let i = 0; i < 3; i++) {
+      emitChannelBytes(sid, new Uint8Array(NINE_MIB));
+    }
+    expect(entry.flowPaused).toBe(true);
+
+    // Park the pane while still paused — detach must resume the PTY so the
+    // background (daemon-backed) agent isn't left blocked on write.
+    detachFromContainer(sid);
+
+    expect(resumePtyOutput).toHaveBeenCalledWith(sid);
+    expect(entry.flowPaused).toBe(false);
+
+    // Draining the leftover queue must NOT issue a second resume (flowPaused
+    // is already cleared).
+    await waitForPumpDrain();
+    expect(resumePtyOutput).toHaveBeenCalledTimes(1);
+
+    writeSpy.mockRestore();
+    disposeTerminal(sid);
   });
 });
 

--- a/src/components/terminal/terminal-cache.ts
+++ b/src/components/terminal/terminal-cache.ts
@@ -36,6 +36,8 @@ import {
   writeToPty,
   attachPtyOutput,
   detachPtyOutput,
+  pausePtyOutput,
+  resumePtyOutput,
   getTerminalScrollback,
   cacheTerminalScrollback,
   uncacheTerminalScrollback,
@@ -53,6 +55,30 @@ import { registerTerminalForSerialize } from "@/hooks/use-scrollback-serializer"
 import { suppressQueryResponses } from "./query-suppression";
 
 const PARKING_NODE_ID = "codemux-terminal-parking";
+
+/**
+ * Terminal output flow control watermarks.
+ *
+ * `writeQueue` holds PTY bytes received over IPC but not yet handed to xterm
+ * (the throttled `pumpWrites` drains ~one chunk per macrotask to keep the
+ * main thread responsive). Under a sustained flood — `yes`, `cat huge-file`,
+ * a verbose build, a runaway agent — a fast producer outruns that drain and
+ * the queue would grow without bound, ballooning renderer memory.
+ *
+ * When the queued byte count crosses HIGH we ask the backend to pause the
+ * PTY read loop; the child then blocks on `write()` once the kernel PTY
+ * buffer fills (real backpressure to the producer). We resume once the queue
+ * drains below LOW. The watermarks are deliberately generous so ordinary
+ * bursts and the multi-MB reattach-replay (already spread out by the pump)
+ * never trip backpressure — only genuine floods do.
+ *
+ * Backpressure is enforced only on the daemon spawn path; in-process sessions
+ * treat pause/resume as a no-op and keep their prior behavior. The backend
+ * carries its own fail-safes (resume on attach/close + a max-park backstop)
+ * so a dropped resume can never wedge a PTY.
+ */
+const FLOW_HIGH_WATERMARK_BYTES = 16 * 1024 * 1024; // 16 MiB
+const FLOW_LOW_WATERMARK_BYTES = 4 * 1024 * 1024; // 4 MiB
 
 /**
  * One shared TextDecoder for every channel callback for every session.
@@ -118,6 +144,15 @@ export interface CachedTerminal {
    *  parses thousands of IPC payloads + xterm escape sequences in one
    *  go and freezes hard with input dead until parsing finishes. */
   writeQueue: Uint8Array[];
+  /** Running total of `writeQueue` chunk byte lengths. Kept in lockstep with
+   *  the queue (push adds, pump-drain subtracts, dispose resets) so the
+   *  flow-control watermark check is O(1) instead of summing the queue. */
+  writeQueueBytes: number;
+  /** True when we've asked the backend to pause this session's PTY read loop
+   *  because `writeQueueBytes` crossed the HIGH watermark. Cleared when the
+   *  queue drains below LOW, or on detach/dispose (so a parked pane never
+   *  leaves a background agent blocked on write). */
+  flowPaused: boolean;
   /** True while `pumpWrites` is iterating. Re-entrant pump kicks become
    *  no-ops; the running pump picks up newly queued chunks on its next
    *  iteration. */
@@ -285,6 +320,8 @@ function createCachedTerminal(
     kittyStack: [],
     kittyLevel: 0,
     writeQueue: [],
+    writeQueueBytes: 0,
+    flowPaused: false,
     writePumpRunning: false,
     cleanups: [],
   };
@@ -350,12 +387,56 @@ async function pumpWrites(entry: CachedTerminal): Promise<void> {
     while (entry.writeQueue.length > 0 && !entry.disposed) {
       const next = entry.writeQueue.shift();
       if (!next) continue;
+      // The chunk leaves our queue here; account for it before writing so
+      // the flow-control watermark reflects only bytes still waiting on us.
+      entry.writeQueueBytes -= next.length;
+      if (entry.writeQueueBytes < 0) entry.writeQueueBytes = 0;
       entry.terminal.write(next);
+      maybeReleaseBackpressure(entry);
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
     }
   } finally {
     entry.writePumpRunning = false;
   }
+}
+
+/**
+ * Ask the backend to pause this session's PTY read loop when the write queue
+ * has grown past the HIGH watermark. Called from the channel callback right
+ * after a chunk is queued. Single-shot per pause cycle (guarded by
+ * `flowPaused`).
+ */
+function maybeApplyBackpressure(entry: CachedTerminal): void {
+  if (entry.flowPaused) return;
+  if (entry.writeQueueBytes <= FLOW_HIGH_WATERMARK_BYTES) return;
+  entry.flowPaused = true;
+  pausePtyOutput(entry.sessionId).catch((err) => {
+    // Pause didn't land (e.g. the session just exited). Drop the guard so a
+    // later over-watermark push retries rather than us believing we paused.
+    entry.flowPaused = false;
+    console.error(
+      `[Codemux] flow-control pause failed for ${entry.sessionId}:`,
+      err,
+    );
+  });
+}
+
+/**
+ * Release backpressure once the queue has drained below the LOW watermark.
+ * Called from the pump after each chunk. On failure we still clear
+ * `flowPaused` (fail open): the backend's attach/close/max-park fail-safes
+ * guarantee the PTY resumes regardless, and a fresh flood will re-pause.
+ */
+function maybeReleaseBackpressure(entry: CachedTerminal): void {
+  if (!entry.flowPaused) return;
+  if (entry.writeQueueBytes >= FLOW_LOW_WATERMARK_BYTES) return;
+  entry.flowPaused = false;
+  resumePtyOutput(entry.sessionId).catch((err) => {
+    console.error(
+      `[Codemux] flow-control resume failed for ${entry.sessionId}:`,
+      err,
+    );
+  });
 }
 
 /**
@@ -381,6 +462,10 @@ async function attachPtyChannel(entry: CachedTerminal): Promise<void> {
     // Queue + pump rather than calling terminal.write synchronously. See
     // pumpWrites for the rationale (reattach-replay freeze fix).
     entry.writeQueue.push(bytes);
+    entry.writeQueueBytes += bytes.length;
+    // Flow control: if a fast producer has outrun the pump, ask the backend
+    // to pause the PTY so the queue can't grow without bound.
+    maybeApplyBackpressure(entry);
     void pumpWrites(entry);
   });
 
@@ -406,6 +491,14 @@ function detachPtyChannel(entry: CachedTerminal): void {
   entry.outputAttachEpoch += 1;
   const shouldDetach = entry.outputAttached || entry.outputAttachPromise !== null;
   entry.outputAttached = false;
+  // If we had this session's PTY paused for flow control, resume it on the
+  // way out. A parked/disposed pane keeps its daemon-backed agent running in
+  // the background — leaving it paused would block that agent on write. (The
+  // daemon also resumes on its own fail-safes; this just makes it immediate.)
+  if (entry.flowPaused) {
+    entry.flowPaused = false;
+    resumePtyOutput(entry.sessionId).catch(console.error);
+  }
   if (shouldDetach) {
     detachPtyOutput(entry.sessionId).catch(console.error);
   }
@@ -562,6 +655,7 @@ export function disposeTerminal(sessionId: string): void {
   // Drop any chunks still queued for the throttled write pump — the
   // pump's loop guard re-checks `disposed` between iterations and exits.
   entry.writeQueue.length = 0;
+  entry.writeQueueBytes = 0;
 
   for (const cleanup of entry.cleanups) {
     try {

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -975,6 +975,16 @@ export const clearAgentStatus = (sessionId: string) =>
 export const detachPtyOutput = (sessionId: string) =>
   invoke("detach_pty_output", { sessionId });
 
+/** Terminal output flow control: pause the daemon's PTY read loop when the
+ *  renderer's xterm write queue is backed up by a fast producer. No-op for
+ *  in-process sessions. See `pause_pty_output` in terminal/mod.rs. */
+export const pausePtyOutput = (sessionId: string) =>
+  invoke("pause_pty_output", { sessionId });
+
+/** Resume the daemon's PTY read loop once the write queue has drained. */
+export const resumePtyOutput = (sessionId: string) =>
+  invoke("resume_pty_output", { sessionId });
+
 export const attachPtyOutput = (
   sessionId: string,
   channel: Channel<unknown>,


### PR DESCRIPTION
## What & why

A fast producer (`yes`, `cat huge-file`, a verbose build, a runaway agent) can outrun xterm's parser. The renderer already drains PTY bytes one chunk per macrotask to stay responsive (59081d8), but under a **sustained visible flood** the un-drained `writeQueue` grows without bound and balloons renderer memory. On the daemon side, the per-session broadcast channel (cap 512) silently **drops frames** once a consumer lags, corrupting the rendered terminal until the next redraw.

This adds VS Code–style backpressure:

- **Renderer** (`terminal-cache.ts`) tracks `writeQueueBytes`. Past a HIGH watermark (16 MiB) it calls `pause_pty_output`; once it drains below LOW (4 MiB) it calls `resume_pty_output`. Watermarks are generous so ordinary bursts and the reattach replay never trip it — only genuine floods do.
- **Daemon** (`pty_daemon/server.rs`) gates its per-session read thread on a `flow_paused` flag. While paused it stops draining the master fd, so the kernel PTY buffer fills and the child blocks on `write()` — real kernel-level backpressure to the producer instead of dropped frames.
- New `SetFlowPaused` wire request + `FlowPaused` reply; `PROTOCOL_VERSION` 1 → 2.

## Non-regression

- **In-process (non-daemon) sessions are a deliberate no-op** → the fallback path keeps today's exact behavior.
- Does **not** touch detach-on-park, the 256 MiB `pending_output` scrollback cap (c2897ce), or the `pumpWrites` replay throttle (59081d8). It's additive and only engages while a pane is attached and visibly flooding.

## Fail-safes (a dropped resume can never wedge a PTY)

- Daemon clears `flow_paused` on every `Attach` (stale pause self-heals on the next attach / app restart / pane reopen) and on `Close` (parked read thread wakes, reads EOF, exits — no leak).
- 10 s max-park backstop in the read loop force-resumes a wedged session.
- Renderer resumes on detach/park so a backgrounded daemon agent is never left blocked.

## Upgrade note

First daemon protocol bump. The supervisor won't adopt a mismatched (v1) daemon — it spawns a fresh one; persistent agents from the old daemon are relaunched/resumed in the new one via the existing resume path (orphaned old PTYs are the pre-existing "protocol bumps will be rare" TODO in `supervisor.rs`). Remote daemons aren't version-gated on connect, so a not-yet-upgraded remote degrades gracefully: sessions keep working, flow control just no-ops until the upgrade poller updates it.

## Tests

- **Rust integration** (`pty_daemon_persistence.rs`):
  - `set_flow_paused_stops_and_resumes_output` — spawns real `yes`, asserts output floods, pause stops it (<8 KiB over 500 ms while the child is blocked), resume restores the flood.
  - `attach_clears_a_stale_flow_pause` — pause, drop the client without resuming, reconnect + re-attach, assert output flows again.
- **Frontend** (`terminal-cache.test.ts`): watermark crossing pauses once; draining below LOW resumes once; detach-while-paused resumes exactly once.
- Verified locally: `cargo check`, `terminal::` lib tests (85), pty_daemon persistence (10) + circuit-breaker, `tsc`, 1783 frontend tests, clippy (no new warnings).

## How to test by hand

```
cargo test --manifest-path src-tauri/Cargo.toml --test pty_daemon_persistence set_flow_paused
```

Or run the app, open a terminal, and `yes` it — the app stays smooth and memory plateaus instead of climbing.