### PR TITLE
fix(terminal): split panes inherit workspace cwd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.7.2",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.7.2",
+      "version": "0.7.5",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -1708,7 +1708,11 @@ impl AppStateStore {
         let session_id = SessionId(next_id("session"));
         let new_pane_id = PaneId(next_id("pane"));
         let split_pane_id = PaneId(next_id("pane"));
-        let cwd = current_project_root().display().to_string();
+        let cwd = snapshot
+            .workspaces
+            .get(workspace_index)
+            .map(|w| w.cwd.clone())
+            .unwrap_or_else(|| current_project_root().display().to_string());
         let shell = env::var("SHELL").ok();
         let title = format!("Terminal {}", snapshot.terminal_sessions.len() + 1);
 
@@ -4657,6 +4661,45 @@ mod tests {
         assert_eq!(
             snapshot.active_workspace_id, prior_active,
             "Shell creation must not steal the active workspace slot",
+        );
+    }
+
+    #[test]
+    fn split_pane_inherits_workspace_cwd() {
+        // Shift+clicking a preset (or a plain split) opens a new pane
+        // in the same surface. The new terminal session must spawn in
+        // the workspace directory — not the app process's current dir,
+        // which is typically the home directory. Regression guard for
+        // the split-pane preset landing in $HOME instead of the
+        // workspace.
+        let store = AppStateStore::default();
+        let workspace_id =
+            store.create_workspace_at_path(PathBuf::from("/tmp/codemux-split-cwd-test"));
+
+        let active_pane_id = {
+            let snapshot = store.snapshot();
+            let workspace = workspace_by_id(&snapshot, &workspace_id);
+            let surface = workspace
+                .surfaces
+                .iter()
+                .find(|surface| surface.surface_id == workspace.active_surface_id)
+                .expect("workspace must have an active surface");
+            surface.active_pane_id.clone()
+        };
+
+        let new_session_id = store
+            .split_pane(&active_pane_id.0, SplitDirection::Horizontal)
+            .expect("split must succeed");
+
+        let snapshot = store.snapshot();
+        let session = snapshot
+            .terminal_sessions
+            .iter()
+            .find(|session| session.session_id == new_session_id)
+            .expect("split must create a terminal session");
+        assert_eq!(
+            session.cwd, "/tmp/codemux-split-cwd-test",
+            "split pane must inherit the workspace cwd, not the app's current dir",
         );
     }
 


### PR DESCRIPTION
## Problem

Shift+clicking a preset opens its command in a **split pane** (no new tab). That split pane spawned in the app process's current directory — typically `$HOME` — instead of the workspace directory.

Normal click (new tab) was already correct: `create_tab` sets the new terminal session's cwd from `workspace.cwd`. The split-pane path in `split_pane` used `current_project_root()` instead, which falls back to `env::current_dir()`.

## Fix

`split_pane` now resolves cwd from the pane's own workspace (it already looks up `workspace_index`), falling back to `current_project_root()` only if the workspace can't be located:

```rust
let cwd = snapshot
    .workspaces
    .get(workspace_index)
    .map(|w| w.cwd.clone())
    .unwrap_or_else(|| current_project_root().display().to_string());
```

This fixes shift+click presets **and** plain (non-preset) splits — both now inherit the workspace directory.

## Verification

- `cargo check` — clean.
- Added regression test `split_pane_inherits_workspace_cwd` (passes).
- Confirmed it's a real guard: reverting the fix makes the test fail with the exact bug (`left` = process dir, `right` = workspace dir).