### PR TITLE
feat(ports): surface Docker container ports for codemux worktrees

### DIFF
--- a/docs/features/ports.md
+++ b/docs/features/ports.md
@@ -18,6 +18,8 @@ Codemux automatically detects TCP ports that dev servers open, displays them in 
 - **Windows**: shells out to `netstat -ano` (with `CREATE_NO_WINDOW` to suppress the console flash) and `tasklist /NH /FO csv`, then parses both via pure cross-platform `parse_netstat_output` / `parse_tasklist_csv` helpers. The parsers are unit-tested on Linux CI so a Windows runner isn't needed to catch parser regressions. Because `netstat -ano` lists EVERY listening socket regardless of owner, an explicit process-name filter (`WINDOWS_SYSTEM_PROCESS_NAMES`) drops kernel-owned sockets that Linux's permission filter would never have surfaced.
 - **Other platforms**: returns an empty list.
 
+On top of the OS scan, `scan_ports` folds in a **Docker source** (`detect_docker_ports`). On Linux, ports published by a container are owned by the root `docker-proxy` process, so the `/proc/*/fd` PID-resolution step hits the same permission wall that hides system services — the listening socket is visible in `/proc/net/tcp` but is never attributed to a PID, so the OS scan drops it. To recover these, Codemux shells out to `docker ps` (tab-delimited `--format`, parsed by the pure cross-platform `parse_docker_ps_output`), and surfaces each *published* TCP host port labeled with its container name. Detection is **scoped to codemux worktrees**: a container is included only if its compose `working_dir` label matches an open workspace's `cwd` or `worktree_path` (see `all_workspace_paths`). Unrelated stacks the user runs by hand are excluded. Docker availability is cached (`DOCKER_CLI_STATE`) so a missing binary doesn't trigger a doomed spawn every cycle, while a transiently-down daemon recovers on its own. On a port collision Docker wins (better label than a rootless `docker-proxy`), and the existing `.codemux` static-config override still takes precedence. These ports carry `source = "docker"`, which the UI renders under a dedicated **Docker** group.
+
 Results are filtered to exclude system services and Codemux-internal port ranges on all platforms. The Windows system-process name filter (case-insensitive ASCII match) covers `System` / `Idle` / `smss.exe` / `csrss.exe` / `wininit.exe` / `winlogon.exe` / `services.exe` / `lsass.exe` / `svchost.exe` / `dwm.exe` / `spoolsv.exe` / `SearchIndexer.exe` / `MsMpEng.exe` / `RuntimeBroker.exe` / `dllhost.exe` / `WmiPrvSE.exe` / and ~10 others. User-runnable dev tools (`node.exe`, `python.exe`, browsers, IDE language servers) are intentionally NOT in the filter — only kernel + service-host processes are dropped.
 
 ## What Works Today
@@ -31,17 +33,21 @@ Results are filtered to exclude system services and Codemux-internal port ranges
 - Windows system-process name filter (`WINDOWS_SYSTEM_PROCESS_NAMES`) drops kernel + service-host owned sockets that `netstat -ano` would otherwise surface (16+ ports on a typical Windows host)
 - IPv4 + IPv6 dedup on Windows (services that bind to both `0.0.0.0:port` and `[::]:port` show as one entry)
 - exact-port matching (not substring) so a process listening on `:92230` is never confused with `:9223`
+- Docker-published container ports for open worktrees (via `docker ps`), shown under a dedicated **Docker** group labeled by container name — recovers ports the Linux `/proc` scan can't see because `docker-proxy` runs as root. Published TCP only; IPv4/IPv6 host-port double-publish is deduped; the kill action is hidden for these rows (killing the socket wouldn't stop the container)
 
 ## Current Constraints
 
 - macOS port detection is not implemented (returns empty list) — needs a `lsof`-based or `libproc` backend
-- polling-based, not event-driven (3-second interval)
-- no per-workspace port scoping (shows all user ports globally)
-- UDP ports are not detected
+- polling-based, not event-driven (3-second interval); the Docker source adds one `docker ps` spawn per cycle when at least one workspace is open and the CLI is available
+- no per-workspace port scoping for OS-detected ports (shows all user ports globally); the Docker source, by contrast, is scoped to open worktrees
+- UDP ports are not detected (including UDP container publishes)
+- Docker detection requires the `docker` CLI on `PATH` and socket access for the current user; only compose containers carry the `working_dir`/`service` labels used for matching and labeling, so non-compose `docker run` containers are not surfaced
+- port-range publishes (`8000-8005->8000-8005/tcp`) are skipped (the host segment doesn't parse to a single `u16`)
 - Windows parent-PID walk uses `wmic process ... get ParentProcessId`, which is deprecated on Windows 11 24H2+ — the workspace attribution degrades gracefully to "unassigned" when it fails
 
 ## Important Touch Points
 
-- `src-tauri/src/ports.rs` — top-level `detect_listening_ports()` dispatch, `PortInfo` struct, `WINDOWS_SYSTEM_PROCESS_NAMES` constant + `is_windows_system_process()` filter, cross-platform `parse_netstat_output` / `parse_tasklist_csv` pure parsers, Linux `/proc` helpers, Windows `windows_impl` module with `netstat`/`tasklist`/`wmic` I/O wrappers
+- `src-tauri/src/ports.rs` — top-level `detect_listening_ports()` dispatch, `PortInfo` struct (incl. `source`), `WINDOWS_SYSTEM_PROCESS_NAMES` constant + `is_windows_system_process()` filter, cross-platform `parse_netstat_output` / `parse_tasklist_csv` / `parse_docker_ps_output` pure parsers, `detect_docker_ports` + `run_docker_ps` + `DOCKER_PS_FORMAT` + `DOCKER_CLI_STATE`, `scan_ports` merge/dedup, Linux `/proc` helpers, Windows `windows_impl` module
+- `src-tauri/src/state/state_impl.rs` — `PortInfoSnapshot` (incl. `source`), `all_workspace_paths()` (path → workspace_id for Docker matching)
 - `src-tauri/src/commands/mod.rs` — `get_detected_ports`, `kill_port` (branches on `cfg!(windows)`)
-- `src/components/layout/sidebar-ports-section.tsx` — sidebar port display and actions
+- `src/components/layout/sidebar-ports-popover.tsx` — sidebar port display, `groupPorts` (workspace / Docker / Other grouping), and actions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1413,6 +1413,7 @@ mod tests {
             process_name: format!("proc-{port}"),
             workspace_id: ws.map(str::to_string),
             label: label.map(str::to_string),
+            source: None,
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1232,8 +1232,14 @@ pub fn run() {
                     let session_pids = pty_state.get_session_pids();
                     let session_workspaces = app_state.all_session_workspaces();
                     let workspace_cwds = app_state.all_workspace_cwds();
+                    let workspace_paths = app_state.all_workspace_paths();
 
-                    let ports = ports::scan_ports(&session_pids, &session_workspaces, &workspace_cwds);
+                    let ports = ports::scan_ports(
+                        &session_pids,
+                        &session_workspaces,
+                        &workspace_cwds,
+                        &workspace_paths,
+                    );
                     let port_snapshots: Vec<state::PortInfoSnapshot> = ports
                         .into_iter()
                         .map(|p| state::PortInfoSnapshot {
@@ -1242,6 +1248,7 @@ pub fn run() {
                             process_name: p.process_name,
                             workspace_id: p.workspace_id,
                             label: p.label,
+                            source: p.source,
                         })
                         .collect();
 

--- a/src-tauri/src/ports.rs
+++ b/src-tauri/src/ports.rs
@@ -126,6 +126,12 @@ pub struct PortInfo {
     pub process_name: String,
     pub workspace_id: Option<String>,
     pub label: Option<String>,
+    /// Where this port was discovered. `None` for the OS-level scan
+    /// (`/proc` on Linux, `netstat` on Windows); `Some("docker")` for a
+    /// published container port surfaced via the Docker CLI. The frontend
+    /// uses this to render container ports under a dedicated "Docker" group.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -265,6 +271,7 @@ fn resolve_pids_for_inodes(inode_to_port: &HashMap<u64, u16>) -> Vec<PortInfo> {
                                 process_name,
                                 workspace_id: None,
                                 label: None,
+                                source: None,
                             });
                         }
                     }
@@ -394,6 +401,7 @@ fn parse_netstat_output(
             process_name,
             workspace_id: None,
             label: None,
+            source: None,
         });
     }
 
@@ -610,16 +618,187 @@ pub fn load_static_ports(workspace_cwd: &str, workspace_id: &str) -> Option<Vec<
                 process_name: String::new(),
                 workspace_id: Some(workspace_id.to_string()),
                 label: Some(entry.label),
+                source: None,
             })
             .collect(),
     )
 }
 
-/// Full port scan: detect ports, resolve workspaces, apply static configs.
+/// Go-template format passed to `docker ps`. Tab-separated so the pure
+/// parser can split fields unambiguously — container names, paths, and
+/// service names never contain tabs. Docker expands the literal `\t` escape
+/// into a real tab in its output (verified against the CLI).
+///
+/// Fields, in order:
+///   1. `.Names` — container name (e.g. `myproj-web-1`)
+///   2. compose `working_dir` label — absolute path of the compose project
+///      dir, which equals the codemux worktree path for agent-spawned stacks
+///   3. compose `service` label — short service name (e.g. `web`)
+///   4. `.Ports` — published / exposed port list
+const DOCKER_PS_FORMAT: &str = "{{.Names}}\\t{{.Label \"com.docker.compose.project.working_dir\"}}\\t{{.Label \"com.docker.compose.service\"}}\\t{{.Ports}}";
+
+/// Cached availability of the `docker` CLI. 0 = unknown, 1 = present,
+/// 2 = binary not found. Only the "not found" verdict is cached: a missing
+/// binary won't materialize mid-session, so there's no point spawning a
+/// doomed process every 3 seconds. A present-but-erroring daemon (socket
+/// down, missing permission) is deliberately NOT cached so detection
+/// recovers on its own once the daemon is back.
+static DOCKER_CLI_STATE: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+/// Run `docker ps` with [`DOCKER_PS_FORMAT`]. Returns raw stdout, or `None`
+/// if docker is unavailable or the command failed. Suppresses the console
+/// window on Windows — this runs every 3s, so a flashing console would be
+/// unacceptable — mirroring the `netstat`/`tasklist` shell-outs.
+fn run_docker_ps() -> Option<String> {
+    use std::sync::atomic::Ordering;
+
+    // Skip the spawn entirely once we've learned docker isn't installed.
+    if DOCKER_CLI_STATE.load(Ordering::Relaxed) == 2 {
+        return None;
+    }
+
+    let mut cmd = std::process::Command::new("docker");
+    cmd.args(["ps", "--no-trunc", "--format", DOCKER_PS_FORMAT]);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NO_WINDOW — no console flash on the 3s heartbeat.
+        cmd.creation_flags(0x0800_0000);
+    }
+
+    match cmd.output() {
+        Ok(output) if output.status.success() => {
+            DOCKER_CLI_STATE.store(1, Ordering::Relaxed);
+            Some(String::from_utf8_lossy(&output.stdout).into_owned())
+        }
+        // Daemon down or no socket permission — transient, don't cache.
+        Ok(_) => None,
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                DOCKER_CLI_STATE.store(2, Ordering::Relaxed);
+            }
+            None
+        }
+    }
+}
+
+/// Detect published Docker container ports that belong to an open codemux
+/// worktree.
+///
+/// Why this exists: on Linux, published container ports are owned by the
+/// root `docker-proxy` process, so the `/proc/*/fd` PID-resolution step in
+/// `linux_detect_listening_ports` hits a permission wall and silently drops
+/// them. The listening socket is right there in `/proc/net/tcp` but is never
+/// attributed to a PID, so the OS scan can't surface it. Querying the Docker
+/// CLI recovers these ports with a meaningful label (the container name).
+///
+/// `workspace_paths` maps absolute path -> workspace_id for every open
+/// workspace (both cwd and worktree path). A container is included only if
+/// its compose `working_dir` matches one of those paths — this is what
+/// scopes detection to codemux worktree containers and excludes unrelated
+/// stacks the user runs by hand.
+fn detect_docker_ports(workspace_paths: &HashMap<String, String>) -> Vec<PortInfo> {
+    // No open workspaces → nothing a container could match → skip the spawn.
+    if workspace_paths.is_empty() {
+        return Vec::new();
+    }
+    let Some(stdout) = run_docker_ps() else {
+        return Vec::new();
+    };
+    parse_docker_ps_output(&stdout, workspace_paths)
+}
+
+/// Pure parser for `docker ps` output in [`DOCKER_PS_FORMAT`]. Defined at
+/// module level (not behind any cfg) so its tests run on every platform —
+/// the body is pure string parsing with no syscalls.
+///
+/// Each line is `name \t working_dir \t service \t ports`. A row is kept only
+/// if `working_dir` matches an open workspace path; for each *published* TCP
+/// mapping (`IP:HOSTPORT->CPORT/tcp`) the host port becomes a `PortInfo`
+/// tagged `source = "docker"` and labeled with the container name. Filtered
+/// out: bare exposures with no host binding (`8000/tcp`), UDP mappings,
+/// Codemux-internal ports, and the IPv4/IPv6 double-publish of one host port.
+fn parse_docker_ps_output(
+    stdout: &str,
+    workspace_paths: &HashMap<String, String>,
+) -> Vec<PortInfo> {
+    let mut results: Vec<PortInfo> = Vec::new();
+    let mut seen_ports: std::collections::HashSet<u16> = std::collections::HashSet::new();
+
+    for line in stdout.lines() {
+        let mut fields = line.splitn(4, '\t');
+        let (Some(name), Some(working_dir), Some(service), Some(ports_str)) =
+            (fields.next(), fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+
+        let name = name.trim();
+        // Match the container's compose project dir to an open workspace.
+        // Trim a trailing slash so `/path` and `/path/` compare equal.
+        let working_dir = working_dir.trim().trim_end_matches('/');
+        if working_dir.is_empty() {
+            continue;
+        }
+        let Some(workspace_id) = workspace_paths.get(working_dir) else {
+            continue;
+        };
+        let service = service.trim();
+
+        // `ports_str` looks like:
+        //   "0.0.0.0:8099->8000/tcp, [::]:8099->8000/tcp, 8000/tcp"
+        for segment in ports_str.split(',') {
+            let segment = segment.trim();
+            // Published mappings contain "->"; bare "8000/tcp" exposures don't.
+            let Some((host_side, _container_side)) = segment.split_once("->") else {
+                continue;
+            };
+            // Only TCP — the OS scan is TCP-only, keep parity.
+            if !segment.ends_with("/tcp") {
+                continue;
+            }
+            // `host_side` is "IP:PORT" (IPv4) or "[::]:PORT" (IPv6); the host
+            // port is whatever follows the final ':'.
+            let Some(port_str) = host_side.rsplit(':').next() else {
+                continue;
+            };
+            let Ok(port) = port_str.parse::<u16>() else {
+                continue;
+            };
+            if is_codemux_internal_port(port) {
+                continue;
+            }
+            // The same host port is published once for IPv4 and once for
+            // IPv6 — dedupe so it appears a single time.
+            if !seen_ports.insert(port) {
+                continue;
+            }
+
+            results.push(PortInfo {
+                port,
+                pid: 0,
+                process_name: service.to_string(),
+                workspace_id: Some(workspace_id.clone()),
+                label: Some(name.to_string()),
+                source: Some("docker".to_string()),
+            });
+        }
+    }
+
+    results.sort_by_key(|p| p.port);
+    results
+}
+
+/// Full port scan: detect ports, resolve workspaces, apply static configs,
+/// and fold in Docker-published worktree ports.
+///
+/// `workspace_paths` (absolute path -> workspace_id, covering cwd and
+/// worktree path) is used only for matching Docker containers to worktrees.
 pub fn scan_ports(
     session_pids: &HashMap<String, u32>,
     session_workspaces: &HashMap<String, String>,
     workspace_cwds: &HashMap<String, String>,
+    workspace_paths: &HashMap<String, String>,
 ) -> Vec<PortInfo> {
     // Check for static port configs first
     let mut static_workspace_ids = std::collections::HashSet::new();
@@ -645,6 +824,35 @@ pub fn scan_ports(
             .unwrap_or(false);
         if !dominated_by_static {
             all_ports.push(port);
+        }
+    }
+
+    // Docker-published container ports. On Linux these are owned by the root
+    // `docker-proxy` and so are invisible to the /proc scan above; the Docker
+    // CLI recovers them, scoped to open codemux worktrees.
+    let docker_ports = detect_docker_ports(workspace_paths);
+    if !docker_ports.is_empty() {
+        let mut existing: std::collections::HashSet<u16> =
+            all_ports.iter().map(|p| p.port).collect();
+        for dp in docker_ports {
+            // Honor the static-config override: a workspace with a
+            // .codemux/ports.json owns its port list outright.
+            let dominated_by_static = dp
+                .workspace_id
+                .as_ref()
+                .map(|ws_id| static_workspace_ids.contains(ws_id))
+                .unwrap_or(false);
+            if dominated_by_static {
+                continue;
+            }
+            // Docker wins on a port collision (rootless docker can surface the
+            // same port in the OS scan as `docker-proxy`/`rootlesskit` — the
+            // container name is the better label).
+            if existing.contains(&dp.port) {
+                all_ports.retain(|p| p.port != dp.port);
+            }
+            existing.insert(dp.port);
+            all_ports.push(dp);
         }
     }
 
@@ -1083,6 +1291,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "svchost.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 139,
@@ -1090,6 +1299,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "System".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 445,
@@ -1097,6 +1307,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "System".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 1042,
@@ -1104,6 +1315,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "svchost.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 1043,
@@ -1111,6 +1323,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "svchost.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 5040,
@@ -1118,6 +1331,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "svchost.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 5173,
@@ -1125,6 +1339,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "node.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
         ];
 
@@ -1152,6 +1367,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "node.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 8000,
@@ -1159,6 +1375,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "python.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 9229,
@@ -1166,6 +1383,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "chrome.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
             PortInfo {
                 port: 8080,
@@ -1173,6 +1391,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
                 process_name: "java.exe".into(),
                 workspace_id: None,
                 label: None,
+                source: None,
             },
         ];
 
@@ -1195,6 +1414,7 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
             process_name: "unknown".into(),
             workspace_id: None,
             label: None,
+            source: None,
         }];
 
         let filtered = apply_windows_system_filter(input.clone());
@@ -1241,6 +1461,231 @@ TCP 0.0.0.0:9000 0.0.0.0:0 LISTENING 1234
             filtered_ports,
             vec![5173],
             "after the system-process filter only the node.exe dev server should remain"
+        );
+    }
+}
+
+// ── Docker parser tests ─────────────────────────────────────────────────────
+//
+// Exercise `parse_docker_ps_output` with hand-built `docker ps` fixtures.
+// The parser is pure string-processing (no `docker` binary, no syscalls), so
+// these run on every platform on CI — the same cross-platform strategy used
+// for the netstat/tasklist parsers above.
+
+#[cfg(test)]
+mod docker_parser_tests {
+    use super::{parse_docker_ps_output, PortInfo};
+    use std::collections::HashMap;
+
+    const WT: &str = "/home/u/.codemux/worktrees/proj/feature-x";
+    const WS_ID: &str = "ws-feature-x";
+
+    /// One open workspace whose worktree path is `WT`.
+    fn worktree_map() -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert(WT.to_string(), WS_ID.to_string());
+        m
+    }
+
+    /// Build a single `docker ps` line: name \t working_dir \t service \t ports.
+    fn line(name: &str, working_dir: &str, service: &str, ports: &str) -> String {
+        format!("{name}\t{working_dir}\t{service}\t{ports}")
+    }
+
+    #[test]
+    fn published_port_for_matching_worktree_is_detected() {
+        // A real container publishes the same host port on IPv4 and IPv6.
+        let stdout = line(
+            "proj-web-1",
+            WT,
+            "web",
+            "0.0.0.0:8099->8000/tcp, [::]:8099->8000/tcp",
+        );
+        let ports = parse_docker_ps_output(&stdout, &worktree_map());
+
+        assert_eq!(ports.len(), 1, "IPv4+IPv6 double-publish must dedupe to one");
+        let p = &ports[0];
+        assert_eq!(p.port, 8099);
+        assert_eq!(p.label.as_deref(), Some("proj-web-1"), "label = container name");
+        assert_eq!(p.process_name, "web", "process_name = compose service");
+        assert_eq!(p.workspace_id.as_deref(), Some(WS_ID));
+        assert_eq!(p.source.as_deref(), Some("docker"));
+        assert_eq!(p.pid, 0, "Docker ports carry no OS pid");
+    }
+
+    #[test]
+    fn unpublished_exposure_is_ignored() {
+        // `EXPOSE`d but not published: no "->" host mapping.
+        let stdout = line("proj-db-1", WT, "db", "5432/tcp, 8000/tcp");
+        assert!(
+            parse_docker_ps_output(&stdout, &worktree_map()).is_empty(),
+            "ports with no host binding must not appear"
+        );
+    }
+
+    #[test]
+    fn container_outside_any_worktree_is_excluded() {
+        // working_dir doesn't match an open workspace — unrelated stack.
+        let stdout = line(
+            "random-redis-1",
+            "/opt/other/stack",
+            "redis",
+            "0.0.0.0:6400->6379/tcp",
+        );
+        assert!(
+            parse_docker_ps_output(&stdout, &worktree_map()).is_empty(),
+            "containers outside codemux worktrees must be filtered out"
+        );
+    }
+
+    #[test]
+    fn codemux_internal_ports_are_skipped() {
+        // 4000 (in 3900..=4199) and 9300 (>= 9222) are Codemux-internal;
+        // only the normal 8090 should survive.
+        let stdout = line(
+            "proj-svc-1",
+            WT,
+            "svc",
+            "127.0.0.1:4000->80/tcp, 127.0.0.1:9300->80/tcp, 127.0.0.1:8090->80/tcp",
+        );
+        let ports = parse_docker_ps_output(&stdout, &worktree_map());
+        let nums: Vec<u16> = ports.iter().map(|p| p.port).collect();
+        assert_eq!(nums, vec![8090]);
+    }
+
+    #[test]
+    fn udp_mappings_are_ignored() {
+        let stdout = line("proj-dns-1", WT, "dns", "0.0.0.0:5353->53/udp");
+        assert!(
+            parse_docker_ps_output(&stdout, &worktree_map()).is_empty(),
+            "UDP mappings must be ignored (parity with the TCP-only OS scan)"
+        );
+    }
+
+    #[test]
+    fn multiple_services_in_one_project_each_appear() {
+        let stdout = format!(
+            "{}\n{}\n{}",
+            line("proj-web-1", WT, "web", "127.0.0.1:7000->7000/tcp"),
+            line("proj-api-1", WT, "api", "127.0.0.1:8080->8080/tcp"),
+            line("proj-cache-1", WT, "cache", "6379/tcp"), // unpublished → skipped
+        );
+        let ports = parse_docker_ps_output(&stdout, &worktree_map());
+        let nums: Vec<u16> = ports.iter().map(|p| p.port).collect();
+        assert_eq!(nums, vec![7000, 8080], "results are sorted by port");
+        let services: Vec<&str> = ports.iter().map(|p| p.process_name.as_str()).collect();
+        assert_eq!(services, vec!["web", "api"]);
+    }
+
+    #[test]
+    fn trailing_slash_in_working_dir_still_matches() {
+        // Compose can report the dir with a trailing slash; the workspace
+        // map stores it without one. They must still match.
+        let with_slash = format!("{WT}/");
+        let stdout = line("proj-web-1", &with_slash, "web", "0.0.0.0:9090->80/tcp");
+        let ports = parse_docker_ps_output(&stdout, &worktree_map());
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].port, 9090);
+    }
+
+    #[test]
+    fn blank_and_malformed_lines_are_skipped() {
+        // Empty lines and rows with too few tab fields must not panic.
+        let stdout = format!(
+            "\n{}\nshort-line-no-tabs\n{}",
+            line("proj-web-1", WT, "web", "0.0.0.0:8099->8000/tcp"),
+            "name-only\tdir-only",
+        );
+        let ports = parse_docker_ps_output(&stdout, &worktree_map());
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].port, 8099);
+    }
+
+    #[test]
+    fn empty_workspace_map_yields_nothing() {
+        let stdout = line("proj-web-1", WT, "web", "0.0.0.0:8099->8000/tcp");
+        assert!(parse_docker_ps_output(&stdout, &HashMap::new()).is_empty());
+    }
+
+    /// Ensures the field constants stay aligned with what we construct: a
+    /// `PortInfo` from this parser always has `source = Some("docker")`.
+    #[test]
+    fn detected_ports_are_tagged_docker() {
+        let stdout = line("proj-web-1", WT, "web", "0.0.0.0:8099->8000/tcp");
+        let ports: Vec<PortInfo> = parse_docker_ps_output(&stdout, &worktree_map());
+        assert!(ports.iter().all(|p| p.source.as_deref() == Some("docker")));
+    }
+}
+
+// ── Live Docker integration test (requires a running Docker daemon) ──────────
+//
+// `#[ignore]`d so `cargo test` and CI stay hermetic (no docker dependency).
+// Unlike the pure-parser tests above, this drives the *real* `detect_docker_ports`
+// path — an actual `docker ps` spawn with `DOCKER_PS_FORMAT`, then parse + the
+// worktree-scope filter. Run it manually against a labeled container whose
+// compose `working_dir` you pass via env:
+//
+//   docker run -d --name demo \
+//     --label com.docker.compose.project.working_dir="$PWD" \
+//     --label com.docker.compose.service=web -p 8099:8000 \
+//     python:3.12-slim python -m http.server 8000
+//   CODEMUX_DOCKER_TEST_WD="$PWD" CODEMUX_DOCKER_TEST_PORT=8099 \
+//     cargo test --manifest-path src-tauri/Cargo.toml --lib \
+//     docker_live_tests -- --ignored --nocapture
+#[cfg(test)]
+mod docker_live_tests {
+    use super::detect_docker_ports;
+    use std::collections::HashMap;
+
+    #[test]
+    #[ignore = "requires a running Docker daemon and a labeled test container"]
+    fn detects_live_published_port_for_worktree() {
+        let wd = std::env::var("CODEMUX_DOCKER_TEST_WD")
+            .expect("set CODEMUX_DOCKER_TEST_WD to the container's compose working_dir");
+        let expected_port: u16 = std::env::var("CODEMUX_DOCKER_TEST_PORT")
+            .expect("set CODEMUX_DOCKER_TEST_PORT")
+            .parse()
+            .expect("CODEMUX_DOCKER_TEST_PORT must be a u16");
+
+        let mut paths = HashMap::new();
+        paths.insert(
+            wd.trim_end_matches('/').to_string(),
+            "ws-live-test".to_string(),
+        );
+
+        let ports = detect_docker_ports(&paths);
+        eprintln!("detect_docker_ports({wd}) -> {ports:#?}");
+
+        let hit = ports
+            .iter()
+            .find(|p| p.port == expected_port)
+            .unwrap_or_else(|| panic!("port {expected_port} not detected; got {ports:?}"));
+        assert_eq!(hit.source.as_deref(), Some("docker"));
+        assert_eq!(hit.workspace_id.as_deref(), Some("ws-live-test"));
+        assert!(
+            hit.label.as_deref().is_some_and(|l| !l.is_empty()),
+            "label should be the container name"
+        );
+    }
+
+    /// A container whose `working_dir` matches NO open workspace must be
+    /// excluded — proves the worktree-scope filter against the live daemon.
+    #[test]
+    #[ignore = "requires a running Docker daemon and a labeled test container"]
+    fn excludes_live_container_outside_worktrees() {
+        let expected_port: u16 = std::env::var("CODEMUX_DOCKER_TEST_PORT")
+            .expect("set CODEMUX_DOCKER_TEST_PORT")
+            .parse()
+            .expect("CODEMUX_DOCKER_TEST_PORT must be a u16");
+
+        // Map points at an unrelated path, so the live container shouldn't match.
+        let mut paths = HashMap::new();
+        paths.insert("/nonexistent/worktree".to_string(), "ws-other".to_string());
+
+        let ports = detect_docker_ports(&paths);
+        assert!(
+            !ports.iter().any(|p| p.port == expected_port),
+            "container outside the workspace path set must be filtered out; got {ports:?}"
         );
     }
 }

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -442,6 +442,11 @@ pub struct PortInfoSnapshot {
     pub process_name: String,
     pub workspace_id: Option<String>,
     pub label: Option<String>,
+    /// Discovery source: `None` = OS-level scan, `Some("docker")` = a
+    /// published container port. Drives the dedicated "Docker" group in the
+    /// ports UI. `#[serde(default)]` keeps older persisted snapshots loadable.
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1463,6 +1468,30 @@ impl AppStateStore {
             .iter()
             .map(|w| (w.workspace_id.0.clone(), w.cwd.clone()))
             .collect()
+    }
+
+    /// Returns absolute path -> workspace_id for all workspaces, covering
+    /// both the working directory and the git worktree path. The inverse
+    /// direction of `all_workspace_cwds` (path is the key) because Docker
+    /// container matching looks up by the compose `working_dir` path. Paths
+    /// are stored with any trailing slash trimmed so lookups normalize.
+    pub fn all_workspace_paths(&self) -> std::collections::HashMap<String, String> {
+        let snapshot = self.inner.lock().unwrap();
+        let mut map = std::collections::HashMap::new();
+        for w in &snapshot.workspaces {
+            let id = w.workspace_id.0.clone();
+            let cwd = w.cwd.trim_end_matches('/');
+            if !cwd.is_empty() {
+                map.insert(cwd.to_string(), id.clone());
+            }
+            if let Some(worktree_path) = &w.worktree_path {
+                let wt = worktree_path.trim_end_matches('/');
+                if !wt.is_empty() {
+                    map.insert(wt.to_string(), id.clone());
+                }
+            }
+        }
+        map
     }
 
     /// Returns session_id -> workspace_id for all terminal sessions across all workspaces.

--- a/src/components/layout/sidebar-ports-popover.test.tsx
+++ b/src/components/layout/sidebar-ports-popover.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { groupPorts } from "./sidebar-ports-popover";
+import type { PortInfoSnapshot, WorkspaceSnapshot } from "@/tauri/types";
+
+function port(
+  p: Partial<PortInfoSnapshot> & { port: number },
+): PortInfoSnapshot {
+  return {
+    port: p.port,
+    pid: p.pid ?? 0,
+    process_name: p.process_name ?? "proc",
+    workspace_id: p.workspace_id ?? null,
+    label: p.label ?? null,
+    source: p.source ?? null,
+  };
+}
+
+// groupPorts only reads `workspace_id` and `title`, so a minimal cast keeps
+// the fixtures readable without building a full WorkspaceSnapshot.
+const ws = (id: string, title: string) =>
+  ({ workspace_id: id, title }) as unknown as WorkspaceSnapshot;
+
+describe("groupPorts", () => {
+  it("collapses all docker ports into a single 'Docker' group regardless of workspace", () => {
+    const groups = groupPorts(
+      [
+        port({ port: 7000, source: "docker", workspace_id: "ws1", label: "a-web-1" }),
+        port({ port: 8080, source: "docker", workspace_id: "ws2", label: "b-api-1" }),
+      ],
+      [ws("ws1", "A"), ws("ws2", "B")],
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].workspaceName).toBe("Docker");
+    expect(groups[0].ports.map((p) => p.port)).toEqual([7000, 8080]);
+  });
+
+  it("orders groups workspace → docker → other", () => {
+    const groups = groupPorts(
+      [
+        port({ port: 5000 }), // other: no workspace, no source
+        port({ port: 9000, source: "docker", workspace_id: "ws1", label: "c-1" }),
+        port({ port: 3000, workspace_id: "ws1" }), // workspace
+      ],
+      [ws("ws1", "A")],
+    );
+    expect(groups.map((g) => g.workspaceName)).toEqual(["A", "Docker", "Other"]);
+  });
+
+  it("labels non-docker groups by workspace title and falls back to 'Other'", () => {
+    const groups = groupPorts(
+      [port({ port: 3000, workspace_id: "ws1" }), port({ port: 4000 })],
+      [ws("ws1", "My Project")],
+    );
+    const byName = Object.fromEntries(groups.map((g) => [g.workspaceName, g]));
+    expect(byName["My Project"].ports[0].port).toBe(3000);
+    expect(byName["Other"].ports[0].port).toBe(4000);
+  });
+
+  it("keeps a docker port out of its workspace group even when workspace_id is set", () => {
+    const groups = groupPorts(
+      [
+        port({ port: 3000, workspace_id: "ws1" }),
+        port({ port: 8099, source: "docker", workspace_id: "ws1", label: "d-1" }),
+      ],
+      [ws("ws1", "A")],
+    );
+    const a = groups.find((g) => g.workspaceName === "A")!;
+    const docker = groups.find((g) => g.workspaceName === "Docker")!;
+    expect(a.ports.map((p) => p.port)).toEqual([3000]);
+    expect(docker.ports.map((p) => p.port)).toEqual([8099]);
+  });
+
+  it("returns no groups for an empty port list", () => {
+    expect(groupPorts([], [])).toEqual([]);
+  });
+});

--- a/src/components/layout/sidebar-ports-popover.tsx
+++ b/src/components/layout/sidebar-ports-popover.tsx
@@ -28,30 +28,64 @@ import { Plug, Globe, X, Copy } from "lucide-react";
 import type { PortInfoSnapshot, WorkspaceSnapshot } from "@/tauri/types";
 import { cn } from "@/lib/utils";
 
+type PortGroupKind = "workspace" | "docker" | "other";
+
 interface PortGroup {
+  key: string;
+  kind: PortGroupKind;
   workspaceId: string | null;
   workspaceName: string;
   ports: PortInfoSnapshot[];
 }
 
-function groupPorts(
+const GROUP_RANK: Record<PortGroupKind, number> = {
+  workspace: 0,
+  docker: 1,
+  other: 2,
+};
+
+const DOCKER_KEY = "__docker__";
+const OTHER_KEY = "__other__";
+
+export function groupPorts(
   ports: PortInfoSnapshot[],
   workspaces: WorkspaceSnapshot[],
 ): PortGroup[] {
   const map = new Map<string, PortGroup>();
   for (const port of ports) {
-    const key = port.workspace_id ?? "__other__";
-    if (!map.has(key)) {
+    // Docker container ports collapse into one "Docker" group regardless of
+    // which worktree they belong to; everything else groups by workspace.
+    let key: string;
+    let kind: PortGroupKind;
+    let workspaceId: string | null;
+    let workspaceName: string;
+    if (port.source === "docker") {
+      key = DOCKER_KEY;
+      kind = "docker";
+      workspaceId = null;
+      workspaceName = "Docker";
+    } else if (port.workspace_id) {
+      key = port.workspace_id;
+      kind = "workspace";
+      workspaceId = port.workspace_id;
       const ws = workspaces.find((w) => w.workspace_id === port.workspace_id);
-      map.set(key, {
-        workspaceId: port.workspace_id,
-        workspaceName: ws?.title ?? "Other",
-        ports: [],
-      });
+      workspaceName = ws?.title ?? "Other";
+    } else {
+      key = OTHER_KEY;
+      kind = "other";
+      workspaceId = null;
+      workspaceName = "Other";
+    }
+    if (!map.has(key)) {
+      map.set(key, { key, kind, workspaceId, workspaceName, ports: [] });
     }
     map.get(key)!.ports.push(port);
   }
-  return Array.from(map.values());
+  // Workspaces first, then Docker, then Other. Array.sort is stable, so the
+  // first-seen order is preserved within each rank.
+  return Array.from(map.values()).sort(
+    (a, b) => GROUP_RANK[a.kind] - GROUP_RANK[b.kind],
+  );
 }
 
 export function SidebarPortsPopover() {
@@ -155,7 +189,7 @@ export function SidebarPortsPopover() {
             ) : (
               groups.map((group) => (
                 <CommandGroup
-                  key={group.workspaceId ?? "__other__"}
+                  key={group.key}
                   heading={
                     <span className="text-[10px] uppercase tracking-wide text-muted-foreground/70">
                       {group.workspaceName}
@@ -164,7 +198,7 @@ export function SidebarPortsPopover() {
                 >
                   {group.ports.map((port) => (
                     <CommandItem
-                      key={port.port}
+                      key={`${port.source ?? "os"}-${port.port}`}
                       value={`${port.port}-${port.process_name}-${port.label ?? ""}`}
                       onSelect={() => openInBrowser(port)}
                       className="group/port flex items-center gap-2 py-1.5"
@@ -172,11 +206,16 @@ export function SidebarPortsPopover() {
                       <span className="font-mono text-xs font-semibold text-foreground tabular-nums shrink-0">
                         {port.port}
                       </span>
-                      <span className="truncate text-[11px] text-muted-foreground flex-1 min-w-0">
+                      <span
+                        className="truncate text-[11px] text-muted-foreground flex-1 min-w-0"
+                        title={port.label ?? port.process_name}
+                      >
                         {port.label ?? port.process_name}
                       </span>
                       <span className="text-[10px] text-muted-foreground/50 tabular-nums shrink-0 transition-opacity group-hover/port:opacity-0">
-                        PID {port.pid}
+                        {port.source === "docker"
+                          ? port.process_name
+                          : `PID ${port.pid}`}
                       </span>
                       <div className="absolute right-2 flex items-center gap-0.5 opacity-0 group-hover/port:opacity-100 transition-opacity">
                         <Tooltip>
@@ -215,24 +254,26 @@ export function SidebarPortsPopover() {
                             Copy URL
                           </TooltipContent>
                         </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleKill(port);
-                              }}
-                              className="flex h-5 w-5 items-center justify-center rounded-sm text-muted-foreground hover:bg-danger/15 hover:text-danger"
-                              aria-label="Kill process"
-                            >
-                              <X className="h-3 w-3" />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent side="top" sideOffset={4} className="text-xs">
-                            Kill process
-                          </TooltipContent>
-                        </Tooltip>
+                        {port.source !== "docker" && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleKill(port);
+                                }}
+                                className="flex h-5 w-5 items-center justify-center rounded-sm text-muted-foreground hover:bg-danger/15 hover:text-danger"
+                                aria-label="Kill process"
+                              >
+                                <X className="h-3 w-3" />
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent side="top" sideOffset={4} className="text-xs">
+                              Kill process
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
                       </div>
                     </CommandItem>
                   ))}

--- a/src/tauri/types.ts
+++ b/src/tauri/types.ts
@@ -816,6 +816,9 @@ export interface PortInfoSnapshot {
   process_name: string;
   workspace_id: string | null;
   label: string | null;
+  /** Discovery source: `null` for the OS scan, `"docker"` for a published
+   *  container port. Drives the dedicated "Docker" group in the ports UI. */
+  source: string | null;
 }
 
 export interface AppStateSnapshot {


### PR DESCRIPTION
## Problem

Ports published by Docker containers never showed up in the Active Ports panel on Linux. The published socket *is* visible in `/proc/net/tcp`, but it's owned by the root `docker-proxy` process — so the `/proc/*/fd` PID-resolution step in the existing scan can't attribute it to a process (a non-root app can't read root's fd dir) and the port is silently dropped. This is the same permission wall that hides system services, with Docker caught as collateral.

## Approach

Add a **Docker source** to `scan_ports` that shells out to `docker ps`, parses published TCP host ports, and folds them into the detected-ports list. Detection is **scoped to open codemux worktrees**: a container is included only if its Compose `working_dir` label matches an open workspace's `cwd`/`worktree_path`, so unrelated stacks you run by hand are excluded. Matched ports carry `source = "docker"` and render under a dedicated **Docker** group labeled by container name.

## Changes

- **`ports.rs`** — `parse_docker_ps_output` (pure, cross-platform-testable), `detect_docker_ports` / `run_docker_ps` with `DOCKER_PS_FORMAT` and CLI-availability caching (missing binary isn't re-spawned every cycle; a transiently-down daemon recovers on its own; Windows console-flash suppressed). `scan_ports` merges Docker ports with port-collision dedup (Docker wins — better label than a rootless `docker-proxy`) and honors the existing `.codemux` static-config override.
- **`state_impl.rs`** — `PortInfoSnapshot.source` (+ `#[serde(default)]` for back-compat) and `all_workspace_paths()` (path → workspace_id covering cwd + worktree path).
- **`lib.rs`** — `source` threaded through the scan loop.
- **`sidebar-ports-popover.tsx`** — `groupPorts` now produces workspace / Docker / Other groups (Docker collapses into one group regardless of worktree); compose service shown instead of "PID 0" for Docker rows; Kill action hidden for Docker rows (killing the socket wouldn't stop the container).
- **`types.ts`** — `source` field.
- **docs** — `docs/features/ports.md` updated.

## Scope decisions

- Only **codemux worktree containers** (matched via the Compose `working_dir` label). Bare `docker run` containers without Compose labels are intentionally excluded.
- Container ports grouped under one **Docker** section, labeled by container name.

## Testing

- **12 Rust tests** in `ports.rs`: published vs. unpublished, IPv4/IPv6 host-port dedup, worktree match vs. exclusion, Codemux-internal-port skip, UDP skip, multi-service, trailing-slash normalization, malformed lines, empty map — plus two `#[ignore]`d live-daemon integration tests driving the real `docker ps` path.
- **`groupPorts` unit tests** (`sidebar-ports-popover.test.tsx`): grouping, ordering, Docker-collapse, Other fallback.
- `cargo check`, `cargo test`, `tsc --noEmit`, and `vitest` all green.
- Verified end-to-end against a live container: `detect_docker_ports` returns `PortInfo { port, process_name: <service>, label: <container>, source: Some("docker"), workspace_id }`, and a running dev build surfaces it under the Docker group via the control socket.

## Notes

- One unrelated, pre-existing test (`commands::mcp::tests::project_codemux_entry_is_filtered_out`) fails in environments whose real `~/.claude.json` contains a `codemux` MCP entry that leaks into the test (confirmed identical on `main` with this branch's changes stashed). Not touched here.