### PR TITLE
fix(sidebar): make workspace close button legible and stop press jump

### DIFF
--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -831,7 +831,7 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
               <Button
                 variant="ghost"
                 size="icon-xs"
-                className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover/row:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+                className="absolute right-2 inset-y-0 my-auto opacity-0 group-hover/row:opacity-100 transition-opacity bg-muted text-muted-foreground shadow-sm hover:text-foreground dark:hover:bg-muted"
                 onClick={(e) => { e.stopPropagation(); setShowRemoveDialog(true); }}
                 aria-label="Remove workspace"
               >


### PR DESCRIPTION
## Summary

Fixes two issues with the hover-reveal **remove (X) button** on workspace rows in the left sidebar.

### 1. Hard to see over long titles
The button used a transparent `ghost` background (only a faint background on direct hover). When a workspace title was long and truncated, the title text ran right under the `✕` glyph and camouflaged it.

**Fix:** give the button an opaque `bg-muted` chip with a subtle `shadow-sm` so the X always sits on a solid backdrop and stays legible regardless of title length. `dark:hover:bg-muted` overrides the ghost variant's translucent dark-hover so the chip stays solid when hovered directly.

### 2. "Drop and pop" on press
The button was centered with `top-1/2 -translate-y-1/2`. The base `Button` component carries an app-wide press affordance — `active:not-aria-[haspopup]:translate-y-px` — and in Tailwind v4 both of those write the **same** `--tw-translate-y` custom property through the single `translate` CSS property. Since this button has no `aria-haspopup`, pressing it flipped `--tw-translate-y` from `-50%` to `1px`, so it jumped down ~13px (half its 24px height + 1px) and snapped back on release. `transition-all` on the base button animated the jump.

**Fix:** center with `inset-y-0 my-auto` (margins, no transform). The transform property is now free, so the `active:translate-y-px` press just nudges 1px — the same subtle press as every other button, no jump.

## Change

A single className edit on the close button in `src/components/layout/sidebar-workspace-row.tsx`:

```diff
- className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover/row:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+ className="absolute right-2 inset-y-0 my-auto opacity-0 group-hover/row:opacity-100 transition-opacity bg-muted text-muted-foreground shadow-sm hover:text-foreground dark:hover:bg-muted"
```

Uses standard shadcn tokens (`bg-muted`, `shadow-sm`), consistent with the `codemux-ui` hover-reveal pattern. No design-token rules broken.

## Verification

- `npm run check` (tsc) passes.
- The component's 17 unit tests pass (`sidebar-workspace-row.test.tsx`).
- Rendered the row with the app's actual compiled Tailwind CSS in the browser pane: the new chip cleanly occludes a long truncated title and reads as a distinct button, where the old transparent X collided with the text.