### PR TITLE
fix(new-workspace): make issue-link dedup honest instead of silent

### DIFF
--- a/src/components/overlays/new-workspace-dialog.test.tsx
+++ b/src/components/overlays/new-workspace-dialog.test.tsx
@@ -78,6 +78,15 @@ vi.mock("@/tauri/commands", () => ({
   getDefaultBranch: vi.fn().mockResolvedValue("main"),
 }));
 
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 import {
   listBranches,
   checkIsGitRepo,
@@ -94,6 +103,7 @@ import {
   _defaultBranchCache,
   _defaultBranchInFlight,
 } from "@/components/layout/default-branch-cache";
+import { toast } from "@/lib/toast";
 
 // ── Helpers ──
 
@@ -389,6 +399,45 @@ describe("Submit flow", () => {
       expect(activateWorkspace).toHaveBeenCalledWith("ws-extra-0");
     });
 
+    expect(createWorktreeWorkspace).not.toHaveBeenCalled();
+    // The dedup must not be silent — that's what made re-linking an issue
+    // look like "nothing happened" and quietly dropped the typed message.
+    expect(toast.info).toHaveBeenCalledWith(
+      expect.stringContaining("already has a workspace"),
+    );
+  });
+
+  it("surfaces an 'Open it' notice before submit when the branch already has a workspace", async () => {
+    setAppState("/path/to/project", [
+      {
+        cwd: "/path/to/project/wt",
+        git_branch: "my-feature",
+        project_root: "/path/to/project",
+      },
+    ]);
+    const onOpenChange = vi.fn();
+    renderDialog(true, onOpenChange);
+
+    const dialog = await screen.findByRole("dialog");
+    const branchInput = within(dialog).getByPlaceholderText("branch name");
+    // Mirrors what linking an issue does: auto-fill a branch that already
+    // belongs to a workspace.
+    fireEvent.change(branchInput, { target: { value: "my-feature" } });
+
+    // Proactive notice + action appear without submitting.
+    const openBtn = await within(dialog).findByRole("button", {
+      name: /Open it/i,
+    });
+    expect(
+      within(dialog).getByText(/already has a workspace/i),
+    ).toBeInTheDocument();
+
+    fireEvent.click(openBtn);
+
+    await waitFor(() => {
+      expect(activateWorkspace).toHaveBeenCalledWith("ws-extra-0");
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(createWorktreeWorkspace).not.toHaveBeenCalled();
   });
 });

--- a/src/components/overlays/new-workspace-dialog.tsx
+++ b/src/components/overlays/new-workspace-dialog.tsx
@@ -325,6 +325,26 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     return map;
   }, [appState, projectDir]);
 
+  // When the branch we're about to create already belongs to a workspace,
+  // surface it up-front instead of silently deduping at submit. Linking an
+  // issue auto-fills a deterministic branch name, so this is how the user
+  // learns "you already have a workspace for issue #N" before hitting send.
+  // Scoped to create_new — the open_existing flow is an explicit "open it"
+  // choice already.
+  const existingWorkspaceForBranch = useMemo(() => {
+    if (branchMode !== "create_new") return undefined;
+    const branch = branchName.trim();
+    return branch ? branchWorkspaceMap.get(branch) : undefined;
+  }, [branchMode, branchName, branchWorkspaceMap]);
+
+  const handleOpenExistingWorkspace = useCallback(
+    async (wsId: string) => {
+      onOpenChange(false);
+      await activateWorkspace(wsId);
+    },
+    [onOpenChange],
+  );
+
   // Worktree paths already owned by a Codemux workspace. Used to filter
   // `git worktree list` so "Open ↵ <branch>" doesn't try to re-import a
   // worktree that's already attached to another workspace row.
@@ -474,6 +494,11 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
       if (branchMode === "open_existing" && openExistingBranch) {
         const existingWsId = branchWorkspaceMap.get(openExistingBranch);
         if (existingWsId) {
+          toast.info(
+            linkedIssue
+              ? `Issue #${linkedIssue.number} already has a workspace — switched to it.`
+              : `"${openExistingBranch}" already has a workspace — switched to it.`,
+          );
           await activateWorkspace(existingWsId);
           removePendingWorkspace(tempId);
           return;
@@ -561,9 +586,18 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
         }
       }
 
-      // Check if workspace already exists for this branch
+      // Check if workspace already exists for this branch. Linking an issue
+      // auto-fills a deterministic `feature/<n>-<slug>` branch name, so
+      // re-linking an issue that already has a workspace lands here. Switch
+      // to it AND tell the user: a silent return reads as "nothing happened"
+      // and quietly drops the message they just typed.
       const existingWsId = branchWorkspaceMap.get(resolvedBranch);
       if (existingWsId) {
+        toast.info(
+          linkedIssue
+            ? `Issue #${linkedIssue.number} already has a workspace — switched to it.`
+            : `"${resolvedBranch}" already has a workspace — switched to it.`,
+        );
         await activateWorkspace(existingWsId);
         removePendingWorkspace(tempId);
         return;
@@ -794,6 +828,28 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
                     </button>
                   </span>
                 ))}
+              </div>
+            )}
+
+            {/* Already-exists notice: the linked issue (or typed branch)
+                already has a workspace. Offer to open it instead of the
+                silent submit-time dedup that drops the typed message. */}
+            {existingWorkspaceForBranch && (
+              <div className="mx-3 mb-2 flex items-center justify-between gap-2 rounded-md border border-border bg-muted/40 px-3 py-1.5 text-[11px] text-muted-foreground">
+                <span className="min-w-0 truncate">
+                  {linkedIssue
+                    ? `Issue #${linkedIssue.number} already has a workspace.`
+                    : `"${branchName.trim()}" already has a workspace.`}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    handleOpenExistingWorkspace(existingWorkspaceForBranch)
+                  }
+                  className="shrink-0 rounded-md border border-border bg-background px-2 py-0.5 font-medium text-foreground transition-colors hover:bg-muted"
+                >
+                  Open it
+                </button>
               </div>
             )}
 


### PR DESCRIPTION
## Problem

Creating a workspace by **linking a GitHub issue and hitting send** appeared to do nothing — no new workspace, no error, and the typed message vanished. Plain \`+\` workspaces worked fine. The failure showed up specifically in projects with many issue-linked workspaces (observed in a repo with 13).

## Root cause

Linking an issue auto-fills a **deterministic** branch name via \`github::suggest_branch_name\` → \`feature/<n>-<slug>\`, which reproduces the existing branch for that issue exactly.

On submit, \`handleSubmit\` checks \`branchWorkspaceMap.get(branch)\`; when a workspace for that branch already exists it calls \`activateWorkspace(...)\` and **returns silently**, discarding the prompt the user typed. Plain workspaces use a *random* branch name, so they never collide — which is why only the issue path was affected, and increasingly so as a project accumulates issue-linked workspaces. The dedup itself is correct (no two worktrees on one branch); the problem is that it was silent and lossy.

## Fix

`src/components/overlays/new-workspace-dialog.tsx`:

- **Never silent at submit** — both dedup paths now `toast.info("Issue #N already has a workspace — switched to it")` before activating.
- **Caught before send** — when the linked issue (or typed branch) already maps to a workspace, an inline notice appears with an **"Open it"** button, so the user sees what's happening and their message isn't silently dropped.

The dedup behavior is unchanged; only the feedback is added.

## Tests

- Extended the existing "activates existing workspace when branch already has one" test to assert the toast.
- Added a test for the inline "already has a workspace / Open it" notice.
- `npm run check`: pass · full vitest suite: 119 files / 1793 tests pass.

## Notes / follow-ups (not in this PR)

- The **PR-linking** path likely shares this structure and may want the same treatment.
- Pre-existing flaky test `"does not override the pill once the user has manually picked a branch"` (a default-branch resolution timing race) flakes on `main` too; untouched here.
- Separate backend scaling smell: the 5s refresh loop runs the *synchronous* `populate_git_info` for every workspace on the Tokio runtime (`lib.rs:790`) when an async twin exists for exactly that reason.