### PR TITLE
perf(terminal): enable xterm.js WebGL renderer with DOM fallback

### DIFF
--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -12,11 +12,11 @@ The terminal system provides multi-session PTY terminals rendered with xterm.js.
 
 ## Current Model
 
-The Rust layer uses `portable-pty` to spawn shells. Each terminal session has a master PTY handle, a read thread, and a write path. The frontend uses xterm.js's DOM renderer for display, matching the pre-`v0.1.30` latency profile. Data flows: PTY read thread -> Tauri channel -> xterm.js write. User input flows: xterm.js onData -> Tauri command `write_to_pty` -> PTY master write. PTY output delivery clones the Tauri channel under the session lock and sends outside that lock, so active keystrokes do not block behind IPC delivery for busy terminals.
+The Rust layer uses `portable-pty` to spawn shells. Each terminal session has a master PTY handle, a read thread, and a write path. The frontend renders with xterm.js's **WebGL renderer** (`@xterm/addon-webgl`), which offloads glyph rasterization to the GPU — the recommended renderer for the fast, long-running agent output Codemux streams. The addon is loaded after `term.open()` (it needs the opened terminal's DOM element) and registers an `onContextLoss` handler that disposes it so xterm falls back to its DOM renderer if the GPU drops the canvas context; construction is wrapped in try/catch so an environment without WebGL2 support also falls back to the DOM renderer instead of breaking the pane. Data flows: PTY read thread -> Tauri channel -> xterm.js write. User input flows: xterm.js onData -> Tauri command `write_to_pty` -> PTY master write. PTY output delivery clones the Tauri channel under the session lock and sends outside that lock, so active keystrokes do not block behind IPC delivery for busy terminals.
 
 ### Terminal Pane Lifecycle (per-mount) + throttled write pump
 
-The live terminal render path is `src/components/terminal/TerminalPane.tsx`. Each pane constructs its own xterm.js `Terminal` (DOM renderer) on mount and disposes it on unmount. Because `src/components/layout/workspace-main.tsx` only renders the active workspace and `PaneContainer` only renders the active surface (tab), switching workspaces or tabs **unmounts** the previous pane tree and **mounts** the new one — terminals are rebuilt from scratch on every switch (a fresh xterm + scrollback restore + PTY reattach).
+The live terminal render path is `src/components/terminal/TerminalPane.tsx`. Each pane constructs its own xterm.js `Terminal` (WebGL renderer, DOM fallback) on mount and disposes it — including the WebGL addon — on unmount. Because `src/components/layout/workspace-main.tsx` only renders the active workspace and `PaneContainer` only renders the active surface (tab), switching workspaces or tabs **unmounts** the previous pane tree and **mounts** the new one — terminals are rebuilt from scratch on every switch (a fresh xterm + scrollback restore + PTY reattach).
 
 To keep that switch from freezing the UI, every byte destined for xterm — disk-scrollback restore, the PTY reattach replay, and steady live output — is funneled through a single throttled write pump (`src/components/terminal/terminal-write-pump.ts`). The pump drains a bounded byte budget per macrotask and yields between batches, so a multi-MB `attach_pty_output` replay (the backend replays the whole `pending_output` ring on every attach) fills in over a few frames instead of blocking the click + visibly "pouring in". Historical bytes are enqueued **before** the live channel attaches, so the single FIFO drain preserves xterm's stateful parse order (alt-screen / cursor state across the history→live boundary).
 
@@ -31,7 +31,7 @@ On unmount the outgoing pane serializes its buffer (`@xterm/addon-serialize`) an
   - **Unix**: respects `$SHELL` and falls back to `/bin/bash`
   - **Windows**: prefers `pwsh.exe` (PowerShell 7+) when on `PATH`, falls back to `powershell.exe` (Windows PowerShell 5.1, pre-installed on every supported Windows version), then `%COMSPEC%`, then literal `"cmd.exe"`. PowerShell wins because the Windows preset wrappers emit PowerShell `$env:VAR` syntax for context injection — see `agent_context.rs` and `docs/features/presets.md`
 - PTY resize on pane/window resize
-- xterm.js renderer with kitty keyboard protocol support
+- xterm.js WebGL renderer (GPU glyph rendering) with automatic DOM-renderer fallback on GPU context loss or missing WebGL2 support, plus kitty keyboard protocol support
 - terminal theme reads dynamically from CSS variables via MutationObserver
 - session state tracking (running, exited, error)
 - environment injection: `CODEMUX`, `CODEMUX_VERSION`, `CODEMUX_WORKSPACE_ID`, `CODEMUX_BROWSER_CMD`, `BROWSER`, `CODEMUX_AGENT_CONTEXT`
@@ -58,7 +58,7 @@ Note: terminal scrollback is saved and restored across app restarts. See `docs/f
 
 ## Important Touch Points
 
-- `src/components/terminal/TerminalPane.tsx` — **the live terminal component**: per-mount xterm lifecycle, scrollback restore + reattach via the throttled write pump, ResizeObserver, focus, status overlay, custom key handler, alt-screen serialize skip
+- `src/components/terminal/TerminalPane.tsx` — **the live terminal component**: per-mount xterm lifecycle, WebGL renderer load (after `term.open()`, with `onContextLoss` → DOM fallback and a try/catch guard for no-WebGL2 environments; disposed on unmount), scrollback restore + reattach via the throttled write pump, ResizeObserver, focus, status overlay, custom key handler, alt-screen serialize skip
 - `src/components/terminal/terminal-write-pump.ts` — **the live freeze fix**: ordered, byte-budgeted write queue that throttles scrollback restore + reattach replay + live output across macrotasks; unit-tested in `terminal-write-pump.test.ts`
 - `src-tauri/src/terminal/mod.rs` — PTY spawning, read/write, session management, comm log locks, `attach_pty_output` (replays the full `pending_output` ring on attach — the reattach replay the write pump throttles), dropped-chunk observability counter, `pause_pty_output` / `resume_pty_output` flow-control commands
 - `src-tauri/src/pty_daemon/{protocol,client,server}.rs` — `SetFlowPaused` wire request + per-session `flow_paused` flag gating the daemon read loop (with `Attach`/`Close`/max-park fail-safes); only invoked by the disabled cache today (see below)

--- a/src/components/terminal/TerminalPane.tsx
+++ b/src/components/terminal/TerminalPane.tsx
@@ -3,6 +3,7 @@ import { Terminal } from "@xterm/xterm";
 import type { ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { isAppShortcut } from "@/lib/app-shortcuts";
 import { matchesKeyCombo } from "@/lib/keybind-utils";
 import {
@@ -130,6 +131,7 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
   const termRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const serializeAddonRef = useRef<SerializeAddon | null>(null);
+  const webglAddonRef = useRef<WebglAddon | null>(null);
   const attachedSessionRef = useRef<string | null>(null);
   // Adapter captures from the scrollback restore — persists across tab switches
   // even when the pane state (layout.json) doesn't have them.
@@ -281,9 +283,36 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
     term.loadAddon(serializeAddon);
     term.open(containerEl);
 
+    // ── WebGL renderer ──
+    // Offload glyph rendering to the GPU — substantially faster and smoother
+    // for the long-running, high-output agent sessions Codemux runs. Must load
+    // AFTER term.open() because the addon needs the opened terminal's DOM
+    // element. Wrapped in try/catch so an environment without WebGL2 support
+    // (e.g. a software-only WebView) falls back to the default DOM renderer
+    // instead of throwing and breaking the whole pane.
+    let webglAddon: WebglAddon | null = null;
+    try {
+      const addon = new WebglAddon();
+      // Required: when the GPU drops the canvas context, dispose the addon so
+      // xterm falls back to the DOM renderer rather than rendering a blank pane.
+      addon.onContextLoss(() => {
+        addon.dispose();
+        webglAddonRef.current = null;
+      });
+      term.loadAddon(addon);
+      webglAddon = addon;
+    } catch (err) {
+      console.warn(
+        "[codemux::terminal] WebGL renderer unavailable, using DOM renderer:",
+        err,
+      );
+      webglAddon = null;
+    }
+
     termRef.current = term;
     fitAddonRef.current = fitAddon;
     serializeAddonRef.current = serializeAddon;
+    webglAddonRef.current = webglAddon;
     kittyStackRef.current = [];
     kittyLevelRef.current = 0;
 
@@ -682,6 +711,12 @@ export function TerminalPane({ sessionId, paneId, focused, visible }: Props) {
       }
 
       unregisterSerialize();
+      // Dispose the WebGL addon before the terminal so its GPU context /
+      // canvas is released deterministically (no leak across mounts). The
+      // wrapped dispose unregisters it from xterm's addon manager, so the
+      // following term.dispose() won't double-dispose it.
+      webglAddonRef.current?.dispose();
+      webglAddonRef.current = null;
       serializeAddonRef.current = null;
       fitAddonRef.current = null;
       kittyStackRef.current = [];


### PR DESCRIPTION
Closes #72.

## Summary
The terminal pane rendered with xterm.js's slower DOM renderer. `@xterm/addon-webgl` was already a dependency but **never loaded**. This loads it after `term.open()` to offload glyph rasterization to the GPU — the recommended renderer for the fast, long-running, high-output agent sessions Codemux streams — with a clean fallback to the DOM renderer.

## Changes (`src/components/terminal/TerminalPane.tsx`)
- Import `WebglAddon` and load it **after** `term.open(containerEl)` (the addon needs the opened terminal's DOM element).
- Register the required `onContextLoss` handler that disposes the addon so xterm falls back to the DOM renderer (rather than rendering a blank pane) when the GPU drops the canvas context.
- Wrap construction/`loadAddon` in try/catch so an environment without WebGL2 support falls back to the DOM renderer instead of throwing.
- Track `webglAddonRef` (matching the existing `fitAddonRef`/`serializeAddonRef` pattern) and dispose it on pane unmount so the GPU context/canvas is released (no leak); the wrapped dispose unregisters it from xterm's addon manager so `term.dispose()` won't double-dispose.

Also updates `docs/features/terminal.md` to reflect WebGL rendering + DOM fallback.

## Acceptance criteria
- [x] Terminal uses the WebGL renderer when available — verified: a live `webgl2` canvas + texture-atlas canvas, `.xterm-rows` absent (= GPU rendering, not DOM).
- [x] On WebGL context loss the terminal keeps working (DOM fallback) — no blank pane: forced `WEBGL_lose_context`, canvases removed, `.xterm-rows` reappeared, content preserved.
- [x] No regressions in selection/copy/paste, theming (`buildThemeFromCSS`), cursor, or fit/resize — viewport resize re-fit the WebGL canvas; theming/cursor render correctly on both paths.
- [x] Addon disposed on pane unmount (no leak).

## Verification
- `npm run check` (tsc) — clean
- `npm run test` (vitest) — 1818 passed
- `cargo check` — compiles
- Manual (dev browser): fresh mount renders via a live WebGL2 canvas; `WEBGL_lose_context` swaps to the DOM renderer with content preserved; resize/fit and theming unaffected; console clean (no fallback warning).

Note: two `cargo test` failures (`resolve_binary_finds_native_binary_from_project_root`, `project_codemux_entry_is_filtered_out`) are pre-existing and environment-specific (host has a system-wide `/usr/bin/agent-browser`; host MCP config), unrelated to this frontend-only change.