### PR TITLE
fix(sidebar): stop workspace X button from blocking the linked-issue badge

### DIFF
--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -764,7 +764,13 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                   )}
 
                   {hasAheadBehind && (
-                    <span className="flex items-center gap-1 shrink-0 tabular-nums">
+                    <span className={cn(
+                      "flex items-center gap-1 shrink-0 tabular-nums",
+                      // Fade out with the diff stats on hover so the issue
+                      // chip never collides with the ahead/behind glyphs as
+                      // it slides left to clear the X button.
+                      canDelete && "transition-opacity group-hover/row:opacity-0",
+                    )}>
                       {workspace.git_behind > 0 && (
                         <span className="text-warning/80">↓{workspace.git_behind}</span>
                       )}
@@ -797,8 +803,21 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                       a PR number. */}
                   {(workspace.linked_issue || workspace.notifications_muted) && (
                     <div className={cn(
-                      "flex items-center gap-1 shrink-0",
+                      "flex items-center gap-1 shrink-0 rounded-md px-1",
                       !hasDiff && "ml-auto",
+                      // The hover-reveal remove (X) button is pinned at the
+                      // right edge and overlays this slot. Unlike the diff
+                      // stats / notification badge (which fade out on hover),
+                      // the linked-issue badge is interactive, so instead of
+                      // hiding it we slide the cluster left by the X button's
+                      // footprint (size-6 + right-2 ≈ 32px) so the issue stays
+                      // visible and clickable while the X gets a clear slot.
+                      // On hover it also gains an opaque chip (bg-muted +
+                      // shadow, mirroring the X button) so it reads as a
+                      // distinct pill sitting cleanly over the branch name it
+                      // now overlaps, instead of colliding glyph-on-glyph.
+                      canDelete &&
+                        "transition-all group-hover/row:-translate-x-8 group-hover/row:bg-muted group-hover/row:shadow-sm",
                     )}>
                       {workspace.notifications_muted && (
                         <Tooltip>


### PR DESCRIPTION
## Problem

The hover-reveal remove (**X**) button on workspace rows is pinned absolutely at the right edge with an opaque \`bg-muted\` chip (since #?? / commit \`da74f55\` made it legible). The **linked-issue badge** (\`#418\`, the \`IssueDetailPopover\`) lives in the *same* right-edge slot of line 2. On hover the X overlaid the badge and, being absolutely positioned on top, swallowed the click — so the linked issue was unreachable.

Before the X was made legible it was a transparent ghost, so the overlap was less obvious; the opaque chip surfaced it.

## Fix

Reuses patterns already in the row rather than inventing new ones:

- **Issue cluster slides left on hover** by the X button's footprint (\`size-6\` + \`right-2\` ≈ 32px → \`-translate-x-8\`) so it stays visible and clickable while the X gets a clear slot.
- **Issue cluster gains its own opaque chip on hover** (\`bg-muted\` + \`shadow-sm\`, mirroring the X button) so it reads as a distinct pill sitting cleanly over the branch name it now overlaps, instead of colliding glyph-on-glyph. Background is hover-only, so the resting row is unchanged.
- **Ahead/behind arrows fade on hover** (same \`group-hover/row:opacity-0\` the diff stats already use) since they sit in the issue's slide path — nothing pokes out beside the chip.

## Result

On hover, line 2 simplifies to \`branch …\` + \`[● #418]\` chip + \`[✕]\` chip — two muted pills ~8px apart over the (masked) branch name. Transient sync info (diff stats, ahead/behind, notification count) fades together. Nothing overlaps, everything stays clickable. Resting state is pixel-identical to before.

## Verification

CSS-only change; Tailwind utilities (\`transition-all\`, negative translate, \`group-hover/row:\`, \`bg-muted\`/\`shadow-sm\`) all match existing usage in this codebase (Tailwind v4). Not run locally (worktree has no \`node_modules\`); visual check recommended on next dev build — hover a workspace row with a linked issue and confirm \`#nnn\` nudges left of the X and clicks through to the popover.