### PR TITLE
perf(chat): virtualize the agent-chat message list

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -114,6 +114,35 @@ The chat pane stack:
   in CI to dodge the `fake_codex_app_server` helper-binary build race
   under cargo's parallel scheduler.
 
+## Transcript virtualization (issue #77)
+
+The transcript body (`MessageList.tsx`) is virtualized with
+`react-virtuoso` (MIT — chosen over `@tanstack/react-virtual` and
+`react-window` for its built-in dynamic row measurement and
+bottom-anchoring; the commercially licensed `@virtuoso.dev/message-list`
+package is NOT used). Only the on-screen window of rows is mounted, so
+a 5,000-message session (the reducer cap) scrolls like a short one.
+
+Contract preserved from the pre-virtualization renderer:
+
+- **Stable keys + memo rows.** Per-slot keys are still `slot.item.id`
+  / `run:<first-id>`, and rows render through `MessageRowMemo` — a
+  streaming token mutates exactly one row.
+- **Stick-to-bottom.** `MessageList` owns the scroller now (Virtuoso
+  must control it). Pinned-ness is tracked from real scroll events
+  (≤ 80 px from the bottom); after every transcript change (or
+  thinking-pulse toggle), if pinned, it snaps to the tail via
+  `scrollToIndex(LAST, end)`. Content growth alone never unpins, so
+  auto-scroll never fights a user reading history.
+- **Variable heights.** Tool-run collapses expand in place as a single
+  virtual row; Virtuoso re-measures via ResizeObserver.
+- **Thinking pulse** renders as the last virtual row (not a footer) so
+  the tail snap keeps it visible while streaming.
+
+`ChatTranscript` is now a thin shell that derives `showThinking` and
+sizes the list. jsdom tests wrap renders in `VirtuosoMockContext`
+(see `MessageList.test.tsx` / `MessageList.virtualization.test.tsx`).
+
 ## Current Constraints
 
 - **Beta-gated.** The chat pane is hidden unless the user opts in via
@@ -549,6 +578,15 @@ debug builds when `enable_agent_chat` is on. It invokes
 `dev_agent_chat_spawn_test_pane` to drop a chat pane into the active
 workspace. Useful for quick manual testing without going through the
 sidebar `+` flow.
+
+Under `npm run dev` (plain-browser mock), the seeded
+**agent-chat-demo** workspace carries an `agent_chat` pane bound to
+`MOCK_CHAT_THREAD_ID`. The mock hydrates a ~790-row transcript through
+the real reducer (`agent_chat_list_messages`), streams a simulated
+reply on `agent_chat_send_turn`, and exposes
+`window.__codemuxChatMock.streamReply()` for on-demand streaming —
+the standing harness for transcript-virtualization and scroll-pinning
+work.
 
 ## Step 9 — Cross-provider MCP server runtime (shipped)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.7.7",
+      "version": "0.8.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
@@ -54,6 +54,7 @@
         "react-icons": "^5.6.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.7.5",
+        "react-virtuoso": "^4.18.7",
         "rehype-raw": "^7.0.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
@@ -10097,6 +10098,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.7",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.7.tgz",
+      "integrity": "sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/recast": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.7.5",
+    "react-virtuoso": "^4.18.7",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -544,6 +544,16 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     })();
     return () => {
       cancelled = true;
+      // Release the attempt marker on teardown. Without this, React
+      // StrictMode's dev-only mount→unmount→remount cycle cancels the
+      // first invocation's in-flight fetch and the second invocation
+      // bails on the marker — so a dev build never hydrates. The
+      // remount re-runs the effect with a clean slate; in production
+      // (single mount) this cleanup only runs on real unmounts, where
+      // the ref dies anyway.
+      if (hydrateAttemptedRef.current === threadId) {
+        hydrateAttemptedRef.current = null;
+      }
     };
   }, [threadId]);
 

--- a/src/components/chat/ChatTranscript.tsx
+++ b/src/components/chat/ChatTranscript.tsx
@@ -1,13 +1,8 @@
-import { useEffect, useLayoutEffect, useRef } from "react";
-
 import { shouldShowThinkingIndicator } from "@/lib/agent-chat/thinking";
 import type { ChatViewItem } from "@/lib/agent-chat/types";
 import type { ApprovalDecision } from "@/tauri/events";
 
 import { MessageList } from "./MessageList";
-import { ThinkingIndicator } from "./ThinkingIndicator";
-
-const PIN_THRESHOLD_PX = 80;
 
 interface Props {
   messages: ChatViewItem[];
@@ -20,6 +15,13 @@ interface Props {
   onRejectPlan: (requestId: string) => void | Promise<void>;
 }
 
+/**
+ * Transcript shell. The scroll container, stick-to-bottom pinning and
+ * row windowing all live inside the virtualized `MessageList` (the
+ * virtualizer must own its scroller to map scroll offsets onto the
+ * rendered window) — this layer just sizes it and derives the
+ * thinking-pulse flag.
+ */
 export function ChatTranscript({
   messages,
   streaming,
@@ -27,57 +29,17 @@ export function ChatTranscript({
   onAcceptPlan,
   onRejectPlan,
 }: Props) {
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const pinnedToBottomRef = useRef(true);
-
-  // Track whether the user is pinned to the bottom so auto-scroll only
-  // fires when the tail is already visible.
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const onScroll = () => {
-      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-      pinnedToBottomRef.current = distance <= PIN_THRESHOLD_PX;
-    };
-    el.addEventListener("scroll", onScroll, { passive: true });
-    return () => el.removeEventListener("scroll", onScroll);
-  }, []);
-
   const showThinking = shouldShowThinkingIndicator(messages, streaming);
 
-  // After each message update — or when the thinking indicator toggles —
-  // if we were pinned, stick to the bottom so the pulse stays visible.
-  useLayoutEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    if (pinnedToBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [messages, showThinking]);
-
   return (
-    <div
-      ref={scrollRef}
-      className="flex-1 min-h-0 w-full overflow-y-auto px-4 py-4"
-    >
-      <div className="mx-auto w-full max-w-2xl">
-        <MessageList
-          messages={messages}
-          onRespondToRequest={onRespondToRequest}
-          onAcceptPlan={onAcceptPlan}
-          onRejectPlan={onRejectPlan}
-        />
-        {showThinking && (
-          <div
-            role="status"
-            aria-label="Agent is thinking"
-            className="mt-3"
-          >
-            <ThinkingIndicator />
-          </div>
-        )}
-        <div className="h-4" />
-      </div>
+    <div className="flex-1 min-h-0 w-full">
+      <MessageList
+        messages={messages}
+        showThinking={showThinking}
+        onRespondToRequest={onRespondToRequest}
+        onAcceptPlan={onAcceptPlan}
+        onRejectPlan={onRejectPlan}
+      />
     </div>
   );
 }

--- a/src/components/chat/MessageList.test.tsx
+++ b/src/components/chat/MessageList.test.tsx
@@ -1,6 +1,7 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { afterEach, describe, it, expect, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { VirtuosoMockContext } from "react-virtuoso";
 
 import type {
   ChatViewItem,
@@ -11,6 +12,21 @@ import type {
 import { MessageList } from "./MessageList";
 
 afterEach(() => cleanup());
+
+/** Render the (virtualized) MessageList inside react-virtuoso's mock
+ *  context — jsdom has no layout, so Virtuoso needs synthetic viewport
+ *  and row heights to decide what to mount. 2000/100 → a 20-row
+ *  window, comfortably larger than any fixture in this file except
+ *  the windowing test (which relies on the bound). */
+function renderList(messages: ChatViewItem[]) {
+  return render(
+    <VirtuosoMockContext.Provider
+      value={{ viewportHeight: 2000, itemHeight: 100 }}
+    >
+      <MessageList messages={messages} {...noopHandlers} />
+    </VirtuosoMockContext.Provider>,
+  );
+}
 
 function planReq(
   overrides: Partial<PermissionRequestItem> = {},
@@ -81,7 +97,7 @@ const noopHandlers = {
 describe("MessageList dispatch", () => {
   it("routes request_kind=plan to PlanProposalBlock", () => {
     const messages: ChatViewItem[] = [planReq()];
-    render(<MessageList messages={messages} {...noopHandlers} />);
+    renderList(messages);
     // PlanProposalBlock's "Plan proposed" label is a stable marker.
     expect(screen.getByText("Plan proposed")).toBeInTheDocument();
     expect(screen.getByText("Accept & execute")).toBeInTheDocument();
@@ -89,7 +105,7 @@ describe("MessageList dispatch", () => {
 
   it("reduces request_kind=user-input to a transcript marker; full panel lives with the composer", () => {
     const messages: ChatViewItem[] = [askReq()];
-    render(<MessageList messages={messages} {...noopHandlers} />);
+    renderList(messages);
     // The inline transcript row is just a one-line pointer — the
     // actual interactive panel is mounted above the composer by
     // AgentChatPane (see ComposerPendingInputPanel).
@@ -104,7 +120,7 @@ describe("MessageList dispatch", () => {
 
   it("falls back to PermissionRequestBlock for unknown request_kind", () => {
     const messages: ChatViewItem[] = [genericReq()];
-    render(<MessageList messages={messages} {...noopHandlers} />);
+    renderList(messages);
     // Generic fallback renders the classic "Approval requested" label.
     expect(screen.getByText(/Approval requested/)).toBeInTheDocument();
   });
@@ -135,9 +151,7 @@ describe("MessageList dispatch", () => {
         request_id: "tu-plan-x",
         tool_use_id: "tu-plan-x",
       });
-      render(
-        <MessageList messages={[tool, req]} {...noopHandlers} />,
-      );
+      renderList([tool, req]);
       // PlanProposalBlock renders, not the generic approval block.
       expect(screen.getByText("Plan proposed")).toBeInTheDocument();
       expect(screen.getByText("Accept & execute")).toBeInTheDocument();
@@ -160,9 +174,7 @@ describe("MessageList dispatch", () => {
         request_id: "tu-ask-x",
         tool_use_id: "tu-ask-x",
       });
-      render(
-        <MessageList messages={[tool, req]} {...noopHandlers} />,
-      );
+      renderList([tool, req]);
       // The dispatch survives the orphan-ToolCallItem scenario: the
       // user-input request still resolves to the transcript marker
       // (not the generic PermissionRequestBlock fallback).
@@ -201,7 +213,7 @@ describe("MessageList dispatch", () => {
         readCall(3, "/d"),
         readCall(4, "/e"),
       ];
-      render(<MessageList messages={messages} {...noopHandlers} />);
+      renderList(messages);
       expect(screen.queryByText(/earlier tool call/)).toBeNull();
       expect(screen.getByText("/a")).toBeInTheDocument();
       expect(screen.getByText("/e")).toBeInTheDocument();
@@ -212,7 +224,7 @@ describe("MessageList dispatch", () => {
       // default, latest 4 stay visible.
       const messages: ChatViewItem[] = [];
       for (let i = 0; i < 8; i++) messages.push(readCall(i, `/f${i}`));
-      render(<MessageList messages={messages} {...noopHandlers} />);
+      renderList(messages);
 
       // Collapsed state: f0..f3 hidden, f4..f7 visible.
       expect(
@@ -245,7 +257,7 @@ describe("MessageList dispatch", () => {
         streaming: false,
       });
       for (let i = 6; i < 11; i++) messages.push(readCall(i, `/y${i}`));
-      render(<MessageList messages={messages} {...noopHandlers} />);
+      renderList(messages);
       expect(screen.queryByText(/earlier tool call/)).toBeNull();
       expect(screen.getByText("between bursts")).toBeInTheDocument();
       // Every row from both runs is rendered.
@@ -265,7 +277,7 @@ describe("MessageList dispatch", () => {
         streaming: false,
       });
       for (let i = 8; i < 15; i++) messages.push(readCall(i, `/q${i}`));
-      render(<MessageList messages={messages} {...noopHandlers} />);
+      renderList(messages);
       // Each run has 7 items → hides 3, shows 4 → two independent
       // "Show 3 earlier tool calls" toggles.
       const toggles = screen.getAllByText(/Show 3 earlier tool calls/);

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,5 +1,13 @@
 import { ChevronDown, ChevronUp } from "lucide-react";
-import { memo, useCallback, useMemo, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 
 import type {
   ChatViewItem,
@@ -11,6 +19,7 @@ import type { ApprovalDecision } from "@/tauri/events";
 import { AssistantMessage } from "./AssistantMessage";
 import { PermissionRequestBlock } from "./PermissionRequestBlock";
 import { PlanProposalBlock } from "./PlanProposalBlock";
+import { ThinkingIndicator } from "./ThinkingIndicator";
 import { ToolCallCard } from "./ToolCallCard";
 import { UserMessage } from "./UserMessage";
 
@@ -20,9 +29,20 @@ const RUN_COLLAPSE_THRESHOLD = 6;
 /** When a run is collapsed, keep this many most-recent tool calls
  *  visible — "a handful of the most recent tool calls happening." */
 const RUN_TAIL_VISIBLE = 4;
+/** How close to the bottom (px) the user must be for auto-scroll to
+ *  keep following the streaming tail. Matches the pre-virtualization
+ *  ChatTranscript pin threshold. */
+const PIN_THRESHOLD_PX = 80;
+/** Extra off-screen pixels Virtuoso keeps rendered above/below the
+ *  viewport. Trades a few more mounted rows for smoother scrolling. */
+const OVERSCAN_PX = 600;
 
 interface Props {
   messages: ChatViewItem[];
+  /** Render the tail "thinking" pulse as the last virtual row. Lives
+   *  inside the virtualized list (not a footer) so the stick-to-bottom
+   *  scroll keeps it visible while streaming. */
+  showThinking?: boolean;
   onRespondToRequest: (requestId: string, decision: ApprovalDecision) => void;
   /** Plan-accept: parent flips the live session to `default` mode
    *  and sends a "Proceed with the plan." synthetic turn. The
@@ -32,12 +52,37 @@ interface Props {
   onAcceptPlan: (requestId: string) => void | Promise<void>;
   /** Plan-reject: parent sends a generic "Please revise the plan."
    *  turn. No feedback is collected from the user — matching the
-   *  Cursor / VS Code plan UIs. */
+   *  plan UIs of other agentic editors. */
   onRejectPlan: (requestId: string) => void | Promise<void>;
 }
 
+/**
+ * Virtualized transcript body (issue #77). Only the on-screen window
+ * of rows (plus OVERSCAN_PX of slack) is mounted in the DOM, so a
+ * 5,000-message session scrolls like a 50-message one.
+ *
+ * Library choice: `react-virtuoso` (MIT). Evaluated against
+ * `@tanstack/react-virtual` and `react-window` — Virtuoso is the only
+ * one with built-in dynamic row measurement (ResizeObserver-driven,
+ * required because messages / tool cards / plan blocks / collapses
+ * vary wildly in height and resize on expand) plus first-class
+ * bottom-anchoring primitives. The commercially licensed
+ * `@virtuoso.dev/message-list` package is NOT used.
+ *
+ * MessageList owns the scroll container now (Virtuoso must control
+ * its own scroller to translate scroll offsets into the rendered
+ * window). The stick-to-bottom contract is unchanged from the
+ * pre-virtualization ChatTranscript:
+ *   - track "pinned" from scroll events (distance ≤ PIN_THRESHOLD_PX);
+ *   - after every transcript change (and thinking-pulse toggle), if
+ *     pinned, snap to the tail;
+ *   - content growth alone never unpins (growth fires no scroll
+ *     event), and a user wheel-up unpins on the next scroll event,
+ *     so auto-scroll never fights the user.
+ */
 export function MessageList({
   messages,
+  showThinking = false,
   onRespondToRequest,
   onAcceptPlan,
   onRejectPlan,
@@ -83,6 +128,9 @@ export function MessageList({
   // transcript. Non-tool items break a run. Tool calls carrying an
   // active approval footer stay out of runs — the approval needs to
   // remain interactable without the user hunting for it.
+  //
+  // Each slot is one virtual row: a collapsed run is a single row that
+  // expands in place (Virtuoso re-measures it via ResizeObserver).
   const slots = useMemo<RenderSlot[]>(() => {
     const out: RenderSlot[] = [];
     let run: ToolCallItem[] = [];
@@ -107,52 +155,135 @@ export function MessageList({
       }
     }
     flush();
+    if (showThinking) out.push({ kind: "thinking" });
     return out;
-  }, [ordered]);
+  }, [ordered, showThinking]);
 
-  // Pre-resolve the approval lookup at the parent so MessageRow gets
-  // a stable `approval` reference instead of the requestsById map
-  // (which is a fresh Map ref on every parent render). Without this
-  // the React.memo on MessageRow can never skip a re-render — the
-  // map identity churn alone would force a re-mount of every row on
-  // every streaming token.
-  return (
-    <div className="flex flex-col gap-3">
-      {slots.map((slot) => {
-        if (slot.kind === "item") {
-          return (
-            <MessageRowMemo
-              key={slot.item.id}
-              item={slot.item}
-              approval={lookupApproval(slot.item, requestsById)}
-              isMerged={isMerged(slot.item, mergedRequestIds)}
+  const virtuosoRef = useRef<VirtuosoHandle | null>(null);
+  // Whether the user is at (or near) the bottom. Starts true so a
+  // freshly mounted pane follows the tail immediately — matching the
+  // pre-virtualization behavior.
+  const pinnedToBottomRef = useRef(true);
+
+  // Track pinned-ness from real scroll events on Virtuoso's scroller
+  // element. Content growth doesn't fire `scroll`, so streaming can
+  // never unpin by itself; only the user (or our own snap) moves it.
+  const scrollerCleanupRef = useRef<(() => void) | null>(null);
+  const handleScrollerRef = useCallback((el: HTMLElement | Window | null) => {
+    scrollerCleanupRef.current?.();
+    scrollerCleanupRef.current = null;
+    if (!(el instanceof HTMLElement)) return;
+    const onScroll = () => {
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      pinnedToBottomRef.current = distance <= PIN_THRESHOLD_PX;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    scrollerCleanupRef.current = () =>
+      el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // After each transcript update — or when the thinking pulse toggles —
+  // if we were pinned, stick to the tail. `scrollToIndex(LAST, end)`
+  // also covers the tail-row-grows-without-count-change case (token
+  // deltas mutate the trailing assistant row in place). Runs on mount
+  // too (pinned starts true), so a remounted pane with an existing
+  // transcript opens at the tail, like a conversation should.
+  useLayoutEffect(() => {
+    if (!pinnedToBottomRef.current) return;
+    virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
+  }, [slots]);
+
+  const itemContent = useCallback(
+    (_index: number, slot: RenderSlot) => {
+      if (slot.kind === "thinking") {
+        return (
+          <div className="px-4 pb-3">
+            <div
+              className="mx-auto w-full max-w-2xl"
+              role="status"
+              aria-label="Agent is thinking"
+            >
+              <ThinkingIndicator />
+            </div>
+          </div>
+        );
+      }
+      if (slot.kind === "item") {
+        return (
+          <div className="px-4 pb-3">
+            <div className="mx-auto w-full max-w-2xl">
+              <MessageRowMemo
+                item={slot.item}
+                approval={lookupApproval(slot.item, requestsById)}
+                isMerged={isMerged(slot.item, mergedRequestIds)}
+                onRespondToRequest={onRespondToRequest}
+                onAcceptPlan={onAcceptPlan}
+                onRejectPlan={onRejectPlan}
+              />
+            </div>
+          </div>
+        );
+      }
+      return (
+        <div className="px-4 pb-3">
+          <div className="mx-auto w-full max-w-2xl">
+            <ToolRunCollapse
+              items={slot.items}
+              requestsById={requestsById}
               onRespondToRequest={onRespondToRequest}
               onAcceptPlan={onAcceptPlan}
               onRejectPlan={onRejectPlan}
             />
-          );
-        }
-        return (
-          <ToolRunCollapse
-            // Key on the first item's id so React preserves expand
-            // state across re-renders even when new tool calls arrive
-            // at the tail of a streaming run.
-            key={`run:${slot.items[0].id}`}
-            items={slot.items}
-            requestsById={requestsById}
-            onRespondToRequest={onRespondToRequest}
-            onAcceptPlan={onAcceptPlan}
-            onRejectPlan={onRejectPlan}
-          />
-        );
-      })}
-    </div>
+          </div>
+        </div>
+      );
+    },
+    [
+      requestsById,
+      mergedRequestIds,
+      onRespondToRequest,
+      onAcceptPlan,
+      onRejectPlan,
+    ],
+  );
+
+  return (
+    <Virtuoso<RenderSlot>
+      ref={virtuosoRef}
+      scrollerRef={handleScrollerRef}
+      style={VIRTUOSO_STYLE}
+      data={slots}
+      computeItemKey={computeSlotKey}
+      itemContent={itemContent}
+      increaseViewportBy={OVERSCAN_PX}
+      components={VIRTUOSO_COMPONENTS}
+    />
   );
 }
 
+const VIRTUOSO_STYLE = { height: "100%" } as const;
+
+/** Top/bottom breathing room inside the scroller — replaces the old
+ *  ChatTranscript `py-4` + trailing `h-4` spacer. Stable component
+ *  refs (module scope) so Virtuoso never remounts them. */
+const VIRTUOSO_COMPONENTS = {
+  Header: () => <div className="h-4" />,
+  Footer: () => <div className="h-4" />,
+};
+
 type RenderSlot =
   | { kind: "item"; item: ChatViewItem }
-  | { kind: "toolRun"; items: ToolCallItem[] };
+  | { kind: "toolRun"; items: ToolCallItem[] }
+  | { kind: "thinking" };
+
+/** Stable per-slot keys: the same id-based keys the plain `.map()`
+ *  render used, so React row identity (and `MessageRowMemo` skips)
+ *  survives the virtualization window sliding around. */
+function computeSlotKey(_index: number, slot: RenderSlot): string {
+  if (slot.kind === "item") return slot.item.id;
+  if (slot.kind === "toolRun") return `run:${slot.items[0].id}`;
+  return "thinking";
+}
 
 function lookupApproval(
   item: ChatViewItem,
@@ -179,9 +310,9 @@ function isMerged(
  * calls into a "Show N earlier tool calls" toggle + the last
  * RUN_TAIL_VISIBLE rows. Click to expand; click again to collapse.
  *
- * Uses `display: contents` on the wrapper so the inner rows remain
- * direct flex children of the parent transcript and inherit its
- * `gap-3` vertical rhythm without introducing a nested box.
+ * The whole run is a single virtual row; expanding it grows the row
+ * in place and Virtuoso re-measures via its ResizeObserver. The inner
+ * rows reproduce the transcript's `gap-3` vertical rhythm.
  */
 function ToolRunCollapse({
   items,
@@ -202,7 +333,7 @@ function ToolRunCollapse({
   const pluralSuffix = hiddenCount === 1 ? "" : "s";
 
   return (
-    <div className="contents">
+    <div className="flex flex-col gap-3">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}

--- a/src/components/chat/MessageList.virtualization.test.tsx
+++ b/src/components/chat/MessageList.virtualization.test.tsx
@@ -1,0 +1,114 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+/**
+ * Virtualization guarantees for the transcript (issue #77):
+ *
+ *  1. A long session mounts only a bounded window of rows in the DOM,
+ *     not one node per message.
+ *  2. A streaming token delta (tail row replaced in place by the
+ *     reducer) re-renders exactly one row — the React.memo win from
+ *     before virtualization is preserved.
+ *
+ * Rendered inside `VirtuosoMockContext` because jsdom has no layout:
+ * the mock provides synthetic viewport/row heights so Virtuoso can
+ * decide what to mount.
+ */
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VirtuosoMockContext } from "react-virtuoso";
+
+import type {
+  AssistantMessageItem,
+  ChatViewItem,
+} from "@/lib/agent-chat/types";
+
+import { MessageList } from "./MessageList";
+
+// Replace the prose renderer with a counting stub so we can observe
+// per-row render counts without markdown noise.
+const renderCounts = new Map<string, number>();
+vi.mock("./AssistantMessage", () => ({
+  AssistantMessage: ({ item }: { item: AssistantMessageItem }) => {
+    renderCounts.set(item.id, (renderCounts.get(item.id) ?? 0) + 1);
+    return <div data-am-row>{item.text}</div>;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  renderCounts.clear();
+});
+
+function assistantMsg(seq: number, text: string): AssistantMessageItem {
+  return {
+    kind: "assistant_message",
+    id: `am-${seq}`,
+    seq,
+    turn_id: "turn-1",
+    text,
+    streaming: false,
+  };
+}
+
+const noopHandlers = {
+  onRespondToRequest: vi.fn(),
+  onAcceptPlan: vi.fn(),
+  onRejectPlan: vi.fn(),
+};
+
+function renderList(messages: ChatViewItem[]) {
+  return render(
+    <VirtuosoMockContext.Provider
+      value={{ viewportHeight: 2000, itemHeight: 100 }}
+    >
+      <MessageList messages={messages} {...noopHandlers} />
+    </VirtuosoMockContext.Provider>,
+  );
+}
+
+describe("MessageList virtualization", () => {
+  it("mounts only a bounded window of rows for a 1,000-message session", () => {
+    const messages: ChatViewItem[] = [];
+    for (let i = 0; i < 1000; i++) {
+      messages.push(assistantMsg(i, `message body ${i}`));
+    }
+    renderList(messages);
+
+    const mounted = document.querySelectorAll("[data-am-row]").length;
+    // 2000px viewport / 100px rows = 20 visible (+ a little overscan).
+    expect(mounted).toBeGreaterThan(0);
+    expect(mounted).toBeLessThan(60);
+  });
+
+  it("re-renders exactly one row when a token delta mutates the tail", () => {
+    // 12 rows — all inside the mock 20-row window, so every row is
+    // mounted and a memo miss anywhere would be observable.
+    const initial: ChatViewItem[] = [];
+    for (let i = 0; i < 12; i++) {
+      initial.push(assistantMsg(i, `message body ${i}`));
+    }
+    const { rerender } = renderList(initial);
+    expect(screen.getByText("message body 11")).toBeInTheDocument();
+
+    const before = new Map(renderCounts);
+
+    // Simulate the reducer's `replaceItem` for a streaming delta: a
+    // fresh array, every row identity preserved except the tail.
+    const next = initial.slice();
+    next[11] = { ...assistantMsg(11, "message body 11 plus-token") };
+    rerender(
+      <VirtuosoMockContext.Provider
+        value={{ viewportHeight: 2000, itemHeight: 100 }}
+      >
+        <MessageList messages={next} {...noopHandlers} />
+      </VirtuosoMockContext.Provider>,
+    );
+    expect(
+      screen.getByText("message body 11 plus-token"),
+    ).toBeInTheDocument();
+
+    for (let i = 0; i < 11; i++) {
+      expect(renderCounts.get(`am-${i}`)).toBe(before.get(`am-${i}`));
+    }
+    expect(renderCounts.get("am-11")).toBe((before.get("am-11") ?? 0) + 1);
+  });
+});

--- a/src/dev/mock-fixtures.ts
+++ b/src/dev/mock-fixtures.ts
@@ -112,6 +112,50 @@ function terminalSurface(label: string, cwd: string): PaneRefs {
   return { pane, surface, tab, session };
 }
 
+/** Thread id of the pre-seeded agent-chat workspace. The mock's
+ *  `agent_chat_list_messages` returns a long generated transcript for
+ *  this id so the virtualized MessageList can be exercised in a plain
+ *  browser (issue #77). */
+export const MOCK_CHAT_THREAD_ID = "thread-mock-chat";
+
+/** Build an agent-chat surface (+ tab) for a workspace. Mirrors the
+ *  backend's `create_agent_chat_pane`: the surface root is an
+ *  `agent_chat` pane and the tab keeps `kind: "terminal"` (TabKind has
+ *  no chat variant — the pane node drives rendering). */
+function chatSurface(
+  label: string,
+  cwd: string,
+): { pane: PaneNodeSnapshot; surface: SurfaceSnapshot; tab: TabSnapshot } {
+  const n = ++paneSeq;
+  const paneId = `pane-${n}`;
+  const surfaceId = `surface-${n}`;
+  const tabId = `tab-${n}`;
+
+  const pane: PaneNodeSnapshot = {
+    kind: "agent_chat",
+    pane_id: paneId,
+    title: label,
+    thread_id: MOCK_CHAT_THREAD_ID,
+    provider: "claude",
+    cwd,
+  };
+  const surface: SurfaceSnapshot = {
+    surface_id: surfaceId,
+    title: label,
+    root: pane,
+    active_pane_id: paneId,
+  };
+  const tab: TabSnapshot = {
+    tab_id: tabId,
+    kind: "terminal",
+    title: label,
+    surface_id: surfaceId,
+    browser_id: null,
+    icon: null,
+  };
+  return { pane, surface, tab };
+}
+
 interface WorkspaceSeed extends Partial<WorkspaceSnapshot> {
   workspace_id: string;
   title: string;
@@ -208,6 +252,29 @@ const wsCodemuxMain = makeWorkspace({
   git_branch: "main",
   status: "working", // amber pulsing dot on the primary row
 });
+
+/** Agent-chat workspace: a single `agent_chat` pane bound to
+ *  `MOCK_CHAT_THREAD_ID`. The mock hydrates a long transcript for it
+ *  so list virtualization is observable in the browser. */
+const wsCodemuxChat: WorkspaceSnapshot = (() => {
+  const ws = makeWorkspace({
+    workspace_id: "ws-codemux-chat",
+    title: "agent-chat-demo",
+    cwd: codemuxRoot,
+    project_root: codemuxRoot,
+    project_uid: codemuxUid,
+    workspace_kind: "main",
+    git_branch: "main",
+  });
+  const { surface, tab } = chatSurface("Agent Chat", codemuxRoot);
+  return {
+    ...ws,
+    tabs: [tab],
+    active_tab_id: tab.tab_id,
+    active_surface_id: surface.surface_id,
+    surfaces: [surface],
+  };
+})();
 
 const wsCodemuxAuth = makeWorkspace({
   workspace_id: "ws-codemux-auth",
@@ -374,6 +441,7 @@ const wsSiteRedesign = makeWorkspace({
 
 const ALL_WORKSPACES: WorkspaceSnapshot[] = [
   wsCodemuxMain,
+  wsCodemuxChat,
   wsCodemuxAuth,
   wsCodemuxSidebar,
   wsCodemuxMock,

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -33,12 +33,14 @@
  * falls through to a logged, shape-safe default.
  */
 import {
+  MOCK_CHAT_THREAD_ID,
   MOCK_HOME_DIR,
   MOCK_USER,
   createSeedAppState,
 } from "./mock-fixtures";
 import type {
   AppStateSnapshot,
+  ChatModelInfo,
   CliToolInfo,
   FeatureFlags,
   PresetStoreSnapshot,
@@ -160,7 +162,10 @@ const FEATURE_FLAGS: FeatureFlags = {
   unstable_openflow: false,
   unstable_browser_automation: false,
   unstable_indexing: false,
-  enable_agent_chat: false,
+  // On in the mock so the seeded agent-chat workspace renders its chat
+  // pane (the virtualized transcript is a primary dev-iteration
+  // surface — issue #77). All chat IPC is mocked below.
+  enable_agent_chat: true,
   enable_lazy_workspace_creation: false,
 };
 
@@ -191,6 +196,210 @@ const EMPTY_CAPABILITIES: ProviderChatCapabilities = {
   permission_modes: [],
   default_permission_mode: null,
   permission_granularity: "per_session",
+};
+
+// ── Agent chat (mocked end-to-end) ──────────────────────────────────
+//
+// The seeded `ws-codemux-chat` workspace carries an `agent_chat` pane
+// bound to MOCK_CHAT_THREAD_ID. On mount the pane hydrates via
+// `agent_chat_list_messages`, which returns a long generated
+// transcript replayed through the real reducer — so the virtualized
+// MessageList renders real ChatViewItems. `agent_chat_send_turn`
+// simulates a streaming reply through the real `agent_chat_event`
+// channel; `window.__codemuxChatMock.streamReply()` triggers one on
+// demand for scroll/perf testing.
+
+const MOCK_CHAT_MODEL: ChatModelInfo = {
+  id: "mock-sonnet",
+  label: "Mock Sonnet",
+  description: "Simulated model served by the dev mock",
+  effort_levels: [],
+  default_effort: null,
+  prompt_injected_effort_levels: [],
+  context_window_options: [],
+  supports_adaptive_thinking: false,
+  supports_thinking_toggle: false,
+  supports_fast_mode: false,
+  supports_images: false,
+  sub_provider: null,
+  is_free: false,
+};
+
+const CLAUDE_CAPABILITIES: ProviderChatCapabilities = {
+  models: [MOCK_CHAT_MODEL],
+  effort_granularity: "per_session",
+  effort_label_map: {},
+  permission_modes: [
+    {
+      value: "bypassPermissions",
+      label: "Full access",
+      description: "Run every tool without asking",
+      is_default: true,
+    },
+    {
+      value: "default",
+      label: "Ask first",
+      description: "Prompt before tool use",
+      is_default: false,
+    },
+  ],
+  default_permission_mode: "bypassPermissions",
+  permission_granularity: "per_session",
+};
+
+/** Number of simulated turns in the seeded transcript. Every 5th turn
+ *  includes an 8-call tool burst (exercises the run-collapse row), so
+ *  the item total lands well past 1,200 — enough to make unbounded
+ *  row mounting obvious in devtools if virtualization ever regresses. */
+const MOCK_CHAT_TURNS = 220;
+
+const ASSISTANT_BODIES = [
+  "Short answer: yes — the transcript only mounts the rows that intersect the viewport.",
+  "Here's the longer explanation.\n\nThe message list used to render every item with a plain `.map()`, which meant a 5,000-message session mounted 5,000 DOM subtrees. Virtualization replaces that with a window: rows are measured as they appear and recycled as they leave.\n\n- Stable keys keep React row identity\n- `React.memo` still skips untouched rows\n- The tail snap only fires while you're pinned to the bottom",
+  "Let me check a few files to confirm the behavior before answering.",
+  "```ts\nconst distance = el.scrollHeight - el.scrollTop - el.clientHeight;\npinned = distance <= PIN_THRESHOLD_PX;\n```\n\nThat predicate decides whether the next token snaps the view to the tail or leaves you reading history in peace.",
+  "Done. The change keeps the DOM bounded regardless of conversation length, so session-open time and scroll cost stop scaling with history size.\n\nA second paragraph pads this message out so row heights vary — fixed-height assumptions are exactly what dynamic measurement has to absorb.\n\nAnd a third paragraph for good measure, because real assistant turns are rarely uniform.",
+];
+
+let mockChatTranscriptCache: string[] | null = null;
+
+/** Generate the persisted-payload list `agent_chat_list_messages`
+ *  returns for the seeded thread: the same JSON envelopes the real
+ *  backend stores, replayed by the frontend through the pure reducer. */
+function mockChatTranscript(): string[] {
+  if (mockChatTranscriptCache) return mockChatTranscriptCache;
+  const T = MOCK_CHAT_THREAD_ID;
+  const out: string[] = [];
+  const push = (envelope: unknown) => out.push(JSON.stringify(envelope));
+  for (let i = 0; i < MOCK_CHAT_TURNS; i++) {
+    const turnId = `seed-turn-${i + 1}`;
+    push({
+      type: "user_message",
+      thread_id: T,
+      text: `Turn ${i + 1}: how does the virtualized transcript hold up at scale?`,
+    });
+    if (i % 5 === 4) {
+      // Tool burst — 8 consecutive calls so the run-collapse toggle
+      // ("Show 4 earlier tool calls") appears inside one virtual row.
+      for (let k = 0; k < 8; k++) {
+        const toolUseId = `seed-tu-${i}-${k}`;
+        push({
+          type: "item_completed",
+          thread_id: T,
+          turn_id: turnId,
+          item: {
+            kind: "tool_use",
+            tool_name: "Read",
+            input: { file_path: `/src/components/chat/file-${i}-${k}.ts` },
+            tool_use_id: toolUseId,
+          },
+        });
+        push({
+          type: "item_completed",
+          thread_id: T,
+          turn_id: turnId,
+          item: {
+            kind: "tool_result",
+            tool_use_id: toolUseId,
+            content: `// mock contents ${i}-${k}\nexport const value = ${k};`,
+            is_error: false,
+          },
+        });
+      }
+    }
+    push({
+      type: "item_completed",
+      thread_id: T,
+      turn_id: turnId,
+      item: {
+        kind: "assistant_text",
+        text: `(${i + 1}/${MOCK_CHAT_TURNS}) ${ASSISTANT_BODIES[i % ASSISTANT_BODIES.length]}`,
+      },
+    });
+    push({
+      type: "turn_completed",
+      thread_id: T,
+      turn_id: turnId,
+      status: { kind: "success" },
+      usage: null,
+    });
+  }
+  mockChatTranscriptCache = out;
+  return out;
+}
+
+let mockChatTurnSeq = 0;
+
+/** Simulate a streaming assistant reply on the real event channel.
+ *  Returns the turn id immediately; deltas tick on an interval so
+ *  stick-to-bottom / scroll-up-freedom can be observed live. */
+function streamMockChatReply(
+  threadId: string,
+  opts: { tokens?: number; intervalMs?: number } = {},
+): string {
+  const turnId = `live-turn-${++mockChatTurnSeq}`;
+  const tokens = Math.max(1, opts.tokens ?? 120);
+  const intervalMs = Math.max(5, opts.intervalMs ?? 40);
+  const send = (event: unknown) =>
+    emitEvent("agent_chat_event", { thread_id: threadId, event });
+
+  send({
+    type: "session_state_changed",
+    thread_id: threadId,
+    status: { status: "running", active_turn: turnId },
+  });
+
+  let emitted = 0;
+  let fullText = "";
+  const timer = window.setInterval(() => {
+    emitted += 1;
+    const chunk =
+      emitted % 12 === 0
+        ? `token ${emitted}.\n\n`
+        : `token ${emitted} `;
+    fullText += chunk;
+    send({
+      type: "content_delta",
+      thread_id: threadId,
+      turn_id: turnId,
+      delta: { kind: "text", text: chunk },
+    });
+    if (emitted >= tokens) {
+      window.clearInterval(timer);
+      send({
+        type: "item_completed",
+        thread_id: threadId,
+        turn_id: turnId,
+        item: { kind: "assistant_text", text: fullText },
+      });
+      send({
+        type: "turn_completed",
+        thread_id: threadId,
+        turn_id: turnId,
+        status: { kind: "success" },
+        usage: null,
+      });
+      send({
+        type: "session_state_changed",
+        thread_id: threadId,
+        status: { status: "ready" },
+      });
+    }
+  }, intervalMs);
+  return turnId;
+}
+
+// Expose the stream trigger for browser-console / automation use.
+(
+  window as unknown as {
+    __codemuxChatMock: {
+      threadId: string;
+      streamReply: typeof streamMockChatReply;
+    };
+  }
+).__codemuxChatMock = {
+  threadId: MOCK_CHAT_THREAD_ID,
+  streamReply: streamMockChatReply,
 };
 
 const EMPTY_PRESETS: PresetStoreSnapshot = {
@@ -310,8 +519,24 @@ const handlers: Record<string, Handler> = {
   // ── Resource monitor ──
   get_resource_metrics: () => resourceMetrics(),
 
-  // ── Agent chat capabilities (gated off, returned safe anyway) ──
-  list_chat_provider_capabilities: () => EMPTY_CAPABILITIES,
+  // ── Agent chat (mocked end-to-end for the seeded chat workspace) ──
+  list_chat_provider_capabilities: (a) =>
+    a.provider === "claude" ? CLAUDE_CAPABILITIES : EMPTY_CAPABILITIES,
+  agent_chat_list_messages: (a) =>
+    a.threadId === MOCK_CHAT_THREAD_ID ? mockChatTranscript() : [],
+  agent_chat_list_sessions: () => [],
+  agent_chat_start_session: (a) =>
+    (a.input as { thread_id: string }).thread_id,
+  agent_chat_send_turn: (a) =>
+    streamMockChatReply((a.input as { thread_id: string }).thread_id),
+  agent_chat_interrupt_turn: () => undefined,
+  agent_chat_respond_to_request: () => undefined,
+  agent_chat_set_model: () => undefined,
+  agent_chat_set_permission_mode: () => undefined,
+  agent_chat_stop_session: () => undefined,
+  agent_chat_rename_session: () => undefined,
+  agent_chat_delete_session: () => undefined,
+  grep_count_pattern: () => 0,
 
   // ── Presets ──
   get_presets: () => EMPTY_PRESETS,


### PR DESCRIPTION
Closes #77

## Summary

Replaces the plain `slots.map()` transcript render in `MessageList.tsx` with a virtualized list, so only the on-screen window of rows is mounted regardless of conversation length. A 797-message session now mounts at most ~20 row nodes (was: one DOM subtree per message, up to the 5,000-message reducer cap).

### Library choice (issue item 1)

**`react-virtuoso` v4.18.7 (MIT).** Evaluated against `@tanstack/react-virtual` (MIT, headless — would require hand-rolled dynamic measurement + bottom-pinning) and `react-window` (MIT, weak variable-height support). Virtuoso is the only one with built-in ResizeObserver-driven row measurement **and** bottom-anchoring primitives — exactly the two hard parts called out in the issue. The commercially licensed `@virtuoso.dev/message-list` package is **not** used.

### What's preserved (issue item 2)

- **Stable keys + memo rows** — per-slot keys are still `slot.item.id` / `run:<first-id>`, rows render through `MessageRowMemo`; a streaming token re-renders exactly one row.
- **Tail-follow auto-scroll** — `MessageList` owns the scroller now (the virtualizer must control it). Pinned-ness is tracked from real scroll events (≤ 80 px, same threshold as before); every transcript change snaps to the tail only while pinned. Content growth never fires a scroll event, so streaming can never unpin — and a user wheel-up unpins immediately, so auto-scroll never fights the reader.
- **Variable row heights** — tool-run collapses render as a single virtual row that expands in place; Virtuoso re-measures via ResizeObserver. The thinking pulse renders as the last virtual row (not a footer) so the tail snap keeps it visible while streaming.
- **Tool-run collapse / merged-slot logic** — unchanged; `ChatTranscript` shrinks to a thin shell that derives `showThinking`.

### Also in this PR

- **StrictMode hydrate fix** (`AgentChatPane.tsx`): hydrate-on-mount never applied in dev builds — the first effect invocation was cancelled by StrictMode's mount/unmount cycle and its attempt marker blocked the re-run. Production (single mount) was unaffected.
- **Dev-mock chat harness** (`src/dev/`): seeded `agent-chat-demo` workspace with `enable_agent_chat` on, a ~790-row transcript hydrated through the real reducer via `agent_chat_list_messages`, simulated streaming replies on `agent_chat_send_turn`, and `window.__codemuxChatMock.streamReply()` for on-demand streams. Verified tree-shaken from the production bundle.
- Docs: virtualization contract + dev harness documented in `docs/features/agent-chat.md`.

## Acceptance criteria — verified E2E in the real UI (browser mock, real store/reducer/event pipeline)

- [x] **1,000+ message session keeps only on-screen rows in the DOM** — 797 store messages → max 20 mounted rows across a full-history scroll sweep (11 at rest); session opens at the tail (Turn 220 visible).
- [x] **Streaming auto-scroll + manual scroll-up behave** — pinned 100-token stream: distance-from-bottom samples all ≤ 80 px, tail visible; mid-stream wheel-up: scrollTop frozen exactly while tokens kept appending; scrolled-up reading position unmoved by a background stream.
- [x] **Tokens re-render exactly one row** — MutationObserver during a 30-token stream: only the tail item mutated (plus a render-count unit test in `MessageList.virtualization.test.tsx`).
- [x] **Tool collapses, approvals, plan blocks render and resize correctly** — collapse expands 4→8 rows in place and back with zero scroll drift; dispatch tests (plan / user-input / generic approval) all green under `VirtuosoMockContext`.

## Verify

- `npm run verify` fully green: cargo check, 1684 Rust lib tests + all integration suites, `tsc --noEmit`, 124 test files / 1826 frontend tests (2 new virtualization tests; existing `MessageList` tests updated to render inside `VirtuosoMockContext`).
- `npm run build` (production) passes; `dist/` contains no mock code.
- Note: two pre-existing Rust tests are environment-sensitive on dev machines (`project_codemux_entry_is_filtered_out` reads the real `~/.claude.json`; `resolve_binary_finds_native_binary_from_project_root` depends on a system-installed `agent-browser` outside `npm run` PATH). Both pass under a clean-HOME `npm run verify`; this PR touches no Rust beyond zero lines.

## Manual repro for reviewers

1. `npm run dev` → `codemux browser open http://localhost:1420`
2. Open the **agent-chat-demo** workspace — long transcript opens at the tail.
3. DevTools: `document.querySelector('[data-testid="virtuoso-item-list"]').children.length` stays ~10–20 while scrolling.
4. `window.__codemuxChatMock.streamReply('thread-mock-chat', { tokens: 120 })` — pinned: view follows; scrolled up: view stays put.