### PR TITLE
fix(new-workspace): polish PR attach to match the issue picker

### DIFF
--- a/docs/features/workspace-creation.md
+++ b/docs/features/workspace-creation.md
@@ -74,6 +74,7 @@ After onboarding: scripts saved to project config, worktree workspace created, w
 - `src/components/overlays/project-picker.tsx` — project directory selection
 - `src/components/overlays/clone-dialog.tsx` — git clone flow
 - `src/components/github/issue-picker.tsx` — issue linking UI
+- `src/components/github/pr-picker.tsx` — PR linking UI (floating picker mirroring the issue picker; state-aware icons shared with the sidebar via `pr-status-icon.tsx`)
 - `src-tauri/src/commands/workspace.rs` — workspace creation Tauri commands
 - `src-tauri/src/commands/package_detect.rs` — package manager detection
 - `src-tauri/src/branch_name.rs` — AI branch name generation

--- a/src/components/github/pr-picker.tsx
+++ b/src/components/github/pr-picker.tsx
@@ -1,18 +1,12 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { cn } from "@/lib/utils";
-import {
-  GitPullRequest,
-  GitPullRequestClosed,
-  GitMerge,
-  GitPullRequestDraft,
-  Search,
-  Loader2,
-} from "lucide-react";
+import { Search, Loader2 } from "lucide-react";
+import { PrStatusIcon, type PrStatusState } from "@/components/github/pr-status-icon";
 import { listPullRequests, getGithubPrByPath } from "@/tauri/commands";
 import type { PullRequestInfo } from "@/tauri/types";
 
 /**
- * Stage 5 — pull-request picker, mirroring `IssuePickerPanel`.
+ * Pull-request picker, mirroring `IssuePickerPanel`.
  *
  * Renders a search input plus a flat list of recent PRs from the
  * given repo path, fetched via the cached `gh pr list` wrapper. The
@@ -20,13 +14,11 @@ import type { PullRequestInfo } from "@/tauri/types";
  * left, `#N` number, title, and a hover-revealed "Link ↵" affordance
  * matching the rest of the picker family.
  *
- * State conventions (icon + tint):
- *   - OPEN (non-draft) → GitPullRequest, primary
- *   - OPEN (draft)     → GitPullRequestDraft, muted
- *   - MERGED           → GitMerge, purple-ish (`text-chart-4` falls
- *                        back nicely if the project hasn't customised
- *                        the chart palette)
- *   - CLOSED           → GitPullRequestClosed, destructive
+ * The status icon + color reuse `PrStatusIcon` — the same component
+ * used for the sidebar PR pill — so a row reads identically here and
+ * in the sidebar: merged → purple GitMerge, open → green
+ * GitPullRequest, draft → muted GitPullRequestDraft, closed → red
+ * GitPullRequestClosed.
  */
 
 function fuzzyMatch(text: string, query: string): boolean {
@@ -39,37 +31,14 @@ function fuzzyMatch(text: string, query: string): boolean {
   return qi === q.length;
 }
 
-interface PrIconConfig {
-  Icon:
-    | typeof GitPullRequest
-    | typeof GitPullRequestClosed
-    | typeof GitMerge
-    | typeof GitPullRequestDraft;
-  className: string;
-}
-
-function configForState(pr: PullRequestInfo): PrIconConfig {
+/** Collapse the `state` string + `is_draft` flag into the single
+ *  state token `PrStatusIcon` understands. A draft only matters while
+ *  the PR is still open; merged/closed take precedence. */
+function effectivePrState(pr: PullRequestInfo): PrStatusState {
   const upper = (pr.state ?? "OPEN").toUpperCase();
-  if (upper === "MERGED") {
-    // Purple is the universal merged colour across GH/GL UIs.
-    // `text-chart-4` is one of shadcn's chart palette tokens that
-    // renders purple in both themes; falls back to muted if the
-    // project tweaked the palette.
-    return { Icon: GitMerge, className: "text-chart-4" };
-  }
-  if (upper === "CLOSED") {
-    return {
-      Icon: GitPullRequestClosed,
-      className: "text-destructive",
-    };
-  }
-  if (pr.is_draft) {
-    return {
-      Icon: GitPullRequestDraft,
-      className: "text-muted-foreground",
-    };
-  }
-  return { Icon: GitPullRequest, className: "text-success" };
+  if (upper === "MERGED") return "merged";
+  if (upper === "CLOSED") return "closed";
+  return pr.is_draft ? "draft" : "open";
 }
 
 function PrRow({
@@ -83,7 +52,6 @@ function PrRow({
   onSelect: () => void;
   onMouseEnter: () => void;
 }) {
-  const { Icon, className: iconClass } = configForState(pr);
   return (
     <div
       role="option"
@@ -97,7 +65,7 @@ function PrRow({
       onClick={onSelect}
       onMouseEnter={onMouseEnter}
     >
-      <Icon className={cn("size-3.5 shrink-0", iconClass)} />
+      <PrStatusIcon state={effectivePrState(pr)} className="shrink-0" />
       <span className="text-muted-foreground text-[0.75rem] shrink-0 font-mono tabular-nums">
         #{pr.number}
       </span>

--- a/src/components/overlays/new-workspace-dialog.tsx
+++ b/src/components/overlays/new-workspace-dialog.tsx
@@ -38,6 +38,7 @@ import { useUIStore } from "@/stores/ui-store";
 import { PresetIcon } from "@/components/icons/preset-icon";
 import { ProjectPicker } from "./project-picker";
 import { IssuePickerPanel } from "@/components/github/issue-picker";
+import { PrPickerPanel } from "@/components/github/pr-picker";
 import { useDefaultBranch } from "@/components/layout/default-branch-cache";
 import {
   listBranches,
@@ -136,6 +137,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
   const [attachments, setAttachments] = useState<string[]>([]);
   const [linkedIssue, setLinkedIssue] = useState<GitHubIssue | null>(null);
   const [issuePickerOpen, setIssuePickerOpen] = useState(false);
+  const [prPickerOpen, setPrPickerOpen] = useState(false);
   const [branchAutoFilled, setBranchAutoFilled] = useState(false);
   const [branchMode, setBranchMode] = useState<"create_new" | "open_existing">("create_new");
   const [openExistingBranch, setOpenExistingBranch] = useState<string | null>(null);
@@ -157,11 +159,11 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
   const [currentBranch, setCurrentBranch] = useState<string | null>(null);
   const [isGitRepo, setIsGitRepo] = useState<boolean | null>(null);
   const [prBranches, setPrBranches] = useState<Set<string>>(new Set());
-  const [openPrs, setOpenPrs] = useState<PullRequestInfo[]>([]);
   const [ghAvailable, setGhAvailable] = useState(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const issuePickerRef = useRef<HTMLDivElement>(null);
+  const prPickerRef = useRef<HTMLDivElement>(null);
 
   // Reset state when dialog opens
   const prevOpenRef = useRef(false);
@@ -178,6 +180,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     setAttachments([]);
     setLinkedIssue(null);
     setIssuePickerOpen(false);
+    setPrPickerOpen(false);
     setBranchAutoFilled(false);
     setBranchMode("create_new");
     setOpenExistingBranch(null);
@@ -266,7 +269,6 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
           listPullRequests(projectDir, "open")
             .then((prs) => {
               if (cancelled) return;
-              setOpenPrs(prs);
               const heads = new Set<string>();
               for (const pr of prs) {
                 if (pr.head_branch) heads.add(pr.head_branch);
@@ -444,6 +446,16 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     },
     [branchName, branchAutoFilled, branchMode],
   );
+
+  const handlePrSelect = useCallback((pr: PullRequestInfo) => {
+    // Linking a PR fills the branch from its head ref so the workspace
+    // tracks the PR's branch. Mark it as an explicit (non-auto) choice
+    // so a later issue link won't clobber it.
+    if (pr.head_branch) {
+      setBranchName(pr.head_branch);
+      setBranchAutoFilled(false);
+    }
+  }, []);
 
   const handleOpenExisting = useCallback((branch: string) => {
     setBranchMode("open_existing");
@@ -722,6 +734,18 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     return () => document.removeEventListener("mousedown", handleMouseDown);
   }, [issuePickerOpen]);
 
+  // Close PR picker on click outside it (within the dialog)
+  useEffect(() => {
+    if (!prPickerOpen) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (prPickerRef.current && !prPickerRef.current.contains(e.target as Node)) {
+        setPrPickerOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [prPickerOpen]);
+
   // Handle Ctrl+Enter
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
@@ -928,53 +952,22 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
 
                 {/* Link pull request */}
                 {ghAvailable && (
-                  <DropdownMenu>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            aria-label="Link pull request"
-                            className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground outline-none"
-                          >
-                            <GitPullRequest className="h-4 w-4" />
-                          </button>
-                        </DropdownMenuTrigger>
-                      </TooltipTrigger>
-                      <TooltipContent side="top">Link pull request</TooltipContent>
-                    </Tooltip>
-                    <DropdownMenuContent align="end" className="w-[260px] max-h-[240px] overflow-y-auto">
-                      {openPrs.length === 0 ? (
-                        <DropdownMenuItem disabled className="text-xs text-muted-foreground">
-                          No open pull requests
-                        </DropdownMenuItem>
-                      ) : (
-                        openPrs.map((pr) => (
-                          <DropdownMenuItem
-                            key={pr.number}
-                            className="text-xs gap-2"
-                            disabled={!pr.head_branch}
-                            onClick={() => {
-                              if (pr.head_branch) setBranchName(pr.head_branch);
-                            }}
-                          >
-                            <div className="min-w-0 flex-1">
-                              <div className="truncate">{pr.title}</div>
-                              <div className="text-[10px] text-muted-foreground flex items-center gap-1">
-                                <span>#{pr.number}</span>
-                                {pr.head_branch && (
-                                  <>
-                                    <span className="opacity-40">-</span>
-                                    <span className="truncate font-mono">{pr.head_branch}</span>
-                                  </>
-                                )}
-                              </div>
-                            </div>
-                          </DropdownMenuItem>
-                        ))
-                      )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Link pull request"
+                        className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground outline-none"
+                        onClick={() => {
+                          setIssuePickerOpen(false);
+                          setPrPickerOpen(true);
+                        }}
+                      >
+                        <GitPullRequest className="h-4 w-4" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">Link pull request</TooltipContent>
+                  </Tooltip>
                 )}
 
                 {/* Link issue */}
@@ -985,7 +978,10 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
                         type="button"
                         aria-label="Link issue"
                         className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground outline-none"
-                        onClick={() => setIssuePickerOpen(true)}
+                        onClick={() => {
+                          setPrPickerOpen(false);
+                          setIssuePickerOpen(true);
+                        }}
                       >
                         <CircleDot className="h-4 w-4" />
                       </button>
@@ -1025,6 +1021,21 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
                 open={issuePickerOpen}
                 onSelect={handleIssueSelect}
                 onClose={() => setIssuePickerOpen(false)}
+              />
+            </div>
+          )}
+
+          {/* PR picker — same floating treatment as the issue picker */}
+          {prPickerOpen && projectDir && (
+            <div
+              ref={prPickerRef}
+              className="absolute right-0 top-full mt-1 z-50 w-[320px] rounded-lg border border-border bg-popover shadow-lg overflow-hidden animate-in fade-in-0 zoom-in-95 duration-150"
+            >
+              <PrPickerPanel
+                projectPath={projectDir}
+                open={prPickerOpen}
+                onSelect={handlePrSelect}
+                onClose={() => setPrPickerOpen(false)}
               />
             </div>
           )}


### PR DESCRIPTION
## Problem

In the New Workspace dialog (the project `+` popup), the **attach issue** and **attach PR** buttons were built two different ways:

- **Issue** → polished `IssuePickerPanel`: header, search bar, scrollable list, state-aware icons.
- **PR** → a bare `DropdownMenu` with a cramped two-line layout (`title` + `#1420 · branch`), no search, no icons — visually "completely off" next to the issue picker.

A clean `PrPickerPanel` (already powering the chat composer's PR submode) existed but the dialog wasn't using it.

## Fix

**`new-workspace-dialog.tsx`**
- Replaced the inline dropdown with the existing `PrPickerPanel`, wired identically to the issue picker (same floating popover, animation, click-outside, reset-on-open).
- Added `handlePrSelect` that fills the branch from the PR's head ref and marks it an explicit choice.
- Opening one picker now closes the other (they share screen position).
- Removed the dead `openPrs` state (the panel fetches its own list); kept `prBranches` for the branch picker badges.

**`pr-picker.tsx`**
- Row icons now reuse `PrStatusIcon` (the sidebar PR pill component) as a single source of truth: **merged → purple**, **open → green**, draft → muted, closed → red.
- Fixes a latent color mismatch where the picker used `text-chart-4` instead of the sidebar's purple, so the picker and sidebar now read identically.

The PR picker now matches the issue picker: header, search (with direct `#number` lookup), skeleton loading, scroll, and hover `Link ↵` affordance.

## Verification

- `npm run check` (tsc) — clean
- `npm run test` for affected suites — 169 component tests pass (new-workspace-dialog, github, composer)
- Note: the populated list can't be rendered headlessly since it pulls from `gh` via the Tauri bridge; relied on the reused, already-shipping `PrPickerPanel` + the test suite.