### PR TITLE
fix(remote): harden cross-device workspace pull/push/adopt + codemux-remote pipeline

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -660,7 +660,7 @@ pub(crate) async fn close_workspace_with_worktree_impl(
     // Worktree metadata still needs a pre-close snapshot for teardown +
     // MCP cleanup. Session IDs come from `state.close_workspace`'s result
     // below — no TOCTOU race with concurrent pane creation.
-    let (worktree_path, branch, ws_title) = {
+    let (worktree_path, branch, ws_title, ws_host_id) = {
         let snapshot = state.snapshot();
         let ws = snapshot
             .workspaces
@@ -670,6 +670,7 @@ pub(crate) async fn close_workspace_with_worktree_impl(
             ws.and_then(|w| w.worktree_path.clone()),
             ws.and_then(|w| w.git_branch.clone()),
             ws.map(|w| w.title.clone()).unwrap_or_default(),
+            ws.and_then(|w| w.host_id),
         )
     };
 
@@ -695,6 +696,23 @@ pub(crate) async fn close_workspace_with_worktree_impl(
     let close_result = state
         .close_workspace(&workspace_id)
         .map_err(|e| format!("Failed to close workspace: {e}"))?;
+
+    // Tear down the SSH tunnel + cached remote client for a workspace
+    // that was pushed to a host. Without this, closing a remote
+    // workspace leaks the `TunnelSupervisor` task, the bound local
+    // socket, and the remote `codemux-remote pty-daemon` for the rest
+    // of the app's lifetime — the only other teardown site is
+    // pull-back (commands/hosts.rs). Order matches pull-back: forget the
+    // cached client (it holds the socket) BEFORE shutting down the
+    // supervisor that unbinds it. No-op for local workspaces and
+    // idempotent when no supervisor was ever registered.
+    #[cfg(unix)]
+    if ws_host_id.is_some() {
+        crate::ssh::forget_workspace_client(&workspace_id).await;
+        crate::ssh::shutdown_supervisor(&workspace_id).await;
+    }
+    #[cfg(not(unix))]
+    let _ = ws_host_id;
 
     // Reconcile the sync mirror BEFORE the optimistic emit so the
     // workspaces overview sees the soft-delete in the same tick that

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -969,13 +969,16 @@ pub async fn close_workspace(
     // We still need cwd + title for teardown + MCP cleanup before the
     // state mutation. Session IDs are now obtained from
     // `state.close_workspace`'s result below — no snapshot race.
-    let workspace_cwd = {
+    let (workspace_cwd, ws_host_id) = {
         let snapshot = state.snapshot();
-        snapshot
+        let ws = snapshot
             .workspaces
             .iter()
-            .find(|w| w.workspace_id.0 == workspace_id)
-            .map(|w| (w.cwd.clone(), w.title.clone()))
+            .find(|w| w.workspace_id.0 == workspace_id);
+        (
+            ws.map(|w| (w.cwd.clone(), w.title.clone())),
+            ws.and_then(|w| w.host_id),
+        )
     };
 
     // Run teardown scripts before closing
@@ -1017,6 +1020,21 @@ pub async fn close_workspace(
     }
 
     let result = state.close_workspace(&workspace_id)?;
+
+    // Tear down the SSH tunnel + cached client for a workspace that was
+    // pushed to a host. This is the sibling of the teardown in
+    // `close_workspace_with_worktree_impl` — a PLAIN (non-worktree)
+    // pushed workspace gets `host_id` set (push falls back to its cwd)
+    // and the sidebar routes its close through THIS command, so without
+    // this it would leak the tunnel supervisor + remote pty-daemon.
+    // Idempotent + no-op for local workspaces.
+    #[cfg(unix)]
+    if ws_host_id.is_some() {
+        crate::ssh::forget_workspace_client(&workspace_id).await;
+        crate::ssh::shutdown_supervisor(&workspace_id).await;
+    }
+    #[cfg(not(unix))]
+    let _ = ws_host_id;
 
     // Reconcile the sync mirror BEFORE the optimistic emit — see the
     // matching block in `close_workspace_with_worktree_impl` for the

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -826,9 +826,24 @@ async fn adopt_worktree_via_repo_rsync(
             Some(branch.clone()),
         );
         // It's local right away (the files are already on disk) — clear
-        // host_id so panes spawn against the local pty-daemon.
-        app_state.set_workspace_host_id(&workspace_id.0, None)?;
-        db.link_workspace_sync_to_local(&server_id, &workspace_id.0)?;
+        // host_id so panes spawn against the local pty-daemon, and link
+        // the sync row. Roll back the just-created shell if EITHER
+        // mutation fails: otherwise the failure leaves an orphan shell
+        // (host_id maybe still set, row maybe unlinked) that the
+        // idempotency guard can't recover, and a retry would create a
+        // SECOND duplicate shell. Mirrors the single-dir adopt rollback.
+        if let Err(e) = app_state
+            .set_workspace_host_id(&workspace_id.0, None)
+            .and_then(|_| {
+                db.link_workspace_sync_to_local(&server_id, &workspace_id.0)
+            })
+        {
+            let _ = app_state.close_workspace(&workspace_id.0);
+            drop(app_state);
+            drop(db);
+            crate::state::emit_app_state(&app);
+            return Err(e);
+        }
         // Carry the daemon-derived project identity onto the adopted
         // workspace so it converges with its siblings and the upcoming
         // reconcile doesn't push a None uid back over the row (see the
@@ -1057,6 +1072,16 @@ pub async fn workspaces_adopt_via_clone(
     );
     // Clear host_id since this is a local clone (not a remote pull).
     app_state.set_workspace_host_id(&workspace_id.0, None)?;
+
+    // Stamp project identity from the freshly-cloned repo. Clone-adopt
+    // mints a NEW server_id (it doesn't link the sibling row), so the
+    // identity must be (re)derived locally — and because the clone has
+    // the same canonical git remote as its siblings, the deterministic
+    // UUIDv5 matches, so this independent copy still GROUPS/converges
+    // with them in the overview instead of rendering as a stray project
+    // (and being re-adopted as a duplicate). Recomputing from the local
+    // checkout mirrors every other create path.
+    app_state.set_workspace_project_root(&workspace_id.0, project_path_str.clone());
 
     // Nudge sync so the server learns about the new workspace.
     if let Err(e) = crate::workspaces_sync::try_sync_with_app(&app).await {

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -471,7 +471,7 @@ pub async fn workspaces_adopt_synced(
     // Step 1+2+3+4+5: do all the sync DB lookups in a scope so the
     // State<'_> guard is dropped before we await anything (Tauri's
     // State is not Send across awaits).
-    let (workspace_id, worktree_path) = {
+    let (workspace_id, worktree_path, adopted_project_uid, adopted_kind) = {
         let db: tauri::State<'_, DatabaseStore> = app.state();
         let app_state: tauri::State<'_, crate::state::AppStateStore> =
             app.state();
@@ -581,7 +581,12 @@ pub async fn workspaces_adopt_synced(
         // local entry instead of "lives on another device".
         db.link_workspace_sync_to_local(&server_id, &workspace_id_str)?;
 
-        (workspace_id_str, worktree_path)
+        (
+            workspace_id_str,
+            worktree_path,
+            row.project_uid.clone(),
+            row.workspace_kind.clone(),
+        )
     };
 
     // Step 8: drive the existing pull-back machinery. `_impl` takes
@@ -593,6 +598,48 @@ pub async fn workspaces_adopt_synced(
         workspace_id.clone(),
     )
     .await?;
+
+    // CRITICAL: `workspace_pull_back_impl` reports rsync/SSH failure as
+    // `Ok(WorkspacePullOutcome { ok: false, .. })`, NOT `Err`. The `?`
+    // above only unwraps the OUTER Result, so a failed pull would
+    // otherwise fall straight through to the success `Ok(AdoptOutcome)`
+    // below — the user sees a "Pulled!" toast while an empty/broken
+    // shell sits linked with `host_id` still set, and the idempotency
+    // guard at the top then refuses every retry ("already adopted").
+    // Roll the optimistic shell + link back so the row reverts to a
+    // re-pullable sibling and surface the failure as a real error.
+    if !pull_outcome.ok {
+        {
+            let app_state: tauri::State<'_, crate::state::AppStateStore> =
+                app.state();
+            let db: tauri::State<'_, DatabaseStore> = app.state();
+            // Remove the half-created shell (it has no PTY sessions yet,
+            // so this is a clean no-side-effect removal).
+            let _ = app_state.close_workspace(&workspace_id);
+            // Revert the row to a sibling/remote-only row (workspace_id
+            // NULL) so reconcile doesn't tombstone it and the overview
+            // keeps offering "Pull to this device".
+            let _ = db.unlink_workspace_sync_from_local(&server_id);
+        }
+        crate::state::emit_app_state(&app);
+        return Err(pull_outcome.message);
+    }
+
+    // Stamp the adopted workspace's cross-device identity from the synced
+    // row BEFORE the post-adopt reconcile/push runs. The shell was created
+    // with `project_uid: None`; without this, `reconcile_from_snapshot`
+    // (a plain SET) would push that None straight back to the row and WIPE
+    // the daemon-derived uid, so the adopted copy would stop converging
+    // with its siblings and could be re-adopted as a duplicate.
+    {
+        let app_state: tauri::State<'_, crate::state::AppStateStore> =
+            app.state();
+        app_state.set_workspace_project_identity(
+            &workspace_id,
+            adopted_project_uid,
+            adopted_kind,
+        );
+    }
 
     // Step 9: nudge the reconcile so the server learns the workspace
     // is now also on this device. Failures here are non-fatal — the
@@ -636,7 +683,15 @@ async fn adopt_worktree_via_repo_rsync(
     server_id: String,
 ) -> Result<AdoptOutcome, String> {
     // ── resolve row + host + paths (no awaits) ──
-    let (host, remote_repo_path, local_project_path, branch, title) = {
+    let (
+        host,
+        remote_repo_path,
+        local_project_path,
+        branch,
+        title,
+        adopted_project_uid,
+        adopted_kind,
+    ) = {
         let db: tauri::State<'_, DatabaseStore> = app.state();
         let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
 
@@ -708,6 +763,8 @@ async fn adopt_worktree_via_repo_rsync(
             local_project_path,
             branch,
             row.title.clone(),
+            row.project_uid.clone(),
+            row.workspace_kind.clone(),
         )
     };
 
@@ -772,6 +829,15 @@ async fn adopt_worktree_via_repo_rsync(
         // host_id so panes spawn against the local pty-daemon.
         app_state.set_workspace_host_id(&workspace_id.0, None)?;
         db.link_workspace_sync_to_local(&server_id, &workspace_id.0)?;
+        // Carry the daemon-derived project identity onto the adopted
+        // workspace so it converges with its siblings and the upcoming
+        // reconcile doesn't push a None uid back over the row (see the
+        // single-dir adopt path for the full rationale).
+        app_state.set_workspace_project_identity(
+            &workspace_id.0,
+            adopted_project_uid,
+            adopted_kind,
+        );
         drop(app_state);
         drop(db);
 
@@ -793,7 +859,15 @@ async fn adopt_worktree_via_repo_rsync(
     }
     #[cfg(not(unix))]
     {
-        let _ = (host, remote_repo_path, local_project_path, branch, title);
+        let _ = (
+            host,
+            remote_repo_path,
+            local_project_path,
+            branch,
+            title,
+            adopted_project_uid,
+            adopted_kind,
+        );
         Err("SSH transport is Unix-only for now.".into())
     }
 }

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -276,6 +276,19 @@ pub fn workspaces_adoption_preview(
                 .map_or(true, |adopted| w.workspace_id.0 != adopted)
     });
 
+    // The set of workspace ids actually live in app_state right now.
+    // The same-branch conflict guard below intersects against this so
+    // a sync row still linked to a CLOSED workspace (its soft-delete
+    // hasn't purged yet, or was resurrected by a pull) is not mistaken
+    // for "you already have this branch open." Mirrors the liveness
+    // check the overview (`use-overview-items`) and the adopt
+    // idempotency path already apply.
+    let live_workspace_ids: std::collections::HashSet<String> = snapshot
+        .workspaces
+        .iter()
+        .map(|w| w.workspace_id.0.clone())
+        .collect();
+
     let already_adopted_workspace_id = row.workspace_id.clone();
 
     // Cross-machine same-branch-same-project guard. The dialog uses
@@ -295,6 +308,7 @@ pub fn workspaces_adoption_preview(
     let same_branch_project_exists_at = detect_same_branch_project_conflict(
         &db,
         &row,
+        &live_workspace_ids,
     );
 
     Ok(AdoptionPreview {
@@ -323,9 +337,21 @@ pub fn workspaces_adoption_preview(
 /// repositories on this device with the same basename and the same
 /// branch, both with `project_path` recorded — extremely rare in
 /// practice.
+///
+/// `live_workspace_ids` is the set of workspace ids currently present
+/// in app_state. A sync row's `workspace_id` is only treated as "this
+/// device already has it" when that id is still live. Without this
+/// guard a row left linked to a CLOSED workspace — its soft-delete not
+/// yet purged, or resurrected by a `pull` from the server — would
+/// surface a phantom "you already have this branch open" conflict and
+/// block a legitimate re-pull. This matches the liveness filter the
+/// overview (`use-overview-items`) and the adopt idempotency path
+/// already apply, so the three surfaces agree on what counts as
+/// locally present.
 fn detect_same_branch_project_conflict(
     db: &DatabaseStore,
     previewed: &WorkspaceSyncRecord,
+    live_workspace_ids: &std::collections::HashSet<String>,
 ) -> Option<String> {
     let previewed_branch = previewed.git_branch.as_deref()?;
     // Prefer the stable, deterministic project_uid when the previewed
@@ -351,6 +377,15 @@ fn detect_same_branch_project_conflict(
         let Some(local_wid) = r.workspace_id.as_deref() else {
             continue;
         };
+        // Skip rows whose linked workspace is no longer live in
+        // app_state. A non-null `workspace_id` alone doesn't mean the
+        // workspace still exists — it may have been closed/deleted with
+        // a stale sync row left behind. Treating such an orphan as a
+        // conflict is exactly the phantom "you already have this branch
+        // open" bug this guard must avoid.
+        if !live_workspace_ids.contains(local_wid) {
+            continue;
+        }
         // Don't flag the previewed row's own local copy.
         if previewed.workspace_id.as_deref() == Some(local_wid) {
             continue;
@@ -979,6 +1014,11 @@ mod tests {
     // deliberately basename-based because two devices almost never
     // store the same repo at the same absolute path.
 
+    /// Build the live-workspace-id set the guard intersects against.
+    fn live_set(ids: &[&str]) -> std::collections::HashSet<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
     fn insert_local(
         db: &DatabaseStore,
         workspace_id: &str,
@@ -1043,11 +1083,44 @@ mod tests {
             Some("feature/x"),
             None,
         );
-        let hit = detect_same_branch_project_conflict(&db, &remote);
+        let hit = detect_same_branch_project_conflict(
+            &db,
+            &remote,
+            &live_set(&["workspace-local"]),
+        );
         assert_eq!(
             hit.as_deref(),
             Some("workspace-local"),
             "matching basename + matching branch must surface the local workspace id"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn conflict_detection_ignores_orphan_closed_workspace() {
+        // Regression: the local row still references a workspace that
+        // was closed/deleted, so its id is NOT in app_state. Pulling
+        // the same branch back from a host must NOT be blocked by this
+        // stale link — the overview already hides such orphans, and
+        // this guard must agree instead of showing a phantom "you
+        // already have this branch open" message.
+        let db = DatabaseStore::new_in_memory();
+        insert_local(
+            &db,
+            "workspace-closed",
+            Some("/home/zeus/projects/my-repo"),
+            Some("main"),
+        );
+        let remote = make_remote_row(
+            Some("/home/deus/projects/my-repo"),
+            Some("main"),
+            None,
+        );
+        // Empty live set → the workspace is gone from app_state.
+        assert!(
+            detect_same_branch_project_conflict(&db, &remote, &live_set(&[]))
+                .is_none(),
+            "an orphaned sync row for a closed workspace must not flag as a conflict"
         );
     }
 
@@ -1068,7 +1141,12 @@ mod tests {
             Some("feature/x"),
             None,
         );
-        assert!(detect_same_branch_project_conflict(&db, &remote).is_none());
+        assert!(detect_same_branch_project_conflict(
+            &db,
+            &remote,
+            &live_set(&["workspace-local"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -1086,7 +1164,12 @@ mod tests {
             Some("feature/x"),
             None,
         );
-        assert!(detect_same_branch_project_conflict(&db, &remote).is_none());
+        assert!(detect_same_branch_project_conflict(
+            &db,
+            &remote,
+            &live_set(&["workspace-local"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -1109,7 +1192,12 @@ mod tests {
             Some("workspace-local"),
         );
         assert!(
-            detect_same_branch_project_conflict(&db, &remote).is_none(),
+            detect_same_branch_project_conflict(
+                &db,
+                &remote,
+                &live_set(&["workspace-local"]),
+            )
+            .is_none(),
             "the row's own adopted copy must not flag as a conflict"
         );
     }
@@ -1142,7 +1230,14 @@ mod tests {
             Some("feature/x"),
             None,
         );
-        assert!(detect_same_branch_project_conflict(&db, &remote).is_none());
+        // Sibling row has no local workspace_id, so liveness is moot —
+        // pass it anyway to mirror the production call shape.
+        assert!(detect_same_branch_project_conflict(
+            &db,
+            &remote,
+            &live_set(&["workspace-local"]),
+        )
+        .is_none());
     }
 
     #[test]
@@ -1158,10 +1253,20 @@ mod tests {
         // Missing branch.
         let no_branch =
             make_remote_row(Some("/home/deus/projects/my-repo"), None, None);
-        assert!(detect_same_branch_project_conflict(&db, &no_branch).is_none());
+        assert!(detect_same_branch_project_conflict(
+            &db,
+            &no_branch,
+            &live_set(&["workspace-local"]),
+        )
+        .is_none());
         // Missing path.
         let no_path = make_remote_row(None, Some("feature/x"), None);
-        assert!(detect_same_branch_project_conflict(&db, &no_path).is_none());
+        assert!(detect_same_branch_project_conflict(
+            &db,
+            &no_path,
+            &live_set(&["workspace-local"]),
+        )
+        .is_none());
     }
 }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -1264,6 +1264,32 @@ impl DatabaseStore {
         Ok(())
     }
 
+    /// Revert a sync row back to a sibling/remote-only row by clearing
+    /// its local `workspace_id` link (set NULL). Used to ROLL BACK an
+    /// optimistic adoption whose pull failed: the row must become a
+    /// re-pullable sibling again rather than stay linked to a shell
+    /// that was torn down — otherwise `reconcile_from_snapshot` would
+    /// see a linked row with no live workspace and soft-delete
+    /// (tombstone) it, making the workspace vanish from the overview
+    /// instead of staying available to retry. We deliberately do NOT
+    /// mark the row dirty: clearing a local-only link is not a change
+    /// the cloud needs to hear about (the row's server_id/identity is
+    /// unchanged), and the next inventory poll keeps it fresh.
+    pub fn unlink_workspace_sync_from_local(
+        &self,
+        server_id: &str,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE workspaces_sync
+             SET workspace_id = NULL, updated_at = datetime('now')
+             WHERE user_id = 'local' AND server_id = ?1",
+            params![server_id],
+        )
+        .map_err(|e| format!("Failed to unlink workspace sync row: {e}"))?;
+        Ok(())
+    }
+
     // ── Host-inventory auto-publish helpers ─────────────────────────
     //
     // The desktop's host-inventory poller (see `hosts_inventory.rs`)
@@ -1317,6 +1343,7 @@ impl DatabaseStore {
                  WHERE user_id = 'local'
                    AND host_server_id = ?1
                    AND origin_uid = ?2
+                   AND deleted_at IS NULL
                  LIMIT 1",
             )
             .ok()?;
@@ -1416,6 +1443,90 @@ impl DatabaseStore {
             ],
         )
         .map_err(|e| format!("Failed to update remote-discovered row: {e}"))?;
+        Ok(())
+    }
+
+    /// Find a remote-discovered row for `(host_server_id, origin_uid)`
+    /// that is SOFT-DELETED (a tombstone). Used only by the inventory
+    /// reconcile's undelete-on-reappear path: when a host workspace that
+    /// was previously adopted-then-closed (its row tombstoned by the
+    /// close-path reconcile) shows up again in a fresh poll, we resurrect
+    /// the SAME row instead of inserting a duplicate — so the cloud
+    /// `server_id` (cross-device identity) survives the close/reopen
+    /// round-trip and other devices don't see the workspace vanish then
+    /// reappear as a brand-new row. If multiple tombstones exist, the
+    /// most recent by id wins.
+    pub fn find_remote_discovered_tombstone(
+        &self,
+        host_server_id: &str,
+        origin_uid: &str,
+    ) -> Option<WorkspaceSyncRecord> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, server_id, workspace_id, title, host_server_id,
+                        project_path, project_remote, git_branch, git_head_sha,
+                        created_at, updated_at, deleted_at, dirty, origin_uid,
+                        project_uid, workspace_kind, origin_path
+                 FROM workspaces_sync
+                 WHERE user_id = 'local'
+                   AND host_server_id = ?1
+                   AND origin_uid = ?2
+                   AND deleted_at IS NOT NULL
+                 ORDER BY id DESC
+                 LIMIT 1",
+            )
+            .ok()?;
+        stmt.query_row(params![host_server_id, origin_uid], row_to_workspace_sync)
+            .ok()
+    }
+
+    /// Resurrect a soft-deleted remote-discovered row (matched by primary
+    /// `id`): clear `deleted_at`, ALSO clear any stale `workspace_id`
+    /// link, refresh the mutable fields from the latest inventory, and
+    /// mark `dirty=1`.
+    ///
+    /// Clearing `workspace_id` is essential: the tombstone may have been
+    /// created by closing an *adopted* workspace, so it still points at a
+    /// local id that no longer exists. Reviving that link would recreate
+    /// the exact "linked row with no live workspace" orphan that produces
+    /// the phantom "you already have this branch open" pull-conflict. A
+    /// resurrected row must be a clean, re-pullable sibling
+    /// (`workspace_id IS NULL`). Marking dirty makes the next push re-assert
+    /// the row to the cloud as a PATCH on the surviving `server_id` rather
+    /// than a churny DELETE-then-POST.
+    pub fn undelete_remote_discovered_workspace_sync(
+        &self,
+        id: i64,
+        title: &str,
+        project_path: Option<&str>,
+        project_remote: Option<&str>,
+        git_branch: Option<&str>,
+        project_uid: Option<&str>,
+        workspace_kind: Option<&str>,
+        origin_path: Option<&str>,
+    ) -> Result<(), String> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE workspaces_sync
+             SET deleted_at = NULL, workspace_id = NULL,
+                 title = ?1, project_path = ?2, project_remote = ?3,
+                 git_branch = ?4, project_uid = ?5, workspace_kind = ?6,
+                 origin_path = ?8,
+                 updated_at = datetime('now'), dirty = 1
+             WHERE id = ?7",
+            params![
+                title,
+                project_path,
+                project_remote,
+                git_branch,
+                project_uid,
+                workspace_kind,
+                id,
+                origin_path,
+            ],
+        )
+        .map_err(|e| format!("Failed to undelete remote-discovered row: {e}"))?;
         Ok(())
     }
 

--- a/src-tauri/src/hosts_inventory.rs
+++ b/src-tauri/src/hosts_inventory.rs
@@ -359,7 +359,14 @@ pub fn reconcile_host_inventory(
 
     let mut seen_uids: HashSet<String> = HashSet::new();
     for ws in &inventory.workspaces {
-        seen_uids.insert(ws.id.clone());
+        // Guard against a single inventory envelope listing the same id
+        // twice: `local_by_uid` is built once before the loop and never
+        // updated, so without this a duplicate id would INSERT a second
+        // row (it misses the live map on the second pass). `insert`
+        // returns false when the id was already present this envelope.
+        if !seen_uids.insert(ws.id.clone()) {
+            continue;
+        }
 
         // We use `project_root` (the originating repo root on the
         // host) as a `project_path` analog — it's the closest the
@@ -425,6 +432,32 @@ pub fn reconcile_host_inventory(
                 }
                 stats.updated += 1;
             }
+        } else if let Some(tomb) =
+            db.find_remote_discovered_tombstone(host_server_id, &ws.id)
+        {
+            // Not in the live map, but a soft-deleted tombstone exists for
+            // this (host, origin_uid) — left behind when a previously
+            // adopted-then-closed workspace's row was tombstoned. Resurrect
+            // it (clearing the stale workspace_id link) instead of inserting
+            // a duplicate, so the cloud identity survives the close/reopen
+            // and other devices don't see a vanish-then-reappear.
+            if let Err(e) = db.undelete_remote_discovered_workspace_sync(
+                tomb.id,
+                &ws.name,
+                project_path,
+                project_remote,
+                branch,
+                project_uid,
+                workspace_kind,
+                origin_path,
+            ) {
+                eprintln!(
+                    "[hosts_inventory] undelete failed for {host_server_id}/{}: {e}",
+                    ws.id
+                );
+                continue;
+            }
+            stats.updated += 1;
         } else if let Err(e) = db.insert_remote_discovered_workspace_sync(
             host_server_id,
             &ws.id,
@@ -883,6 +916,74 @@ mod tests {
             tombstone.dirty,
             "tombstone must be dirty so push DELETEs the cloud row"
         );
+    }
+
+    #[test]
+    fn reconcile_undeletes_tombstone_on_reappear_instead_of_duplicating() {
+        // Models the adopt → close → re-poll race that used to leak a
+        // duplicate sibling row (and churn the cloud row). A
+        // remote-discovered workspace is adopted (workspace_id linked),
+        // then the local workspace is CLOSED — the close-path reconcile
+        // soft-deletes the row BY workspace_id, leaving a tombstone that
+        // still carries the host's origin_uid. The host still has the
+        // workspace, so the next poll must RESURRECT the same row (cloud
+        // server_id preserved, stale link cleared), not insert a second.
+        let db = fresh_db();
+        let env = make_envelope(vec![make_remote("uid-1", "proj", Some("main"))]);
+
+        reconcile_host_inventory(&db, "host-99", &env);
+        let row = db
+            .find_workspace_sync_by_host_and_origin_uid("host-99", "uid-1")
+            .expect("first poll inserts the row");
+        // Simulate the first cloud push assigning a server_id.
+        db.mark_workspace_sync_synced(row.id, Some("srv-1")).unwrap();
+        // Simulate ADOPTION (link) then CLOSE (soft-delete by workspace_id).
+        db.link_workspace_sync_to_local("srv-1", "workspace-7").unwrap();
+        db.soft_delete_workspace_sync_by_workspace_id("workspace-7")
+            .unwrap();
+
+        // Now: zero live remote rows, one tombstone still keyed by uid-1.
+        assert!(db.list_remote_discovered_for_host("host-99").is_empty());
+        assert!(db
+            .find_remote_discovered_tombstone("host-99", "uid-1")
+            .is_some());
+
+        // Re-poll: the host still reports uid-1.
+        let stats = reconcile_host_inventory(&db, "host-99", &env);
+        assert_eq!(stats.inserted, 0, "must NOT insert a duplicate row");
+        assert_eq!(stats.updated, 1, "must resurrect the tombstone in place");
+
+        let live = db.list_remote_discovered_for_host("host-99");
+        assert_eq!(live.len(), 1, "exactly one live row — no duplicate");
+        assert_eq!(
+            live[0].id, row.id,
+            "same row resurrected, so the cloud server_id survives"
+        );
+        assert_eq!(live[0].server_id.as_deref(), Some("srv-1"));
+        assert!(
+            live[0].workspace_id.is_none(),
+            "stale adoption link must be cleared so it's a clean re-pullable sibling"
+        );
+        assert!(live[0].deleted_at.is_none());
+        assert!(
+            live[0].dirty,
+            "resurrected row must be dirty so push re-asserts it as a PATCH"
+        );
+    }
+
+    #[test]
+    fn reconcile_dedupes_duplicate_ids_within_one_envelope() {
+        // Defensive guard: `local_by_uid` is built once before the loop,
+        // so if a daemon ever reported the same id twice in one envelope
+        // the second pass would miss the live map and INSERT again.
+        let db = fresh_db();
+        let env = make_envelope(vec![
+            make_remote("dup", "proj", Some("main")),
+            make_remote("dup", "proj", Some("main")),
+        ]);
+        let stats = reconcile_host_inventory(&db, "host-99", &env);
+        assert_eq!(stats.inserted, 1, "duplicate id inserts exactly once");
+        assert_eq!(db.list_remote_discovered_for_host("host-99").len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/ssh/bootstrap.rs
+++ b/src-tauri/src/ssh/bootstrap.rs
@@ -526,7 +526,21 @@ pub async fn provision_workspace_mcp_config(
     // name. The "codemux" key here matches the desktop's per-workspace
     // entry so users get a consistent tool name whether they're on
     // their laptop or on a pushed host.
-    let exec_path = remote_install_path.replacen('~', "%h", 1);
+    // The `.mcp.json` "command" must be an ABSOLUTE path. Agent CLIs
+    // (Claude Code, Codex, …) spawn this command directly — they do NOT
+    // run it through a shell (so `~` is not expanded) and they certainly
+    // don't expand the systemd `%h` specifier. The previous `%h`
+    // rewrite produced a literal `%h/.local/bin/codemux-remote` that no
+    // agent could exec, silently breaking remote MCP auto-discovery.
+    // Resolve the remote $HOME and emit an absolute path, matching the
+    // user-level config `codemux-remote serve` writes via mcp_register
+    // (which uses the daemon's absolute `current_exe()`).
+    let exec_path = if let Some(rest) = remote_install_path.strip_prefix("~/") {
+        let home = resolve_remote_home(ssh_target, deadline).await?;
+        format!("{}/{}", home.trim_end_matches('/'), rest)
+    } else {
+        remote_install_path.to_string()
+    };
     let content = serde_json::to_string_pretty(&serde_json::json!({
         "mcpServers": {
             "codemux": {
@@ -584,12 +598,17 @@ async fn ssh_upload_executable(
     // 0700 before the rename. `mv -f` overwrites whatever was at the
     // destination — important when a stale older binary from a
     // previous Codemux install is sitting there.
+    // Tilde-aware shell quoting: preserves a leading `~/` (so the
+    // remote shell still expands it to $HOME) while single-quoting the
+    // rest, closing any shell-injection surface if a future caller ever
+    // passes a path with metacharacters. Today's callers pass a
+    // hardcoded path, so this is defense-in-depth.
+    let p = crate::ssh::push::shell_escape(remote_path);
     let script = format!(
         "umask 077 && mkdir -p \"$(dirname {p})\" && \
          cat > {p}.tmp && \
          chmod +x {p}.tmp && \
-         mv -f {p}.tmp {p}",
-        p = remote_path
+         mv -f {p}.tmp {p}"
     );
 
     let mut child = Command::new("ssh")
@@ -629,6 +648,44 @@ async fn ssh_upload_executable(
     Ok(())
 }
 
+/// Resolve the remote login user's absolute `$HOME` over SSH. Used to
+/// turn a `~/…`-relative install path into the absolute path agent CLIs
+/// need in `.mcp.json` (they spawn the command directly, with no shell
+/// or systemd token expansion). `printf %s` avoids a trailing newline.
+async fn resolve_remote_home(
+    ssh_target: &str,
+    deadline: Duration,
+) -> Result<String, String> {
+    let out = timeout(
+        deadline,
+        Command::new("ssh")
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg("-o")
+            .arg("ConnectTimeout=10")
+            .arg(ssh_target)
+            .arg("printf %s \"$HOME\"")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output(),
+    )
+    .await
+    .map_err(|_| "resolving remote $HOME timed out".to_string())?
+    .map_err(|e| format!("ssh spawn failed: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "could not resolve remote $HOME: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    let home = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if home.is_empty() {
+        return Err("remote $HOME resolved to empty".to_string());
+    }
+    Ok(home)
+}
+
 /// `ssh <target> 'umask 077; mkdir -p <dir>; cat > <path>'` with
 /// `content` streamed over stdin so a secret never appears in an
 /// argv the host's process list could expose.
@@ -646,10 +703,13 @@ async fn ssh_write_file(
         .arg("-o")
         .arg("ConnectTimeout=10")
         .arg(ssh_target)
-        .arg(format!(
-            "umask 077 && mkdir -p \"$(dirname {p})\" && cat > {p}",
-            p = remote_path
-        ))
+        .arg({
+            // Tilde-aware shell quoting (see ssh_upload_executable):
+            // keeps `~/` expandable, quotes the body, neutralizes any
+            // metacharacters in a future caller's path.
+            let p = crate::ssh::push::shell_escape(remote_path);
+            format!("umask 077 && mkdir -p \"$(dirname {p})\" && cat > {p}")
+        })
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src-tauri/src/ssh/push.rs
+++ b/src-tauri/src/ssh/push.rs
@@ -305,7 +305,15 @@ pub async fn pull_workspace_back(opts: PullOptions<'_>) -> PullResult {
     // Verify the remote path actually exists. Without this, an empty
     // mirror would happily delete every local file (because of
     // --delete).
-    let remote_check = run_with_timeout(
+    //
+    // We signal presence via a STDOUT sentinel rather than the remote
+    // command's exit code: the remote `if … then echo … fi` always exits
+    // 0, so a genuinely-missing directory is distinguished by the token,
+    // not by string-matching `ExitStatus`'s Display (whose exact shape —
+    // e.g. `exit status: 7` with a colon — is not contractual and bit us
+    // before: a missing path was misreported as `HostUnreachable`). Only
+    // a real SSH/transport failure yields a non-zero exit → `Err` here.
+    let remote_check = run_capture_with_timeout(
         Command::new("ssh")
             .arg("-o")
             .arg("BatchMode=yes")
@@ -313,23 +321,37 @@ pub async fn pull_workspace_back(opts: PullOptions<'_>) -> PullResult {
             .arg("ConnectTimeout=10")
             .arg(opts.ssh_target)
             .arg(format!(
-                "test -d {} || exit 7",
+                "if test -d {} ; then echo CMX_REMOTE_DIR_OK ; else echo CMX_REMOTE_DIR_MISSING ; fi",
                 shell_escape(opts.remote_path)
             )),
         opts.step_timeout,
     )
     .await;
-    if let Err(reason) = remote_check {
-        // exit 7 means our explicit "not a directory" signal; anything
-        // else means SSH itself failed.
-        if reason.contains("exit status 7") {
+    match remote_check {
+        Ok(stdout) if stdout.contains("CMX_REMOTE_DIR_MISSING") => {
             return PullResult::RemoteNotFound {
                 path: opts.remote_path.to_string(),
             };
         }
-        return PullResult::HostUnreachable {
-            reason: format!("remote_check failed: {reason}"),
-        };
+        Ok(stdout) if stdout.contains("CMX_REMOTE_DIR_OK") => {
+            // Remote dir confirmed present — safe to rsync with --delete.
+        }
+        Ok(stdout) => {
+            // SSH connected but didn't return our sentinel (shell init
+            // noise, unexpected error). Treat as unreachable rather than
+            // risk a --delete against an unconfirmed remote.
+            return PullResult::HostUnreachable {
+                reason: format!(
+                    "remote_check returned unexpected output: {}",
+                    stdout.trim()
+                ),
+            };
+        }
+        Err(reason) => {
+            return PullResult::HostUnreachable {
+                reason: format!("remote_check failed: {reason}"),
+            };
+        }
     }
 
     let argv = build_pull_rsync_argv(&opts);
@@ -362,7 +384,7 @@ pub async fn pull_workspace_back(opts: PullOptions<'_>) -> PullResult {
 /// this in production with the push flow: mkdir succeeded
 /// creating `~/...` in cwd, then rsync failed because the
 /// expected `$HOME/...` parent didn't exist.
-fn shell_escape(path: &str) -> String {
+pub(crate) fn shell_escape(path: &str) -> String {
     if let Some(rest) = path.strip_prefix("~/") {
         return format!("~/{}", shell_escape_body(rest));
     }

--- a/src-tauri/src/ssh/registry.rs
+++ b/src-tauri/src/ssh/registry.rs
@@ -102,7 +102,10 @@ pub fn local_socket_for_workspace(workspace_id: &str) -> PathBuf {
     let mut hasher = DefaultHasher::new();
     workspace_id.hash(&mut hasher);
     let short = format!("{:x}", hasher.finish());
-    let truncated = &short[..short.len().min(12)];
+    // Full 16 hex chars (the whole u64) — truncating to 12 left only a
+    // 48-bit space (birthday collisions ~2^24 workspaces). 16 stays well
+    // under the 104-byte macOS sun_path limit (see the test below).
+    let truncated = &short[..short.len().min(16)];
     std::env::temp_dir().join(format!("codemux-tunnel-{truncated}.sock"))
 }
 
@@ -117,7 +120,10 @@ pub fn remote_socket_for_workspace(workspace_id: &str) -> String {
     let mut hasher = DefaultHasher::new();
     workspace_id.hash(&mut hasher);
     let short = format!("{:x}", hasher.finish());
-    let truncated = &short[..short.len().min(12)];
+    // Full 16 hex chars (the whole u64) — truncating to 12 left only a
+    // 48-bit space (birthday collisions ~2^24 workspaces). 16 stays well
+    // under the 104-byte macOS sun_path limit (see the test below).
+    let truncated = &short[..short.len().min(16)];
     format!("/tmp/codemux-ptyd-{truncated}.sock")
 }
 

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -1387,6 +1387,40 @@ impl AppStateStore {
         }
     }
 
+    /// Stamp a workspace's cross-device project identity directly from
+    /// known values (e.g. the synced row the workspace was adopted
+    /// from), WITHOUT recomputing the uid or touching `project_root`.
+    ///
+    /// Adoption uses this instead of `set_workspace_project_root`: the
+    /// synced row already carries the daemon-computed `project_uid`, so
+    /// copying it verbatim guarantees the adopted workspace converges
+    /// with its siblings on every device — including local-only repos,
+    /// whose path-derived uid would otherwise DIVERGE if recomputed
+    /// against the (different) local landing path. Without this stamp
+    /// the shell's `project_uid: None` also gets pushed back to the
+    /// sync row by `reconcile_from_snapshot` (a plain SET, not COALESCE),
+    /// actively wiping the row's identity.
+    pub fn set_workspace_project_identity(
+        &self,
+        workspace_id: &str,
+        project_uid: Option<String>,
+        workspace_kind: Option<String>,
+    ) {
+        let mut snapshot = self.inner.lock().unwrap();
+        if let Some(workspace) = snapshot
+            .workspaces
+            .iter_mut()
+            .find(|w| w.workspace_id.0 == workspace_id)
+        {
+            if project_uid.is_some() {
+                workspace.project_uid = project_uid;
+            }
+            if workspace_kind.is_some() {
+                workspace.workspace_kind = workspace_kind;
+            }
+        }
+    }
+
     pub fn set_workspace_type(&self, workspace_id: &str, workspace_type: WorkspaceType) -> bool {
         let mut snapshot = self.inner.lock().unwrap();
         if let Some(workspace) = snapshot
@@ -4639,6 +4673,50 @@ mod tests {
         assert!(
             workspace.tabs.is_empty(),
             "Shell must have no tabs",
+        );
+    }
+
+    #[test]
+    fn set_workspace_project_identity_stamps_uid_from_synced_row() {
+        // Adoption stamps the daemon-derived identity from the synced
+        // row (NOT a local recompute) so the adopted workspace converges
+        // with its siblings and the post-adopt reconcile doesn't push a
+        // None uid back over the row, wiping it.
+        let store = AppStateStore::default();
+        let wid = store.create_synced_workspace_shell(
+            "proj".into(),
+            7,
+            Some("/srv/proj".into()),
+            "/home/zeus/.codemux/worktrees/proj/main".into(),
+            Some("main".into()),
+        );
+        // Shell starts with no project_uid.
+        assert!(workspace_by_id(&store.snapshot(), &wid).project_uid.is_none());
+
+        store.set_workspace_project_identity(
+            &wid.0,
+            Some("daemon-uid-xyz".into()),
+            Some("main".into()),
+        );
+
+        let snap = store.snapshot();
+        let w = workspace_by_id(&snap, &wid);
+        assert_eq!(
+            w.project_uid.as_deref(),
+            Some("daemon-uid-xyz"),
+            "uid must be copied verbatim from the synced row",
+        );
+        assert_eq!(w.workspace_kind.as_deref(), Some("main"));
+
+        // A None passed in must NOT clobber an already-set value
+        // (older daemons send no uid — leave whatever's there).
+        store.set_workspace_project_identity(&wid.0, None, None);
+        assert_eq!(
+            workspace_by_id(&store.snapshot(), &wid)
+                .project_uid
+                .as_deref(),
+            Some("daemon-uid-xyz"),
+            "None must be a no-op, not a wipe",
         );
     }
 

--- a/src-tauri/src/workspaces_sync.rs
+++ b/src-tauri/src/workspaces_sync.rs
@@ -770,6 +770,76 @@ mod tests {
         assert_eq!(listed[0].workspace_id.as_deref(), Some("workspace-42"));
     }
 
+    #[test]
+    #[serial]
+    fn unlink_reverts_adopted_row_to_remote_only() {
+        // Adoption-failure rollback: after linking a row to a local
+        // shell, if the pull fails we must REVERT the row to a sibling
+        // (workspace_id NULL) so reconcile doesn't tombstone it and the
+        // overview keeps offering "Pull to this device".
+        let db = fresh_db();
+        db.upsert_workspace_sync_from_server(
+            "300",
+            "discovered",
+            Some("12"),
+            None,
+            None,
+            None,
+            None,
+            "2026-01-01 00:00:00",
+            "2026-01-01 00:00:00",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        db.link_workspace_sync_to_local("300", "workspace-42").unwrap();
+        assert_eq!(
+            db.list_workspaces_sync()[0].workspace_id.as_deref(),
+            Some("workspace-42")
+        );
+
+        db.unlink_workspace_sync_from_local("300").unwrap();
+        let listed = db.list_workspaces_sync();
+        assert!(
+            listed[0].workspace_id.is_none(),
+            "unlink must revert the row to a remote-only sibling"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn find_by_host_and_origin_uid_excludes_soft_deleted() {
+        // Contract: the live-row lookup must not return a tombstone — a
+        // future production caller expecting "live" semantics would
+        // otherwise reintroduce the resurrection class of bug. The
+        // dedicated `find_remote_discovered_tombstone` is the only path
+        // that may see soft-deleted rows.
+        let db = fresh_db();
+        let row = db
+            .insert_remote_discovered_workspace_sync(
+                "host-1", "uuid-abc", "ws", None, None, Some("main"), None, None,
+                None,
+            )
+            .unwrap();
+        assert!(db
+            .find_workspace_sync_by_host_and_origin_uid("host-1", "uuid-abc")
+            .is_some());
+
+        db.soft_delete_remote_discovered_workspace_sync_by_id(row.id)
+            .unwrap();
+        assert!(
+            db.find_workspace_sync_by_host_and_origin_uid("host-1", "uuid-abc")
+                .is_none(),
+            "live lookup must not surface a soft-deleted row"
+        );
+        assert!(
+            db.find_remote_discovered_tombstone("host-1", "uuid-abc")
+                .is_some(),
+            "the tombstone lookup still finds it (for undelete-on-reappear)"
+        );
+    }
+
     // ── reconcile_from_snapshot regression guards ───────────────
     //
     // These exercise the full reconcile bridge, not just the DB

--- a/src-tauri/tests/codemux_ssh_roundtrip.rs
+++ b/src-tauri/tests/codemux_ssh_roundtrip.rs
@@ -1,0 +1,202 @@
+//! Live SSH push/pull round-trip against a real host.
+//!
+//! Exercises the ACTUAL transport code — `ssh::push_workspace` and
+//! `ssh::pull_workspace_back` — over a real `ssh`/`rsync` to a real
+//! host, rather than asserting on argv construction. Proves:
+//!   - push lands the worktree contents (not dir-nested) at the remote
+//!     path, honoring the excludes (`node_modules/`, `.git/index.lock`);
+//!   - `--delete` mirrors a subsequent push (removed local file vanishes
+//!     remotely);
+//!   - pull brings it back intact;
+//!   - the `test -d` guard returns `RemoteNotFound` for a missing remote
+//!     path and does NOT `--delete`-wipe the local target (the dangerous
+//!     edge the guard exists to prevent).
+//!
+//! GATED: skips unless `CODEMUX_E2E_SSH_HOST` names an SSH target the
+//! current user can reach passwordlessly (e.g. a `~/.ssh/config` alias).
+//! CI without such a host simply no-ops. Unix-only (matches `ssh` mod).
+
+#![cfg(unix)]
+
+use std::path::Path;
+use std::time::Duration;
+
+use codemux_lib::ssh::{
+    pull_workspace_back, push_workspace, PullOptions, PullResult, PushOptions,
+    PushResult,
+};
+
+fn host() -> Option<String> {
+    match std::env::var("CODEMUX_E2E_SSH_HOST") {
+        Ok(h) if !h.trim().is_empty() => Some(h),
+        _ => None,
+    }
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn ssh_push_pull_round_trip_against_real_host() {
+    let Some(host) = host() else {
+        eprintln!("SKIP: set CODEMUX_E2E_SSH_HOST to run the live SSH round-trip");
+        return;
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    // Unique sandbox under /tmp; remote == localhost in the loopback
+    // setup, so the "remote" path is inspectable on this filesystem.
+    let stamp = std::process::id();
+    let base = std::env::temp_dir().join(format!("cmx-ssh-rt-{stamp}"));
+    let src = base.join("src_ws");
+    let remote = base.join("remote_ws");
+    let pulled = base.join("pulled_ws");
+    let _ = std::fs::remove_dir_all(&base);
+
+    // A realistic worktree: tracked files, nested dirs, a .git dir, and
+    // the two things the excludes must drop.
+    write(&src.join("README.md"), "hello\n");
+    write(&src.join("src/lib/util.rs"), "pub fn x() {}\n");
+    write(&src.join(".git/HEAD"), "ref: refs/heads/main\n");
+    write(&src.join(".git/index.lock"), "LOCK\n"); // must be excluded
+    write(&src.join("node_modules/junk.js"), "// huge\n"); // must be excluded
+
+    let opts = PushOptions {
+        ssh_target: &host,
+        local_worktree: &src,
+        remote_path: remote.to_str().unwrap(),
+        step_timeout: Duration::from_secs(60),
+    };
+    match rt.block_on(push_workspace(opts)) {
+        PushResult::Pushed { .. } => {}
+        other => panic!("push failed: {other:?}"),
+    }
+
+    // Contents landed (not nested under an extra dir level).
+    assert!(remote.join("README.md").exists(), "README must land");
+    assert!(
+        remote.join("src/lib/util.rs").exists(),
+        "nested file must land"
+    );
+    assert!(remote.join(".git/HEAD").exists(), ".git/HEAD must land");
+    // Excludes honored.
+    assert!(
+        !remote.join("node_modules/junk.js").exists(),
+        "node_modules must be excluded"
+    );
+    assert!(
+        !remote.join(".git/index.lock").exists(),
+        ".git/index.lock must be excluded"
+    );
+
+    // R5 regression: the .mcp.json the push provisions must carry an
+    // ABSOLUTE command path. Agent CLIs spawn it directly — no shell
+    // (so `~` won't expand) and no systemd (`%h` won't expand). The old
+    // `%h` rewrite silently broke remote MCP auto-discovery.
+    let mcp_json = std::fs::read_to_string(remote.join(".mcp.json"))
+        .expect(".mcp.json must be provisioned by push");
+    let v: serde_json::Value = serde_json::from_str(&mcp_json).unwrap();
+    let cmd = v["mcpServers"]["codemux"]["command"].as_str().unwrap();
+    assert!(cmd.starts_with('/'), "mcp command must be absolute, got: {cmd}");
+    assert!(
+        !cmd.contains('~') && !cmd.contains("%h"),
+        "mcp command must not contain a ~ or %h token: {cmd}"
+    );
+    assert!(
+        cmd.ends_with("/.local/bin/codemux-remote"),
+        "expected the resolved codemux-remote path, got: {cmd}"
+    );
+
+    // --delete mirror: remove a file locally, add another, re-push.
+    std::fs::remove_file(src.join("README.md")).unwrap();
+    write(&src.join("NEW.txt"), "added\n");
+    let opts2 = PushOptions {
+        ssh_target: &host,
+        local_worktree: &src,
+        remote_path: remote.to_str().unwrap(),
+        step_timeout: Duration::from_secs(60),
+    };
+    match rt.block_on(push_workspace(opts2)) {
+        PushResult::Pushed { .. } => {}
+        other => panic!("second push failed: {other:?}"),
+    }
+    assert!(
+        !remote.join("README.md").exists(),
+        "--delete must remove the file that was deleted locally"
+    );
+    assert!(remote.join("NEW.txt").exists(), "new file must land");
+
+    // Pull back into a fresh dir → contents match the current source.
+    let pull = PullOptions {
+        ssh_target: &host,
+        remote_path: remote.to_str().unwrap(),
+        local_worktree: &pulled,
+        step_timeout: Duration::from_secs(60),
+    };
+    match rt.block_on(pull_workspace_back(pull)) {
+        PullResult::Pulled { .. } => {}
+        other => panic!("pull failed: {other:?}"),
+    }
+    assert!(pulled.join("NEW.txt").exists(), "pulled NEW.txt");
+    assert!(pulled.join("src/lib/util.rs").exists(), "pulled nested file");
+    assert!(
+        !pulled.join("README.md").exists(),
+        "pulled tree must reflect the deletion"
+    );
+
+    // RemoteNotFound guard: pulling a missing remote path must NOT wipe
+    // the local target (the whole reason for the `test -d` pre-check).
+    let guard_local = base.join("guard_local");
+    write(&guard_local.join("sentinel.txt"), "do not delete me\n");
+    let missing = base.join("does_not_exist_remote");
+    let guard = PullOptions {
+        ssh_target: &host,
+        remote_path: missing.to_str().unwrap(),
+        local_worktree: &guard_local,
+        step_timeout: Duration::from_secs(60),
+    };
+    match rt.block_on(pull_workspace_back(guard)) {
+        PullResult::RemoteNotFound { .. } => {}
+        other => panic!("expected RemoteNotFound for a missing remote, got: {other:?}"),
+    }
+    assert!(
+        guard_local.join("sentinel.txt").exists(),
+        "RemoteNotFound must NOT --delete-wipe the local target",
+    );
+
+    // R6 regression: a `~/`-relative remote path must be tilde-EXPANDED
+    // by the remote shell. push's mkdir AND provision's ssh_write_file
+    // both quote via the tilde-aware shell_escape; a naive single-quote
+    // would create a literal `~` directory and lose the files.
+    let home = std::env::var("HOME").unwrap();
+    let tilde_rel = format!("cmx-e2e-tilde-{stamp}");
+    let tilde_abs = std::path::PathBuf::from(&home).join(&tilde_rel);
+    let _ = std::fs::remove_dir_all(&tilde_abs);
+    let tsrc = base.join("tilde_src");
+    write(&tsrc.join("marker.txt"), "tilde\n");
+    let tpush = PushOptions {
+        ssh_target: &host,
+        local_worktree: &tsrc,
+        remote_path: &format!("~/{tilde_rel}"),
+        step_timeout: Duration::from_secs(60),
+    };
+    match rt.block_on(push_workspace(tpush)) {
+        PushResult::Pushed { .. } => {}
+        other => panic!("tilde push failed: {other:?}"),
+    }
+    assert!(
+        tilde_abs.join("marker.txt").exists(),
+        "~/ remote path must expand to $HOME (not a literal ~ dir)"
+    );
+    assert!(
+        tilde_abs.join(".mcp.json").exists(),
+        "tilde-aware ssh_write_file must drop .mcp.json under $HOME"
+    );
+    let _ = std::fs::remove_dir_all(&tilde_abs);
+
+    let _ = std::fs::remove_dir_all(&base);
+}


### PR DESCRIPTION
## Summary

Hardens the full cross-device workspace pipeline — the flow where an agent on a `codemux-remote` host creates work that a dev device polls, publishes, and pulls/pushes/adopts. Found via a deep multi-pass audit **and live end-to-end testing** (real `codemux-remote` binary, daemon HTTP + MCP stdio, and a real SSH push/pull round-trip), all confined to failure-mode/lifecycle/transport correctness — no behavior was removed.

Three commits:

### 1. `d15fcff` — phantom pull-conflict on a stale link
The pull dialog refused to pull a branch back from a host, claiming "you already have this branch open," when the local workspace had actually been closed. The conflict guard trusted a non-null `workspace_id` without checking the workspace was still live in app state. Now liveness-gated, matching the overview and adopt-idempotency paths.

### 2. `cd6f1f9` — failure-mode + lifecycle gaps
- **Swallowed adopt failure (critical):** a failed rsync during adopt returned a success toast over an empty/broken shell while the idempotency guard then blocked retry. Now checks the pull outcome, rolls back the shell + unlinks the row, and surfaces a real error.
- **Tunnel/daemon leak on close (critical):** closing a worktree-kind pushed workspace never tore down the SSH tunnel supervisor + remote pty-daemon. Now torn down on close.
- **Identity wipe (high):** adopted workspaces weren't stamped with `project_uid`, and the plain-SET reconcile then wiped the daemon-derived uid from the row. Now stamped from the synced row.
- **Duplicate-on-repoll (high):** an adopt→close→re-poll inserted a duplicate sibling row and churned the cloud row. Now undeletes the tombstone on reappear (clearing the stale link) + dedupes ids within one inventory envelope.
- **Soft-deleted-row lookup footgun (low):** `find_workspace_sync_by_host_and_origin_uid` now excludes tombstones.

### 3. `fe61318` — gaps found by a second pass + live testing
- **`close_workspace` (plain command) also leaked the tunnel** — the worktree-kind close was fixed in #2 but its non-worktree twin (the sidebar's default close path) wasn't. Completed.
- **Worktree-adopt had no rollback** on its post-shell fallible mutations → orphan shell + duplicate on retry. Completed.
- **Clone-adopt never stamped identity** → cloned copy wouldn't converge with siblings. Completed (derives the deterministic uid from the cloned repo's canonical remote).
- **`RemoteNotFound` misclassified as `HostUnreachable`** (found by live testing): the code string-matched `"exit status 7"` but the real error is `"exit status: 7"`. Replaced with a robust stdout sentinel.
- **Remote MCP auto-discovery was broken:** the pushed `.mcp.json` used the systemd `%h` token, which agent CLIs can't expand. Now resolves the remote `$HOME` and writes an absolute path (matching the user-level `mcp_register` pattern).
- **Hardening:** routed SSH `remote_path` interpolation through the tilde-aware `shell_escape` (injection defense without breaking `~` expansion); widened the tunnel socket hash 12→16 hex (collision hardening).

## Testing

- Full Rust lib suite green except 2–3 pre-existing flaky/environmental tests in `agent_browser`/`commands::mcp` (unrelated files; fail without these changes too).
- The 5 modules changed here: **156/156 deterministic** across repeated runs.
- All 18 `codemux_remote_*` integration tests pass (binary, daemon HTTP, MCP stdio, the `workspace list` → reconcile wire contract).
- **Live end-to-end** against a loopback host: daemon `serve` (manifest 0600, loopback, auth-enforced), all 12 MCP tools (HTTP + stdio), `workspace_create`/`worktree_create` with correct identity, PTY I/O, SSH push→`--delete`-mirror→pull-back, the `RemoteNotFound` guard, the absolute `.mcp.json`, `~/`-relative expansion, and the binary-install path.
- New CI-safe (env-gated) harness `codemux_ssh_roundtrip.rs` encodes the round-trip, `RemoteNotFound`, `.mcp.json`-absolute, and tilde-expansion regressions.

## Notes / follow-ups
- The desktop-side adopt/push/close Tauri commands require an `AppHandle` and weren't run headlessly; they're covered by unit tests + code review + live testing of the underlying transport/daemon.
- Daemon SQLite migration safety, MCP JSON-RPC compliance, and the cloud `COALESCE` server-authority were all reviewed and verified correct (no change needed).