### PR TITLE
feat(dev): mock Tauri runtime so the UI boots in a plain browser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,18 @@
 - Default to `npm run verify` after meaningful changes.
 - Use `cargo check --manifest-path src-tauri/Cargo.toml`, `cargo test --manifest-path src-tauri/Cargo.toml`, `npm run check`, and `npm run test` when iterating on one layer.
 
+## Visual Verification
+
+### Visual verification (UI work)
+
+When iterating on UI:
+
+1. `npm run dev` — boots Vite with the Tauri mock auto-installed.
+2. `codemux browser open http://localhost:1420` — the real Codemux UI loads with seed data.
+3. `codemux browser screenshot` — capture visual proof.
+
+The mock lives in `src/dev/` and only loads when no real Tauri runtime is detected. For real-IPC testing, use `npm run tauri:dev` (desktop window, not browser-pane-visible).
+
 ## UI & Feature Work
 
 - The `/codemux-ui` skill auto-loads for visual and component work. It defines design standards, theming rules, and ADE feature patterns.

--- a/src/dev/mock-fixtures.ts
+++ b/src/dev/mock-fixtures.ts
@@ -1,0 +1,454 @@
+/**
+ * Hand-curated seed data for the dev-only Tauri mock (`tauri-mock.ts`).
+ *
+ * This module is loaded ONLY by `tauri-mock.ts`, which is itself
+ * dynamically imported by `main.tsx` exclusively under `npm run dev`
+ * (Vite dev) when no real Tauri runtime is present. The dual guard in
+ * `main.tsx` (`import.meta.env.DEV` + `!("__TAURI_INTERNALS__" in window)`)
+ * guarantees Rollup tree-shakes this whole file out of the production
+ * bundle and that it never loads under `npm run tauri:dev`.
+ *
+ * The shapes here mirror `src/tauri/types.ts` exactly so TypeScript
+ * catches drift the moment a real snapshot field changes.
+ *
+ * Coverage baked into the seed (per issue #40 acceptance criteria):
+ *   - 3 mock projects (codemux / vexis / personal-site)
+ *   - each project has a primary workspace + worktree workspaces
+ *   - PR states: open, merged, closed, draft (≥1 each)
+ *   - agent states (via `pane_statuses`): working (amber pulse),
+ *     review (green), permission (red pulse)
+ *   - a workspace with `linked_issue` populated
+ *   - a workspace with `notifications_muted: true`
+ *   - a workspace with non-zero git ahead/behind/additions/deletions
+ *   - a workspace with a non-zero `notification_count`
+ */
+import type {
+  AppStateSnapshot,
+  AuthUser,
+  CodemuxConfigSnapshot,
+  LinkedIssue,
+  PaneNodeSnapshot,
+  PaneStatus,
+  PersistenceSchema,
+  SurfaceSnapshot,
+  TabSnapshot,
+  TerminalSessionSnapshot,
+  WorkspaceSnapshot,
+} from "@/tauri/types";
+
+/** Authenticated user reported by the mock `check_auth`. Bypasses the
+ *  login screen so the real app shell renders immediately. */
+export const MOCK_USER: AuthUser = {
+  id: "dev-mock-user",
+  email: "dev@localhost",
+  name: "Mock Dev",
+  image: null,
+};
+
+const HOME = "/home/dev";
+const PROJECTS = `${HOME}/projects`;
+
+// ── Small builders ──────────────────────────────────────────────────
+//
+// Keep the workspace literals below readable: a workspace's main
+// surface is always a single terminal pane in the mock (the terminal
+// body itself is out of scope — see issue #40 "Out of scope"). These
+// helpers stamp the repetitive pane/surface/tab plumbing.
+
+let paneSeq = 0;
+let sessionSeq = 0;
+
+interface PaneRefs {
+  pane: PaneNodeSnapshot;
+  surface: SurfaceSnapshot;
+  tab: TabSnapshot;
+  session: TerminalSessionSnapshot;
+}
+
+/** Build a one-terminal surface (+ its tab + backing session) for a
+ *  workspace. The returned `pane.pane_id` is what you key into
+ *  `pane_statuses` to drive the sidebar status dot. */
+function terminalSurface(label: string, cwd: string): PaneRefs {
+  const n = ++paneSeq;
+  const s = ++sessionSeq;
+  const paneId = `pane-${n}`;
+  const sessionId = `sess-${s}`;
+  const surfaceId = `surface-${n}`;
+  const tabId = `tab-${n}`;
+
+  const pane: PaneNodeSnapshot = {
+    kind: "terminal",
+    pane_id: paneId,
+    session_id: sessionId,
+    title: label,
+  };
+  const surface: SurfaceSnapshot = {
+    surface_id: surfaceId,
+    title: label,
+    root: pane,
+    active_pane_id: paneId,
+  };
+  const tab: TabSnapshot = {
+    tab_id: tabId,
+    kind: "terminal",
+    title: label,
+    surface_id: surfaceId,
+    browser_id: null,
+    icon: null,
+  };
+  const session: TerminalSessionSnapshot = {
+    session_id: sessionId,
+    title: label,
+    shell: "/bin/bash",
+    cwd,
+    cols: 120,
+    rows: 32,
+    state: "ready",
+    last_message: null,
+    exit_code: null,
+    original_command: null,
+    adapter_captures: {},
+  };
+  return { pane, surface, tab, session };
+}
+
+interface WorkspaceSeed extends Partial<WorkspaceSnapshot> {
+  workspace_id: string;
+  title: string;
+  cwd: string;
+  /** Terminal-pane label (defaults to the title). */
+  paneLabel?: string;
+  /** Agent status to surface on the sidebar dot, keyed onto this
+   *  workspace's pane in `pane_statuses`. `idle` => no dot. */
+  status?: PaneStatus;
+}
+
+const terminalSessions: TerminalSessionSnapshot[] = [];
+const paneStatuses: Record<string, PaneStatus> = {};
+
+/** Materialize a `WorkspaceSnapshot` from a terse seed, filling in the
+ *  many optional/boilerplate fields with sane defaults and wiring the
+ *  terminal surface + status-dot plumbing. */
+function makeWorkspace(seed: WorkspaceSeed): WorkspaceSnapshot {
+  const { pane, surface, tab, session } = terminalSurface(
+    seed.paneLabel ?? seed.title,
+    seed.cwd,
+  );
+  terminalSessions.push(session);
+  if (seed.status && seed.status !== "idle") {
+    paneStatuses[pane.pane_id] = seed.status;
+  }
+
+  return {
+    workspace_id: seed.workspace_id,
+    title: seed.title,
+    workspace_type: seed.workspace_type ?? "standard",
+    cwd: seed.cwd,
+    git_branch: seed.git_branch ?? null,
+    git_ahead: seed.git_ahead ?? 0,
+    git_behind: seed.git_behind ?? 0,
+    git_additions: seed.git_additions ?? 0,
+    git_deletions: seed.git_deletions ?? 0,
+    git_changed_files: seed.git_changed_files ?? 0,
+    notification_count: seed.notification_count ?? 0,
+    latest_agent_state: seed.latest_agent_state ?? seed.status ?? null,
+    worktree_path: seed.worktree_path ?? null,
+    project_root: seed.project_root ?? null,
+    project_uid: seed.project_uid ?? null,
+    workspace_kind: seed.workspace_kind ?? null,
+    protected: seed.protected ?? false,
+    divergent_copy: seed.divergent_copy ?? false,
+    pr_number: seed.pr_number ?? null,
+    pr_state: seed.pr_state ?? null,
+    pr_url: seed.pr_url ?? null,
+    linked_issue: seed.linked_issue ?? null,
+    notifications_muted: seed.notifications_muted ?? false,
+    tabs: [tab],
+    active_tab_id: tab.tab_id,
+    active_surface_id: surface.surface_id,
+    surfaces: [surface],
+    host_id: seed.host_id ?? null,
+    remote_cwd: seed.remote_cwd ?? null,
+    attach_only: seed.attach_only ?? false,
+  };
+}
+
+// ── Linked issues ───────────────────────────────────────────────────
+
+const ISSUE_AUTH: LinkedIssue = {
+  number: 128,
+  title: "Refactor auth token refresh to avoid mid-session expiry",
+  state: "Closed",
+  labels: ["enhancement", "auth"],
+};
+
+const ISSUE_MOCK: LinkedIssue = {
+  number: 40,
+  title: "dev: mock Tauri runtime so the Codemux UI boots in a plain browser",
+  state: "Open",
+  labels: ["enhancement"],
+};
+
+// ── Workspaces ──────────────────────────────────────────────────────
+//
+// Project 1 — codemux: 1 primary (repo root) + 4 worktrees, covering
+// the full PR matrix and all three agent states.
+
+const codemuxRoot = `${PROJECTS}/codemux`;
+const codemuxUid = "uid-codemux";
+
+const wsCodemuxMain = makeWorkspace({
+  workspace_id: "ws-codemux-main",
+  title: "codemux",
+  cwd: codemuxRoot,
+  project_root: codemuxRoot,
+  project_uid: codemuxUid,
+  workspace_kind: "main",
+  protected: true,
+  git_branch: "main",
+  status: "working", // amber pulsing dot on the primary row
+});
+
+const wsCodemuxAuth = makeWorkspace({
+  workspace_id: "ws-codemux-auth",
+  title: "auth-refactor",
+  cwd: `${HOME}/.codemux/worktrees/codemux/feature-auth-refactor`,
+  worktree_path: `${HOME}/.codemux/worktrees/codemux/feature-auth-refactor`,
+  project_root: codemuxRoot,
+  project_uid: codemuxUid,
+  workspace_kind: "worktree",
+  git_branch: "feature/auth-refactor",
+  pr_number: 128,
+  pr_state: "merged",
+  pr_url: "https://github.com/example/codemux/pull/128",
+  linked_issue: ISSUE_AUTH,
+  status: "review", // green dot
+});
+
+const wsCodemuxSidebar = makeWorkspace({
+  workspace_id: "ws-codemux-sidebar",
+  title: "sidebar-flicker",
+  cwd: `${HOME}/.codemux/worktrees/codemux/fix-sidebar-flicker`,
+  worktree_path: `${HOME}/.codemux/worktrees/codemux/fix-sidebar-flicker`,
+  project_root: codemuxRoot,
+  project_uid: codemuxUid,
+  workspace_kind: "worktree",
+  git_branch: "fix/sidebar-flicker",
+  pr_number: 131,
+  pr_state: "closed",
+  pr_url: "https://github.com/example/codemux/pull/131",
+  notifications_muted: true,
+});
+
+const wsCodemuxMock = makeWorkspace({
+  workspace_id: "ws-codemux-mock",
+  title: "dev-mock-runtime",
+  cwd: `${HOME}/.codemux/worktrees/codemux/feature-40-dev-mock`,
+  worktree_path: `${HOME}/.codemux/worktrees/codemux/feature-40-dev-mock`,
+  project_root: codemuxRoot,
+  project_uid: codemuxUid,
+  workspace_kind: "worktree",
+  git_branch: "feature/40-dev-mock-tauri-runtime",
+  pr_number: 140,
+  pr_state: "draft",
+  pr_url: "https://github.com/example/codemux/pull/140",
+  linked_issue: ISSUE_MOCK,
+  notification_count: 3,
+  git_ahead: 2,
+  git_behind: 1,
+  git_additions: 214,
+  git_deletions: 37,
+  git_changed_files: 6,
+});
+
+const wsCodemuxPorts = makeWorkspace({
+  workspace_id: "ws-codemux-ports",
+  title: "port-detection",
+  cwd: `${HOME}/.codemux/worktrees/codemux/chore-port-detection`,
+  worktree_path: `${HOME}/.codemux/worktrees/codemux/chore-port-detection`,
+  project_root: codemuxRoot,
+  project_uid: codemuxUid,
+  workspace_kind: "worktree",
+  git_branch: "chore/port-detection",
+  pr_number: 142,
+  pr_state: "open",
+  pr_url: "https://github.com/example/codemux/pull/142",
+  git_additions: 58,
+  git_deletions: 4,
+  git_changed_files: 2,
+});
+
+// Project 2 — vexis: 1 primary + 3 worktrees (one in `permission`).
+
+const vexisRoot = `${PROJECTS}/vexis`;
+const vexisUid = "uid-vexis";
+
+const wsVexisMain = makeWorkspace({
+  workspace_id: "ws-vexis-main",
+  title: "vexis",
+  cwd: vexisRoot,
+  project_root: vexisRoot,
+  project_uid: vexisUid,
+  workspace_kind: "main",
+  protected: true,
+  git_branch: "main",
+});
+
+const wsVexisCuda = makeWorkspace({
+  workspace_id: "ws-vexis-cuda",
+  title: "cuda-variant",
+  cwd: `${HOME}/.codemux/worktrees/vexis/feat-cuda-variant`,
+  worktree_path: `${HOME}/.codemux/worktrees/vexis/feat-cuda-variant`,
+  project_root: vexisRoot,
+  project_uid: vexisUid,
+  workspace_kind: "worktree",
+  git_branch: "feat/cuda-variant",
+  pr_number: 88,
+  pr_state: "open",
+  pr_url: "https://github.com/example/vexis/pull/88",
+  notification_count: 1,
+  status: "permission", // red pulsing dot
+});
+
+const wsVexisBench = makeWorkspace({
+  workspace_id: "ws-vexis-bench",
+  title: "bench-suite",
+  cwd: `${HOME}/.codemux/worktrees/vexis/perf-bench-suite`,
+  worktree_path: `${HOME}/.codemux/worktrees/vexis/perf-bench-suite`,
+  project_root: vexisRoot,
+  project_uid: vexisUid,
+  workspace_kind: "worktree",
+  git_branch: "perf/bench-suite",
+  pr_number: 90,
+  pr_state: "draft",
+  pr_url: "https://github.com/example/vexis/pull/90",
+  git_additions: 132,
+  git_deletions: 9,
+  git_changed_files: 4,
+});
+
+const wsVexisInstaller = makeWorkspace({
+  workspace_id: "ws-vexis-installer",
+  title: "installer-detect",
+  cwd: `${HOME}/.codemux/worktrees/vexis/fix-installer-detect`,
+  worktree_path: `${HOME}/.codemux/worktrees/vexis/fix-installer-detect`,
+  project_root: vexisRoot,
+  project_uid: vexisUid,
+  workspace_kind: "worktree",
+  git_branch: "fix/installer-detect",
+});
+
+// Project 3 — personal-site: 1 primary + 1 worktree (open PR + diff).
+
+const siteRoot = `${PROJECTS}/personal-site`;
+const siteUid = "uid-personal-site";
+
+const wsSiteMain = makeWorkspace({
+  workspace_id: "ws-site-main",
+  title: "personal-site",
+  cwd: siteRoot,
+  project_root: siteRoot,
+  project_uid: siteUid,
+  workspace_kind: "main",
+  protected: true,
+  git_branch: "main",
+});
+
+const wsSiteRedesign = makeWorkspace({
+  workspace_id: "ws-site-redesign",
+  title: "landing-refresh",
+  cwd: `${HOME}/.codemux/worktrees/personal-site/design-landing-refresh`,
+  worktree_path: `${HOME}/.codemux/worktrees/personal-site/design-landing-refresh`,
+  project_root: siteRoot,
+  project_uid: siteUid,
+  workspace_kind: "worktree",
+  git_branch: "design/landing-refresh",
+  pr_number: 12,
+  pr_state: "open",
+  pr_url: "https://github.com/example/personal-site/pull/12",
+  git_ahead: 5,
+  git_additions: 401,
+  git_deletions: 220,
+  git_changed_files: 11,
+});
+
+const ALL_WORKSPACES: WorkspaceSnapshot[] = [
+  wsCodemuxMain,
+  wsCodemuxAuth,
+  wsCodemuxSidebar,
+  wsCodemuxMock,
+  wsCodemuxPorts,
+  wsVexisMain,
+  wsVexisCuda,
+  wsVexisBench,
+  wsVexisInstaller,
+  wsSiteMain,
+  wsSiteRedesign,
+];
+
+// ── Config + persistence ────────────────────────────────────────────
+
+const MOCK_CONFIG: CodemuxConfigSnapshot = {
+  config_version: 1,
+  default_shell: "/bin/bash",
+  theme_source: "system",
+  linux_first: true,
+  notification_sound_enabled: true,
+  ai_commit_message_enabled: true,
+  ai_commit_message_cli: null,
+  ai_commit_message_model: null,
+  ai_resolver_enabled: false,
+  ai_resolver_cli: null,
+  ai_resolver_model: null,
+  ai_resolver_strategy: "smart_merge",
+};
+
+const MOCK_PERSISTENCE: PersistenceSchema = {
+  schema_version: 1,
+  stores_layout_metadata: true,
+  stores_terminal_metadata: true,
+  stores_live_process_state: false,
+};
+
+/** The home directory string the mock `get_home_dir` returns. Used by
+ *  the sidebar's "Home" project grouping rule. */
+export const MOCK_HOME_DIR = HOME;
+
+/**
+ * Build a fresh, deep-ish-cloned `AppStateSnapshot`. The mock holds a
+ * single mutable instance and re-emits it after mutating commands, so
+ * we hand out a structuredClone to keep the canonical seed pristine
+ * across hot reloads / re-installs.
+ */
+export function createSeedAppState(): AppStateSnapshot {
+  return structuredClone({
+    schema_version: 1,
+    active_workspace_id: wsCodemuxMock.workspace_id,
+    workspaces: ALL_WORKSPACES,
+    terminal_sessions: terminalSessions,
+    browser_sessions: [],
+    agent_browser_sessions: [],
+    notifications: [],
+    detected_ports: [
+      {
+        port: 1420,
+        pid: 4242,
+        process_name: "vite",
+        workspace_id: wsCodemuxMock.workspace_id,
+        label: "dev server",
+        source: null,
+      },
+      {
+        port: 5432,
+        pid: 909,
+        process_name: "postgres",
+        workspace_id: null,
+        label: null,
+        source: "docker",
+      },
+    ],
+    pane_statuses: paneStatuses,
+    persistence: MOCK_PERSISTENCE,
+    config: MOCK_CONFIG,
+  });
+}

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -1,0 +1,569 @@
+/**
+ * Dev-only Tauri runtime shim.
+ *
+ * Loaded EXCLUSIVELY by `main.tsx` under `npm run dev` (Vite serving the
+ * frontend at localhost:1420 with no desktop window) when no real Tauri
+ * runtime is present. The dual guard in `main.tsx`:
+ *
+ *     if (import.meta.env.DEV && !("__TAURI_INTERNALS__" in window)) {
+ *       await import("./dev/tauri-mock");
+ *     }
+ *
+ * guarantees two things:
+ *   1. `import.meta.env.DEV` is statically `false` in production, so
+ *      Rollup drops this dynamic-import branch entirely — `grep -r
+ *      "tauri-mock" dist/` is empty after `npm run build`.
+ *   2. The runtime `__TAURI_INTERNALS__` check keeps the shim dormant
+ *      under `npm run tauri:dev`, where the real desktop WebView already
+ *      injected `window.__TAURI_INTERNALS__`. So real-IPC behavior is
+ *      byte-identical to today.
+ *
+ * How it works: every `@tauri-apps/api` surface — `invoke()`, the event
+ * system (`listen`/`emit`/`once`), the window/app plugins, and the
+ * `plugin-opener` / `plugin-updater` / `plugin-process` / `plugin-dialog`
+ * wrappers — ultimately funnels through `window.__TAURI_INTERNALS__`.
+ * We install a faithful enough `__TAURI_INTERNALS__` (plus the event
+ * plugin internals) so the unmodified `@tauri-apps/api` code routes
+ * every call into the command router below. No module aliasing needed.
+ *
+ * The command surface was enumerated once at implementation time (see
+ * issue #40 §2). Boot-critical reads return hand-curated fixtures;
+ * mutators update the in-memory `AppStateSnapshot` and re-emit
+ * `app-state-changed` so the UI reflects the change; everything else
+ * falls through to a logged, shape-safe default.
+ */
+import {
+  MOCK_HOME_DIR,
+  MOCK_USER,
+  createSeedAppState,
+} from "./mock-fixtures";
+import type {
+  AppStateSnapshot,
+  CliToolInfo,
+  FeatureFlags,
+  PresetStoreSnapshot,
+  ProviderChatCapabilities,
+  ResourceMetricsSnapshot,
+  ShellAppearance,
+  ThemeColors,
+  UserSettings,
+  WorkspaceSnapshot,
+} from "@/tauri/types";
+
+console.log(
+  "%c[dev mock] installed",
+  "color:#f59e0b;font-weight:bold",
+  "— Tauri IPC is mocked. Run `npm run tauri:dev` for real IPC.",
+);
+
+// ── Mutable seed state ──────────────────────────────────────────────
+
+let appState: AppStateSnapshot = createSeedAppState();
+
+function findWorkspace(id: unknown): WorkspaceSnapshot | undefined {
+  return appState.workspaces.find((w) => w.workspace_id === id);
+}
+
+/** Re-emit the current snapshot so subscribers (`useAppStateInit`) pick
+ *  up an in-memory mutation, mirroring the backend's `emit_app_state`. */
+function emitAppState(): void {
+  emitEvent("app-state-changed", appState);
+}
+
+// ── Event subsystem ─────────────────────────────────────────────────
+//
+// `@tauri-apps/api/event`'s `listen()` calls
+// `invoke("plugin:event|listen", { event, target, handler })` where
+// `handler` is an id returned by `transformCallback`. We keep the raw
+// callbacks in `callbacks`, the per-event subscription map in
+// `eventListeners`, and fan out on emit.
+
+type RawCallback = (payload: unknown) => void;
+
+const callbacks = new Map<number, { fn: RawCallback; once: boolean }>();
+let nextCallbackId = 1;
+
+// event name -> (eventId -> callbackId)
+const eventListeners = new Map<string, Map<number, number>>();
+let nextEventId = 1;
+
+function transformCallback(fn: RawCallback, once = false): number {
+  const id = nextCallbackId++;
+  callbacks.set(id, { fn, once });
+  return id;
+}
+
+function registerListener(event: string, callbackId: number): number {
+  const eventId = nextEventId++;
+  let map = eventListeners.get(event);
+  if (!map) {
+    map = new Map();
+    eventListeners.set(event, map);
+  }
+  map.set(eventId, callbackId);
+  return eventId;
+}
+
+function unregisterListener(event: string, eventId: number): void {
+  eventListeners.get(event)?.delete(eventId);
+}
+
+/** Fan a payload out to every listener subscribed to `name`. Exposed to
+ *  the rest of the mock so mutators can push `app-state-changed`. */
+function emitEvent(name: string, payload: unknown): void {
+  const map = eventListeners.get(name);
+  if (!map) return;
+  // Snapshot entries first — a once-listener mutates the map mid-loop.
+  for (const [eventId, callbackId] of [...map.entries()]) {
+    const cb = callbacks.get(callbackId);
+    if (!cb) continue;
+    try {
+      cb.fn({ event: name, id: eventId, payload } as unknown as never);
+    } catch (err) {
+      console.error(`[dev mock] listener for "${name}" threw:`, err);
+    }
+    if (cb.once) {
+      callbacks.delete(callbackId);
+      map.delete(eventId);
+    }
+  }
+}
+
+/**
+ * Feed a one-shot banner line into a terminal pane's PTY output
+ * `Channel`. A `@tauri-apps/api` `Channel` registers its internal
+ * dispatcher through `transformCallback`, exposing the resulting id as
+ * `channel.id`. We look that callback up and hand it a single ordered
+ * message (`{ index: 0, message }`); the dispatcher forwards
+ * `message` to the pane's `onmessage`, which decodes the string to
+ * bytes and writes them to xterm. Best-effort: any shape mismatch is
+ * swallowed so a terminal that renders differently never breaks boot.
+ */
+function pushMockTerminalBanner(channel: unknown): void {
+  const id = (channel as { id?: number } | undefined)?.id;
+  if (typeof id !== "number") return;
+  const cb = callbacks.get(id);
+  if (!cb) return;
+  const banner =
+    "\r\n  \x1b[2m(mock terminal — no PTY in plain-browser dev; " +
+    "run `npm run tauri:dev` for a real shell)\x1b[0m\r\n";
+  try {
+    cb.fn({ index: 0, message: banner } as unknown as never);
+  } catch {
+    /* channel shape differs — banner is cosmetic, ignore */
+  }
+}
+
+// ── Static command returns ──────────────────────────────────────────
+
+const FEATURE_FLAGS: FeatureFlags = {
+  unstable_openflow: false,
+  unstable_browser_automation: false,
+  unstable_indexing: false,
+  enable_agent_chat: false,
+  enable_lazy_workspace_creation: false,
+};
+
+const SYNCED_SETTINGS: UserSettings = {
+  appearance: {
+    theme: "system",
+    shell_font: null,
+    terminal_font_size: 13,
+    show_resource_monitor: true,
+  },
+  editor: { default_ide: null },
+  terminal: { scrollback_limit: 10_000, cursor_style: "bar" },
+  git: { default_base_branch: "main" },
+  keyboard: { shortcuts: {} },
+  notifications: { sound_enabled: true, desktop_enabled: true },
+  file_tree: { show_hidden_files: false },
+  session_restore: {
+    enabled: true,
+    scrollback_lines: 10_000,
+    max_total_mb: 100,
+  },
+};
+
+const EMPTY_CAPABILITIES: ProviderChatCapabilities = {
+  models: [],
+  effort_granularity: "per_session",
+  effort_label_map: {},
+  permission_modes: [],
+  default_permission_mode: null,
+  permission_granularity: "per_session",
+};
+
+const EMPTY_PRESETS: PresetStoreSnapshot = {
+  presets: [],
+  bar_visible: false,
+  default_preset_id: null,
+};
+
+// A plausible dark palette so `useTerminalThemeSync` has real values to
+// apply to xterm instead of choking on a partial object.
+const THEME: ThemeColors = {
+  accent: "#f59e0b",
+  cursor: "#e5e7eb",
+  foreground: "#e5e7eb",
+  background: "#0a0a0a",
+  selection_foreground: "#0a0a0a",
+  selection_background: "#f59e0b",
+  color0: "#1e1e1e",
+  color1: "#f87171",
+  color2: "#4ade80",
+  color3: "#fbbf24",
+  color4: "#60a5fa",
+  color5: "#c084fc",
+  color6: "#22d3ee",
+  color7: "#e5e7eb",
+  color8: "#6b7280",
+  color9: "#ef4444",
+  color10: "#22c55e",
+  color11: "#f59e0b",
+  color12: "#3b82f6",
+  color13: "#a855f7",
+  color14: "#06b6d4",
+  color15: "#f9fafb",
+};
+
+const SHELL_APPEARANCE: ShellAppearance = {
+  font_family: "'JetBrains Mono Variable', monospace",
+};
+
+const CLI_TOOLS: CliToolInfo[] = [
+  { id: "claude", name: "Claude Code", available: true, path: "/usr/bin/claude" },
+  { id: "codex", name: "Codex", available: false, path: null },
+];
+
+function resourceMetrics(): ResourceMetricsSnapshot {
+  return {
+    app: {
+      cpu: 3.2,
+      memory: 412_000_000,
+      main: { cpu: 1.1, memory: 180_000_000 },
+      web_view: { cpu: 2.0, memory: 210_000_000 },
+      other: { cpu: 0.1, memory: 22_000_000 },
+    },
+    workspaces: [],
+    host: {
+      total_memory: 32_000_000_000,
+      free_memory: 18_000_000_000,
+      used_memory: 14_000_000_000,
+      memory_usage_percent: 43.75,
+      cpu_core_count: 16,
+      load_average_1m: 1.42,
+    },
+    total_cpu: 3.2,
+    total_memory: 412_000_000,
+    collected_at: Date.now(),
+  };
+}
+
+// ── Command router ──────────────────────────────────────────────────
+//
+// Keyed by exact Tauri command name. Boot-critical reads return seed
+// data; mutators patch `appState` and re-emit. Args arrive with the
+// SAME camelCase keys the `src/tauri/commands.ts` wrappers pass.
+
+type Args = Record<string, unknown>;
+type Handler = (args: Args) => unknown;
+
+const handlers: Record<string, Handler> = {
+  // ── Auth / sync ──
+  check_auth: () => MOCK_USER,
+  get_auth_token: () => "mock-token",
+  get_sync_status: () => ({ syncAvailable: true, authMethod: "github" }),
+  sign_out: () => undefined,
+  skills_sync_status: () => ({ state: "idle", lastSyncAtMillis: null }),
+  skills_sync_now: () => ({
+    pushedCount: 0,
+    pulledCount: 0,
+    conflictCount: 0,
+    errorCount: 0,
+  }),
+
+  // ── Core state ──
+  get_app_state: () => appState,
+  get_home_dir: () => MOCK_HOME_DIR,
+  get_feature_flags: () => FEATURE_FLAGS,
+  get_platform: () => "linux",
+  get_package_format: () => "AppImage",
+
+  // ── Settings ──
+  get_synced_settings: () => SYNCED_SETTINGS,
+  update_synced_settings: (a) => (a.settings as UserSettings) ?? SYNCED_SETTINGS,
+  update_setting: () => SYNCED_SETTINGS,
+  reset_synced_settings: () => SYNCED_SETTINGS,
+  db_get_all_settings: () => ({}),
+  db_get_ui_state: () => null,
+  db_set_ui_state: () => undefined,
+  db_set_setting: () => undefined,
+  db_get_setting: () => null,
+  db_delete_setting: () => undefined,
+  db_get_recent_projects: () => [],
+  db_add_recent_project: () => undefined,
+
+  // ── Theme / appearance ──
+  get_current_theme: () => THEME,
+  get_shell_appearance: () => SHELL_APPEARANCE,
+
+  // ── Resource monitor ──
+  get_resource_metrics: () => resourceMetrics(),
+
+  // ── Agent chat capabilities (gated off, returned safe anyway) ──
+  list_chat_provider_capabilities: () => EMPTY_CAPABILITIES,
+
+  // ── Presets ──
+  get_presets: () => EMPTY_PRESETS,
+
+  // ── Editors / tooling ──
+  detect_editors: () => [],
+  list_available_cli_tools: () => CLI_TOOLS,
+
+  // ── GitHub / PRs (pre-seeded; never hit a real API) ──
+  check_gh_available: () => true,
+  check_gh_status: () => ({ status: "Authenticated", username: "mock-dev" }),
+  refresh_workspace_pr: (a) => findWorkspace(a.workspaceId)?.pr_number ?? null,
+  refresh_workspace_issue: () => null,
+  list_incoming_prs: () => [],
+
+  // ── Hosts (remote devices) ──
+  hosts_list: () => [],
+
+  // ── MCP runtime ──
+  get_mcp_runtime_status: () => ({ servers: [], running: false }),
+  list_mcp_servers: () => [],
+
+  // ── Workspace config / scripts (sidebar setup banner, default-branch
+  //    cache) ──
+  get_default_branch: () => "main",
+  get_workspace_config: () => ({
+    setup: [],
+    teardown: [],
+    run: null,
+    worktree_includes: [],
+  }),
+  get_project_scripts: () => ({
+    setup: [],
+    teardown: [],
+    run: null,
+    worktree_includes: [],
+  }),
+
+  // ── Terminal (the body is out of scope per issue #40, but the mount
+  //    MUST NOT crash). `get_terminal_status` is the load-bearing one:
+  //    TerminalPane writes whatever it returns into a ref that the next
+  //    render reads, so a `null` here poisons the render and black-screens
+  //    the app. Return a valid "ready" payload (hides the loading
+  //    overlay), then push a one-shot "(mock terminal)" banner through
+  //    the PTY output channel so the pane reads as an intentional mock
+  //    rather than a dead black box. ──
+  get_terminal_status: (a) => ({
+    session_id: a.sessionId as string,
+    state: "ready",
+    message: null,
+    exit_code: null,
+  }),
+  get_terminal_scrollback: () => null,
+  attach_pty_output: (a) => {
+    pushMockTerminalBanner(a.channel);
+    return undefined;
+  },
+  resize_pty: () => undefined,
+  write_to_pty: () => undefined,
+  detach_pty_output: () => undefined,
+  pause_pty_output: () => undefined,
+  resume_pty_output: () => undefined,
+  clear_agent_status: () => undefined,
+  cache_terminal_scrollback: () => undefined,
+  uncache_terminal_scrollback: () => undefined,
+  save_terminal_scrollback: () => undefined,
+  flush_scrollback_cache: () => 0,
+
+  // ── Mutators: patch in-memory state + re-emit ──
+  activate_workspace: (a) => {
+    if (findWorkspace(a.workspaceId)) {
+      appState = { ...appState, active_workspace_id: a.workspaceId as string };
+      emitAppState();
+    }
+    return undefined;
+  },
+  rename_workspace: (a) => {
+    const ws = findWorkspace(a.workspaceId);
+    if (ws && typeof a.title === "string") {
+      ws.title = a.title;
+      emitAppState();
+    }
+    return undefined;
+  },
+  set_workspace_muted: (a) => {
+    const ws = findWorkspace(a.workspaceId);
+    if (ws) {
+      ws.notifications_muted = Boolean(a.muted);
+      emitAppState();
+    }
+    return undefined;
+  },
+  close_workspace: (a) => removeWorkspace(a.workspaceId),
+  close_workspace_with_worktree: (a) => removeWorkspace(a.workspaceId),
+};
+
+/** Drop a workspace from the in-memory snapshot, reassigning the active
+ *  workspace if it was the one closed, then re-emit. */
+function removeWorkspace(id: unknown): string {
+  const next = appState.workspaces.filter((w) => w.workspace_id !== id);
+  let active = appState.active_workspace_id;
+  if (active === id) active = next[0]?.workspace_id ?? "";
+  appState = { ...appState, workspaces: next, active_workspace_id: active };
+  emitAppState();
+  return String(id);
+}
+
+// ── Plugin routing ──────────────────────────────────────────────────
+
+/** Sentinel returned by `routePlugin` when a command isn't a plugin
+ *  command, so `invoke` can fall through to the default. */
+const MISS = Symbol("mock-miss");
+
+async function showOpenerToast(url: unknown): Promise<void> {
+  const msg = `Would open: ${url}`;
+  console.log(`[dev mock] openUrl →`, url);
+  try {
+    // Lazy-import so the mock doesn't eagerly pull sonner; the <Toaster />
+    // is mounted by App, so the toast renders once the UI is up.
+    const { toast } = await import("sonner");
+    toast.message(msg);
+  } catch {
+    /* toast unavailable (pre-mount) — the console.log above suffices */
+  }
+}
+
+function routePlugin(cmd: string, args: Args): unknown {
+  // Event system — the backbone of listen()/emit()/once().
+  if (cmd === "plugin:event|listen") {
+    return registerListener(args.event as string, args.handler as number);
+  }
+  if (cmd === "plugin:event|unlisten") {
+    unregisterListener(args.event as string, args.eventId as number);
+    return undefined;
+  }
+  if (cmd === "plugin:event|emit" || cmd === "plugin:event|emit_to") {
+    emitEvent(args.event as string, args.payload);
+    return undefined;
+  }
+
+  // Opener — surface a toast instead of throwing/navigating away.
+  if (cmd === "plugin:opener|open_url" || cmd === "plugin:opener|open_path") {
+    void showOpenerToast(args.url ?? args.path);
+    return undefined;
+  }
+  if (cmd.startsWith("plugin:opener|")) {
+    console.log(`[dev mock] ${cmd}`, args);
+    return undefined;
+  }
+
+  // Window controls — no-op so WindowControls / drag regions don't crash.
+  if (cmd.startsWith("plugin:window|") || cmd.startsWith("plugin:webview")) {
+    if (cmd.endsWith("|scale_factor")) return 1;
+    if (cmd.endsWith("|theme")) return "dark";
+    // is_maximized / is_minimized / is_fullscreen / is_focused / … → false
+    if (/\|is_/.test(cmd)) return false;
+    return undefined;
+  }
+
+  // App metadata.
+  if (cmd === "plugin:app|version") return "0.0.0-dev-mock";
+  if (cmd === "plugin:app|name") return "Codemux";
+  if (cmd === "plugin:app|tauri_version") return "2.10.1";
+  if (cmd === "plugin:app|identifier") return "dev.codemux.mock";
+  if (cmd.startsWith("plugin:app|")) return undefined;
+
+  // Process control — log the intent, do nothing.
+  if (cmd.startsWith("plugin:process|")) {
+    console.log(`[dev mock] ${cmd} (no-op in browser)`);
+    return undefined;
+  }
+
+  // Updater — always "no update available".
+  if (cmd.startsWith("plugin:updater|")) return null;
+
+  // Dialogs — cancelled (null) so file pickers resolve cleanly.
+  if (cmd.startsWith("plugin:dialog|")) return null;
+
+  // Resource cleanup, misc plugins.
+  if (cmd.startsWith("plugin:")) {
+    console.warn(`[dev mock] unhandled plugin command: ${cmd}`);
+    return undefined;
+  }
+
+  return MISS;
+}
+
+// ── Default fallback ────────────────────────────────────────────────
+
+const warnedCommands = new Set<string>();
+
+/** Shape-safe default for any command without an explicit handler.
+ *  `list_*` returns `[]` so `.map()` call sites survive; everything
+ *  else returns `null`. Warns once per command so gaps surface during
+ *  UI iteration without spamming the console. */
+function defaultResult(cmd: string): unknown {
+  if (!warnedCommands.has(cmd)) {
+    warnedCommands.add(cmd);
+    console.warn(`[dev mock] no handler for "${cmd}" — returning default`);
+  }
+  return cmd.startsWith("list_") ? [] : null;
+}
+
+// ── The internals contract ──────────────────────────────────────────
+
+async function invoke(cmd: string, args: Args = {}): Promise<unknown> {
+  const handler = handlers[cmd];
+  if (handler) return handler(args);
+
+  const viaPlugin = routePlugin(cmd, args);
+  if (viaPlugin !== MISS) return viaPlugin;
+
+  return defaultResult(cmd);
+}
+
+interface TauriInternals {
+  invoke: (cmd: string, args?: Args, options?: unknown) => Promise<unknown>;
+  transformCallback: (cb: RawCallback, once?: boolean) => number;
+  unregisterCallback: (id: number) => void;
+  convertFileSrc: (filePath: string, protocol?: string) => string;
+  metadata: {
+    currentWindow: { label: string };
+    currentWebview: { label: string; windowLabel: string };
+  };
+}
+
+const internals: TauriInternals = {
+  invoke,
+  transformCallback,
+  unregisterCallback: (id) => callbacks.delete(id),
+  // The webview can't load file:// directly; in the browser we just pass
+  // the path through. Mock images may 404, but nothing crashes.
+  convertFileSrc: (filePath) => filePath,
+  metadata: {
+    currentWindow: { label: "main" },
+    currentWebview: { label: "main", windowLabel: "main" },
+  },
+};
+
+// `globalThis.isTauri` is read by `@tauri-apps/api`'s `isTauri()`. We
+// deliberately DON'T set it — some app code uses it to distinguish real
+// runtime from web, and the mock should read as "not the real thing".
+
+(window as unknown as { __TAURI_INTERNALS__: TauriInternals }).__TAURI_INTERNALS__ =
+  internals;
+
+(
+  window as unknown as {
+    __TAURI_EVENT_PLUGIN_INTERNALS__: {
+      unregisterListener: (event: string, eventId: number) => void;
+    };
+  }
+).__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener };
+
+export {};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,19 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import "./globals.css";
 
+// Dev-only Tauri runtime shim. Two guards, both required:
+//   - `import.meta.env.DEV` is statically `false` in production, so
+//     Rollup drops this entire branch from the prod bundle (verified by
+//     `grep -r "tauri-mock" dist/` being empty after `npm run build`).
+//   - The `__TAURI_INTERNALS__` check keeps the mock dormant under
+//     `npm run tauri:dev`, where the real WebView already injected it —
+//     so real-IPC behavior is byte-identical to today.
+// The top-level await guarantees the shim is installed before React
+// mounts and any component calls `invoke()`.
+if (import.meta.env.DEV && !("__TAURI_INTERNALS__" in window)) {
+  await import("./dev/tauri-mock");
+}
+
 // Single QueryClient for the whole app. Defaults are tuned for the
 // Review-tab use case where we want fresh-ish data on focus + a
 // reasonable refetch interval, without thrashing `gh` on quiet windows.


### PR DESCRIPTION
## What

Lets `npm run dev` boot the **real Codemux UI** in a plain browser at `localhost:1420`, with hand-crafted fixtures standing in for IPC — so UI iteration (by a human or an agent) can navigate to the dev server, see the actual sidebar / panes / chrome rendered with mock data, and screenshot it. No more ad-hoc preview HTML files.

Closes #40.

## How

Every `@tauri-apps/api` surface funnels through `window.__TAURI_INTERNALS__`, so a single faithful internals object routes the whole API — `invoke()`, the event system (`listen`/`emit`/`once`), and the window / app / opener / updater / process / dialog plugins — into one command router. No module aliasing.

- **`src/dev/tauri-mock.ts`** — installs `__TAURI_INTERNALS__` + the event plugin internals. Boot-critical reads return seed data; mutators (`activate_workspace`, `rename_workspace`, `set_workspace_muted`, `close_workspace*`) patch in-memory state and re-emit `app-state-changed`; unknown commands warn once and return a shape-safe default (`[]` for `list_*`, else `null`) so the surface can drift without crashing the boot. `openUrl` shows a toast; the terminal (out of scope) shows a `(mock terminal)` banner.
- **`src/dev/mock-fixtures.ts`** — 3 projects with primary + worktree workspaces covering every PR state (open / merged / closed / draft), all three agent states (working / review / permission), a linked issue, muted notifications, non-zero git ahead/behind/additions/deletions, and a non-zero notification count. Typed against `src/tauri/types.ts` so type drift is caught by `tsc`.
- **`src/main.tsx`** — dual-guarded dynamic import:
  - `import.meta.env.DEV` → statically `false` in prod, so Rollup drops the branch entirely.
  - `!("__TAURI_INTERNALS__" in window)` → dormant under `tauri:dev`, where the WebView already injected the real runtime.
- **`CLAUDE.md`** — new "Visual Verification" section.

## Verification

- ✅ `npm run dev` + `localhost:1420` renders the full UI: sidebar populated, status dots (amber working spinner, green review, red pulsing permission), PR icons in correct colors, diff stats, notification badges, muted bell, linked-issue chip, working window controls. (Verified via screenshots + DOM inspection.)
- ✅ Clicking a PR icon shows a "Would open: …" toast instead of throwing.
- ✅ Activating / switching workspaces re-renders correctly (mutator → emit loop).
- ✅ `npm run build` → `grep -r "tauri-mock\|mock-fixtures" dist/` is **empty** (no production trace).
- ✅ `cargo check`, `npm run check`, and `npm run test` (1818 tests) all pass.
- ✅ Clean console on boot — no warnings/errors.

`tauri:dev` is unchanged: it loads the same Vite server where Tauri injects `__TAURI_INTERNALS__`, so the runtime guard skips the mock and the `[dev mock] installed` canary never fires.

## Out of scope (per the issue)

PTY/terminal stdout simulation (shows a static `(mock terminal)` message), a second component-playground path, and mocking the real GitHub API / `gh`.
