### PR TITLE
fix(sidebar): refresh project favicon on re-save instead of serving stale cache

### DIFF
--- a/src/components/layout/sidebar-project-group.tsx
+++ b/src/components/layout/sidebar-project-group.tsx
@@ -82,6 +82,9 @@ export function SidebarProjectGroup({
   const [collapsed, setCollapsed] = useState(false);
   const [customColor, setCustomColor] = useState<string | null>(null);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
+  // Cache-bust token for the derived favicon. Bumped on every save so a site
+  // that changed its favicon is re-fetched instead of served stale from cache.
+  const [imageVersion, setImageVersion] = useState<string | null>(null);
   const setShowNewWorkspaceDialog = useUIStore((s) => s.setShowNewWorkspaceDialog);
   const enableAgentChat = useFeatureFlags((s) => s.enableAgentChat);
   const enableLazyWorkspaceCreation = useFeatureFlags(
@@ -97,6 +100,9 @@ export function SidebarProjectGroup({
     }).catch(() => {});
     dbGetUiState(`project.image:${projectPath}`).then((val) => {
       if (val) setImageUrl(val);
+    }).catch(() => {});
+    dbGetUiState(`project.image.v:${projectPath}`).then((val) => {
+      if (val) setImageVersion(val);
     }).catch(() => {});
   }, [projectPath]);
 
@@ -120,10 +126,17 @@ export function SidebarProjectGroup({
   const handleSaveImage = (next: string | null) => {
     if (!next) {
       setImageUrl(null);
+      setImageVersion(null);
       dbSetUiState(`project.image:${projectPath}`, "").catch(console.error);
+      dbSetUiState(`project.image.v:${projectPath}`, "").catch(console.error);
     } else {
+      // New token on every save forces the favicon to refresh, so re-adding a
+      // site whose favicon changed picks up the new icon instead of the cached one.
+      const version = String(Date.now());
       setImageUrl(next);
+      setImageVersion(version);
       dbSetUiState(`project.image:${projectPath}`, next).catch(console.error);
+      dbSetUiState(`project.image.v:${projectPath}`, version).catch(console.error);
     }
   };
 
@@ -201,6 +214,7 @@ export function SidebarProjectGroup({
                 name={projectName}
                 color={customColor}
                 imageUrl={imageUrl}
+                cacheBust={imageVersion}
                 size="md"
                 shape="circle"
                 className="mr-2.5"

--- a/src/components/overlays/project-image-dialog.tsx
+++ b/src/components/overlays/project-image-dialog.tsx
@@ -33,12 +33,18 @@ export function ProjectImageDialog({
   onSave,
 }: Props) {
   const [value, setValue] = useState(initialValue ?? "");
+  // Fresh token each time the dialog opens so the preview re-fetches the
+  // favicon — lets the user see a site's *current* icon, not a cached one.
+  const [previewBust, setPreviewBust] = useState<string | null>(null);
 
   useEffect(() => {
-    if (open) setValue(initialValue ?? "");
+    if (open) {
+      setValue(initialValue ?? "");
+      setPreviewBust(String(Date.now()));
+    }
   }, [open, initialValue]);
 
-  const resolved = resolveImageUrl(value);
+  const resolved = resolveImageUrl(value, previewBust);
   const isWebsite = resolved.isFavicon;
   const isDirect = !isWebsite && resolved.url.length > 0;
 
@@ -72,6 +78,7 @@ export function ProjectImageDialog({
             <ProjectAvatar
               name={projectName}
               imageUrl={value || null}
+              cacheBust={previewBust}
               size="lg"
               shape="circle"
             />

--- a/src/components/ui/project-avatar.tsx
+++ b/src/components/ui/project-avatar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { resolveImageUrl } from "@/lib/project-image";
 
@@ -6,6 +6,12 @@ interface Props {
   name: string;
   color?: string | null;
   imageUrl?: string | null;
+  /**
+   * Token appended to derived favicon URLs to bust the WebView image cache.
+   * Change it when the user re-saves/re-opens the picker so a site's updated
+   * favicon is actually re-fetched instead of served stale from cache.
+   */
+  cacheBust?: string | number | null;
   size?: "sm" | "md" | "lg";
   shape?: "circle" | "square";
   className?: string;
@@ -28,6 +34,7 @@ export function ProjectAvatar({
   name,
   color,
   imageUrl,
+  cacheBust,
   size = "lg",
   shape = "circle",
   className,
@@ -35,8 +42,16 @@ export function ProjectAvatar({
   const [imgFailed, setImgFailed] = useState(false);
 
   const letter = (name || "?").charAt(0).toUpperCase();
-  const resolved = imageUrl ? resolveImageUrl(imageUrl) : null;
-  const hasImage = !!resolved?.url && !imgFailed;
+  const resolved = imageUrl ? resolveImageUrl(imageUrl, cacheBust) : null;
+  const resolvedUrl = resolved?.url ?? "";
+
+  // Retry the image whenever the resolved URL changes (new image or a fresh
+  // cache-bust token) so a previous load failure doesn't pin us to the letter.
+  useEffect(() => {
+    setImgFailed(false);
+  }, [resolvedUrl]);
+
+  const hasImage = !!resolvedUrl && !imgFailed;
   const hasColor = !!color;
   const shapeClass = shape === "circle" ? "rounded-full" : "rounded";
 
@@ -52,7 +67,7 @@ export function ProjectAvatar({
         )}
       >
         <img
-          src={resolved!.url}
+          src={resolvedUrl}
           alt=""
           className="h-full w-full object-cover"
           onError={() => setImgFailed(true)}

--- a/src/lib/project-image.test.ts
+++ b/src/lib/project-image.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { resolveImageUrl } from "./project-image";
+
+describe("resolveImageUrl", () => {
+  it("returns empty for blank input", () => {
+    expect(resolveImageUrl("")).toEqual({
+      url: "",
+      isFavicon: false,
+      domain: null,
+    });
+    expect(resolveImageUrl("   ")).toEqual({
+      url: "",
+      isFavicon: false,
+      domain: null,
+    });
+  });
+
+  it("passes data URLs through untouched", () => {
+    const data = "data:image/png;base64,AAAA";
+    expect(resolveImageUrl(data)).toEqual({
+      url: data,
+      isFavicon: false,
+      domain: null,
+    });
+  });
+
+  it("passes direct image URLs through by extension", () => {
+    const png = "https://example.com/logo.png";
+    expect(resolveImageUrl(png)).toEqual({
+      url: png,
+      isFavicon: false,
+      domain: null,
+    });
+    // Extension with a trailing query string is still recognised.
+    const ico = "https://example.com/fav.ico?x=1";
+    expect(resolveImageUrl(ico).isFavicon).toBe(false);
+    expect(resolveImageUrl(ico).url).toBe(ico);
+  });
+
+  it("derives a favicon URL from a bare domain", () => {
+    const r = resolveImageUrl("codemux.com");
+    expect(r.isFavicon).toBe(true);
+    expect(r.domain).toBe("codemux.com");
+    expect(r.url).toBe(
+      "https://www.google.com/s2/favicons?domain=codemux.com&sz=128",
+    );
+  });
+
+  it("strips a leading www and derives the favicon", () => {
+    const r = resolveImageUrl("https://www.codemux.com/some/path");
+    expect(r.isFavicon).toBe(true);
+    expect(r.domain).toBe("codemux.com");
+  });
+
+  it("appends the cache-bust token to derived favicon URLs", () => {
+    const a = resolveImageUrl("codemux.com", "123");
+    expect(a.url).toBe(
+      "https://www.google.com/s2/favicons?domain=codemux.com&sz=128&v=123",
+    );
+
+    // A different token yields a different URL, so the WebView re-fetches
+    // instead of serving the previously cached favicon.
+    const b = resolveImageUrl("codemux.com", "456");
+    expect(b.url).not.toBe(a.url);
+  });
+
+  it("does not append a cache-bust token to direct or data URLs", () => {
+    const png = "https://example.com/logo.png";
+    expect(resolveImageUrl(png, "123").url).toBe(png);
+
+    const data = "data:image/png;base64,AAAA";
+    expect(resolveImageUrl(data, "123").url).toBe(data);
+  });
+
+  it("ignores an empty/zero cache-bust token", () => {
+    const base =
+      "https://www.google.com/s2/favicons?domain=codemux.com&sz=128";
+    expect(resolveImageUrl("codemux.com", "").url).toBe(base);
+    expect(resolveImageUrl("codemux.com", 0).url).toBe(base);
+    expect(resolveImageUrl("codemux.com", null).url).toBe(base);
+  });
+
+  it("falls back to passthrough for unparseable input", () => {
+    const r = resolveImageUrl("not a url");
+    expect(r.isFavicon).toBe(false);
+    expect(r.domain).toBe(null);
+    expect(r.url).toBe("not a url");
+  });
+});

--- a/src/lib/project-image.ts
+++ b/src/lib/project-image.ts
@@ -22,7 +22,20 @@ export interface ResolvedImage {
   domain: string | null;
 }
 
-export function resolveImageUrl(input: string): ResolvedImage {
+/**
+ * @param input     Raw user input (image URL, data URL, website, or domain).
+ * @param cacheBust Optional token appended to derived favicon URLs as `&v=`.
+ *   The favicon service URL is otherwise identical for a given domain, so the
+ *   WebView's image cache serves the same bytes forever — meaning a site that
+ *   changes its favicon never visibly updates. Passing a token that changes
+ *   when the user re-saves (or re-opens the picker) forces a fresh fetch.
+ *   Only applied to derived favicons; direct/data URLs are passed through
+ *   untouched so we never corrupt a signed or already-complete URL.
+ */
+export function resolveImageUrl(
+  input: string,
+  cacheBust?: string | number | null,
+): ResolvedImage {
   const trimmed = input.trim();
   if (!trimmed) return { url: "", isFavicon: false, domain: null };
 
@@ -39,11 +52,11 @@ export function resolveImageUrl(input: string): ResolvedImage {
   // Try to interpret as a website / bare domain.
   const domain = extractDomain(trimmed);
   if (domain) {
-    return {
-      url: `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=128`,
-      isFavicon: true,
-      domain,
-    };
+    let url = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=128`;
+    if (cacheBust) {
+      url += `&v=${encodeURIComponent(String(cacheBust))}`;
+    }
+    return { url, isFavicon: true, domain };
   }
 
   // Fallback: pass through and let the <img onError> fallback handle it.


### PR DESCRIPTION
## Problem

The sidebar project avatar lets you paste a website/domain and it uses that site's favicon. But the favicon **never refreshed**: re-adding a site whose favicon had changed kept showing the old icon.

Root cause: the picker stores the raw site/domain and derives a **fixed** favicon URL on every render —

```
https://www.google.com/s2/favicons?domain=<domain>&sz=128
```

That URL is byte-identical every time, so deleting and re-adding the same site produced the same URL and the WebView's image cache just served the copy it already had — it never re-fetched.

## Fix

Attach a cache-bust token (`&v=<token>`) to **derived favicon URLs only** that changes when:
- the image is saved (persisted per project under `project.image.v:<path>`, so the sidebar avatar stays stable between saves but re-fetches on the next save), and
- the picker dialog is opened (fresh preview shows the site's *current* favicon).

Direct image URLs and `data:` URLs pass through untouched so a signed/complete URL is never corrupted. The avatar's image-failure flag now resets when the resolved URL changes, so a refreshed favicon retries instead of staying pinned to the letter fallback.

## Caveat

This fixes the layer we control (the local image cache). The favicon service also caches per-domain on its side and refreshes on its own schedule (typically within ~a day), so re-saving forces a fresh request but may briefly still return their cached version until they update.

## Changes

- `src/lib/project-image.ts` — `resolveImageUrl()` accepts an optional cache-bust token, appended only to favicons
- `src/components/layout/sidebar-project-group.tsx` — stamp + persist a fresh token on each save; feed it to the avatar
- `src/components/overlays/project-image-dialog.tsx` — fresh token per dialog open so the preview reflects the current favicon
- `src/components/ui/project-avatar.tsx` — thread the token through; reset the image-failure flag when the URL changes
- `src/lib/project-image.test.ts` — new unit tests covering the cache-bust behavior

## Verification

- `npm run check` (tsc) passes
- `npm run test` — full suite green (1809 existing + 9 new)