### PR TITLE
perf(agent-chat): stream chat events over per-thread Tauri Channels

### DIFF
--- a/docs/core/STATUS.md
+++ b/docs/core/STATUS.md
@@ -261,7 +261,7 @@ The frontend is React + Tailwind v4 + shadcn + Vite. The Rust backend is unchang
 - Pane splits (horizontal/vertical) with CSS Grid, resize handles, drag-to-swap
 - Right panel with Changes panel, File tree, and Review (PR) panel tabs
 - OpenFlow UI: orchestration view, agent config, communication panel, agent graph
-- Agent Chat UI: chat pane, composer (with `+` popup, `@` mention popup, slash command popup, image paste/drop), transcript, mode pill, model picker, session selector, attachment chips, plan proposal block, AskUserQuestion panel, thinking indicator, permission request block, tool-call card with per-tool body rendering, debug-mode banner + exit dialog
+- Agent Chat UI: chat pane, composer (with `+` popup, `@` mention popup, slash command popup, image paste/drop), transcript, mode pill, model picker, session selector, attachment chips, plan proposal block, AskUserQuestion panel, thinking indicator, permission request block, tool-call card with per-tool body rendering, debug-mode banner + exit dialog; runtime events (incl. `content_delta` token stream) arrive per-thread over a Tauri Channel (`attach_agent_chat_output`, issue #75) instead of the global event bus
 - Settings panel (15+ sections including Beta Features, Sync, Skills, MCP, Permissions)
 - Command palette (Ctrl+K) with fuzzy search
 - Search: file name search (Ctrl+Shift+P) and content search (Ctrl+Shift+F)

--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -488,18 +488,44 @@ string.
 ## Event bridge
 
 Every registered provider's canonical event stream is forwarded to
-the frontend on a single Tauri channel named `agent_chat_event`.
-Payloads carry the originating `thread_id` alongside the raw
-`ProviderRuntimeEvent` so subscribers can filter without re-parsing.
-Global events (`RuntimeWarning` without a thread id) are still
-forwarded, with an empty `ThreadId`. The frontend hook
+the frontend per thread over a `tauri::ipc::Channel` (issue #75).
+Payloads (`AgentChatEventPayload`) carry the originating `thread_id`
+alongside the raw `ProviderRuntimeEvent`.
+
+Transport split:
+
+- **Thread-scoped events** — including the high-frequency streaming
+  `content_delta` tokens — are routed to the `Channel` the owning
+  pane registered via `attach_agent_chat_output(thread_id, channel)`
+  (`AgentChatChannelRegistry` in `commands/agent_chat.rs`, mirroring
+  the PTY `attach_pty_output` pattern). A pane only ever receives its
+  own thread's events; nothing is broadcast app-wide. Tauri's event
+  system is explicitly not designed for high-throughput streaming;
+  Channels are the documented mechanism for it.
+- **Thread-less events** (global `RuntimeWarning`s) keep the
+  low-frequency `agent_chat_event` global event bus, with an empty
+  `ThreadId`.
+
+Replay split: the channel carries **live events only**. Transcript
+events are persisted to SQLite by `forward_event` whether or not a
+channel is attached, and a late-attaching / resumed pane rebuilds
+history through the DB hydrate (`agent_chat_list_messages` →
+`hydrateThread`). Non-persisted lifecycle notices that fire while no
+pane is attached are dropped — the same outcome the event bus had
+for unmounted panes.
+
+Attach/detach lifecycle: `attach_agent_chat_output` returns a
+generation token; `detach_agent_chat_output(thread_id, generation)`
+only removes a matching generation, so a stale unmount can never tear
+down the channel a newer pane just installed. The frontend hook
 `useAgentChatEvents(threadId, handler)` in
-`src/hooks/use-agent-chat-events.ts` wires this up with a
-thread-id filter.
+`src/hooks/use-agent-chat-events.ts` owns this lifecycle: it attaches
+a `Channel` per mounted thread and serializes its detach behind the
+attach promise.
 
 The bridge is a thin loop: one background Tokio task per provider,
-each consuming the provider's `event_stream()` and re-emitting each
-event via `AppHandle::emit`. `broadcast::error::RecvError::Lagged`
+each consuming the provider's `event_stream()` and routing each
+event through `forward_event`. `broadcast::error::RecvError::Lagged`
 is already swallowed by each provider's event-stream helper, so slow
 subscribers never crash the loop — they just drop old events.
 

--- a/docs/features/dev-mock-runtime.md
+++ b/docs/features/dev-mock-runtime.md
@@ -42,6 +42,18 @@ Command handling:
 - Mutations re-emit `app-state-changed`, so interactive flows update live
 - Compatible with the Codemux browser commands (`codemux browser open http://localhost:1420`, `snapshot`, `screenshot`) for visual proof
 - Tree-shaken out of production builds; dormant under `npm run tauri:dev`
+- **Agent-chat streaming simulator** (issue #75): the seed includes a
+  `chat-streaming` workspace whose tab opens directly on an
+  `agent_chat` pane (`enable_agent_chat` is ON in the mock flags).
+  The mock implements `agent_chat_start_session` / `agent_chat_send_turn`
+  plus the per-thread channel pair
+  `attach_agent_chat_output` / `detach_agent_chat_output`, and answers
+  each turn by streaming token-by-token `content_delta` frames through
+  the registered `@tauri-apps/api` `Channel` — same ordered
+  `{ index, message }` dispatch the real IPC layer uses — followed by
+  `item_completed` / `turn_completed` / `session_state_changed`. This
+  exercises the real chat pane, reducer, and channel machinery in
+  plain-browser dev.
 
 ## Current Constraints
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codemux",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codemux",
-      "version": "0.7.7",
+      "version": "0.8.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -13,9 +13,12 @@
 //! any session is bound to it. Provider-session commands and the
 //! event bridge land in follow-up commits.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
+use tauri::ipc::Channel;
 use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 
 use crate::agent_provider::{
@@ -27,17 +30,27 @@ use crate::database::{AgentChatSessionRecord, DatabaseStore};
 use crate::observability::ObservabilityStore;
 use crate::state::AppStateStore;
 
-/// Event name emitted by the backend whenever a provider produces a
-/// runtime event. The frontend's `useAgentChatEvents` hook subscribes
-/// to this channel and filters by `thread_id`.
+/// Event name used for the few provider events that are NOT scoped to
+/// a single thread (global `RuntimeWarning`s with no `thread_id`).
+///
+/// Thread-scoped events — including the high-frequency streaming
+/// `content_delta` tokens — do NOT ride this global event bus anymore.
+/// They are routed per-thread through a `tauri::ipc::Channel`
+/// registered via [`attach_agent_chat_output`], mirroring how PTY
+/// output streams through `attach_pty_output` (see
+/// `terminal/mod.rs`). Tauri's event system is JSON-broadcast to every
+/// listener and not designed for high-throughput streaming; Channels
+/// are the documented mechanism for exactly this case.
 pub const AGENT_CHAT_EVENT: &str = "agent_chat_event";
 
-/// Payload emitted on the [`AGENT_CHAT_EVENT`] Tauri channel.
+/// Payload delivered to the frontend for every provider runtime event.
 ///
-/// Carries the originating thread id alongside the raw canonical
-/// event so subscribers can filter without re-parsing the payload.
-/// Events that are not scoped to a single thread (global
-/// `RuntimeWarning`s) are emitted with an empty `ThreadId`.
+/// Thread-scoped events arrive over the per-thread `Channel` attached
+/// via [`attach_agent_chat_output`]; events without a thread id
+/// (global `RuntimeWarning`s) are emitted on the [`AGENT_CHAT_EVENT`]
+/// event bus with an empty `ThreadId`. The shape is identical on both
+/// transports so the frontend reducer does not care which path an
+/// event took.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentChatEventPayload {
     pub thread_id: ThreadId,
@@ -132,6 +145,127 @@ impl ProviderRegistry {
         }
         out
     }
+}
+
+// ── Per-thread live event channels ───────────────────────────────────
+
+/// A live subscriber for one thread's runtime events.
+struct AgentChatChannelEntry {
+    channel: Channel<AgentChatEventPayload>,
+    /// Attach generation minted by the registry. A detach only removes
+    /// the entry when its generation matches, so a stale detach from a
+    /// pane that already lost the thread (unmount racing a remount, or
+    /// a second pane re-attaching the same thread) can never tear down
+    /// the channel a newer subscriber just installed. Same guard idea
+    /// as `SessionRuntime::output_channel_generation` on the PTY path.
+    generation: u64,
+}
+
+/// Registry of per-thread frontend event channels (Tauri-managed
+/// state).
+///
+/// Analogous to `SessionRuntime.output_channel` in `terminal/mod.rs`:
+/// when a chat pane mounts with a bound thread it invokes
+/// [`attach_agent_chat_output`] with a fresh `Channel`; the event
+/// bridge ([`forward_event`]) then routes that thread's live events —
+/// crucially the high-frequency `content_delta` token stream — to
+/// exactly that channel instead of broadcasting them app-wide.
+///
+/// Replay split (decided in issue #75): the channel carries **live
+/// events only**. Transcript-affecting events are persisted to SQLite
+/// by `forward_event` regardless of whether a channel is attached, and
+/// a late-attaching / resumed pane rebuilds history through the
+/// existing DB hydrate (`agent_chat_list_messages` +
+/// `hydrateThread`). Events that fire while no channel is attached and
+/// that are not persisted (lifecycle notices like
+/// `session_state_changed`) are dropped — exactly the behaviour the
+/// event-bus path had for unmounted panes, where no listener was
+/// registered to hear them.
+#[derive(Default)]
+pub struct AgentChatChannelRegistry {
+    channels: Mutex<HashMap<String, AgentChatChannelEntry>>,
+    next_generation: AtomicU64,
+}
+
+impl AgentChatChannelRegistry {
+    /// Install `channel` as the live subscriber for `thread_id`,
+    /// replacing any previous subscriber (newest pane wins, like a PTY
+    /// reattach). Returns the generation token the caller must hand
+    /// back to [`detach`](Self::detach).
+    pub fn attach(
+        &self,
+        thread_id: &str,
+        channel: Channel<AgentChatEventPayload>,
+    ) -> u64 {
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed) + 1;
+        let mut channels = self.channels.lock().expect("channel registry poisoned");
+        channels.insert(
+            thread_id.to_string(),
+            AgentChatChannelEntry {
+                channel,
+                generation,
+            },
+        );
+        generation
+    }
+
+    /// Remove the subscriber for `thread_id`, but only when
+    /// `generation` still matches the installed entry. Returns whether
+    /// an entry was actually removed. Idempotent: detaching an unknown
+    /// thread or a superseded generation is a no-op.
+    pub fn detach(&self, thread_id: &str, generation: u64) -> bool {
+        let mut channels = self.channels.lock().expect("channel registry poisoned");
+        match channels.get(thread_id) {
+            Some(entry) if entry.generation == generation => {
+                channels.remove(thread_id);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Clone the live channel for `thread_id`, if any. Cloning is
+    /// cheap (the `Channel` is internally ref-counted) and keeps the
+    /// lock scope tight on the hot streaming path.
+    pub fn channel_for(&self, thread_id: &str) -> Option<Channel<AgentChatEventPayload>> {
+        let channels = self.channels.lock().expect("channel registry poisoned");
+        channels.get(thread_id).map(|entry| entry.channel.clone())
+    }
+}
+
+/// Register a per-thread `Channel` that will receive every live
+/// runtime event for `thread_id` (see [`AgentChatChannelRegistry`]).
+/// Returns the attach generation; the frontend passes it back to
+/// [`detach_agent_chat_output`] on unmount so a stale detach cannot
+/// clobber a newer attach.
+///
+/// Not gated on `enable_agent_chat`, same rationale as
+/// `agent_chat_list_messages`: a pane bound to a session that predates
+/// a flag flip-off must still be able to stream/teardown cleanly, and
+/// attaching is side-effect-free beyond the registry entry.
+#[tauri::command]
+pub fn attach_agent_chat_output(
+    channels: State<'_, AgentChatChannelRegistry>,
+    thread_id: String,
+    channel: Channel<AgentChatEventPayload>,
+) -> Result<u64, String> {
+    if thread_id.is_empty() {
+        return Err("validation_error: thread_id cannot be empty".to_string());
+    }
+    Ok(channels.attach(&thread_id, channel))
+}
+
+/// Tear down the per-thread channel installed by
+/// [`attach_agent_chat_output`]. Idempotent; a mismatched generation
+/// (a newer pane re-attached first) is a silent no-op.
+#[tauri::command]
+pub fn detach_agent_chat_output(
+    channels: State<'_, AgentChatChannelRegistry>,
+    thread_id: String,
+    generation: u64,
+) -> Result<(), String> {
+    channels.detach(&thread_id, generation);
+    Ok(())
 }
 
 fn provider_err(err: ProviderError) -> String {
@@ -697,9 +831,11 @@ pub async fn agent_chat_list_messages(
 /// Start the provider-event forwarding tasks.
 ///
 /// Spawns one Tokio task per registered provider. Each task consumes
-/// the provider's canonical event stream and re-emits each event on
-/// the [`AGENT_CHAT_EVENT`] Tauri channel wrapped in an
-/// [`AgentChatEventPayload`]. When a provider's stream ends (on
+/// the provider's canonical event stream and forwards each event to
+/// the frontend wrapped in an [`AgentChatEventPayload`] —
+/// thread-scoped events go to the thread's attached `Channel` (see
+/// [`AgentChatChannelRegistry`]), thread-less ones to the
+/// [`AGENT_CHAT_EVENT`] event bus. When a provider's stream ends (on
 /// shutdown) the task exits cleanly; the `event_stream()` helper on
 /// each provider already swallows `broadcast::error::RecvError::Lagged`
 /// and continues, so slow subscribers never crash this loop.
@@ -728,7 +864,16 @@ pub async fn spawn_event_bridge<R: Runtime>(app: AppHandle<R>) {
     }
 }
 
-/// Emit a single provider event to the frontend.
+/// Forward a single provider event to the frontend.
+///
+/// Routing:
+/// - thread-scoped events → the thread's live `Channel`, when one is
+///   attached (high-throughput path; carries the `content_delta`
+///   token stream). No channel attached → the event is dropped after
+///   persistence; a late-attaching pane recovers transcript state via
+///   the DB hydrate.
+/// - thread-less events (global `RuntimeWarning`) → the
+///   [`AGENT_CHAT_EVENT`] global event bus, unchanged.
 ///
 /// Extracted so tests can exercise the translation without spinning a
 /// Tokio task or a real provider. Also used as the inner loop of
@@ -791,9 +936,33 @@ pub fn forward_event<R: Runtime>(app: &AppHandle<R>, event: ProviderRuntimeEvent
         // forwarded with an empty ThreadId so the frontend at least
         // sees them; a richer global-warning channel is a follow-up.
         .unwrap_or_else(|| ThreadId(String::new()));
-    let payload = AgentChatEventPayload { thread_id, event };
-    if let Err(error) = app.emit(AGENT_CHAT_EVENT, &payload) {
-        eprintln!("[codemux::agent_chat] Failed to emit {AGENT_CHAT_EVENT}: {error}");
+    let payload = AgentChatEventPayload {
+        thread_id: thread_id.clone(),
+        event,
+    };
+    if thread_id.0.is_empty() {
+        // Thread-less lifecycle/warning traffic is low-frequency; the
+        // global event bus stays the simplest transport for it.
+        if let Err(error) = app.emit(AGENT_CHAT_EVENT, &payload) {
+            eprintln!(
+                "[codemux::agent_chat] Failed to emit {AGENT_CHAT_EVENT}: {error}"
+            );
+        }
+        return;
+    }
+    // Thread-scoped events (incl. the content_delta token stream) go
+    // over the per-thread Channel only — never the global bus. A
+    // missing channel means no pane is currently attached to this
+    // thread; transcript events were already persisted above, so the
+    // DB hydrate replays them on (re)attach.
+    let channels: State<'_, AgentChatChannelRegistry> = app.state();
+    if let Some(channel) = channels.channel_for(&thread_id.0) {
+        if let Err(error) = channel.send(payload) {
+            eprintln!(
+                "[codemux::agent_chat] Failed to send event on thread channel {}: {error}",
+                thread_id.0
+            );
+        }
     }
 }
 
@@ -1051,6 +1220,143 @@ mod tests {
             original_payload: None,
         };
         assert!(!should_persist_event(&e));
+    }
+
+    // ── AgentChatChannelRegistry ──
+    //
+    // Pure registry semantics; the end-to-end routing through
+    // forward_event (incl. DB persistence side effects and the
+    // thread-less event-bus fallback) lives in
+    // tests/agent_chat_commands.rs where a mock app handle exists.
+
+    /// Real `tauri::ipc::Channel` whose handler captures every decoded
+    /// payload — same pattern as the terminal module's channel tests.
+    fn capture_channel() -> (
+        Channel<AgentChatEventPayload>,
+        Arc<Mutex<Vec<AgentChatEventPayload>>>,
+    ) {
+        let captured: Arc<Mutex<Vec<AgentChatEventPayload>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let captured_handler = captured.clone();
+        let channel = Channel::new(move |body| {
+            let payload = body
+                .deserialize::<AgentChatEventPayload>()
+                .expect("decode AgentChatEventPayload");
+            captured_handler.lock().unwrap().push(payload);
+            Ok(())
+        });
+        (channel, captured)
+    }
+
+    fn delta_payload(thread: &str, text: &str) -> AgentChatEventPayload {
+        AgentChatEventPayload {
+            thread_id: ThreadId(thread.into()),
+            event: ProviderRuntimeEvent::ContentDelta {
+                thread_id: ThreadId(thread.into()),
+                turn_id: turn(),
+                delta: ContentDelta::Text { text: text.into() },
+            },
+        }
+    }
+
+    #[test]
+    fn registry_attach_routes_sends_through_channel() {
+        let registry = AgentChatChannelRegistry::default();
+        let (channel, captured) = capture_channel();
+        registry.attach("t1", channel);
+
+        let live = registry.channel_for("t1").expect("channel installed");
+        live.send(delta_payload("t1", "hello")).expect("send ok");
+
+        let received = captured.lock().unwrap();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].thread_id.0, "t1");
+        match &received[0].event {
+            ProviderRuntimeEvent::ContentDelta { delta, .. } => match delta {
+                ContentDelta::Text { text } => assert_eq!(text, "hello"),
+                other => panic!("unexpected delta: {other:?}"),
+            },
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn registry_channel_for_unknown_thread_is_none() {
+        let registry = AgentChatChannelRegistry::default();
+        assert!(registry.channel_for("nope").is_none());
+    }
+
+    #[test]
+    fn registry_newest_attach_wins() {
+        let registry = AgentChatChannelRegistry::default();
+        let (first, first_captured) = capture_channel();
+        let (second, second_captured) = capture_channel();
+        let g1 = registry.attach("t1", first);
+        let g2 = registry.attach("t1", second);
+        assert_ne!(g1, g2, "each attach mints a fresh generation");
+
+        registry
+            .channel_for("t1")
+            .expect("channel installed")
+            .send(delta_payload("t1", "x"))
+            .expect("send ok");
+
+        assert!(
+            first_captured.lock().unwrap().is_empty(),
+            "superseded channel must not receive events"
+        );
+        assert_eq!(second_captured.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn registry_detach_with_stale_generation_is_noop() {
+        let registry = AgentChatChannelRegistry::default();
+        let (first, _) = capture_channel();
+        let (second, second_captured) = capture_channel();
+        let stale = registry.attach("t1", first);
+        let _current = registry.attach("t1", second);
+
+        // The unmounting pane that owned `first` detaches late — the
+        // newer subscriber must survive.
+        assert!(!registry.detach("t1", stale));
+        registry
+            .channel_for("t1")
+            .expect("newer channel still installed")
+            .send(delta_payload("t1", "still-live"))
+            .expect("send ok");
+        assert_eq!(second_captured.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn registry_detach_with_current_generation_removes() {
+        let registry = AgentChatChannelRegistry::default();
+        let (channel, _) = capture_channel();
+        let generation = registry.attach("t1", channel);
+        assert!(registry.detach("t1", generation));
+        assert!(registry.channel_for("t1").is_none());
+        // Idempotent on repeat.
+        assert!(!registry.detach("t1", generation));
+    }
+
+    #[test]
+    fn registry_threads_are_independent() {
+        let registry = AgentChatChannelRegistry::default();
+        let (a, a_captured) = capture_channel();
+        let (b, b_captured) = capture_channel();
+        registry.attach("thread-a", a);
+        registry.attach("thread-b", b);
+
+        registry
+            .channel_for("thread-a")
+            .unwrap()
+            .send(delta_payload("thread-a", "for-a"))
+            .unwrap();
+
+        assert_eq!(a_captured.lock().unwrap().len(), 1);
+        assert!(
+            b_captured.lock().unwrap().is_empty(),
+            "no cross-thread leakage"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -182,6 +182,12 @@ pub fn run() {
         .manage(encryption::EncryptionManager::default())
         .manage(skills_sync::SyncEngine::new())
         .manage(commands::agent_chat::ProviderRegistry::new())
+        // Per-thread live event channels for the chat pane: each
+        // mounted pane attaches a tauri::ipc::Channel keyed by
+        // thread_id; forward_event routes that thread's runtime
+        // events (incl. the content_delta token stream) to it instead
+        // of broadcasting on the global event bus. See issue #75.
+        .manage(commands::agent_chat::AgentChatChannelRegistry::default())
         // Step 12 Stage 2 — singleton supervisor for the lazily
         // spawned `opencode serve` child. `ensure_running()` is the
         // entry point used by `opencode_list_models`; the server is
@@ -1487,6 +1493,8 @@ pub fn run() {
             commands::agent_chat_rename_session,
             commands::agent_chat_delete_session,
             commands::agent_chat_list_messages,
+            commands::attach_agent_chat_output,
+            commands::detach_agent_chat_output,
             commands::opencode_check_availability,
             commands::opencode_ping,
             commands::opencode_list_models,

--- a/src-tauri/tests/agent_chat_commands.rs
+++ b/src-tauri/tests/agent_chat_commands.rs
@@ -25,7 +25,8 @@ mod mock_agent_provider;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tauri::Listener;
+use tauri::ipc::Channel;
+use tauri::{Listener, State};
 use tokio::time::timeout;
 
 use codemux_lib::agent_provider::{
@@ -33,8 +34,8 @@ use codemux_lib::agent_provider::{
     SendTurnInput, StartSessionInput, ThreadId, TurnId,
 };
 use codemux_lib::commands::agent_chat::{
-    feature_flag_on, forward_event, thread_id_for_event, AgentChatEventPayload,
-    ProviderRegistry, AGENT_CHAT_EVENT, FEATURE_DISABLED_ERROR,
+    feature_flag_on, forward_event, thread_id_for_event, AgentChatChannelRegistry,
+    AgentChatEventPayload, ProviderRegistry, AGENT_CHAT_EVENT, FEATURE_DISABLED_ERROR,
 };
 use codemux_lib::database::DatabaseStore;
 use codemux_lib::observability::{FeatureFlags, ObservabilityStore};
@@ -324,40 +325,64 @@ fn thread_id_for_event_extracts_bound_threads() {
     );
 }
 
-#[tokio::test]
-async fn event_bridge_forwards_runtime_events_to_tauri() {
-    // Build a MockRuntime app, subscribe to the agent_chat_event
-    // channel, and verify that forwarding a runtime event through
-    // forward_event produces a matching AgentChatEventPayload.
-    //
-    // forward_event persists ItemCompleted via DatabaseStore::append_*,
-    // so the mock app must manage a DatabaseStore or `app.state::<…>`
-    // panics with "state() called before manage()". An in-memory store
-    // is sufficient — we're only asserting on the emitted event, not
-    // on what gets written to disk.
+/// Build a MockRuntime app with the managed state `forward_event`
+/// touches: an in-memory DatabaseStore (transcript persistence) and
+/// the per-thread channel registry (issue #75 routing).
+fn mock_app_with_chat_state() -> tauri::App<tauri::test::MockRuntime> {
     let app = tauri::test::mock_app();
     app.manage(DatabaseStore::new_in_memory());
+    app.manage(AgentChatChannelRegistry::default());
+    app
+}
+
+/// Real `tauri::ipc::Channel` whose handler decodes and captures every
+/// payload, mirroring what the frontend's `useAgentChatEvents` channel
+/// receives.
+fn capture_channel() -> (
+    Channel<AgentChatEventPayload>,
+    Arc<std::sync::Mutex<Vec<AgentChatEventPayload>>>,
+) {
+    let captured: Arc<std::sync::Mutex<Vec<AgentChatEventPayload>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let captured_handler = captured.clone();
+    let channel = Channel::new(move |body| {
+        let payload = body
+            .deserialize::<AgentChatEventPayload>()
+            .expect("decode AgentChatEventPayload");
+        captured_handler.lock().unwrap().push(payload);
+        Ok(())
+    });
+    (channel, captured)
+}
+
+fn text_delta(thread: &str, text: &str) -> ProviderRuntimeEvent {
+    ProviderRuntimeEvent::ContentDelta {
+        thread_id: ThreadId(thread.into()),
+        turn_id: TurnId("turn-1".into()),
+        delta: codemux_lib::agent_provider::ContentDelta::Text { text: text.into() },
+    }
+}
+
+#[tokio::test]
+async fn event_bridge_routes_thread_events_to_attached_channel() {
+    // Thread-scoped events must arrive over the per-thread Channel —
+    // and must NOT be broadcast on the global agent_chat_event bus.
+    let app = mock_app_with_chat_state();
     let handle = app.handle().clone();
 
-    let received: Arc<tokio::sync::Mutex<Vec<AgentChatEventPayload>>> =
-        Arc::new(tokio::sync::Mutex::new(Vec::new()));
-    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-    let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
-
-    let received_clone = received.clone();
-    let tx_clone = tx.clone();
+    // Bus spy: any thread-scoped event landing here is a regression.
+    let bus_hits = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let bus_hits_clone = bus_hits.clone();
     handle.listen(AGENT_CHAT_EVENT, move |event| {
-        let payload: AgentChatEventPayload =
-            serde_json::from_str(event.payload()).expect("valid payload JSON");
-        let received = received_clone.clone();
-        let tx = tx_clone.clone();
-        tauri::async_runtime::spawn(async move {
-            received.lock().await.push(payload);
-            if let Some(tx) = tx.lock().unwrap().take() {
-                let _ = tx.send(());
-            }
-        });
+        bus_hits_clone
+            .lock()
+            .unwrap()
+            .push(event.payload().to_string());
     });
+
+    let registry: State<'_, AgentChatChannelRegistry> = handle.state();
+    let (channel, captured) = capture_channel();
+    registry.attach("thread-bridge", channel);
 
     let event = ProviderRuntimeEvent::ItemCompleted {
         thread_id: ThreadId("thread-bridge".into()),
@@ -368,13 +393,10 @@ async fn event_bridge_forwards_runtime_events_to_tauri() {
     };
     forward_event(&handle, event);
 
-    timeout(Duration::from_secs(2), rx)
-        .await
-        .expect("listener should fire within 2s")
-        .expect("one-shot sender should send before dropping");
-
-    let received = received.lock().await;
-    assert_eq!(received.len(), 1, "exactly one event should be received");
+    // Channel delivery is synchronous in the mock runtime (the closure
+    // runs inline inside send), so the capture is observable now.
+    let received = captured.lock().unwrap();
+    assert_eq!(received.len(), 1, "exactly one event over the channel");
     assert_eq!(received[0].thread_id.0, "thread-bridge");
     match &received[0].event {
         ProviderRuntimeEvent::ItemCompleted { thread_id, .. } => {
@@ -382,4 +404,196 @@ async fn event_bridge_forwards_runtime_events_to_tauri() {
         }
         other => panic!("unexpected event variant: {other:?}"),
     }
+    drop(received);
+
+    // Give the (async) event bus a moment, then assert silence.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(
+        bus_hits.lock().unwrap().is_empty(),
+        "thread-scoped events must not ride the global event bus"
+    );
+}
+
+#[tokio::test]
+async fn event_bridge_isolates_threads_and_preserves_order() {
+    // Two panes attached to two threads: each receives only its own
+    // thread's token stream, in emission order.
+    let app = mock_app_with_chat_state();
+    let handle = app.handle().clone();
+
+    let registry: State<'_, AgentChatChannelRegistry> = handle.state();
+    let (channel_a, captured_a) = capture_channel();
+    let (channel_b, captured_b) = capture_channel();
+    registry.attach("thread-a", channel_a);
+    registry.attach("thread-b", channel_b);
+
+    for i in 0..50 {
+        forward_event(&handle, text_delta("thread-a", &format!("a{i}")));
+        forward_event(&handle, text_delta("thread-b", &format!("b{i}")));
+    }
+
+    let a = captured_a.lock().unwrap();
+    let b = captured_b.lock().unwrap();
+    assert_eq!(a.len(), 50, "pane A sees exactly its own 50 deltas");
+    assert_eq!(b.len(), 50, "pane B sees exactly its own 50 deltas");
+    for (i, payload) in a.iter().enumerate() {
+        assert_eq!(payload.thread_id.0, "thread-a", "no cross-thread leakage");
+        match &payload.event {
+            ProviderRuntimeEvent::ContentDelta { delta, .. } => match delta {
+                codemux_lib::agent_provider::ContentDelta::Text { text } => {
+                    assert_eq!(text, &format!("a{i}"), "ordering preserved");
+                }
+                other => panic!("unexpected delta: {other:?}"),
+            },
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+    for payload in b.iter() {
+        assert_eq!(payload.thread_id.0, "thread-b", "no cross-thread leakage");
+    }
+}
+
+#[tokio::test]
+async fn event_bridge_persists_transcript_even_without_channel() {
+    // The replay-semantics split: transcript events are persisted to
+    // the DB regardless of whether a pane is attached, so a
+    // late-attaching pane can hydrate the full transcript and the
+    // channel only ever needs to carry live events.
+    let app = mock_app_with_chat_state();
+    let handle = app.handle().clone();
+
+    // append_agent_chat_message silently drops rows whose parent
+    // session is missing (FK), so seed the session row the way
+    // agent_chat_start_session does.
+    {
+        let db: State<'_, DatabaseStore> = handle.state();
+        db.upsert_agent_chat_session("thread-unattached", "ws-1", None, "claude")
+            .expect("seed session row");
+    }
+
+    let event = ProviderRuntimeEvent::ItemCompleted {
+        thread_id: ThreadId("thread-unattached".into()),
+        turn_id: TurnId("turn-1".into()),
+        item: CompletedItem::AssistantText {
+            text: "persisted while nobody watched".into(),
+        },
+    };
+    // No channel attached — must not panic, must still persist.
+    forward_event(&handle, event);
+
+    let db: State<'_, DatabaseStore> = handle.state();
+    let messages = db.list_agent_chat_messages("thread-unattached");
+    assert_eq!(messages.len(), 1, "transcript persisted without subscriber");
+    assert!(messages[0].contains("persisted while nobody watched"));
+}
+
+#[tokio::test]
+async fn event_bridge_emits_threadless_warnings_on_event_bus() {
+    // Global RuntimeWarnings have no thread to route by; they keep the
+    // low-frequency global event bus.
+    let app = mock_app_with_chat_state();
+    let handle = app.handle().clone();
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<AgentChatEventPayload>();
+    let tx = Arc::new(std::sync::Mutex::new(Some(tx)));
+    handle.listen(AGENT_CHAT_EVENT, move |event| {
+        let payload: AgentChatEventPayload =
+            serde_json::from_str(event.payload()).expect("valid payload JSON");
+        if let Some(tx) = tx.lock().unwrap().take() {
+            let _ = tx.send(payload);
+        }
+    });
+
+    forward_event(
+        &handle,
+        ProviderRuntimeEvent::RuntimeWarning {
+            thread_id: None,
+            message: "global warning".into(),
+            original_payload: None,
+        },
+    );
+
+    let payload = timeout(Duration::from_secs(2), rx)
+        .await
+        .expect("bus listener should fire within 2s")
+        .expect("one-shot sender should send before dropping");
+    assert_eq!(payload.thread_id.0, "", "thread-less payload has empty id");
+    match payload.event {
+        ProviderRuntimeEvent::RuntimeWarning { message, .. } => {
+            assert_eq!(message, "global warning");
+        }
+        other => panic!("unexpected event variant: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn full_bridge_pipeline_streams_provider_events_per_thread() {
+    // End-to-end through the real pipeline: provider broadcast →
+    // spawn_event_bridge task → forward_event → per-thread Channel.
+    // This is the same path a live Claude/Codex session takes, with
+    // only the provider mocked.
+    let app = mock_app_with_chat_state();
+    app.manage(ProviderRegistry::new());
+    let handle = app.handle().clone();
+
+    let registry: State<'_, ProviderRegistry> = handle.state();
+    let provider = Arc::new(MockAgentProvider::new(ProviderKind::Claude));
+    registry.set_claude(provider.clone() as _).await;
+
+    codemux_lib::commands::agent_chat::spawn_event_bridge(handle.clone()).await;
+
+    let channels: State<'_, AgentChatChannelRegistry> = handle.state();
+    let (channel_a, captured_a) = capture_channel();
+    let (channel_b, captured_b) = capture_channel();
+    channels.attach("pipe-a", channel_a);
+    channels.attach("pipe-b", channel_b);
+
+    // Interleave token streams for two threads plus a completion.
+    for i in 0..20 {
+        provider.emit(text_delta("pipe-a", &format!("tok-a{i}")));
+        provider.emit(text_delta("pipe-b", &format!("tok-b{i}")));
+    }
+    provider.emit(ProviderRuntimeEvent::ItemCompleted {
+        thread_id: ThreadId("pipe-a".into()),
+        turn_id: TurnId("turn-1".into()),
+        item: CompletedItem::AssistantText {
+            text: "done".into(),
+        },
+    });
+
+    // The bridge task consumes the broadcast asynchronously — poll
+    // until everything has flowed through (bounded by a timeout).
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if captured_a.lock().unwrap().len() == 21
+                && captured_b.lock().unwrap().len() == 20
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("bridge should deliver all events within 5s");
+
+    let a = captured_a.lock().unwrap();
+    assert!(a.iter().all(|p| p.thread_id.0 == "pipe-a"));
+    // Token ordering survives the async hop.
+    for (i, payload) in a.iter().take(20).enumerate() {
+        match &payload.event {
+            ProviderRuntimeEvent::ContentDelta { delta, .. } => match delta {
+                codemux_lib::agent_provider::ContentDelta::Text { text } => {
+                    assert_eq!(text, &format!("tok-a{i}"));
+                }
+                other => panic!("unexpected delta: {other:?}"),
+            },
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+    match &a[20].event {
+        ProviderRuntimeEvent::ItemCompleted { .. } => {}
+        other => panic!("expected trailing ItemCompleted, got {other:?}"),
+    }
+    let b = captured_b.lock().unwrap();
+    assert!(b.iter().all(|p| p.thread_id.0 == "pipe-b"));
 }

--- a/src/dev/mock-fixtures.ts
+++ b/src/dev/mock-fixtures.ts
@@ -112,6 +112,44 @@ function terminalSurface(label: string, cwd: string): PaneRefs {
   return { pane, surface, tab, session };
 }
 
+/** Build a one-chat surface (+ its tab) for a workspace: the surface
+ *  root is an `agent_chat` pane with no thread bound yet, exactly the
+ *  state `create_agent_chat_pane` leaves a fresh pane in. Mounting it
+ *  drives the full mock chat flow (start_session → attach channel →
+ *  send_turn → streamed `content_delta`s) in plain-browser dev. */
+function chatSurface(cwd: string): {
+  surface: SurfaceSnapshot;
+  tab: TabSnapshot;
+} {
+  const n = ++paneSeq;
+  const paneId = `pane-${n}`;
+  const pane: PaneNodeSnapshot = {
+    kind: "agent_chat",
+    pane_id: paneId,
+    title: "Agent Chat",
+    thread_id: null,
+    provider: "claude",
+    cwd,
+  };
+  const surface: SurfaceSnapshot = {
+    surface_id: `surface-${n}`,
+    title: "Agent Chat",
+    root: pane,
+    active_pane_id: paneId,
+  };
+  const tab: TabSnapshot = {
+    tab_id: `tab-${n}`,
+    // The real backend files chat tabs under TabKind::Terminal too
+    // (state_impl.rs::create_agent_chat_pane).
+    kind: "terminal",
+    title: "Agent Chat",
+    surface_id: surface.surface_id,
+    browser_id: null,
+    icon: null,
+  };
+  return { surface, tab };
+}
+
 interface WorkspaceSeed extends Partial<WorkspaceSnapshot> {
   workspace_id: string;
   title: string;
@@ -261,6 +299,32 @@ const wsCodemuxMock = makeWorkspace({
   git_changed_files: 6,
 });
 
+/** Chat workspace: its tab opens directly on an `agent_chat` pane so
+ *  the per-thread Channel streaming path (issue #75) is exercisable
+ *  in plain-browser dev. The extra chat surface REPLACES the default
+ *  terminal surface from `makeWorkspace`. */
+const wsCodemuxChat = (() => {
+  const cwd = `${HOME}/.codemux/worktrees/codemux/feature-75-chat-channel`;
+  const ws = makeWorkspace({
+    workspace_id: "ws-codemux-chat",
+    title: "chat-streaming",
+    cwd,
+    worktree_path: cwd,
+    project_root: codemuxRoot,
+    project_uid: codemuxUid,
+    workspace_kind: "worktree",
+    git_branch: "feature/75-chat-channel",
+  });
+  const { surface, tab } = chatSurface(cwd);
+  return {
+    ...ws,
+    tabs: [tab],
+    active_tab_id: tab.tab_id,
+    active_surface_id: surface.surface_id,
+    surfaces: [surface],
+  };
+})();
+
 const wsCodemuxPorts = makeWorkspace({
   workspace_id: "ws-codemux-ports",
   title: "port-detection",
@@ -377,6 +441,7 @@ const ALL_WORKSPACES: WorkspaceSnapshot[] = [
   wsCodemuxAuth,
   wsCodemuxSidebar,
   wsCodemuxMock,
+  wsCodemuxChat,
   wsCodemuxPorts,
   wsVexisMain,
   wsVexisCuda,

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -154,13 +154,119 @@ function pushMockTerminalBanner(channel: unknown): void {
   }
 }
 
+// ── Agent chat: per-thread Channel streaming simulator ─────────────
+//
+// Mirrors the issue #75 backend: a chat pane registers a
+// `tauri::ipc::Channel` per thread via `attach_agent_chat_output`,
+// and live runtime events — crucially the `content_delta` token
+// stream — arrive over that channel only (never the global event
+// bus). The mock keeps a thread→channel map and pushes ordered
+// `{ index, message }` frames through the channel's
+// `transformCallback` dispatcher, exactly like the real IPC layer, so
+// the unmodified `@tauri-apps/api` Channel machinery (ordering buffer
+// included) runs for real in browser dev.
+
+interface MockChatChannelEntry {
+  /** The `@tauri-apps/api` Channel object passed by the frontend. */
+  channel: unknown;
+  /** Attach generation; detach only removes on match (issue #75). */
+  generation: number;
+  /** Next ordered frame index for this channel. */
+  nextIndex: number;
+}
+
+const chatChannels = new Map<string, MockChatChannelEntry>();
+let chatChannelGeneration = 0;
+let chatTurnSeq = 0;
+
+function chatChannelPush(entry: MockChatChannelEntry, payload: unknown): void {
+  const id = (entry.channel as { id?: number } | undefined)?.id;
+  if (typeof id !== "number") return;
+  const cb = callbacks.get(id);
+  if (!cb) return;
+  try {
+    cb.fn({ index: entry.nextIndex++, message: payload } as unknown as never);
+  } catch (err) {
+    console.error("[dev mock] chat channel push threw:", err);
+  }
+}
+
+/** Route one runtime event to the thread's attached channel — the
+ *  mock twin of `forward_event`'s channel arm. No channel → drop. */
+function emitChatEvent(threadId: string, event: unknown): void {
+  const entry = chatChannels.get(threadId);
+  if (!entry) return;
+  chatChannelPush(entry, { thread_id: threadId, event });
+}
+
+const chatSleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Simulate a full agent turn: running → token-by-token
+ *  `content_delta`s → `item_completed` → `turn_completed` → ready. */
+async function streamMockChatReply(
+  threadId: string,
+  turnId: string,
+  userText: string,
+): Promise<void> {
+  emitChatEvent(threadId, {
+    type: "session_state_changed",
+    thread_id: threadId,
+    status: { status: "running", active_turn: turnId },
+  });
+  const reply =
+    "Streaming from the dev mock over a per-thread Tauri Channel — " +
+    "every token in this reply arrived as its own `content_delta` " +
+    "frame through the same `@tauri-apps/api` Channel dispatcher the " +
+    "real backend uses.\n\n" +
+    `You said: “${userText.trim().slice(0, 120)}”. ` +
+    "In a real session this text would come from the provider " +
+    "sidecar; run `npm run tauri:dev` for live IPC.";
+  const tokens = reply.match(/\S+\s*/g) ?? [];
+  let assembled = "";
+  for (const token of tokens) {
+    await chatSleep(24);
+    assembled += token;
+    emitChatEvent(threadId, {
+      type: "content_delta",
+      thread_id: threadId,
+      turn_id: turnId,
+      delta: { kind: "text", text: token },
+    });
+  }
+  emitChatEvent(threadId, {
+    type: "item_completed",
+    thread_id: threadId,
+    turn_id: turnId,
+    item: { kind: "assistant_text", text: assembled },
+  });
+  emitChatEvent(threadId, {
+    type: "turn_completed",
+    thread_id: threadId,
+    turn_id: turnId,
+    status: { kind: "success" },
+    usage: {
+      total_cost_usd: null,
+      duration_ms: tokens.length * 24,
+      num_turns: 1,
+    },
+  });
+  emitChatEvent(threadId, {
+    type: "session_state_changed",
+    thread_id: threadId,
+    status: { status: "ready" },
+  });
+}
+
 // ── Static command returns ──────────────────────────────────────────
 
 const FEATURE_FLAGS: FeatureFlags = {
   unstable_openflow: false,
   unstable_browser_automation: false,
   unstable_indexing: false,
-  enable_agent_chat: false,
+  // ON so the seeded `agent_chat` pane (ws-codemux-chat) mounts the
+  // real chat UI and exercises the per-thread Channel streaming path
+  // (issue #75) against the mock token-stream simulator below.
+  enable_agent_chat: true,
   enable_lazy_workspace_creation: false,
 };
 
@@ -310,8 +416,54 @@ const handlers: Record<string, Handler> = {
   // ── Resource monitor ──
   get_resource_metrics: () => resourceMetrics(),
 
-  // ── Agent chat capabilities (gated off, returned safe anyway) ──
+  // ── Agent chat ──
   list_chat_provider_capabilities: () => EMPTY_CAPABILITIES,
+
+  // Session lifecycle: echo back the frontend-minted thread id, and
+  // answer the turn with the channel-streamed mock reply.
+  agent_chat_start_session: (a) => {
+    const input = a.input as { thread_id: string } | undefined;
+    if (!input?.thread_id) throw new Error("mock: missing thread_id");
+    return input.thread_id;
+  },
+  agent_chat_send_turn: (a) => {
+    const input = a.input as { thread_id: string; text: string } | undefined;
+    if (!input?.thread_id) throw new Error("mock: missing thread_id");
+    const turnId = `mock-turn-${++chatTurnSeq}`;
+    void streamMockChatReply(input.thread_id, turnId, input.text ?? "");
+    return turnId;
+  },
+  agent_chat_interrupt_turn: () => undefined,
+  agent_chat_stop_session: () => undefined,
+  agent_chat_set_model: () => undefined,
+  agent_chat_set_permission_mode: () => undefined,
+  agent_chat_respond_to_request: () => undefined,
+  agent_chat_list_sessions: () => [],
+  agent_chat_list_messages: () => [],
+  grep_count_pattern: () => 0,
+
+  // ── Agent chat per-thread event channel (issue #75) ──
+  // Mirrors AgentChatChannelRegistry: newest attach wins, detach is
+  // generation-guarded so a stale unmount can't tear down a newer
+  // pane's channel.
+  attach_agent_chat_output: (a) => {
+    const threadId = a.threadId as string;
+    const generation = ++chatChannelGeneration;
+    chatChannels.set(threadId, {
+      channel: a.channel,
+      generation,
+      nextIndex: 0,
+    });
+    return generation;
+  },
+  detach_agent_chat_output: (a) => {
+    const threadId = a.threadId as string;
+    const entry = chatChannels.get(threadId);
+    if (entry && entry.generation === a.generation) {
+      chatChannels.delete(threadId);
+    }
+    return undefined;
+  },
 
   // ── Presets ──
   get_presets: () => EMPTY_PRESETS,

--- a/src/hooks/use-agent-chat-events.test.tsx
+++ b/src/hooks/use-agent-chat-events.test.tsx
@@ -1,0 +1,175 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+import type { AgentChatEventPayload } from "@/tauri/events";
+
+/**
+ * Fake of the `@tauri-apps/api` Channel re-exported by
+ * `@/tauri/commands`: captures the onmessage handler so tests can
+ * push payloads as if the backend had routed events to this channel.
+ * Built inside `vi.hoisted` because `vi.mock` factories are hoisted
+ * above ordinary top-level declarations.
+ */
+const { FakeChannel, attachAgentChatOutput, detachAgentChatOutput } =
+  vi.hoisted(() => {
+    class FakeChannel<T> {
+      static instances: FakeChannel<unknown>[] = [];
+      onmessage: (payload: T) => void;
+      constructor(onmessage: (payload: T) => void) {
+        this.onmessage = onmessage;
+        FakeChannel.instances.push(this as FakeChannel<unknown>);
+      }
+    }
+    return {
+      FakeChannel,
+      attachAgentChatOutput: vi.fn(),
+      detachAgentChatOutput: vi.fn(),
+    };
+  });
+
+type FakeChannel<T> = InstanceType<typeof FakeChannel<T>>;
+
+vi.mock("@/tauri/commands", () => ({
+  Channel: FakeChannel,
+  attachAgentChatOutput,
+  detachAgentChatOutput,
+}));
+
+import { useAgentChatEvents } from "./use-agent-chat-events";
+
+function payloadFor(threadId: string, text: string): AgentChatEventPayload {
+  return {
+    thread_id: threadId,
+    event: {
+      type: "content_delta",
+      thread_id: threadId,
+      turn_id: "turn-1",
+      delta: { kind: "text", text },
+    },
+  };
+}
+
+function lastChannel(): FakeChannel<AgentChatEventPayload> {
+  const channel = FakeChannel.instances[FakeChannel.instances.length - 1];
+  if (!channel) throw new Error("no channel constructed");
+  return channel as FakeChannel<AgentChatEventPayload>;
+}
+
+describe("useAgentChatEvents", () => {
+  beforeEach(() => {
+    FakeChannel.instances = [];
+    attachAgentChatOutput.mockReset().mockResolvedValue(7);
+    detachAgentChatOutput.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("does not attach when threadId is null", () => {
+    renderHook(() => useAgentChatEvents(null, vi.fn()));
+    expect(attachAgentChatOutput).not.toHaveBeenCalled();
+    expect(FakeChannel.instances).toHaveLength(0);
+  });
+
+  it("attaches a channel for the thread and dispatches payloads to the handler", async () => {
+    const handler = vi.fn();
+    renderHook(() => useAgentChatEvents("thread-1", handler));
+
+    expect(attachAgentChatOutput).toHaveBeenCalledTimes(1);
+    expect(attachAgentChatOutput).toHaveBeenCalledWith(
+      "thread-1",
+      expect.any(FakeChannel),
+    );
+
+    const payload = payloadFor("thread-1", "tok");
+    act(() => lastChannel().onmessage(payload));
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(payload);
+  });
+
+  it("filters payloads for a different thread (defense in depth)", () => {
+    const handler = vi.fn();
+    renderHook(() => useAgentChatEvents("thread-1", handler));
+
+    act(() => lastChannel().onmessage(payloadFor("thread-other", "tok")));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("detaches with the attach generation on unmount and stops dispatching", async () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() =>
+      useAgentChatEvents("thread-1", handler),
+    );
+    const channel = lastChannel();
+
+    unmount();
+    await waitFor(() =>
+      expect(detachAgentChatOutput).toHaveBeenCalledWith("thread-1", 7),
+    );
+
+    // Events racing the async detach are dropped client-side too.
+    channel.onmessage(payloadFor("thread-1", "late"));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not re-attach when only the handler identity changes", () => {
+    const { rerender } = renderHook(
+      ({ handler }: { handler: (p: AgentChatEventPayload) => void }) =>
+        useAgentChatEvents("thread-1", handler),
+      { initialProps: { handler: vi.fn() } },
+    );
+    rerender({ handler: vi.fn() });
+    expect(attachAgentChatOutput).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the latest handler without re-attaching", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ handler }: { handler: (p: AgentChatEventPayload) => void }) =>
+        useAgentChatEvents("thread-1", handler),
+      { initialProps: { handler: first } },
+    );
+    rerender({ handler: second });
+
+    act(() => lastChannel().onmessage(payloadFor("thread-1", "tok")));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-attaches when the thread id changes and detaches the old thread", async () => {
+    const handler = vi.fn();
+    const { rerender } = renderHook(
+      ({ threadId }: { threadId: string }) =>
+        useAgentChatEvents(threadId, handler),
+      { initialProps: { threadId: "thread-1" } },
+    );
+    rerender({ threadId: "thread-2" });
+
+    await waitFor(() =>
+      expect(detachAgentChatOutput).toHaveBeenCalledWith("thread-1", 7),
+    );
+    expect(attachAgentChatOutput).toHaveBeenCalledTimes(2);
+    expect(attachAgentChatOutput).toHaveBeenLastCalledWith(
+      "thread-2",
+      expect.any(FakeChannel),
+    );
+
+    act(() => lastChannel().onmessage(payloadFor("thread-2", "tok")));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips detach when attach failed", async () => {
+    attachAgentChatOutput.mockRejectedValue(new Error("backend gone"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { unmount } = renderHook(() =>
+      useAgentChatEvents("thread-1", vi.fn()),
+    );
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    unmount();
+    // Let the rejected-detach microtask settle; detach must not fire.
+    await act(async () => {});
+    expect(detachAgentChatOutput).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/src/hooks/use-agent-chat-events.ts
+++ b/src/hooks/use-agent-chat-events.ts
@@ -1,38 +1,69 @@
-import { useCallback } from "react";
+import { useEffect, useRef } from "react";
 
-import { useTauriEvent } from "@/hooks/use-tauri-event";
 import {
-  onAgentChatEvent,
-  type AgentChatEventPayload,
-  type EventCallback,
-} from "@/tauri/events";
+  attachAgentChatOutput,
+  Channel,
+  detachAgentChatOutput,
+} from "@/tauri/commands";
+import type { AgentChatEventPayload } from "@/tauri/events";
 
 /**
- * Subscribe to provider runtime events, filtered by thread id.
+ * Subscribe to provider runtime events for one thread over a
+ * per-thread Tauri `Channel`.
  *
- * The Rust side fans every provider's canonical event stream into a
- * single `agent_chat_event` Tauri channel. Each pane is interested in
- * exactly one thread, so the hook takes a thread id and invokes the
- * handler only when the payload's `thread_id` matches.
+ * The Rust side routes each thread's live events — including the
+ * high-frequency streaming `content_delta` tokens — to the `Channel`
+ * registered via `attach_agent_chat_output` (mirroring how PTY output
+ * streams through `attach_pty_output`), instead of broadcasting every
+ * thread's traffic on the global event bus. A pane therefore only
+ * ever receives its own thread's events; the `thread_id` check below
+ * is defense-in-depth, not the routing mechanism.
+ *
+ * The channel carries live events only. Transcript history for a
+ * late-attaching / resumed pane comes from the DB hydrate
+ * (`agentChatListMessages`) that `AgentChatPane` runs on mount —
+ * same split as before this hook moved off the event bus.
  *
  * Passing a `null` thread id disables the subscription — useful for
  * panes that have not yet started a session.
+ *
+ * The handler is kept on a ref so a new handler identity does NOT
+ * re-attach the backend channel; only a thread id change does.
  */
 export function useAgentChatEvents(
   threadId: string | null,
   handler: (payload: AgentChatEventPayload) => void,
 ) {
-  const filtered = useCallback<EventCallback<AgentChatEventPayload>>(
-    (payload) => {
-      if (threadId == null) return;
-      if (payload.thread_id !== threadId) return;
-      handler(payload);
-    },
-    [threadId, handler],
-  );
+  const handlerRef = useRef(handler);
+  useEffect(() => {
+    handlerRef.current = handler;
+  }, [handler]);
 
-  useTauriEvent<AgentChatEventPayload>(onAgentChatEvent, filtered, [
-    threadId,
-    handler,
-  ]);
+  useEffect(() => {
+    if (threadId == null) return;
+    let cancelled = false;
+    const channel = new Channel<AgentChatEventPayload>((payload) => {
+      // `cancelled` guards the gap between unmount and the async
+      // detach landing on the backend.
+      if (cancelled) return;
+      if (payload.thread_id !== threadId) return;
+      handlerRef.current(payload);
+    });
+    const attached = attachAgentChatOutput(threadId, channel);
+    attached.catch((error) => {
+      console.error("[agent-chat] attach_agent_chat_output failed:", error);
+    });
+    return () => {
+      cancelled = true;
+      // Serialize detach behind the attach so out-of-order delivery
+      // can't detach before the attach registers. The generation
+      // token makes a late detach a no-op if a newer pane already
+      // re-attached this thread.
+      void attached
+        .then((generation) => detachAgentChatOutput(threadId, generation))
+        .catch(() => {
+          // Attach failed — nothing to detach.
+        });
+    };
+  }, [threadId]);
 }

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -7,7 +7,7 @@ import type {
   OpenCodeProviderEntry,
   ProviderChatCapabilities,
 } from "./types";
-import type { ApprovalDecision } from "./events";
+import type { AgentChatEventPayload, ApprovalDecision } from "./events";
 import type {
   UserSettings,
   AgentConfig,
@@ -1297,6 +1297,32 @@ export const agentChatDeleteSession = (threadId: string) =>
  */
 export const agentChatListMessages = (threadId: string) =>
   invoke<string[]>("agent_chat_list_messages", { threadId });
+
+/**
+ * Register a per-thread `Channel` that receives every live
+ * `AgentChatEventPayload` for `threadId` — including the
+ * high-frequency `content_delta` token stream. Mirrors the PTY
+ * `attach_pty_output` pattern: Channels are Tauri's high-throughput
+ * streaming primitive, unlike the broadcast event bus.
+ *
+ * Returns the attach generation. Pass it back to
+ * `detachAgentChatOutput` on teardown so a stale detach (unmount
+ * racing a remount) can never clobber a newer pane's channel.
+ *
+ * The channel carries live events only: late-attaching / resumed
+ * panes rebuild history via `agentChatListMessages` hydrate.
+ */
+export const attachAgentChatOutput = (
+  threadId: string,
+  channel: Channel<AgentChatEventPayload>,
+) => invoke<number>("attach_agent_chat_output", { threadId, channel });
+
+/** Tear down the channel installed by `attachAgentChatOutput`.
+ *  Idempotent; a mismatched generation is a silent no-op. */
+export const detachAgentChatOutput = (
+  threadId: string,
+  generation: number,
+) => invoke<void>("detach_agent_chat_output", { threadId, generation });
 
 // ── OpenCode (Step 12 Stage 1) ──
 //

--- a/src/tauri/events.ts
+++ b/src/tauri/events.ts
@@ -113,8 +113,11 @@ export const onSyncStateChanged = (
 //
 // Mirror of src-tauri/src/commands/agent_chat.rs:AgentChatEventPayload
 // and src-tauri/src/agent_provider/events.rs:ProviderRuntimeEvent.
-// The Rust side emits a single channel name; subscribers filter by
-// thread_id via the useAgentChatEvents hook.
+// Thread-scoped events stream over a per-thread `Channel` registered
+// via `attachAgentChatOutput` (see `useAgentChatEvents`), NOT the
+// global event bus — the bus only carries the rare thread-less
+// `runtime_warning` on the `agent_chat_event` name. The payload shape
+// is identical on both transports.
 
 export type ApprovalDecision =
   | {
@@ -228,16 +231,14 @@ export type ProviderRuntimeEvent =
       resume_cursor: unknown;
     };
 
-/** Canonical provider event payload as emitted to the frontend. */
+/** Canonical provider event payload as delivered to the frontend —
+ *  over the per-thread Channel for thread-scoped events, or on the
+ *  `agent_chat_event` bus for thread-less warnings (empty
+ *  `thread_id`). */
 export interface AgentChatEventPayload {
   thread_id: string;
   event: ProviderRuntimeEvent;
 }
-
-export const onAgentChatEvent = (
-  cb: EventCallback<AgentChatEventPayload>,
-): Promise<UnlistenFn> =>
-  listen<AgentChatEventPayload>("agent_chat_event", (e) => cb(e.payload));
 
 // ── Tunnel health ──
 //


### PR DESCRIPTION
Closes #75

## Summary

Agent-chat runtime events — including the high-frequency streaming `content_delta` tokens — were broadcast to every listener via the global Tauri event bus (`app.emit`). Tauri's event system is not designed for high-throughput streaming; Channels are the documented mechanism for it, and PTY output in this repo already streams that way. This PR moves per-thread chat streaming onto `tauri::ipc::Channel`, mirroring `attach_pty_output`.

### Backend
- `AgentChatChannelRegistry` (Tauri-managed state): per-thread `Channel<AgentChatEventPayload>` entries, newest attach wins, generation-guarded detach so a stale unmount can never tear down a newer pane's channel.
- New commands: `attach_agent_chat_output(thread_id, channel) -> u64` generation, `detach_agent_chat_output(thread_id, generation)`.
- `forward_event` routes thread-scoped events to the matching thread's channel only; thread-less `RuntimeWarning`s keep the low-frequency global `agent_chat_event` bus.
- **Replay split (documented in `docs/features/agent-chat.md`):** the channel carries live events only. DB transcript persistence is unchanged, so late-attaching / resumed panes hydrate from `agent_chat_list_messages` exactly as before.

### Frontend
- `useAgentChatEvents` registers a `Channel` per mounted thread (attach on mount, generation-guarded detach on unmount, handler kept on a ref so re-renders never re-attach) instead of filtering a global `listen("agent_chat_event")` stream.
- `onAgentChatEvent` bus subscription removed; `attachAgentChatOutput` / `detachAgentChatOutput` wrappers added.

### Dev mock
- The plain-browser dev mock now simulates the channel path: a seeded `chat-streaming` workspace boots an `agent_chat` pane and `send_turn` streams token-by-token `content_delta` frames through the registered `@tauri-apps/api` Channel dispatcher with ordered `{index, message}` frames — same mechanism as real IPC.

## Acceptance criteria

- [x] Streaming tokens arrive over a Channel, not the global event bus
- [x] No cross-thread leakage — a pane only receives its own thread's events
- [x] Late-attaching / resumed panes still render the full transcript (DB hydrate + live channel)
- [x] No regression in streaming smoothness or event ordering

## Testing

- **Rust:** registry unit tests + 16 integration tests — per-thread routing, no cross-thread leakage, ordering across the async bridge, generation-guarded detach, threadless-warning bus fallback, persistence without a subscriber, and the full provider → `spawn_event_bridge` → channel pipeline with a mock provider and real `tauri::ipc::Channel` consumers.
- **Frontend:** `tsc` clean; 1832/1832 vitest including new hook lifecycle coverage (attach, dispatch, wrong-thread filter, generation detach, no re-attach on handler identity change, thread switch).
- **E2E (mock IPC, browser):** drove the chat pane in the browser; DOM text length grew monotonically during a turn (incremental token rendering), and a decoy channel on another thread received zero events while the target thread received its full ordered stream.
- **E2E (real IPC):** ran the dev desktop app against an isolated `HOME` with a real Claude session; the reply streamed as `content_delta` frames over the thread's channel in order (`session_configured → deltas → item_completed → turn_completed`), nothing thread-scoped appeared on the event bus, and a decoy channel on a second thread received zero events. Session stop + detach were clean.

`cargo check`, `cargo test` (only 2 pre-existing machine-local failures unrelated to this change — both reproduce identically at clean HEAD), `npm run check`, `npm run test` all verified on the merged tree.