### PR TITLE
Bulletproof remote-host / cross-device workspaces

### DIFF
--- a/src-tauri/src/bin/codemux_remote.rs
+++ b/src-tauri/src/bin/codemux_remote.rs
@@ -429,6 +429,14 @@ async fn run_serve_async(port: Option<u16>, state_dir: PathBuf) -> Result<(), St
         Err(e) => eprintln!("[codemux-remote] project-identity backfill skipped: {e}"),
     }
 
+    // Collapse any duplicate `main` rows an agent may have registered for the
+    // same project — one repo root per project, per host. Idempotent.
+    match workspaces.normalize_main_workspaces() {
+        Ok(0) => {}
+        Ok(n) => eprintln!("[codemux-remote] collapsed {n} duplicate main workspace row(s)"),
+        Err(e) => eprintln!("[codemux-remote] main-workspace normalize skipped: {e}"),
+    }
+
     let manifest_value = manifest::Manifest::new(endpoint.clone(), host_id);
     let manifest_path = config::manifest_path(&state_dir);
     manifest::write(&manifest_path, &manifest_value)?;

--- a/src-tauri/src/bin/codemux_remote.rs
+++ b/src-tauri/src/bin/codemux_remote.rs
@@ -524,12 +524,26 @@ fn run_serve_status(state_dir_arg: Option<PathBuf>) -> ExitCode {
         }
         Ok(Some(m)) => {
             let alive = codemux_lib::remote::manifest::pid_alive(m.pid);
+            // When alive, ask the running daemon how many live PTY sessions
+            // it has. The desktop auto-upgrade reads `live_terminals` to
+            // DEFER a daemon restart that would otherwise kill host-side
+            // agents — the "don't end my work when I close my laptop"
+            // guarantee. `app_status` has been in the tool catalog since the
+            // daemon shipped, so this probe works even against an OLD running
+            // daemon during the first upgrade after this change. Best-effort:
+            // a probe failure reports null.
+            let live_terminals = if alive {
+                probe_live_terminals(&m.endpoint, &m.secret)
+            } else {
+                None
+            };
             let payload = serde_json::json!({
                 "endpoint": m.endpoint,
                 "pid": m.pid,
                 "started_at": m.started_at,
                 "host_id": m.host_id,
                 "alive": alive,
+                "live_terminals": live_terminals,
             });
             println!("{}", payload);
             if alive {
@@ -543,6 +557,25 @@ fn run_serve_status(state_dir_arg: Option<PathBuf>) -> ExitCode {
             ExitCode::from(2)
         }
     }
+}
+
+/// Best-effort probe of the running daemon's live PTY-session count via its
+/// `app_status` tool (`terminal_count`). Returns `None` on any failure
+/// (timeout, decode, daemon down) — callers treat `None` as "unknown".
+#[cfg(unix)]
+fn probe_live_terminals(endpoint: &str, secret: &str) -> Option<u64> {
+    let http = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .ok()?;
+    let res = http
+        .post(format!("{endpoint}/tools/call"))
+        .bearer_auth(secret)
+        .json(&serde_json::json!({ "name": "app_status", "arguments": {} }))
+        .send()
+        .ok()?;
+    let body: serde_json::Value = res.json().ok()?;
+    body.get("data")?.get("terminal_count")?.as_u64()
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/commands/hosts.rs
+++ b/src-tauri/src/commands/hosts.rs
@@ -523,10 +523,15 @@ pub async fn workspace_push_to_host(
             );
         }
 
+        // Key the host landing path on project_uid so two different repos
+        // sharing a basename don't clobber each other on the host. The exact
+        // landing path is recorded (origin_path), so pull-back resolves it
+        // directly regardless of the uid suffix.
+        let puid = ws.project_uid.as_deref();
         let remote_path = if is_root {
-            crate::workspace_paths::conventional_remote_root_path(&project_name)
+            crate::workspace_paths::conventional_remote_root_path_keyed(puid, &project_name)
         } else {
-            crate::ssh::conventional_remote_path(&project_name, &branch)
+            crate::ssh::conventional_remote_path_keyed(puid, &project_name, &branch)
         };
         let remote_path_str = remote_path.to_string_lossy().to_string();
         let opts = crate::ssh::PushOptions::new(
@@ -881,8 +886,19 @@ pub async fn workspace_pull_back_impl(
             ws.worktree_path.is_none() && ws.workspace_kind.as_deref() == Some("main");
         let mut candidate_sources: Vec<String> = Vec::new();
         if let Some(op) = origin_path.clone() {
+            // The recorded on-disk path is authoritative — try it first.
             candidate_sources.push(op);
-        } else if is_root {
+        }
+        // Fallbacks (used when origin_path is absent — legacy rows). Try the
+        // uid-keyed path first (where new pushes land), then the legacy
+        // basename path so workspaces pushed before the re-key still pull.
+        let puid = ws.project_uid.as_deref();
+        if is_root {
+            candidate_sources.push(
+                crate::workspace_paths::conventional_remote_root_path_keyed(puid, &project_name)
+                    .to_string_lossy()
+                    .to_string(),
+            );
             candidate_sources.push(
                 crate::workspace_paths::conventional_remote_root_path(&project_name)
                     .to_string_lossy()
@@ -895,11 +911,18 @@ pub async fn workspace_pull_back_impl(
             );
         } else {
             candidate_sources.push(
+                crate::ssh::conventional_remote_path_keyed(puid, &project_name, &branch)
+                    .to_string_lossy()
+                    .to_string(),
+            );
+            candidate_sources.push(
                 crate::ssh::conventional_remote_path(&project_name, &branch)
                     .to_string_lossy()
                     .to_string(),
             );
         }
+        // De-dup while preserving order (uid-keyed == basename when no uid).
+        candidate_sources.dedup();
 
         // Try each candidate; only a "remote path missing" outcome is
         // worth retrying the next one — success / rsync error / host

--- a/src-tauri/src/commands/hosts.rs
+++ b/src-tauri/src/commands/hosts.rs
@@ -575,7 +575,15 @@ pub async fn workspace_push_to_host(
                     // here, tunnel must reach here.
                     "$HOME/.local/bin/codemux-remote".to_string(),
                 );
-                crate::ssh::install_supervisor(&workspace_id, supervisor).await;
+                crate::ssh::install_supervisor(&workspace_id, supervisor.clone())
+                    .await;
+                // Surface reconnect / circuit-open state to the UI for this
+                // freshly-pushed workspace.
+                crate::ssh::spawn_tunnel_status_forwarder(
+                    app.clone(),
+                    workspace_id.clone(),
+                    &supervisor,
+                );
 
                 // Sync Claude session JSONLs from
                 // ~/.claude/projects/<local-encoded>/ to the

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -1323,6 +1323,62 @@ pub async fn workspaces_adopt_project(
     })
 }
 
+/// Non-destructively "reconcile" a divergent standalone copy — the full
+/// `.git`-dir copy that lands under `~/.codemux/worktrees/<repo>/<branch>`
+/// and gets flagged with the amber "standalone copy" chip. Detaches its
+/// workspace card (so the project reads cleanly; the user can then "Pull
+/// project" to get a proper protected root) — **files are left on disk,
+/// never deleted**. Refuses when the copy has uncommitted changes or
+/// unpushed commits, returning guidance, so a card never disappears while
+/// the user has work in flight.
+#[tauri::command]
+pub async fn workspaces_reconcile_copy(
+    app: tauri::AppHandle,
+    workspace_id: String,
+) -> Result<String, String> {
+    // Resolve the copy's on-disk path from app_state (sync scope).
+    let path = {
+        let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
+        app_state
+            .snapshot()
+            .workspaces
+            .iter()
+            .find(|w| w.workspace_id.0 == workspace_id)
+            .map(|w| w.worktree_path.clone().unwrap_or_else(|| w.cwd.clone()))
+            .ok_or_else(|| format!("Workspace not found: {workspace_id}"))?
+    };
+
+    // Off-thread git checks: must be a divergent copy and safe to detach.
+    let blocker = tokio::task::spawn_blocking(move || {
+        let p = std::path::Path::new(&path);
+        if !crate::git::is_divergent_copy(p) {
+            return Err(
+                "This workspace isn't a standalone copy — nothing to reconcile.".to_string(),
+            );
+        }
+        Ok(crate::git::reconcile_copy_blocker(p))
+    })
+    .await
+    .map_err(|e| format!("git check join failed: {e}"))??;
+
+    if let Some(reason) = blocker {
+        return Err(format!("Can't reconcile yet: {reason}."));
+    }
+
+    // Safe: detach the copy's workspace card. close_workspace (state-level)
+    // removes the workspace from app_state WITHOUT deleting the directory —
+    // the files (and any local-only history) stay on disk.
+    {
+        let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
+        app_state.close_workspace(&workspace_id)?;
+    }
+    crate::state::emit_app_state(&app);
+
+    Ok("Closed the standalone copy (files kept on disk). Use \"Pull project\" \
+        to materialize a proper repo root."
+        .to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -41,6 +41,11 @@ pub struct WorkspaceSyncView {
     pub project_uid: Option<String>,
     /// `"main"` | `"worktree"` — the overview renders a kind badge.
     pub workspace_kind: Option<String>,
+    /// The repo's default branch (daemon-reported: `origin/HEAD` →
+    /// main/master → current). Lets the overview render a remote project's
+    /// root distinctly and the pull land it on the right branch even when
+    /// `git_branch` is null. Local-only — never round-trips through the cloud.
+    pub default_branch: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     /// True when the row has unpushed changes. The UI shows a
@@ -62,6 +67,7 @@ impl From<WorkspaceSyncRecord> for WorkspaceSyncView {
             git_head_sha: r.git_head_sha,
             project_uid: r.project_uid,
             workspace_kind: r.workspace_kind,
+            default_branch: r.default_branch,
             created_at: r.created_at,
             updated_at: r.updated_at,
             dirty: r.dirty,
@@ -678,21 +684,20 @@ pub async fn workspaces_adopt_synced(
     // next boot backfill. The root landed at ~/.codemux/projects/<repo>,
     // so it classifies as a genuine (non-divergent) root.
     if is_root {
-        let branch_owned = {
-            let app_state: tauri::State<'_, crate::state::AppStateStore> = app.state();
-            app_state
-                .snapshot()
-                .workspaces
-                .iter()
-                .find(|w| w.workspace_id.0 == workspace_id)
-                .and_then(|w| w.git_branch.clone())
-        };
         let landing_for_check = worktree_path.clone();
         let protected = tokio::task::spawn_blocking(move || {
-            crate::git::is_protected_repo_root(
-                std::path::Path::new(&landing_for_check),
-                branch_owned.as_deref(),
-            )
+            let p = std::path::Path::new(&landing_for_check);
+            // An rsync-pulled root may have copied an arbitrary checked-out
+            // branch (and a clone leaves `origin/HEAD` unset until we ask).
+            // Populate `origin/HEAD` (no-op for local-only repos) and land the
+            // root on its default branch, then classify against the repo's
+            // ACTUAL on-disk branch rather than the synced `git_branch`, which
+            // is frequently NULL for a root checkout the agent never named.
+            // Without this, a NULL synced branch made `is_protected_repo_root`
+            // fail-open to "deletable" — the "fake main" the user saw.
+            let _ = crate::git::ensure_origin_head(p);
+            let local_branch = crate::git::checkout_default_branch(p).ok().flatten();
+            crate::git::is_protected_repo_root(p, local_branch.as_deref())
         })
         .await
         .unwrap_or(false);
@@ -1159,6 +1164,122 @@ pub async fn workspaces_adopt_via_clone(
     })
 }
 
+/// One workspace that failed to adopt during a project-granularity pull.
+/// Collected (not fatal) so a single bad worktree doesn't abort the rest.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectAdoptFailure {
+    pub server_id: String,
+    pub title: String,
+    pub error: String,
+}
+
+/// Result of pulling an entire project (its repo root + every worktree)
+/// in one action.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProjectAdoptOutcome {
+    /// Each workspace successfully materialised on this device.
+    pub adopted: Vec<AdoptOutcome>,
+    /// Worktrees that failed (the root failing aborts with an `Err` instead).
+    pub failures: Vec<ProjectAdoptFailure>,
+    pub message: String,
+}
+
+/// Pull an entire project — its repo ROOT first, then every worktree — in a
+/// single action. This is the "project-first" model: instead of pulling a
+/// lone worktree that lands as a deletable "<branch>" copy, we materialise
+/// the protected repo root at `~/.codemux/projects/<repo>` and recreate each
+/// worktree as a real linked worktree hanging off it.
+///
+/// Ordering matters: the root MUST land before the worktrees so the shared
+/// object store + branch refs exist for each `git worktree add`. We compose
+/// the existing, individually-tested per-row commands rather than
+/// re-implementing their rsync/clone/worktree logic:
+/// - the `kind == "main"` row → `workspaces_adopt_synced` (lands a protected
+///   root at `projects/<repo>`),
+/// - each worktree row → `workspaces_adopt_synced` (routes to
+///   `adopt_worktree_via_repo_rsync`, which reuses the now-present
+///   `projects/<repo>` repo and just `git worktree add`s the branch).
+///
+/// If the project has no `main` row (a legacy registry where the root was
+/// never registered), the first worktree adopt rsyncs the parent repo itself,
+/// so the pull still succeeds — just without a standalone protected-root
+/// shell. Worktree failures are collected; a root failure aborts (nothing can
+/// attach to a missing root).
+#[tauri::command]
+pub async fn workspaces_adopt_project(
+    app: tauri::AppHandle,
+    project_uid: String,
+) -> Result<ProjectAdoptOutcome, String> {
+    // Gather the project's un-adopted, host-backed sync rows (sync scope —
+    // no awaits while holding the State guard).
+    let (root_server_id, worktree_server_ids) = {
+        let db: tauri::State<'_, DatabaseStore> = app.state();
+        let rows: Vec<WorkspaceSyncRecord> = db
+            .list_workspaces_sync()
+            .into_iter()
+            .filter(|r| r.project_uid.as_deref() == Some(project_uid.as_str()))
+            .filter(|r| r.workspace_id.is_none() && r.server_id.is_some())
+            .collect();
+        if rows.is_empty() {
+            return Err(format!(
+                "No un-adopted workspaces found for project {project_uid}. They \
+                 may already be on this device."
+            ));
+        }
+        let root_server_id = rows
+            .iter()
+            .find(|r| r.workspace_kind.as_deref() == Some("main"))
+            .and_then(|r| r.server_id.clone());
+        // Everything that isn't the root (worktrees, plus legacy null-kind
+        // rows) is adopted after the root. Carry (server_id, title) for
+        // failure reporting.
+        let worktree_server_ids: Vec<(String, String)> = rows
+            .iter()
+            .filter(|r| r.workspace_kind.as_deref() != Some("main"))
+            .filter_map(|r| r.server_id.clone().map(|sid| (sid, r.title.clone())))
+            .collect();
+        (root_server_id, worktree_server_ids)
+    };
+
+    let mut adopted: Vec<AdoptOutcome> = Vec::new();
+    let mut failures: Vec<ProjectAdoptFailure> = Vec::new();
+
+    // 1. Root first — a failure here aborts (worktrees can't attach to a
+    //    repo that didn't materialise).
+    if let Some(sid) = root_server_id {
+        let outcome = workspaces_adopt_synced(app.clone(), sid).await?;
+        adopted.push(outcome);
+    }
+
+    // 2. Worktrees — continue-on-error so one bad branch doesn't sink the
+    //    rest. Each reuses the now-present `projects/<repo>` repo.
+    for (sid, title) in worktree_server_ids {
+        match workspaces_adopt_synced(app.clone(), sid.clone()).await {
+            Ok(o) => adopted.push(o),
+            Err(e) => failures.push(ProjectAdoptFailure {
+                server_id: sid,
+                title,
+                error: e,
+            }),
+        }
+    }
+
+    let message = if failures.is_empty() {
+        format!("Pulled {} workspace(s) for this project.", adopted.len())
+    } else {
+        format!(
+            "Pulled {} workspace(s); {} worktree(s) failed.",
+            adopted.len(),
+            failures.len()
+        )
+    };
+    Ok(ProjectAdoptOutcome {
+        adopted,
+        failures,
+        message,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1216,6 +1337,7 @@ mod tests {
             project_uid: None,
             workspace_kind: None,
             origin_path: project_path.map(|s| s.into()),
+            default_branch: None,
             created_at: "2026-01-01 00:00:00".into(),
             updated_at: "2026-01-01 00:00:00".into(),
             deleted_at: None,

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -11,6 +11,41 @@ use tauri::{Manager, State};
 
 use crate::database::{DatabaseStore, WorkspaceSyncRecord};
 
+// ── Adoption serialization lock ──
+//
+// Two near-simultaneous adopts of the SAME row — a double-clicked "Pull",
+// or the host-inventory poller racing a manual pull — would both pass the
+// `workspace_id`-already-set idempotency guard (a TOCTOU window) and create
+// duplicate local shells / clobber the same landing path. A per-key async
+// lock serializes them so the second waits, then sees the first's result
+// and short-circuits. Mirrors Superset's `workspaceCreateLocks`.
+//
+// Keyed by `server_id` (the row identity). The map grows by one entry per
+// distinct row ever adopted on this device — bounded in practice, and the
+// guard is the whole point, so we don't bother pruning.
+fn adopt_locks(
+) -> &'static std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<tokio::sync::Mutex<()>>>>
+{
+    static LOCKS: std::sync::OnceLock<
+        std::sync::Mutex<
+            std::collections::HashMap<String, std::sync::Arc<tokio::sync::Mutex<()>>>,
+        >,
+    > = std::sync::OnceLock::new();
+    LOCKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Acquire the adoption lock for `key`, awaiting any in-flight adopt of the
+/// same key. Hold the returned guard for the whole adopt body.
+async fn acquire_adopt_lock(key: &str) -> tokio::sync::OwnedMutexGuard<()> {
+    let mutex = {
+        let mut map = adopt_locks().lock().unwrap();
+        map.entry(key.to_string())
+            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    };
+    mutex.lock_owned().await
+}
+
 /// Wire shape sent to the frontend. Matches the field naming the
 /// existing UI expects (snake_case from Rust, camelCase from
 /// serde-rename on JS-facing structs would be inconsistent with the
@@ -455,6 +490,11 @@ pub async fn workspaces_adopt_synced(
     app: tauri::AppHandle,
     server_id: String,
 ) -> Result<AdoptOutcome, String> {
+    // Serialize concurrent adopts of this same row (double-click, or poller
+    // racing a manual pull) so they can't both slip past the idempotency
+    // guard and duplicate the local shell. Held for the whole adopt.
+    let _adopt_guard = acquire_adopt_lock(&server_id).await;
+
     // A `worktree` row can't be pulled as a standalone directory: its
     // `.git` is a gitfile pointing at a parent repo that doesn't exist
     // on this device, so a bare rsync of the worktree dir lands with
@@ -997,6 +1037,9 @@ pub async fn workspaces_adopt_via_clone(
     app: tauri::AppHandle,
     server_id: String,
 ) -> Result<AdoptOutcome, String> {
+    // Same per-row serialization as the host-backed adopt path.
+    let _adopt_guard = acquire_adopt_lock(&server_id).await;
+
     // Validate + compute paths in a sync scope (no awaits).
     let (project_remote, project_path, worktree_path, branch, title) = {
         let db: tauri::State<'_, DatabaseStore> = app.state();

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -320,6 +320,7 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
             project_path TEXT,
             project_remote TEXT,
             git_branch TEXT,
+            default_branch TEXT,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at TEXT NOT NULL DEFAULT (datetime('now')),
             deleted_at TEXT,
@@ -372,6 +373,13 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
         "ALTER TABLE workspaces_sync ADD COLUMN project_uid TEXT",
         "ALTER TABLE workspaces_sync ADD COLUMN workspace_kind TEXT",
         "ALTER TABLE workspaces_sync ADD COLUMN origin_path TEXT",
+        // The repo's default branch as reported by the daemon poller
+        // (`origin/HEAD` → main/master → current). Local-only column: it is
+        // NOT sent to the cloud API (`ServerWorkspace`/`WorkspaceUpsertBody`
+        // omit it), so it survives cloud pulls untouched and needs no
+        // server-schema change. Lets a pull land a repo ROOT on the right
+        // branch and protect it even when `git_branch` is null.
+        "ALTER TABLE workspaces_sync ADD COLUMN default_branch TEXT",
     ] {
         if let Err(e) = conn.execute(stmt, []) {
             let msg = e.to_string();
@@ -956,6 +964,12 @@ pub struct WorkspaceSyncRecord {
     /// at an arbitrary path on the host). Local-only column, same
     /// lifecycle as `origin_uid`; survives cloud pulls untouched.
     pub origin_path: Option<String>,
+    /// The repo's default branch from the daemon poller (`origin/HEAD` →
+    /// main/master → current). Local-only column, same lifecycle as
+    /// `origin_path` — set by the host-inventory poller, NOT sent to the
+    /// cloud, survives cloud pulls untouched. Lets a pull land a repo ROOT
+    /// on the right branch and protect it even when `git_branch` is null.
+    pub default_branch: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub deleted_at: Option<String>,
@@ -1002,7 +1016,7 @@ impl DatabaseStore {
         conn.query_row(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path, default_branch
              FROM workspaces_sync WHERE id = ?1",
             params![id],
             row_to_workspace_sync,
@@ -1079,7 +1093,7 @@ impl DatabaseStore {
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path, default_branch
              FROM workspaces_sync
              WHERE user_id = 'local' AND deleted_at IS NULL
              ORDER BY updated_at DESC",
@@ -1099,7 +1113,7 @@ impl DatabaseStore {
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path, default_branch
              FROM workspaces_sync
              WHERE user_id = 'local'",
         ) {
@@ -1117,7 +1131,7 @@ impl DatabaseStore {
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path, default_branch
              FROM workspaces_sync
              WHERE user_id = 'local' AND dirty = 1",
         ) {
@@ -1338,7 +1352,7 @@ impl DatabaseStore {
                 "SELECT id, server_id, workspace_id, title, host_server_id,
                         project_path, project_remote, git_branch, git_head_sha,
                         created_at, updated_at, deleted_at, dirty, origin_uid,
-                        project_uid, workspace_kind, origin_path
+                        project_uid, workspace_kind, origin_path, default_branch
                  FROM workspaces_sync
                  WHERE user_id = 'local'
                    AND host_server_id = ?1
@@ -1370,14 +1384,15 @@ impl DatabaseStore {
         project_uid: Option<&str>,
         workspace_kind: Option<&str>,
         origin_path: Option<&str>,
+        default_branch: Option<&str>,
     ) -> Result<WorkspaceSyncRecord, String> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO workspaces_sync
                 (user_id, workspace_id, title, host_server_id,
                  project_path, project_remote, git_branch, origin_uid,
-                 project_uid, workspace_kind, origin_path, dirty)
-             VALUES ('local', NULL, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 1)",
+                 project_uid, workspace_kind, origin_path, default_branch, dirty)
+             VALUES ('local', NULL, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 1)",
             params![
                 title,
                 host_server_id,
@@ -1388,6 +1403,7 @@ impl DatabaseStore {
                 project_uid,
                 workspace_kind,
                 origin_path,
+                default_branch,
             ],
         )
         .map_err(|e| format!("Failed to insert remote-discovered workspace sync row: {e}"))?;
@@ -1395,7 +1411,7 @@ impl DatabaseStore {
         conn.query_row(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path, default_branch
              FROM workspaces_sync WHERE id = ?1",
             params![id],
             row_to_workspace_sync,
@@ -1421,6 +1437,7 @@ impl DatabaseStore {
         project_uid: Option<&str>,
         workspace_kind: Option<&str>,
         origin_path: Option<&str>,
+        default_branch: Option<&str>,
     ) -> Result<(), String> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
@@ -1428,7 +1445,7 @@ impl DatabaseStore {
              SET title = ?1, project_path = ?2,
                  project_remote = ?3, git_branch = ?4,
                  project_uid = ?5, workspace_kind = ?6,
-                 origin_path = ?8,
+                 origin_path = ?8, default_branch = ?9,
                  updated_at = datetime('now'), dirty = 1
              WHERE id = ?7 AND deleted_at IS NULL",
             params![
@@ -1440,6 +1457,7 @@ impl DatabaseStore {
                 workspace_kind,
                 id,
                 origin_path,
+                default_branch,
             ],
         )
         .map_err(|e| format!("Failed to update remote-discovered row: {e}"))?;
@@ -1467,7 +1485,7 @@ impl DatabaseStore {
                 "SELECT id, server_id, workspace_id, title, host_server_id,
                         project_path, project_remote, git_branch, git_head_sha,
                         created_at, updated_at, deleted_at, dirty, origin_uid,
-                        project_uid, workspace_kind, origin_path
+                        project_uid, workspace_kind, origin_path, default_branch
                  FROM workspaces_sync
                  WHERE user_id = 'local'
                    AND host_server_id = ?1
@@ -1505,6 +1523,7 @@ impl DatabaseStore {
         project_uid: Option<&str>,
         workspace_kind: Option<&str>,
         origin_path: Option<&str>,
+        default_branch: Option<&str>,
     ) -> Result<(), String> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
@@ -1512,7 +1531,7 @@ impl DatabaseStore {
              SET deleted_at = NULL, workspace_id = NULL,
                  title = ?1, project_path = ?2, project_remote = ?3,
                  git_branch = ?4, project_uid = ?5, workspace_kind = ?6,
-                 origin_path = ?8,
+                 origin_path = ?8, default_branch = ?9,
                  updated_at = datetime('now'), dirty = 1
              WHERE id = ?7",
             params![
@@ -1524,6 +1543,7 @@ impl DatabaseStore {
                 workspace_kind,
                 id,
                 origin_path,
+                default_branch,
             ],
         )
         .map_err(|e| format!("Failed to undelete remote-discovered row: {e}"))?;
@@ -1543,7 +1563,7 @@ impl DatabaseStore {
         let mut stmt = match conn.prepare(
             "SELECT id, server_id, workspace_id, title, host_server_id,
                     project_path, project_remote, git_branch, git_head_sha,
-                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path
+                    created_at, updated_at, deleted_at, dirty, origin_uid, project_uid, workspace_kind, origin_path, default_branch
              FROM workspaces_sync
              WHERE user_id = 'local'
                AND host_server_id = ?1
@@ -1603,6 +1623,7 @@ fn row_to_workspace_sync(
         project_uid: row.get(14)?,
         workspace_kind: row.get(15)?,
         origin_path: row.get(16)?,
+        default_branch: row.get(17)?,
     })
 }
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1548,12 +1548,22 @@ pub fn git_list_branches_detailed(repo_path: &Path) -> Result<Vec<BranchDetail>,
 
 /// Find the remote tracking ref for a branch (e.g. `origin/main` for `main`).
 /// Find the default branch for the repo (main, master, etc.).
-/// `pub(crate)` so helpers outside the branch-ops module (e.g.
-/// `checkout_default_branch`) can reuse the same resolution logic. Does NOT
-/// supersede `git_default_branch` — that one is the frontend-facing command
-/// with a slightly different fallback (`Ok("main")` instead of `None`).
-/// Consolidating the two is a separate follow-up.
-pub(crate) fn find_default_branch(repo_path: &Path) -> Option<String> {
+/// `pub` so the cross-device daemon (`remote::workspace`) and the protected-root
+/// classifier can reuse the same resolution logic. Does NOT supersede
+/// `git_default_branch` — that one is the frontend-facing command with a
+/// slightly different fallback (`Ok("main")` instead of `None`). Consolidating
+/// the two is a separate follow-up.
+///
+/// IMPORTANT: this resolver is intentionally *conservative* — `origin/HEAD`,
+/// then `main`, then `master`, else `None`. It deliberately does NOT fall back
+/// to "whatever branch is currently checked out", because two callers rely on
+/// that strictness: `is_protected_repo_root` (a current-branch fallback would
+/// protect a root on any branch) and `git_create_worktree` (it checks out the
+/// default to *free* a branch — a current-branch fallback would return the very
+/// branch it's trying to free). For the looser "best effort, never None for a
+/// real repo" form used to stamp the informational `default_branch` column, use
+/// [`resolve_default_branch`].
+pub fn find_default_branch(repo_path: &Path) -> Option<String> {
     // Try origin/HEAD first
     if let Ok(output) = run_git(repo_path, &["symbolic-ref", "refs/remotes/origin/HEAD"]) {
         if let Some(branch) = output.trim().strip_prefix("refs/remotes/origin/") {
@@ -1567,6 +1577,50 @@ pub(crate) fn find_default_branch(repo_path: &Path) -> Option<String> {
         }
     }
     None
+}
+
+/// Best-effort default-branch resolution for *recording* a repo's default
+/// branch (the cross-device `default_branch` hint), as opposed to the strict
+/// [`find_default_branch`] used for protection/worktree decisions.
+///
+/// Order: `origin/HEAD` → `main`/`master` → the currently checked-out branch.
+/// The last step is what makes this work for **local-only repos whose default
+/// branch is neither `main` nor `master`** (no remote to read `origin/HEAD`
+/// from, e.g. a repo defaulting to `trunk`/`develop`). Returns `None` only for
+/// a detached/unborn HEAD on such a repo.
+///
+/// This value is advisory metadata. The authoritative protection decision is
+/// always recomputed locally via [`is_protected_repo_root`] against the
+/// materialized copy, so a slightly-off hint can never cause a wrong protected
+/// stamp.
+pub fn resolve_default_branch(repo_path: &Path) -> Option<String> {
+    if let Some(b) = find_default_branch(repo_path) {
+        return Some(b);
+    }
+    let current = run_git_permissive(repo_path, &["branch", "--show-current"]);
+    if current.is_empty() {
+        None
+    } else {
+        Some(current)
+    }
+}
+
+/// Populate `refs/remotes/origin/HEAD` so [`find_default_branch`]'s
+/// `origin/HEAD` probe succeeds for freshly-cloned repos. Runs
+/// `git remote set-head origin --auto`.
+///
+/// **No-op by design when there is no `origin` remote** (e.g. local-only repos
+/// adopted via rsync) — calling `set-head` there errors with
+/// "No such remote 'origin'". Any failure of the underlying set-head (offline,
+/// transient) is swallowed: this only ever *improves* default-branch
+/// resolution, never blocks adoption.
+pub fn ensure_origin_head(repo_path: &Path) -> Result<(), String> {
+    let remotes = run_git_permissive(repo_path, &["remote"]);
+    if !remotes.lines().any(|r| r.trim() == "origin") {
+        return Ok(());
+    }
+    let _ = run_git(repo_path, &["remote", "set-head", "origin", "--auto"]);
+    Ok(())
 }
 
 /// Switch the repo to its default branch (main / master / whatever
@@ -1957,6 +2011,40 @@ mod repo_root_tests {
         let plain = root.join("plain");
         std::fs::create_dir_all(&plain).unwrap();
         assert!(!is_protected_repo_root(&plain, Some("main")));
+    }
+
+    #[test]
+    fn resolve_default_branch_falls_back_to_current_for_nonstandard_local_repo() {
+        // A local-only repo whose default branch is neither `main` nor
+        // `master` and which has no remote — exactly the `passpage`-shaped
+        // case where `origin/HEAD` can't be read.
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run(&repo, &["init", "--initial-branch=trunk"]);
+        run(&repo, &["config", "user.email", "t@example.com"]);
+        run(&repo, &["config", "user.name", "T"]);
+        std::fs::write(repo.join("f"), "x").unwrap();
+        run(&repo, &["add", "."]);
+        run(&repo, &["commit", "-m", "init"]);
+
+        // The strict resolver gives up (no origin/HEAD, no main, no master)…
+        assert_eq!(find_default_branch(&repo), None);
+        // …but the record-stamping resolver falls back to the current branch,
+        // so the daemon still records a usable default for a local-only repo.
+        assert_eq!(resolve_default_branch(&repo).as_deref(), Some("trunk"));
+    }
+
+    #[test]
+    fn ensure_origin_head_is_noop_without_origin_remote() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+        // No `origin` remote — must succeed (not error on "No such remote")
+        // and leave default-branch resolution working via the main fallback.
+        assert!(ensure_origin_head(&repo).is_ok());
+        assert_eq!(find_default_branch(&repo).as_deref(), Some("main"));
     }
 }
 

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -1846,6 +1846,34 @@ fn is_divergent_copy_under(path: &Path, worktrees_root: &Path) -> bool {
     path.join(".git").is_dir() && path.starts_with(worktrees_root)
 }
 
+/// Why a divergent copy can't be "reconciled away" (its workspace card
+/// detached) yet, or `None` if it's safe. Blocks on a dirty working tree or
+/// committed-but-unpushed work so a card never silently vanishes while the
+/// user has changes in flight. Reconcile never deletes files, so this is a
+/// guard against *confusion*, not data loss.
+pub fn reconcile_copy_blocker(path: &Path) -> Option<String> {
+    if let Ok(files) = git_status(path) {
+        if !files.is_empty() {
+            return Some(format!(
+                "{} uncommitted change(s) — commit or stash first",
+                files.len()
+            ));
+        }
+    }
+    if let Some(upstream) = resolve_upstream_ref(path) {
+        let out = run_git_permissive(
+            path,
+            &["rev-list", "--count", &format!("{upstream}..HEAD")],
+        );
+        if let Ok(n) = out.trim().parse::<u64>() {
+            if n > 0 {
+                return Some(format!("{n} unpushed commit(s) — push first"));
+            }
+        }
+    }
+    None
+}
+
 /// True when `checkout` is the repo's protected default-branch root —
 /// the entry the overview must not let you delete like a disposable
 /// worktree. It qualifies only when ALL hold:
@@ -2033,6 +2061,22 @@ mod repo_root_tests {
         // …but the record-stamping resolver falls back to the current branch,
         // so the daemon still records a usable default for a local-only repo.
         assert_eq!(resolve_default_branch(&repo).as_deref(), Some("trunk"));
+    }
+
+    #[test]
+    fn reconcile_copy_blocker_flags_dirty_allows_clean() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        init_repo(&repo);
+
+        // Clean, no upstream → safe to reconcile (nothing blocks).
+        assert!(reconcile_copy_blocker(&repo).is_none());
+
+        // Uncommitted change → blocked with guidance.
+        std::fs::write(repo.join("README.md"), "changed").unwrap();
+        let blocker = reconcile_copy_blocker(&repo).expect("dirty tree blocks");
+        assert!(blocker.contains("uncommitted"), "got: {blocker}");
     }
 
     #[test]

--- a/src-tauri/src/hosts_inventory.rs
+++ b/src-tauri/src/hosts_inventory.rs
@@ -311,6 +311,11 @@ pub struct RemoteWorkspace {
     pub kind: Option<String>,
     #[serde(default)]
     pub repo_remote: Option<String>,
+    /// Repo default branch from the daemon (`origin/HEAD` → main/master →
+    /// current). Older daemons omit it → serde defaults to `None` → the
+    /// desktop falls back to resolving it locally at pull time.
+    #[serde(default)]
+    pub default_branch: Option<String>,
     // `owner_id`, `origin_host_id`, `notes`, `created_at`,
     // `updated_at` are accepted by serde but not used by the
     // reconcile — they live on the remote daemon and have no
@@ -396,6 +401,7 @@ pub fn reconcile_host_inventory(
         let project_uid = ws.project_uid.as_deref();
         let workspace_kind = ws.kind.as_deref();
         let branch = ws.branch.as_deref();
+        let default_branch = ws.default_branch.as_deref();
         // The workspace's REAL absolute path on the host. Unlike
         // `project_path` (which collapses to the project root for a
         // worktree), this is the authoritative rsync source for pulling
@@ -412,7 +418,8 @@ pub fn reconcile_host_inventory(
                 || existing.git_branch.as_deref() != branch
                 || existing.project_uid.as_deref() != project_uid
                 || existing.workspace_kind.as_deref() != workspace_kind
-                || existing.origin_path.as_deref() != origin_path;
+                || existing.origin_path.as_deref() != origin_path
+                || existing.default_branch.as_deref() != default_branch;
             if changed {
                 if let Err(e) = db.update_remote_discovered_workspace_sync(
                     existing.id,
@@ -423,6 +430,7 @@ pub fn reconcile_host_inventory(
                     project_uid,
                     workspace_kind,
                     origin_path,
+                    default_branch,
                 ) {
                     eprintln!(
                         "[hosts_inventory] update failed for {host_server_id}/{}: {e}",
@@ -450,6 +458,7 @@ pub fn reconcile_host_inventory(
                 project_uid,
                 workspace_kind,
                 origin_path,
+                default_branch,
             ) {
                 eprintln!(
                     "[hosts_inventory] undelete failed for {host_server_id}/{}: {e}",
@@ -468,6 +477,7 @@ pub fn reconcile_host_inventory(
             project_uid,
             workspace_kind,
             origin_path,
+            default_branch,
         ) {
             eprintln!(
                 "[hosts_inventory] insert failed for {host_server_id}/{}: {e}",
@@ -522,6 +532,7 @@ mod tests {
             project_uid: Some("uid-origin".into()),
             kind: Some("worktree".into()),
             repo_remote: Some("github.com/acme/origin".into()),
+            default_branch: Some("main".into()),
         }
     }
 

--- a/src-tauri/src/hosts_upgrade.rs
+++ b/src-tauri/src/hosts_upgrade.rs
@@ -171,9 +171,36 @@ async fn check_and_upgrade(
         }
     };
 
-    // Step 4: re-provision serve so the systemd unit content stays
-    // in sync AND the running daemon picks up the new binary.
-    // Idempotent + restart-based, so safe to run unconditionally.
+    // Step 4: re-provision serve so the systemd unit content stays in sync
+    // AND the running daemon picks up the new binary. This RESTARTS the
+    // systemd unit — which kills any PTY agents the user is running ON the
+    // host (the "work on a host without pulling" flow). So FIRST ask the
+    // running daemon whether it has live sessions, and if so DEFER the
+    // restart: the new binary is already on disk and will activate on the
+    // next idle upgrade or host reboot. This is the "don't end my work when
+    // I close my laptop" guarantee — an auto-upgrade must never silently
+    // kill a host agent. (Pushed-workspace agents live in the separate
+    // pty-daemon, not this serve unit, so they're unaffected either way.)
+    let live_sessions = probe_live_host_sessions(&host.ssh_target).await;
+    if let Some(n) = live_sessions {
+        if n > 0 {
+            eprintln!(
+                "[hosts_upgrade] {} upgraded binary to {new_version} but DEFERRED \
+                 daemon restart — {n} live host session(s). New binary activates on \
+                 next idle upgrade or host reboot.",
+                host.name
+            );
+            return Ok(UpgradeOutcome::Skipped {
+                reason: format!(
+                    "binary upgraded to {new_version}; daemon restart deferred — \
+                     {n} live host session(s). Restart the daemon when idle to activate."
+                ),
+            });
+        }
+    }
+
+    // No confirmed live sessions (idle, daemon down, or unknown) — safe to
+    // restart and activate the new binary now.
     if let Err(e) = provision_serve(
         &host.ssh_target,
         "~/.local/bin/codemux-remote",
@@ -194,4 +221,55 @@ async fn check_and_upgrade(
         from: current_version,
         to: new_version,
     })
+}
+
+/// Probe the host daemon for its live PTY-session count by running
+/// `codemux-remote serve status` over SSH and reading `live_terminals` from
+/// its JSON output. Returns:
+/// - `Some(n)` — the daemon answered (`n` may be 0).
+/// - `None` — couldn't determine (daemon down, ssh error, or an OLD daemon
+///   binary whose `serve status` predates the field). Callers treat `None`
+///   as "no confirmed live sessions → safe to restart", because a daemon we
+///   can't reach has nothing to lose by restarting.
+async fn probe_live_host_sessions(ssh_target: &str) -> Option<u64> {
+    use std::process::Stdio;
+    // Mirror the PATH fallback every other SSH call site uses: non-interactive
+    // SSH shells often don't have ~/.local/bin on PATH.
+    let cmd_str = "if command -v codemux-remote >/dev/null 2>&1 ; then \
+                     codemux-remote serve status ; \
+                   elif [ -x \"$HOME/.local/bin/codemux-remote\" ] ; then \
+                     \"$HOME/.local/bin/codemux-remote\" serve status ; \
+                   fi";
+    let output = tokio::time::timeout(Duration::from_secs(12), async {
+        tokio::process::Command::new("ssh")
+            .args([
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                ssh_target,
+                cmd_str,
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+    })
+    .await
+    .ok()?
+    .ok()?;
+    // `serve status` prints one JSON line to stdout (even when the daemon is
+    // down, with `live_terminals: null`). Find it and read the field.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+            if let Some(n) = v.get("live_terminals").and_then(|x| x.as_u64()) {
+                return Some(n);
+            }
+        }
+    }
+    None
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1662,6 +1662,7 @@ pub fn run() {
             commands::workspaces_adoption_preview,
             commands::workspaces_adopt_synced,
             commands::workspaces_adopt_via_clone,
+            commands::workspaces_adopt_project,
             commands::get_package_format,
             resource_metrics::get_resource_metrics,
             commands::debug_log,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1663,6 +1663,7 @@ pub fn run() {
             commands::workspaces_adopt_synced,
             commands::workspaces_adopt_via_clone,
             commands::workspaces_adopt_project,
+            commands::workspaces_reconcile_copy,
             commands::get_package_format,
             resource_metrics::get_resource_metrics,
             commands::debug_log,

--- a/src-tauri/src/pty_daemon/server.rs
+++ b/src-tauri/src/pty_daemon/server.rs
@@ -176,6 +176,51 @@ pub async fn run(socket_path: PathBuf) -> Result<(), String> {
         env!("CARGO_PKG_VERSION"),
     );
 
+    // Idle reaper: a daemon with zero live sessions continuously for
+    // `IDLE_REAP` removes its manifest and exits, so an abandoned daemon
+    // doesn't linger forever and stale manifests don't confuse the next
+    // adoption. HARD GUARD: it re-checks the session count under the same
+    // lock immediately before exit, so it can NEVER reap with a live
+    // session — and any spawn/attach naturally resets the idle clock by
+    // making `sessions` non-empty on the next check.
+    {
+        let reaper_state = state.clone();
+        let reaper_socket = socket_path.clone();
+        tokio::spawn(async move {
+            const CHECK_INTERVAL: std::time::Duration =
+                std::time::Duration::from_secs(60);
+            const IDLE_REAP: std::time::Duration =
+                std::time::Duration::from_secs(3600);
+            let mut idle_since: Option<tokio::time::Instant> =
+                Some(tokio::time::Instant::now());
+            loop {
+                tokio::time::sleep(CHECK_INTERVAL).await;
+                if !reaper_state.lock().await.sessions.is_empty() {
+                    idle_since = None;
+                    continue;
+                }
+                let since =
+                    idle_since.get_or_insert_with(tokio::time::Instant::now);
+                if since.elapsed() < IDLE_REAP {
+                    continue;
+                }
+                // Re-check under the lock right before exit — never reap a
+                // daemon that just gained a session between the poll and now.
+                if !reaper_state.lock().await.sessions.is_empty() {
+                    idle_since = None;
+                    continue;
+                }
+                eprintln!(
+                    "[codemux::pty_daemon] idle with no sessions for {IDLE_REAP:?} — \
+                     removing manifest and exiting"
+                );
+                remove_manifest();
+                let _ = std::fs::remove_file(&reaper_socket);
+                std::process::exit(0);
+            }
+        });
+    }
+
     loop {
         match listener.accept().await {
             Ok((stream, _addr)) => {

--- a/src-tauri/src/remote/workspace.rs
+++ b/src-tauri/src/remote/workspace.rs
@@ -273,6 +273,22 @@ impl WorkspaceStore {
             ],
         )
         .map_err(|e| WorkspaceError::Db(e.to_string()))?;
+        drop(conn);
+
+        // One repo root per (project, host): if this is a `main` checkout and
+        // the project already had one registered, collapse to a single
+        // canonical root (earliest wins) and return the survivor — so
+        // re-registering an existing root is idempotent instead of spawning a
+        // duplicate "repo root" card on every device. A genuinely distinct
+        // root has a different `project_uid` (it's derived from the remote /
+        // root path), so this never merges unrelated projects.
+        if ws.kind.as_deref() == Some("main") {
+            if let Some(puid) = ws.project_uid.clone() {
+                if let Some(survivor) = self.collapse_main_for_uid(&puid)? {
+                    return Ok(survivor);
+                }
+            }
+        }
         Ok(ws)
     }
 
@@ -440,6 +456,94 @@ impl WorkspaceStore {
             updated += 1;
         }
         Ok(updated)
+    }
+
+    /// Ensure at most ONE `kind='main'` row exists for `project_uid`: keep the
+    /// earliest-created one and delete the rest. Only registry rows are
+    /// removed — files on disk are never touched. Returns the surviving row
+    /// (or `None` if the project has no main row). Idempotent.
+    ///
+    /// This is the "one repo root per project, per host" guarantee: an agent
+    /// that registers a project's root more than once (or whose root was
+    /// re-registered after a move) must not produce two "repo root" cards on
+    /// every device.
+    pub fn collapse_main_for_uid(
+        &self,
+        project_uid: &str,
+    ) -> Result<Option<Workspace>, WorkspaceError> {
+        let ids: Vec<String> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id FROM workspaces
+                     WHERE project_uid = ?1 AND kind = 'main'
+                     ORDER BY created_at ASC, id ASC",
+                )
+                .map_err(|e| WorkspaceError::Db(e.to_string()))?;
+            let rows = stmt
+                .query_map(rusqlite::params![project_uid], |r| r.get::<_, String>(0))
+                .map_err(|e| WorkspaceError::Db(e.to_string()))?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| WorkspaceError::Db(e.to_string()))?);
+            }
+            out
+        };
+        let Some((keep, extras)) = ids.split_first() else {
+            return Ok(None);
+        };
+        if !extras.is_empty() {
+            let conn = self.conn.lock().unwrap();
+            for id in extras {
+                conn.execute(
+                    "DELETE FROM workspaces WHERE id = ?1",
+                    rusqlite::params![id],
+                )
+                .map_err(|e| WorkspaceError::Db(e.to_string()))?;
+            }
+        }
+        Ok(Some(self.get(keep.as_str())?))
+    }
+
+    /// Boot-time hygiene: collapse every project that has more than one
+    /// `kind='main'` row down to a single canonical root (see
+    /// [`Self::collapse_main_for_uid`]). Returns the number of duplicate rows
+    /// removed. Safe to run on every daemon boot — idempotent, so it does real
+    /// work only when an agent left duplicate roots behind.
+    pub fn normalize_main_workspaces(&self) -> Result<usize, WorkspaceError> {
+        let uids: Vec<String> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT project_uid FROM workspaces
+                     WHERE kind = 'main' AND project_uid IS NOT NULL
+                     GROUP BY project_uid HAVING COUNT(*) > 1",
+                )
+                .map_err(|e| WorkspaceError::Db(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |r| r.get::<_, String>(0))
+                .map_err(|e| WorkspaceError::Db(e.to_string()))?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(|e| WorkspaceError::Db(e.to_string()))?);
+            }
+            out
+        };
+        let mut removed = 0usize;
+        for uid in uids {
+            let before = {
+                let conn = self.conn.lock().unwrap();
+                conn.query_row(
+                    "SELECT COUNT(*) FROM workspaces WHERE project_uid = ?1 AND kind = 'main'",
+                    rusqlite::params![uid],
+                    |r| r.get::<_, i64>(0),
+                )
+                .map_err(|e| WorkspaceError::Db(e.to_string()))? as usize
+            };
+            self.collapse_main_for_uid(&uid)?;
+            removed += before.saturating_sub(1);
+        }
+        Ok(removed)
     }
 }
 
@@ -678,6 +782,38 @@ mod tests {
             .create(None, repo.display().to_string(), None, None)
             .unwrap();
         assert!(ws.project_uid.is_some());
+    }
+
+    #[test]
+    fn create_collapses_duplicate_main_for_same_project() {
+        let dir = TempDir::new().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        let store = open_store(&dir);
+
+        let a = store
+            .create(None, repo.display().to_string(), Some("main".into()), None)
+            .unwrap();
+        assert_eq!(a.kind.as_deref(), Some("main"), "real .git dir → main root");
+
+        // Re-registering the SAME root must NOT create a second main row.
+        let b = store
+            .create(None, repo.display().to_string(), Some("main".into()), None)
+            .unwrap();
+
+        let mains: Vec<_> = store
+            .list()
+            .unwrap()
+            .into_iter()
+            .filter(|w| w.kind.as_deref() == Some("main"))
+            .collect();
+        assert_eq!(mains.len(), 1, "duplicate root collapsed to one");
+        assert_eq!(
+            mains[0].id, b.id,
+            "create returns the surviving canonical root"
+        );
+        // Boot sweep is then a no-op (already collapsed).
+        assert_eq!(store.normalize_main_workspaces().unwrap(), 0);
     }
 
     #[test]

--- a/src-tauri/src/remote/workspace.rs
+++ b/src-tauri/src/remote/workspace.rs
@@ -57,6 +57,14 @@ pub struct Workspace {
     /// the same `project_uid` for an independently-cloned copy.
     #[serde(default)]
     pub repo_remote: Option<String>,
+    /// The repo's default branch (`origin/HEAD` → main/master → current),
+    /// resolved at registration via `crate::git::resolve_default_branch`.
+    /// Lets a pulling device land the repo ROOT on the right branch and
+    /// classify it as a protected root even when `branch` (the per-checkout
+    /// branch) is null — which it routinely is for a root an agent never
+    /// named. Advisory: the desktop re-resolves locally before protecting.
+    #[serde(default)]
+    pub default_branch: Option<String>,
     /// RFC 3339 UTC timestamp.
     pub created_at: String,
     /// RFC 3339 UTC timestamp.
@@ -207,6 +215,19 @@ impl WorkspaceStore {
         });
         let project_name = project_root.as_deref().map(basename);
         let kind = Some(crate::project_identity::derive_kind(std::path::Path::new(&path)).to_string());
+        // Resolve the repo's default branch from the project root (gated on
+        // `.git` to skip the subprocess for not-yet-materialised / test paths,
+        // same as `git_remote_origin_url`). `resolve_default_branch` falls back
+        // to the current branch for local-only repos with a non-standard
+        // default, so a `main`-defaulting repo like the common case still
+        // records "main" even with no remote.
+        let default_branch = project_root.as_deref().and_then(|pr| {
+            if std::path::Path::new(pr).join(".git").exists() {
+                crate::git::resolve_default_branch(std::path::Path::new(pr))
+            } else {
+                None
+            }
+        });
 
         let ws = Workspace {
             id: id.clone(),
@@ -218,6 +239,7 @@ impl WorkspaceStore {
             project_name,
             kind,
             repo_remote,
+            default_branch,
             created_at: now.clone(),
             updated_at: now,
             owner_id: None,
@@ -230,8 +252,8 @@ impl WorkspaceStore {
             "INSERT INTO workspaces (
                 id, name, path, branch, project_root,
                 created_at, updated_at, owner_id, origin_host_id, notes,
-                project_uid, project_name, kind, repo_remote
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                project_uid, project_name, kind, repo_remote, default_branch
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
             rusqlite::params![
                 ws.id,
                 ws.name,
@@ -247,6 +269,7 @@ impl WorkspaceStore {
                 ws.project_name,
                 ws.kind,
                 ws.repo_remote,
+                ws.default_branch,
             ],
         )
         .map_err(|e| WorkspaceError::Db(e.to_string()))?;
@@ -259,7 +282,7 @@ impl WorkspaceStore {
             .prepare(
                 "SELECT id, name, path, branch, project_root,
                         created_at, updated_at, owner_id, origin_host_id, notes,
-                        project_uid, project_name, kind, repo_remote
+                        project_uid, project_name, kind, repo_remote, default_branch
                  FROM workspaces WHERE id = ?1",
             )
             .map_err(|e| WorkspaceError::Db(e.to_string()))?;
@@ -281,7 +304,7 @@ impl WorkspaceStore {
             .prepare(
                 "SELECT id, name, path, branch, project_root,
                         created_at, updated_at, owner_id, origin_host_id, notes,
-                        project_uid, project_name, kind, repo_remote
+                        project_uid, project_name, kind, repo_remote, default_branch
                  FROM workspaces
                  ORDER BY created_at DESC",
             )
@@ -372,6 +395,13 @@ impl WorkspaceStore {
         let mut updated = 0usize;
         let conn = self.conn.lock().unwrap();
         for ws in rows {
+            // Guard on identity only — NOT on default_branch. default_branch
+            // legitimately stays None for repos with no resolvable default
+            // (no commits / detached / non-repo path), so gating on it would
+            // re-update those rows on every sweep and break idempotency. A
+            // legacy row missing identity is backfilled here (default_branch
+            // included); a row that already has identity but no default_branch
+            // is left to pull-time resolution, which is authoritative anyway.
             if ws.project_uid.is_some() && ws.kind.is_some() {
                 continue;
             }
@@ -387,11 +417,24 @@ impl WorkspaceStore {
             let kind = Some(
                 crate::project_identity::derive_kind(std::path::Path::new(&ws.path)).to_string(),
             );
+            // Backfill the default branch for rows registered before the
+            // column existed (gated on `.git` to avoid spawning git for
+            // stale/never-materialised paths). This is what retroactively
+            // gives a legacy root row a non-null branch so a pull can protect
+            // it instead of rendering it as a deletable "<branch>" worktree.
+            let default_branch = ws.default_branch.clone().or_else(|| {
+                if std::path::Path::new(&project_root).join(".git").exists() {
+                    crate::git::resolve_default_branch(std::path::Path::new(&project_root))
+                } else {
+                    None
+                }
+            });
             conn.execute(
                 "UPDATE workspaces
-                 SET project_uid = ?2, project_name = ?3, kind = ?4, repo_remote = ?5
+                 SET project_uid = ?2, project_name = ?3, kind = ?4, repo_remote = ?5,
+                     default_branch = ?6
                  WHERE id = ?1",
-                rusqlite::params![ws.id, project_uid, project_name, kind, repo_remote],
+                rusqlite::params![ws.id, project_uid, project_name, kind, repo_remote, default_branch],
             )
             .map_err(|e| WorkspaceError::Db(e.to_string()))?;
             updated += 1;
@@ -417,7 +460,8 @@ fn create_schema(conn: &Connection) -> Result<(), WorkspaceError> {
             project_uid     TEXT,            -- deterministic project identity (UUIDv5)
             project_name    TEXT,
             kind            TEXT,            -- 'main' | 'worktree'
-            repo_remote     TEXT             -- canonical git remote, null for local-only
+            repo_remote     TEXT,            -- canonical git remote, null for local-only
+            default_branch  TEXT             -- repo default branch (origin/HEAD -> main/master -> current)
         );
         CREATE INDEX IF NOT EXISTS idx_workspaces_origin
             ON workspaces (origin_host_id);
@@ -438,6 +482,7 @@ fn create_schema(conn: &Connection) -> Result<(), WorkspaceError> {
         "ALTER TABLE workspaces ADD COLUMN project_name TEXT",
         "ALTER TABLE workspaces ADD COLUMN kind TEXT",
         "ALTER TABLE workspaces ADD COLUMN repo_remote TEXT",
+        "ALTER TABLE workspaces ADD COLUMN default_branch TEXT",
     ] {
         if let Err(e) = conn.execute(stmt, []) {
             let msg = e.to_string();
@@ -472,6 +517,7 @@ fn row_to_workspace(row: &rusqlite::Row<'_>) -> Result<Workspace, WorkspaceError
         project_name: map(11).map_err(|e| WorkspaceError::Db(e.to_string()))?,
         kind: map(12).map_err(|e| WorkspaceError::Db(e.to_string()))?,
         repo_remote: map(13).map_err(|e| WorkspaceError::Db(e.to_string()))?,
+        default_branch: map(14).map_err(|e| WorkspaceError::Db(e.to_string()))?,
     })
 }
 

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -46,6 +46,7 @@ pub use registry::{
     client_for_workspace, forget_workspace_client, get_supervisor,
     install_supervisor, local_socket_for_workspace,
     remote_socket_for_workspace, shutdown_supervisor,
+    spawn_tunnel_status_forwarder,
 };
 pub use tunnel::{spawn_ssh_tunnel, TunnelHandle};
 pub use tunnel_supervisor::{TunnelStatus, TunnelSupervisor};

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -39,8 +39,9 @@ pub mod tunnel_supervisor;
 pub use bootstrap::{bootstrap_remote, BootstrapResult};
 pub use probe::{probe_host, ProbeOutcome};
 pub use push::{
-    claude_project_dir_name, conventional_remote_path, pull_workspace_back,
-    push_workspace, PullOptions, PullResult, PushOptions, PushResult,
+    claude_project_dir_name, conventional_remote_path,
+    conventional_remote_path_keyed, pull_workspace_back, push_workspace,
+    PullOptions, PullResult, PushOptions, PushResult,
 };
 pub use registry::{
     client_for_workspace, forget_workspace_client, get_supervisor,

--- a/src-tauri/src/ssh/push.rs
+++ b/src-tauri/src/ssh/push.rs
@@ -504,7 +504,9 @@ pub fn claude_project_dir_name(absolute_path: &std::path::Path) -> String {
 /// Kept as a Unix-side re-export so existing call sites compile
 /// unchanged. Windows builds reach the underlying function through
 /// `crate::workspace_paths` directly.
-pub use crate::workspace_paths::conventional_remote_path;
+pub use crate::workspace_paths::{
+    conventional_remote_path, conventional_remote_path_keyed,
+};
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/ssh/registry.rs
+++ b/src-tauri/src/ssh/registry.rs
@@ -22,11 +22,55 @@
 
 #![cfg(unix)]
 
-use crate::ssh::tunnel_supervisor::TunnelSupervisor;
+use crate::ssh::tunnel_supervisor::{TunnelStatus, TunnelSupervisor};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tauri::Emitter;
 use tokio::sync::{Mutex, OnceCell};
+
+/// Payload for the `tunnel-status-changed` event the UI listens to so it
+/// can render a "Reconnecting…" / "Connection lost" pill on remote
+/// workspaces. Keyed by `workspace_id`; `status` is the supervisor's own
+/// `TunnelStatus` (tagged enum: `connected` / `reconnecting` /
+/// `circuit_open` / `pending`).
+#[derive(Clone, serde::Serialize)]
+struct TunnelStatusEvent {
+    workspace_id: String,
+    status: TunnelStatus,
+}
+
+/// Bridge a supervisor's status `watch` channel to a Tauri event so the
+/// frontend can show tunnel health. Spawns one detached task per
+/// supervisor instance; it emits the current status immediately, then on
+/// every change, and **self-terminates** when the supervisor is dropped
+/// (its `status_tx` closes → `changed()` errors). Because a re-push
+/// installs a fresh supervisor (the old one is shut down and dropped),
+/// the old forwarder exits on its own — no explicit deregistration, no
+/// leak, and never two forwarders for one live supervisor.
+pub fn spawn_tunnel_status_forwarder(
+    app: tauri::AppHandle,
+    workspace_id: String,
+    supervisor: &Arc<TunnelSupervisor>,
+) {
+    let mut rx = supervisor.subscribe();
+    tokio::spawn(async move {
+        loop {
+            let status = rx.borrow_and_update().clone();
+            let _ = app.emit(
+                "tunnel-status-changed",
+                TunnelStatusEvent {
+                    workspace_id: workspace_id.clone(),
+                    status,
+                },
+            );
+            if rx.changed().await.is_err() {
+                // Supervisor dropped — stop forwarding.
+                break;
+            }
+        }
+    });
+}
 
 static REGISTRY: OnceCell<Mutex<HashMap<String, Arc<TunnelSupervisor>>>> =
     OnceCell::const_new();
@@ -224,6 +268,11 @@ pub async fn client_for_workspace(
                 "$HOME/.local/bin/codemux-remote".to_string(),
             );
             install_supervisor(workspace_id, s.clone()).await;
+            spawn_tunnel_status_forwarder(
+                app.clone(),
+                workspace_id.to_string(),
+                &s,
+            );
             s
         }
     };

--- a/src-tauri/src/terminal/daemon_backed.rs
+++ b/src-tauri/src/terminal/daemon_backed.rs
@@ -152,7 +152,11 @@ pub async fn spawn_pty_for_agent_via_daemon(
         let branch = owning_ws
             .and_then(|w| w.git_branch.clone())
             .unwrap_or_else(|| "main".to_string());
-        crate::ssh::conventional_remote_path(&project_name, &branch)
+        // Key on project_uid so this matches where push landed the workspace
+        // (collision-safe across same-basename repos). Same uid the push used,
+        // so the two always agree for a workspace pushed by this build.
+        let puid = owning_ws.and_then(|w| w.project_uid.clone());
+        crate::ssh::conventional_remote_path_keyed(puid.as_deref(), &project_name, &branch)
             .to_string_lossy()
             .to_string()
     } else {

--- a/src-tauri/src/terminal/daemon_backed.rs
+++ b/src-tauri/src/terminal/daemon_backed.rs
@@ -284,6 +284,28 @@ pub async fn spawn_pty_for_agent_via_daemon(
         },
     );
 
+    // OpenFlow comm-log tee (parity with the in-process reader). Without
+    // this, OpenFlow agents on the daemon spawn path — the default since
+    // persistent agents — wrote an EMPTY comm log, so the orchestrator's
+    // stuck-detection / progress analysis went blind. Same env contract as
+    // the in-process path: `CODEMUX_COMMUNICATION_LOG` + the instance id
+    // (preferred) or bare role.
+    let comm_log: Option<(std::sync::Arc<std::sync::Mutex<std::fs::File>>, String)> = {
+        let path = extra_env
+            .iter()
+            .find(|(k, _)| k == "CODEMUX_COMMUNICATION_LOG")
+            .map(|(_, v)| v.clone());
+        let role = extra_env
+            .iter()
+            .find(|(k, _)| k == "CODEMUX_AGENT_INSTANCE_ID")
+            .or_else(|| extra_env.iter().find(|(k, _)| k == "CODEMUX_AGENT_ROLE"))
+            .map(|(_, v)| v.clone());
+        match (path, role) {
+            (Some(p), Some(r)) => Some((super::get_comm_log_lock(&p), r)),
+            _ => None,
+        }
+    };
+
     // Reader task — drains the daemon's mpsc and pushes bytes through the
     // same `queue_or_send_output` the in-process path uses.
     let read_sessions = sessions.clone();
@@ -292,6 +314,18 @@ pub async fn spawn_pty_for_agent_via_daemon(
     let read_client = client.clone();
     tauri::async_runtime::spawn(async move {
         while let Some(chunk) = rx.recv().await {
+            // Tee to the comm log BEFORE handing the chunk off (moved) to the
+            // output queue. Flush per chunk — daemon chunks are already
+            // coalesced and OpenFlow needs the log live for stuck-detection.
+            if let Some((ref log_lock, ref role)) = comm_log {
+                if let Some(entry) = super::comm_log_entry_for_chunk(role, &chunk) {
+                    if let Ok(mut file) = log_lock.lock() {
+                        use std::io::Write;
+                        let _ = file.write_all(entry.as_bytes());
+                        let _ = file.flush();
+                    }
+                }
+            }
             queue_or_send_output(&read_sessions, &read_session_id, chunk);
         }
         eprintln!(
@@ -315,11 +349,8 @@ pub async fn spawn_pty_for_agent_via_daemon(
     //
     // - resource-monitor / process-tree views read `child_pid`; that's the
     //   daemon-side pid, which is correct (it's the actual agent process).
-    // - `comm_log` setup: TODO. The in-process path tees comm log writes
-    //   from inside the read loop; we'd need to do the same here. Marking
-    //   as a follow-up because comm-log is OpenFlow-specific and step 1's
-    //   only goal is "agents survive app close" — OpenFlow agents can opt
-    //   out of persistence for now.
+    // - `comm_log`: teed in the reader task above (parity with the
+    //   in-process path), so OpenFlow agents work on the daemon spawn path.
 
     Ok(())
 }

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -55,6 +55,36 @@ pub fn release_comm_log_lock(path: &str) {
     }
 }
 
+/// Turn a raw PTY output chunk into a single OpenFlow comm-log line, or
+/// `None` when the chunk is noise that shouldn't be logged (ANSI-only,
+/// progress spinners, block-glyph redraws, too-short fragments). Shared by
+/// BOTH the in-process reader loop and the daemon-backed reader task so the
+/// two paths can't drift — without it, OpenFlow agents on the daemon spawn
+/// path (the default since persistent agents) wrote an empty comm log and
+/// the orchestrator's stuck-detection went blind.
+pub(crate) fn comm_log_entry_for_chunk(role: &str, data: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(data).ok()?;
+    let cleaned = strip_ansi_codes(text);
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty()
+        || trimmed.len() <= 2
+        || trimmed.starts_with('\x1b')
+        || trimmed.starts_with("No orchestration progress detected")
+        || trimmed.starts_with("STOP: General Agent")
+        || trimmed.chars().all(|c| {
+            c.is_whitespace()
+                || c == '\u{2580}'
+                || c == '\u{2584}'
+                || c == '\u{2588}'
+                || c == ' '
+        })
+    {
+        return None;
+    }
+    let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
+    Some(format!("[{}] [{}] {}\n", timestamp, role.to_uppercase(), trimmed))
+}
+
 fn strip_ansi_codes(s: &str) -> String {
     let mut result = String::new();
     let mut in_escape = false;
@@ -2933,39 +2963,19 @@ fn spawn_pty_for_agent_in_process(
             |data| {
                 // Buffer agent output for communication log (cleaned); flush periodically
                 if let Some((ref log_lock, ref role)) = log_lock_opt {
-                    if let Ok(text) = std::str::from_utf8(data) {
-                        let cleaned = strip_ansi_codes(text);
-                        let trimmed = cleaned.trim();
-
-                        if !trimmed.is_empty()
-                            && trimmed.len() > 2
-                            && !trimmed.starts_with('\x1b')
-                            && !trimmed.starts_with("No orchestration progress detected")
-                            && !trimmed.starts_with("STOP: General Agent")
-                            && !trimmed.chars().all(|c| {
-                                c.is_whitespace()
-                                    || c == '\u{2580}'
-                                    || c == '\u{2584}'
-                                    || c == '\u{2588}'
-                                    || c == ' '
-                            })
+                    if let Some(entry) = comm_log_entry_for_chunk(role, data) {
+                        comm_log_buffer.push(entry);
+                        if comm_log_buffer.len() >= COMM_LOG_FLUSH_BATCH_SIZE
+                            || comm_last_flush.elapsed() >= COMM_LOG_FLUSH_INTERVAL
                         {
-                            let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
-                            let entry =
-                                format!("[{}] [{}] {}\n", timestamp, role.to_uppercase(), trimmed);
-                            comm_log_buffer.push(entry);
-                            if comm_log_buffer.len() >= COMM_LOG_FLUSH_BATCH_SIZE
-                                || comm_last_flush.elapsed() >= COMM_LOG_FLUSH_INTERVAL
-                            {
-                                if let Ok(mut file) = log_lock.lock() {
-                                    for e in &comm_log_buffer {
-                                        let _ = file.write_all(e.as_bytes());
-                                    }
-                                    let _ = file.flush();
+                            if let Ok(mut file) = log_lock.lock() {
+                                for e in &comm_log_buffer {
+                                    let _ = file.write_all(e.as_bytes());
                                 }
-                                comm_log_buffer.clear();
-                                comm_last_flush = Instant::now();
+                                let _ = file.flush();
                             }
+                            comm_log_buffer.clear();
+                            comm_last_flush = Instant::now();
                         }
                     }
                 }
@@ -3120,6 +3130,29 @@ mod tests {
 
     fn make_sessions() -> Arc<Mutex<HashMap<String, SessionRuntime>>> {
         Arc::new(Mutex::new(HashMap::new()))
+    }
+
+    #[test]
+    fn comm_log_entry_formats_and_filters() {
+        // Real agent output → a tagged, timestamped line.
+        let entry = comm_log_entry_for_chunk("builder-0", b"Implementing the parser\n")
+            .expect("real output should log");
+        assert!(entry.contains("[BUILDER-0]"), "role is upper-cased + tagged: {entry}");
+        assert!(entry.contains("Implementing the parser"));
+        assert!(entry.ends_with('\n'));
+
+        // Noise is dropped: empty / too-short / ANSI-only / known spinners /
+        // block-glyph redraws.
+        assert!(comm_log_entry_for_chunk("b", b"").is_none());
+        assert!(comm_log_entry_for_chunk("b", b"ok").is_none(), "<=2 chars");
+        assert!(comm_log_entry_for_chunk("b", b"\x1b[2J\x1b[H").is_none(), "ansi-only");
+        assert!(
+            comm_log_entry_for_chunk("b", "\u{2588}\u{2588}\u{2580}".as_bytes()).is_none(),
+            "block-glyph redraw"
+        );
+        assert!(
+            comm_log_entry_for_chunk("b", b"No orchestration progress detected yet").is_none(),
+        );
     }
 
     // ── Regression tests for the cross-machine push spawn bugs ────────

--- a/src-tauri/src/workspace_paths.rs
+++ b/src-tauri/src/workspace_paths.rs
@@ -9,6 +9,58 @@
 
 use std::path::{Path, PathBuf};
 
+/// Sanitise a single path segment to ASCII-alphanumeric + `_ - .`; anything
+/// else becomes `-`, then trim leading/trailing `-`. Shared by every path
+/// helper here so the layout is identical across push, pull, and adopt.
+fn sanitize_segment(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+/// The project's worktree-tree directory component.
+///
+/// When a deterministic `project_uid` is known, this is
+/// `<basename>-<short-uid>` — collision-safe (two *different* repos that
+/// share a basename, e.g. `acme/api` and `widgets/api`, get distinct
+/// directories because their uids differ) while staying human-readable
+/// (you can still see the repo name when you `cd` in). Without a uid it
+/// degrades to the bare sanitised basename — the legacy layout — so existing
+/// pushed workspaces keep resolving.
+///
+/// The short-uid is the first 8 hex chars of the uid (uids are UUIDs); 32
+/// bits is far more than enough to disambiguate the handful of projects on
+/// one host, and keeps the path short.
+pub fn project_dir_component(project_uid: Option<&str>, project_name: &str) -> String {
+    let base = {
+        let b = sanitize_segment(project_name);
+        if b.is_empty() {
+            "workspace".to_string()
+        } else {
+            b
+        }
+    };
+    match project_uid.map(sanitize_segment).filter(|u| !u.is_empty()) {
+        Some(uid) => {
+            let short: String = uid.chars().filter(|c| *c != '-').take(8).collect();
+            if short.is_empty() {
+                base
+            } else {
+                format!("{base}-{short}")
+            }
+        }
+        None => base,
+    }
+}
+
 /// The canonical worktree path layout used by push, pull, and
 /// adoption across every platform:
 ///
@@ -26,30 +78,27 @@ use std::path::{Path, PathBuf};
 /// for filesystem ops. The `~/` form is kept for the SSH-side
 /// rsync target which lets the remote shell do the expansion.
 pub fn conventional_remote_path(project_name: &str, branch: &str) -> PathBuf {
-    fn sanitize(s: &str) -> String {
-        s.chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
-                    c
-                } else {
-                    '-'
-                }
-            })
-            .collect::<String>()
-            .trim_matches('-')
-            .to_string()
-    }
-    let p = sanitize(project_name);
-    let b = sanitize(branch);
-    let p = if p.is_empty() {
-        "workspace".to_string()
-    } else {
-        p
-    };
-    let b = if b.is_empty() {
-        "main".to_string()
-    } else {
-        b
+    conventional_remote_path_keyed(None, project_name, branch)
+}
+
+/// Like [`conventional_remote_path`] but keyed on the deterministic
+/// `project_uid` when known (`<basename>-<short-uid>`), so two different
+/// repos sharing a basename land in distinct worktree directories instead of
+/// clobbering each other. `project_uid = None` reproduces the legacy
+/// basename-only path exactly, so already-pushed workspaces still resolve.
+pub fn conventional_remote_path_keyed(
+    project_uid: Option<&str>,
+    project_name: &str,
+    branch: &str,
+) -> PathBuf {
+    let p = project_dir_component(project_uid, project_name);
+    let b = {
+        let b = sanitize_segment(branch);
+        if b.is_empty() {
+            "main".to_string()
+        } else {
+            b
+        }
     };
     PathBuf::from(format!("~/.codemux/worktrees/{p}/{b}"))
 }
@@ -67,25 +116,17 @@ pub fn conventional_remote_path(project_name: &str, branch: &str) -> PathBuf {
 /// divergent-copy bug). Same sanitisation + `~/`-prefix contract as
 /// [`conventional_remote_path`].
 pub fn conventional_remote_root_path(project_name: &str) -> PathBuf {
-    fn sanitize(s: &str) -> String {
-        s.chars()
-            .map(|c| {
-                if c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' {
-                    c
-                } else {
-                    '-'
-                }
-            })
-            .collect::<String>()
-            .trim_matches('-')
-            .to_string()
-    }
-    let p = sanitize(project_name);
-    let p = if p.is_empty() {
-        "workspace".to_string()
-    } else {
-        p
-    };
+    conventional_remote_root_path_keyed(None, project_name)
+}
+
+/// Like [`conventional_remote_root_path`] but keyed on `project_uid` when
+/// known (`<basename>-<short-uid>`). `None` reproduces the legacy
+/// basename-only root path exactly.
+pub fn conventional_remote_root_path_keyed(
+    project_uid: Option<&str>,
+    project_name: &str,
+) -> PathBuf {
+    let p = project_dir_component(project_uid, project_name);
     PathBuf::from(format!("~/.codemux/projects/{p}"))
 }
 
@@ -130,6 +171,46 @@ mod tests {
         assert_eq!(
             p.to_string_lossy(),
             "~/.codemux/worktrees/a_b.c-d/x_y.z-1",
+        );
+    }
+
+    #[test]
+    fn uid_keyed_path_disambiguates_same_basename() {
+        // Two DIFFERENT repos sharing a basename get distinct directories —
+        // the collision the re-key fixes.
+        let a = conventional_remote_path_keyed(
+            Some("11111111-2222-3333-4444-555555555555"),
+            "api",
+            "main",
+        );
+        let b = conventional_remote_path_keyed(
+            Some("99999999-8888-7777-6666-555555555555"),
+            "api",
+            "main",
+        );
+        assert_ne!(a, b, "same basename + different uid must not collide");
+        assert_eq!(a.to_string_lossy(), "~/.codemux/worktrees/api-11111111/main");
+        assert_eq!(
+            conventional_remote_root_path_keyed(
+                Some("11111111-2222-3333-4444-555555555555"),
+                "api",
+            )
+            .to_string_lossy(),
+            "~/.codemux/projects/api-11111111",
+        );
+    }
+
+    #[test]
+    fn none_uid_reproduces_legacy_basename_layout() {
+        // The migration's safety net: with no uid, paths are byte-identical
+        // to the pre-re-key layout, so already-pushed workspaces still resolve.
+        assert_eq!(
+            conventional_remote_path_keyed(None, "my-proj", "feature/x").to_string_lossy(),
+            conventional_remote_path("my-proj", "feature/x").to_string_lossy(),
+        );
+        assert_eq!(
+            conventional_remote_path_keyed(None, "my-proj", "feature/x").to_string_lossy(),
+            "~/.codemux/worktrees/my-proj/feature-x",
         );
     }
 

--- a/src-tauri/src/workspaces_sync.rs
+++ b/src-tauri/src/workspaces_sync.rs
@@ -239,7 +239,77 @@ pub async fn pull(token: &str, db: &DatabaseStore) -> Result<(), String> {
         }
     }
 
+    // Collapse cross-device duplicate sibling rows (see `dedupe_sibling_rows`).
+    dedupe_sibling_rows(db);
+
     Ok(())
+}
+
+/// Collapse duplicate **un-adopted sibling** rows that describe the same
+/// physical remote workspace.
+///
+/// When Device A and Device B both poll the same host before either's push
+/// lands, each POSTs its own cloud row for one workspace; after a pull both
+/// devices then see two cards. Until the server enforces uniqueness
+/// (TODO(server): unique partial index on `codemux_workspaces(origin_uid)`
+/// — lives in the `codemux-api` repo), we converge client-side: group
+/// un-adopted siblings (`workspace_id IS NULL`) by `(host, origin_uid)` —
+/// or, since `origin_uid` is local-only and absent on cloud-pulled rows, by
+/// `(host, project_uid, branch, kind)` — keep the canonical row (one with a
+/// `server_id`, lowest id), and tombstone the rest so the next push removes
+/// the cloud duplicate. Adopted rows (a real local workspace) are never
+/// touched.
+fn dedupe_sibling_rows(db: &DatabaseStore) {
+    use std::collections::HashMap;
+    let rows = db.list_workspaces_sync();
+    let mut groups: HashMap<String, Vec<&crate::database::WorkspaceSyncRecord>> =
+        HashMap::new();
+    for r in &rows {
+        // Only un-adopted siblings are dedup candidates; an adopted row is a
+        // real local workspace, not a duplicate card.
+        if r.workspace_id.is_some() {
+            continue;
+        }
+        let Some(host) = r.host_server_id.as_deref() else {
+            continue;
+        };
+        let key = if let Some(uid) = r.origin_uid.as_deref() {
+            format!("u|{host}|{uid}")
+        } else if let Some(puid) = r.project_uid.as_deref() {
+            format!(
+                "p|{host}|{puid}|{}|{}",
+                r.git_branch.as_deref().unwrap_or(""),
+                r.workspace_kind.as_deref().unwrap_or(""),
+            )
+        } else {
+            // No stable identity to group on — leave it alone.
+            continue;
+        };
+        groups.entry(key).or_default().push(r);
+    }
+    for (_key, mut group) in groups {
+        if group.len() < 2 {
+            continue;
+        }
+        // Keeper = a row WITH a server_id first (already known to the cloud),
+        // then lowest server_id, then lowest local id. Index 0 survives.
+        group.sort_by(|a, b| {
+            b.server_id
+                .is_some()
+                .cmp(&a.server_id.is_some())
+                .then_with(|| a.server_id.cmp(&b.server_id))
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        let keep = group[0].id;
+        for dup in &group[1..] {
+            eprintln!(
+                "[workspaces-sync] collapsing duplicate sibling row id={} \
+                 (keeping id={keep})",
+                dup.id
+            );
+            let _ = db.soft_delete_remote_discovered_workspace_sync_by_id(dup.id);
+        }
+    }
 }
 
 /// Push every dirty local row to the server. Each row is handled
@@ -738,6 +808,44 @@ mod tests {
             Some("worktree"),
             "server pull updates workspace_kind in place"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn dedupe_collapses_cross_device_duplicate_siblings() {
+        let db = fresh_db();
+        // The cross-device race: two cloud rows for ONE physical workspace,
+        // both un-adopted siblings, same host + project_uid + branch + kind,
+        // origin_uid null (it's local-only, absent on cloud-pulled rows).
+        db.upsert_workspace_sync_from_server(
+            "S1", "proj", Some("host-1"), Some("/srv/proj"), None,
+            Some("main"), None, "t", "t", None, Some("puid-1"), Some("main"),
+        )
+        .unwrap();
+        db.upsert_workspace_sync_from_server(
+            "S2", "proj", Some("host-1"), Some("/srv/proj"), None,
+            Some("main"), None, "t", "t", None, Some("puid-1"), Some("main"),
+        )
+        .unwrap();
+        assert_eq!(db.list_workspaces_sync().len(), 2, "two dup cards before");
+
+        super::dedupe_sibling_rows(&db);
+
+        // Exactly one survives — the lowest server_id (S1); S2 is tombstoned.
+        let live = db.list_workspaces_sync();
+        assert_eq!(live.len(), 1, "duplicate collapsed to one");
+        assert_eq!(live[0].server_id.as_deref(), Some("S1"));
+
+        // An ADOPTED row sharing the same identity is NOT a dedup candidate.
+        db.link_workspace_sync_to_local("S1", "ws-local").unwrap();
+        db.upsert_workspace_sync_from_server(
+            "S3", "proj", Some("host-1"), Some("/srv/proj"), None,
+            Some("main"), None, "t", "t", None, Some("puid-1"), Some("main"),
+        )
+        .unwrap();
+        super::dedupe_sibling_rows(&db);
+        // S1 (adopted) + S3 (sibling) both remain — adopted rows are spared.
+        assert_eq!(db.list_workspaces_sync().len(), 2);
     }
 
     #[test]

--- a/src-tauri/src/workspaces_sync.rs
+++ b/src-tauri/src/workspaces_sync.rs
@@ -819,7 +819,7 @@ mod tests {
         let row = db
             .insert_remote_discovered_workspace_sync(
                 "host-1", "uuid-abc", "ws", None, None, Some("main"), None, None,
-                None,
+                None, None,
             )
             .unwrap();
         assert!(db
@@ -1065,6 +1065,7 @@ mod tests {
                 Some("proj-uid-1"),
                 Some("worktree"),
                 Some("/srv/discovered/wt"),
+                Some("trunk"),
             )
             .expect("insert remote-discovered");
         assert!(row.workspace_id.is_none(), "remote-discovered rows must have NULL workspace_id");
@@ -1075,6 +1076,11 @@ mod tests {
         assert_eq!(row.title, "discovered-on-host");
         assert_eq!(row.project_uid.as_deref(), Some("proj-uid-1"));
         assert_eq!(row.workspace_kind.as_deref(), Some("worktree"));
+        assert_eq!(
+            row.default_branch.as_deref(),
+            Some("trunk"),
+            "daemon-reported default_branch must round-trip through the sync row"
+        );
 
         // The lookup function returns this row when queried by
         // (host, uid) and rejects mismatching pairs.
@@ -1113,6 +1119,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .unwrap();
         // Simulate the first push assigning a cloud server_id.
@@ -1132,6 +1139,7 @@ mod tests {
             Some("proj-uid-z"),
             Some("main"),
             Some("/srv/new/wt"),
+            Some("main"),
         )
         .unwrap();
 
@@ -1165,11 +1173,11 @@ mod tests {
     #[serial]
     fn list_remote_discovered_for_host_is_scoped() {
         let db = fresh_db();
-        db.insert_remote_discovered_workspace_sync("host-A", "uid-1", "a1", None, None, None, None, None, None)
+        db.insert_remote_discovered_workspace_sync("host-A", "uid-1", "a1", None, None, None, None, None, None, None)
             .unwrap();
-        db.insert_remote_discovered_workspace_sync("host-A", "uid-2", "a2", None, None, None, None, None, None)
+        db.insert_remote_discovered_workspace_sync("host-A", "uid-2", "a2", None, None, None, None, None, None, None)
             .unwrap();
-        db.insert_remote_discovered_workspace_sync("host-B", "uid-3", "b1", None, None, None, None, None, None)
+        db.insert_remote_discovered_workspace_sync("host-B", "uid-3", "b1", None, None, None, None, None, None, None)
             .unwrap();
         // A local-on-this-device row with no origin_uid must not
         // appear in the host scope, even if it carries the same
@@ -1209,6 +1217,7 @@ mod tests {
                 "host-Z",
                 "uid-doomed",
                 "to-be-deleted",
+                None,
                 None,
                 None,
                 None,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useAppStateInit } from "@/hooks/use-app-state";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
 import { useAuthEvents } from "@/hooks/use-auth-events";
+import { useTunnelStatusEvents } from "@/hooks/use-tunnel-status-events";
 import { useSkillsSync } from "@/hooks/use-skills-sync";
 import { useScrollbackSerializer } from "@/hooks/use-scrollback-serializer";
 import { useTerminalCacheGc } from "@/hooks/use-terminal-cache-gc";
@@ -34,6 +35,10 @@ function App() {
 
   // Listen for auth state changes from Tauri (OAuth callback, token expiry)
   useAuthEvents();
+
+  // Bridge SSH tunnel health into the tunnel-status store so remote
+  // workspaces can show a "Reconnecting…" / "Connection lost" pill.
+  useTunnelStatusEvents();
 
   // Skills sync engine triggers: kick a sync after sync becomes
   // available and after the file watcher reports `skills-changed`

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -61,6 +61,10 @@ import {
 } from "@/components/overlays/confirm-push-dialog";
 import type { WorkspaceSnapshot, EditorInfo, ActivePaneStatus } from "@/tauri/types";
 import { useAppStore } from "@/stores/app-store";
+import {
+  useTunnelStatusStore,
+  tunnelStatusKind,
+} from "@/stores/tunnel-status-store";
 import { useChatDraftStore } from "@/stores/chat-draft-store";
 import { getWorkspaceStatus } from "@/lib/pane-status";
 import { StatusIndicator } from "@/components/ui/status-indicator";
@@ -589,6 +593,11 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
   const canDelete = !isPrimary && !isRepoRoot;
   const isRemote =
     workspace.host_id !== null && workspace.host_id !== undefined;
+  // SSH tunnel health for this remote workspace (sleep/wake, WiFi flap,
+  // circuit-breaker). null for local/healthy → no pill.
+  const tunnelKind = tunnelStatusKind(
+    useTunnelStatusStore((s) => s.byWorkspace[workspace.workspace_id]),
+  );
   const isPushOrPullInFlight = useAppStore(
     (s) => s.workspacePushPullInFlight === workspace.workspace_id,
   );
@@ -763,10 +772,24 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
                   indicators. Everything that's optional only renders
                   when relevant — when none of these apply the row is
                   one line, keeping the sidebar calm. */}
-              {(workspace.git_branch || hasDiff || hasAheadBehind) && (
+              {(workspace.git_branch || hasDiff || hasAheadBehind || tunnelKind) && (
                 <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/60 font-mono leading-tight mt-0.5">
                   {workspace.git_branch && (
                     <span className="truncate min-w-0">{workspace.git_branch}</span>
+                  )}
+
+                  {/* SSH tunnel health — only renders for a degraded remote
+                      tunnel (reconnecting / circuit-open). A healthy or local
+                      workspace shows nothing here. */}
+                  {tunnelKind === "reconnecting" && (
+                    <span className="shrink-0 rounded px-1 text-[10px] leading-[14px] text-warning bg-warning/15">
+                      Reconnecting…
+                    </span>
+                  )}
+                  {tunnelKind === "lost" && (
+                    <span className="shrink-0 rounded px-1 text-[10px] leading-[14px] text-danger bg-danger/15">
+                      Connection lost — re-push
+                    </span>
                   )}
 
                   {hasAheadBehind && (

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -580,7 +580,13 @@ export function SidebarWorkspaceRow({ workspace, isActive }: Props) {
   };
 
   const isPrimary = !workspace.worktree_path;
-  const canDelete = !isPrimary;
+  // A protected repo root is never destructively deletable from the sidebar
+  // (close-only), aligning with the overview's `isRepoRoot` guard. Roots
+  // already have a null `worktree_path` (so `isPrimary` covers them), but
+  // gating on `protected` too is belt-and-suspenders against a root that
+  // somehow carries a worktree_path.
+  const isRepoRoot = workspace.protected === true;
+  const canDelete = !isPrimary && !isRepoRoot;
   const isRemote =
     workspace.host_id !== null && workspace.host_id !== undefined;
   const isPushOrPullInFlight = useAppStore(

--- a/src/components/workspaces-overview/pull-to-device-dialog.test.tsx
+++ b/src/components/workspaces-overview/pull-to-device-dialog.test.tsx
@@ -90,6 +90,7 @@ function makeSyncRow(
     git_head_sha: null,
     project_uid: null,
     workspace_kind: null,
+    default_branch: null,
     created_at: "2026-05-20T10:00:00Z",
     updated_at: "2026-05-20T10:00:00Z",
     dirty: false,

--- a/src/components/workspaces-overview/sibling-device-row.test.tsx
+++ b/src/components/workspaces-overview/sibling-device-row.test.tsx
@@ -47,6 +47,7 @@ function makeSyncRow(overrides?: Partial<WorkspaceSyncView>): WorkspaceSyncView 
     git_head_sha: null,
     project_uid: null,
     workspace_kind: null,
+    default_branch: null,
     created_at: "2026-05-20T10:00:00Z",
     updated_at: "2026-05-20T10:00:00Z",
     dirty: false,

--- a/src/components/workspaces-overview/use-overview-items.test.ts
+++ b/src/components/workspaces-overview/use-overview-items.test.ts
@@ -102,6 +102,7 @@ function makeSync(
     git_head_sha: partial.git_head_sha ?? null,
     project_uid: partial.project_uid ?? null,
     workspace_kind: partial.workspace_kind ?? null,
+    default_branch: partial.default_branch ?? null,
     created_at: partial.created_at ?? "2026-01-01T00:00:00Z",
     updated_at: partial.updated_at ?? "2026-01-01T00:00:00Z",
     dirty: partial.dirty ?? false,

--- a/src/components/workspaces-overview/workspace-overview-row.tsx
+++ b/src/components/workspaces-overview/workspace-overview-row.tsx
@@ -11,6 +11,7 @@ import {
   MoreHorizontal,
   Pencil,
   Trash2,
+  Wrench,
   Workflow,
 } from "lucide-react";
 
@@ -36,6 +37,7 @@ import {
   activateWorkspace,
   closeWorkspace,
   closeWorkspaceWithWorktree,
+  workspacesReconcileCopy,
   renameWorkspace,
   workspacePullBack,
   workspacePushToHost,
@@ -312,6 +314,16 @@ function LocalRow({
     );
   }, [workspace.workspace_id, workspace.title, canRemoveWorktree, isRepoRoot]);
 
+  const handleReconcileCopy = useCallback(() => {
+    workspacesReconcileCopy(workspace.workspace_id)
+      .then((msg) => toast.success("Reconciled standalone copy", { description: msg }))
+      .catch((err) =>
+        toast.error("Couldn't reconcile copy", {
+          description: err instanceof Error ? err.message : String(err),
+        }),
+      );
+  }, [workspace.workspace_id]);
+
   const handleCopyBranch = useCallback(() => {
     if (workspace.git_branch) {
       navigator.clipboard
@@ -531,6 +543,16 @@ function LocalRow({
                       ))}
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
+                )}
+
+                {isDivergentCopy && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onClick={handleReconcileCopy}>
+                      <Wrench className="mr-2 size-3.5" />
+                      Reconcile copy…
+                    </DropdownMenuItem>
+                  </>
                 )}
 
                 <DropdownMenuSeparator />

--- a/src/components/workspaces-overview/workspaces-overview-section.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.tsx
@@ -23,11 +23,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { toast } from "@/lib/toast";
 import { useAppStore } from "@/stores/app-store";
 import { useHostsStore } from "@/stores/hosts-store";
 import { useUIStore } from "@/stores/ui-store";
 
-import type { WorkspaceSyncView } from "@/tauri/commands";
+import {
+  workspacesAdoptProject,
+  workspacesSyncNow,
+  type WorkspaceSyncView,
+} from "@/tauri/commands";
 
 import { WorkspaceOverviewRow } from "./workspace-overview-row";
 import {
@@ -95,6 +100,45 @@ export function WorkspacesOverviewSection() {
   const handleRequestPull = useCallback(
     (item: Extract<OverviewItem, { kind: "remote" }>) => {
       setPullRow(item.sync);
+    },
+    [],
+  );
+
+  // Project-first pull: materialize the repo ROOT + every worktree in one
+  // action (root lands protected at ~/.codemux/projects/<repo>; worktrees
+  // recreate as real linked worktrees under it). Surfaced on a project
+  // cluster header when ≥1 sibling-device row remains un-adopted.
+  const [pullingProjectUid, setPullingProjectUid] = useState<string | null>(
+    null,
+  );
+  const handlePullProject = useCallback(
+    async (projectUid: string, projectName: string) => {
+      setPullingProjectUid(projectUid);
+      try {
+        const result = await workspacesAdoptProject(projectUid);
+        if (result.failures.length > 0) {
+          toast.error(
+            `Pulled ${projectName} with ${result.failures.length} issue(s)`,
+            {
+              description: result.failures
+                .map((f) => `${f.title}: ${f.error}`)
+                .join("\n"),
+            },
+          );
+        } else {
+          toast.success(`Pulled ${projectName} to this device`, {
+            description: result.message,
+          });
+        }
+        // Refresh the overview so the newly-local rows re-bucket.
+        await workspacesSyncNow().catch(() => {});
+      } catch (err) {
+        toast.error(`Failed to pull ${projectName}`, {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setPullingProjectUid(null);
+      }
     },
     [],
   );
@@ -620,6 +664,8 @@ export function WorkspacesOverviewSection() {
                 activeWorkspaceId={activeWorkspaceId}
                 onCloseOverview={() => setShowWorkspacesOverview(false)}
                 onRequestPull={handleRequestPull}
+                onPullProject={handlePullProject}
+                pullingProjectUid={pullingProjectUid}
                 onScrollToFirstRemote={handleScrollToFirstRemote}
                 hasAnySibling={allItems.some((i) => i.kind === "remote")}
                 registerRemoteRow={registerRemoteRow}
@@ -648,6 +694,8 @@ function DeviceSection({
   activeWorkspaceId,
   onCloseOverview,
   onRequestPull,
+  onPullProject,
+  pullingProjectUid,
   onScrollToFirstRemote,
   hasAnySibling,
   registerRemoteRow,
@@ -660,6 +708,10 @@ function DeviceSection({
   onRequestPull: (
     item: Extract<OverviewItem, { kind: "remote" }>,
   ) => void;
+  /** Pull an entire project (root + worktrees) in one action. */
+  onPullProject: (projectUid: string, projectName: string) => void;
+  /** project_uid currently being pulled, so its header shows a spinner. */
+  pullingProjectUid: string | null;
   /** Trigger the "Pull from another device" CTA: scroll the overview
    *  to the first sibling-device row and briefly pulse it. */
   onScrollToFirstRemote: () => void;
@@ -765,6 +817,20 @@ function DeviceSection({
                   <ProjectGroupHeader
                     name={group.name}
                     count={group.items.length}
+                    pullable={
+                      group.projectUid !== null &&
+                      group.pullableRemoteCount > 0
+                    }
+                    pulling={
+                      group.projectUid !== null &&
+                      pullingProjectUid === group.projectUid
+                    }
+                    onPull={
+                      group.projectUid
+                        ? () =>
+                            onPullProject(group.projectUid!, group.name)
+                        : undefined
+                    }
                   />
                   <RowGrid items={group.items} {...rowGridProps} />
                 </div>
@@ -791,8 +857,33 @@ function DeviceSection({
  * cluster together, while two unrelated repos that merely share a
  * basename do not. Falls back to the project name when no key exists.
  */
+/** True when an overview item is the repo ROOT (the protected main
+ *  checkout) rather than a per-branch worktree. Used to float the root to
+ *  the top of its project cluster so worktrees read as nested under it. */
+function isRootItem(it: OverviewItem): boolean {
+  if (it.kind === "local") {
+    return (
+      it.workspace.protected === true ||
+      it.workspace.workspace_kind === "main"
+    );
+  }
+  return it.sync.workspace_kind === "main";
+}
+
+type ProjectCluster = {
+  key: string;
+  name: string;
+  /** The actual (non-lowercased) project_uid, when known — needed to drive
+   *  the project-first pull. Null for clusters grouped only by name/path. */
+  projectUid: string | null;
+  items: OverviewItem[];
+  /** Count of still-un-adopted sibling-device rows in this cluster; >0 means
+   *  the whole project can be pulled to this device in one action. */
+  pullableRemoteCount: number;
+};
+
 function partitionByProject(items: OverviewItem[]): {
-  clustered: { key: string; name: string; items: OverviewItem[] }[];
+  clustered: ProjectCluster[];
   rest: OverviewItem[];
 } {
   const groups = new Map<string, { name: string; items: OverviewItem[] }>();
@@ -805,11 +896,25 @@ function partitionByProject(items: OverviewItem[]): {
     else groups.set(key, { name, items: [it] });
   }
 
-  const clustered: { key: string; name: string; items: OverviewItem[] }[] = [];
+  const clustered: ProjectCluster[] = [];
   const clusteredKeys = new Set<string>();
   for (const [key, g] of groups) {
     if (g.items.length >= 2) {
-      clustered.push({ key, name: g.name, items: g.items });
+      // Float the protected root to the top so its worktrees read as
+      // nested beneath it; otherwise preserve incoming order (stable sort).
+      g.items.sort((a, b) => Number(isRootItem(b)) - Number(isRootItem(a)));
+      const projectUid =
+        g.items.map((it) => it.sync?.project_uid).find(Boolean) ?? null;
+      const pullableRemoteCount = g.items.filter(
+        (it) => it.kind === "remote",
+      ).length;
+      clustered.push({
+        key,
+        name: g.name,
+        projectUid,
+        items: g.items,
+        pullableRemoteCount,
+      });
       clusteredKeys.add(key);
     }
   }
@@ -826,19 +931,45 @@ function partitionByProject(items: OverviewItem[]): {
   return { clustered, rest };
 }
 
-/** Subtle caption above a same-project cluster inside a device bucket. */
+/** Subtle caption above a same-project cluster inside a device bucket.
+ *  When the cluster holds un-adopted sibling-device rows, it also offers a
+ *  one-click "Pull project" that materializes the repo root + all worktrees
+ *  together (root-first) via `workspaces_adopt_project`. */
 function ProjectGroupHeader({
   name,
   count,
+  pullable = false,
+  pulling = false,
+  onPull,
 }: {
   name: string;
   count: number;
+  pullable?: boolean;
+  pulling?: boolean;
+  onPull?: () => void;
 }) {
   return (
     <div className="flex items-center gap-1.5 pl-0.5 text-[11px] text-muted-foreground/70">
       <Folder className="size-3 text-muted-foreground/50" aria-hidden />
       <span className="truncate font-medium text-foreground/75">{name}</span>
       <span className="tabular-nums text-muted-foreground/45">{count}</span>
+      {pullable && onPull && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-1 h-5 gap-1 px-1.5 text-[11px] text-muted-foreground/80 hover:text-foreground"
+          disabled={pulling}
+          onClick={onPull}
+          title="Pull this project's repo root and all its worktrees to this device"
+        >
+          {pulling ? (
+            <Loader2 className="size-3 animate-spin" aria-hidden />
+          ) : (
+            <ArrowDownToLine className="size-3" aria-hidden />
+          )}
+          Pull project
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/hooks/use-tunnel-status-events.ts
+++ b/src/hooks/use-tunnel-status-events.ts
@@ -1,0 +1,20 @@
+import { useCallback } from "react";
+
+import { useTauriEvent } from "./use-tauri-event";
+import { onTunnelStatusChanged, type TunnelStatusPayload } from "@/tauri/events";
+import { useTunnelStatusStore } from "@/stores/tunnel-status-store";
+
+/**
+ * Bridges the backend `tunnel-status-changed` event into the
+ * tunnel-status store. Mount once at the app root (next to
+ * `useAuthEvents`). See `src/stores/tunnel-status-store.ts`.
+ */
+export function useTunnelStatusEvents() {
+  const handle = useCallback((payload: TunnelStatusPayload) => {
+    useTunnelStatusStore
+      .getState()
+      .setStatus(payload.workspace_id, payload.status);
+  }, []);
+
+  useTauriEvent(onTunnelStatusChanged, handle, [handle]);
+}

--- a/src/stores/tunnel-status-store.test.ts
+++ b/src/stores/tunnel-status-store.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  useTunnelStatusStore,
+  tunnelStatusKind,
+} from "./tunnel-status-store";
+
+describe("tunnelStatusKind", () => {
+  it("shows chrome only for reconnecting and circuit_open", () => {
+    expect(tunnelStatusKind(undefined)).toBeNull();
+    expect(tunnelStatusKind({ kind: "pending" })).toBeNull();
+    expect(tunnelStatusKind({ kind: "connected", ssh_pid: 1 })).toBeNull();
+    expect(
+      tunnelStatusKind({ kind: "reconnecting", attempt: 2, delay_ms: 1000 }),
+    ).toBe("reconnecting");
+    expect(
+      tunnelStatusKind({ kind: "circuit_open", recent_failures: 5 }),
+    ).toBe("lost");
+  });
+});
+
+describe("useTunnelStatusStore", () => {
+  beforeEach(() => {
+    useTunnelStatusStore.setState({ byWorkspace: {} });
+  });
+
+  it("sets and clears per-workspace status", () => {
+    const { setStatus, clear } = useTunnelStatusStore.getState();
+    setStatus("ws-1", { kind: "reconnecting", attempt: 1, delay_ms: 1000 });
+    expect(useTunnelStatusStore.getState().byWorkspace["ws-1"]).toEqual({
+      kind: "reconnecting",
+      attempt: 1,
+      delay_ms: 1000,
+    });
+    clear("ws-1");
+    expect(useTunnelStatusStore.getState().byWorkspace["ws-1"]).toBeUndefined();
+  });
+
+  it("clear is a no-op for an unknown workspace", () => {
+    const before = useTunnelStatusStore.getState().byWorkspace;
+    useTunnelStatusStore.getState().clear("nope");
+    expect(useTunnelStatusStore.getState().byWorkspace).toBe(before);
+  });
+});

--- a/src/stores/tunnel-status-store.ts
+++ b/src/stores/tunnel-status-store.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+
+import type { TunnelStatus } from "@/tauri/events";
+
+/**
+ * Live SSH-tunnel health per remote workspace, fed by the backend's
+ * `tunnel-status-changed` event (see `src-tauri/src/ssh/registry.rs`).
+ *
+ * The UI reads this to render a compact status pill on remote workspaces
+ * — "Reconnecting…" on a sleep/wake or WiFi flap, "Connection lost" once
+ * the supervisor's circuit breaker trips. Without it the workspace just
+ * appears frozen and the user is never told they must re-push.
+ *
+ * `connected` / `pending` deliberately resolve to "no pill" (see
+ * `tunnelStatusKind`): a healthy tunnel needs no chrome.
+ */
+interface TunnelStatusStore {
+  /** Keyed by workspace_id. Absent = unknown (local, or never pushed). */
+  byWorkspace: Record<string, TunnelStatus>;
+  setStatus: (workspaceId: string, status: TunnelStatus) => void;
+  /** Drop a workspace's status (e.g. on pull-back / close). */
+  clear: (workspaceId: string) => void;
+}
+
+export const useTunnelStatusStore = create<TunnelStatusStore>()((set) => ({
+  byWorkspace: {},
+  setStatus: (workspaceId, status) =>
+    set((s) => ({
+      byWorkspace: { ...s.byWorkspace, [workspaceId]: status },
+    })),
+  clear: (workspaceId) =>
+    set((s) => {
+      if (!(workspaceId in s.byWorkspace)) return s;
+      const next = { ...s.byWorkspace };
+      delete next[workspaceId];
+      return { byWorkspace: next };
+    }),
+}));
+
+/** Narrow a TunnelStatus to the only two states worth showing chrome for.
+ *  `null` = healthy/unknown → render nothing. */
+export function tunnelStatusKind(
+  status: TunnelStatus | undefined,
+): "reconnecting" | "lost" | null {
+  if (!status) return null;
+  if (status.kind === "reconnecting") return "reconnecting";
+  if (status.kind === "circuit_open") return "lost";
+  return null;
+}

--- a/src/stores/workspaces-sync-store.test.tsx
+++ b/src/stores/workspaces-sync-store.test.tsx
@@ -40,6 +40,7 @@ function makeRow(
     git_head_sha: partial.git_head_sha ?? null,
     project_uid: partial.project_uid ?? null,
     workspace_kind: partial.workspace_kind ?? null,
+    default_branch: partial.default_branch ?? null,
     created_at: partial.created_at ?? "2026-01-01T00:00:00Z",
     updated_at: partial.updated_at ?? "2026-01-01T00:00:00Z",
     dirty: partial.dirty ?? false,

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1772,6 +1772,12 @@ export interface WorkspaceSyncView {
   /** "main" (repo root checkout) | "worktree" (per-branch worktree).
    *  Rendered as a small badge in the overview. */
   workspace_kind: string | null;
+  /** The repo's default branch as reported by the daemon poller
+   *  (origin/HEAD → main/master → current branch). Lets the overview
+   *  render a remote project's root distinctly and land a pull on the
+   *  right branch even when git_branch is null. Local-only — never sent
+   *  to or returned from the cloud API. */
+  default_branch: string | null;
   created_at: string;
   updated_at: string;
   /** True iff the row has unpushed changes. UI surfaces this as a
@@ -1847,3 +1853,24 @@ export const workspacesAdoptSynced = (serverId: string) =>
  *  dialog before reaching this. */
 export const workspacesAdoptViaClone = (serverId: string) =>
   invoke<AdoptOutcome>("workspaces_adopt_via_clone", { serverId });
+
+/** One workspace that failed during a project-granularity pull. */
+export interface ProjectAdoptFailure {
+  server_id: string;
+  title: string;
+  error: string;
+}
+
+export interface ProjectAdoptOutcome {
+  adopted: AdoptOutcome[];
+  failures: ProjectAdoptFailure[];
+  message: string;
+}
+
+/** Project-first pull: materialize the repo ROOT (protected, at
+ *  `~/.codemux/projects/<repo>`) first, then recreate every worktree as a
+ *  real linked worktree hanging off it — in one action. Pass the shared
+ *  `project_uid` of the remote project's rows. Worktree failures are
+ *  collected (non-fatal); a root failure rejects. */
+export const workspacesAdoptProject = (projectUid: string) =>
+  invoke<ProjectAdoptOutcome>("workspaces_adopt_project", { projectUid });

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1874,3 +1874,9 @@ export interface ProjectAdoptOutcome {
  *  collected (non-fatal); a root failure rejects. */
 export const workspacesAdoptProject = (projectUid: string) =>
   invoke<ProjectAdoptOutcome>("workspaces_adopt_project", { projectUid });
+
+/** Non-destructively reconcile a divergent "standalone copy": detaches its
+ *  workspace card (files kept on disk) when it's clean, or rejects with
+ *  guidance when it has uncommitted/unpushed work. */
+export const workspacesReconcileCopy = (workspaceId: string) =>
+  invoke<string>("workspaces_reconcile_copy", { workspaceId });

--- a/src/tauri/events.ts
+++ b/src/tauri/events.ts
@@ -238,3 +238,26 @@ export const onAgentChatEvent = (
   cb: EventCallback<AgentChatEventPayload>,
 ): Promise<UnlistenFn> =>
   listen<AgentChatEventPayload>("agent_chat_event", (e) => cb(e.payload));
+
+// ── Tunnel health ──
+//
+// Mirror of src-tauri/src/ssh/tunnel_supervisor.rs:TunnelStatus
+// (serde tag = "kind", snake_case) and the registry's
+// TunnelStatusEvent. Lets the overview/sidebar render a
+// "Reconnecting…" / "Connection lost — re-push" pill on remote
+// workspaces instead of a silent freeze.
+export type TunnelStatus =
+  | { kind: "pending" }
+  | { kind: "connected"; ssh_pid: number }
+  | { kind: "reconnecting"; attempt: number; delay_ms: number }
+  | { kind: "circuit_open"; recent_failures: number };
+
+export interface TunnelStatusPayload {
+  workspace_id: string;
+  status: TunnelStatus;
+}
+
+export const onTunnelStatusChanged = (
+  cb: EventCallback<TunnelStatusPayload>,
+): Promise<UnlistenFn> =>
+  listen<TunnelStatusPayload>("tunnel-status-changed", (e) => cb(e.payload));


### PR DESCRIPTION
Hardens the push/pull → host → multi-device workspace flow, closing a set of verified edge cases where the happy path worked but a sleep/wake, an auto-upgrade, a basename collision, or two devices racing could produce a silent freeze, a killed agent, corrupted state, or a duplicate row. Starts from the original "fake main" fix (a pulled repo root rendered as a deletable worktree) and builds the full bulletproof pass on top.

## What's in here

- **Project-first pull (`2d828c0`)** — a pulled repo root now materializes as a protected root on its real default branch instead of a deletable "main" worktree. Default branch is resolved from git (origin/HEAD → main/master → current) and threaded as a local-only synced column; daemon stamps + backfills it.
- **P1 — tunnel health in the UI (`9fb46c5`)** — `TunnelStatus` was computed for the UI but only consumed internally; now a per-workspace `tunnel-status-changed` event drives a "Reconnecting…" / "Connection lost — re-push" pill, so a dropped tunnel no longer looks like a frozen workspace.
- **P2 — host persistence (`54bdfad`)** — auto-upgrade restarted the serve daemon and silently killed host-side agents; it now defers the restart while live PTY sessions exist (probed via `serve status` → `app_status`). Adds a local pty-daemon idle reaper (hard-guarded against reaping a live session).
- **P4a — adopt lock + dedup (`bfdf76b`)** — a per-row async lock serializes concurrent adopts (double-click / poller race); a pull-time pass collapses cross-device duplicate sibling rows (server-side unique index tracked separately).
- **P3B — one repo root per project (`a80f57b`)** — `collapse_main_for_uid` + a boot sweep + idempotent collapse-on-create ensure a single `kind=main` row per project_uid (registry rows only; files untouched).
- **P5 — comm-log tee (`a0295a5`)** — OpenFlow agents on the daemon-backed spawn path wrote an empty comm log (orchestrator stuck-detection went blind); a shared `comm_log_entry_for_chunk` helper tees both reader paths.
- **P4B — Reconcile copy (`28eba19`)** — a non-destructive action for divergent "standalone copies": detaches the card when clean, refuses with guidance when dirty/unpushed; never deletes files.
- **P3A — uid-keyed host paths (`6ca7a1e`)** — host worktree/root paths key on project_uid (`<basename>-<short-uid>`) so two different repos sharing a basename no longer collide; legacy basename layout is reproduced exactly when no uid is known, and pull-back keeps the recorded `origin_path` plus a basename fallback so already-pushed workspaces still resolve.

P5's other items needed no work — the DevicePicker and the overview "All devices / per-host" filter already existed.

## Tests
- Rust lib: 1635 passing (2 pre-existing environmental failures unrelated to this branch: a system `agent-browser` on PATH and a global codemux MCP entry).
- Frontend: 1804 passing.
- New unit tests: tunnel-status store, cross-device dedup, main-row collapse, comm-log filter, reconcile blocker, default-branch fallback / `ensure_origin_head` no-op, uid-path disambiguation + legacy-layout-unchanged.

## Verification note (P3A)
P3A changes where desktop-pushed workspaces land on a host. The cross-machine round-trip should be confirmed on a real host pair: existing pushed workspaces still pull (recorded path / basename fallback); new pushes land at `<name>-<uid>`; two same-basename repos get distinct directories. Agent-created workspaces (recorded `origin_path`) are unaffected.