### PR TITLE
fix(worktree): reclaim orphan leftover dir on workspace create

### DIFF
--- a/docs/features/workspace-creation.md
+++ b/docs/features/workspace-creation.md
@@ -30,6 +30,8 @@ Creation dispatches one of:
 
 **Base resolution for new branches**: before resolving the base ref, the backend runs a scoped, best-effort `git fetch origin <base>` (10s cap, `GIT_TERMINAL_PROMPT=0`) so the new branch starts from the latest remote commit, not a stale `origin/<base>` snapshot. Offline / no-remote repos fall back to the existing `origin/<base>` ref, else the local branch — creation never hard-fails on fetch problems. Both the desktop path (`src-tauri/src/git.rs::git_create_worktree`) and the headless daemon path (`src-tauri/src/remote/git.rs::create_worktree`) apply the same policy; the fetch runs on the blocking pool so the UI never freezes.
 
+**Orphan worktree reclamation**: a worktree's conventional path is `~/.codemux/worktrees/<repo>/<branch>`. When a previous worktree for the same branch was removed from git's registry but its directory was left on disk (e.g. spinning up a workspace from an already-worked, often closed, issue branch whose `feature/<n>-<slug>` name is auto-suggested), `git worktree add` would otherwise die with `fatal: '<path>' already exists`. Creation now detects a **safe orphan** — a path git no longer tracks as a worktree, with no `.git` entry, holding nothing but Codemux's own `.codemux/` metadata (or empty) — and removes it before adding. Anything resembling user data, or a real path collision against a different registered branch, is left untouched so git still fails loudly. Both the desktop and headless daemon paths share this policy (`is_reclaimable_orphan_worktree`).
+
 After creation: preset applied, issue linked, project marked as recent, workspace activated.
 
 ### Project Onboarding

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -2471,6 +2471,60 @@ pub fn git_recreate_worktree_for_adopted_repo(
     git_create_worktree(repo_path, branch, false, None, None)
 }
 
+/// True when `git worktree list` reports a worktree registered at
+/// `target_path` for ANY branch. Used to refuse reclaiming a directory
+/// git still tracks — removing it would corrupt that worktree.
+fn path_is_registered_worktree(repo_path: &Path, target_path: &Path) -> bool {
+    let Ok(output) = run_git(repo_path, &["worktree", "list", "--porcelain"]) else {
+        return false;
+    };
+    output.lines().any(|line| {
+        line.trim()
+            .strip_prefix("worktree ")
+            .map(|p| Path::new(p) == target_path)
+            .unwrap_or(false)
+    })
+}
+
+/// Decide whether the directory already sitting at a would-be worktree
+/// path is a safe-to-remove leftover: an orphaned Codemux worktree dir
+/// whose git registration is already gone, holding nothing but Codemux's
+/// own metadata. Returns true ONLY when deleting it cannot lose user data
+/// or corrupt a live worktree.
+///
+/// This unblocks the common case where a previous worktree for the same
+/// (often issue-derived) branch was pruned from git's registry but its
+/// directory was left on disk: without reclaiming, `git worktree add`
+/// dies with `fatal: '<path>' already exists`.
+fn is_reclaimable_orphan_worktree(repo_path: &Path, path: &Path) -> bool {
+    // Never touch a path git still tracks as a worktree (for ANY branch):
+    // removing it would corrupt that worktree. A path collision against a
+    // different branch must keep failing loudly.
+    if path_is_registered_worktree(repo_path, path) {
+        return false;
+    }
+    // A `.git` entry marks a real worktree checkout (possibly mid-teardown,
+    // or pruned-but-not-cleaned). Treat as user data — don't delete.
+    if path.join(".git").exists() {
+        return false;
+    }
+    // Every top-level entry must be Codemux-owned metadata; anything else
+    // (source, configs, the user's edits) makes removal unsafe. An empty
+    // directory is trivially reclaimable.
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return false;
+    };
+    const CODEMUX_METADATA: &[&str] = &[".codemux"];
+    for entry in entries {
+        let Ok(entry) = entry else { return false };
+        match entry.file_name().to_str() {
+            Some(name) if CODEMUX_METADATA.contains(&name) => continue,
+            _ => return false,
+        }
+    }
+    true
+}
+
 pub fn git_create_worktree(
     repo_path: &Path,
     branch: &str,
@@ -2522,9 +2576,22 @@ pub fn git_create_worktree(
         if existing_worktree_matches(repo_path, &path_str, branch) {
             return Ok(path_str);
         }
-        // Path exists but isn't a registered worktree for `branch`. Let
-        // git fail with its own diagnostic so the brain sees the real
-        // reason (e.g. a leftover dir from a half-deleted worktree).
+        // Path exists but git doesn't register it as OUR worktree. If it's
+        // a safe-to-remove orphan — a leftover Codemux dir (e.g. from a
+        // previously-worked issue branch) whose registration is already
+        // gone — reclaim it so creation proceeds instead of dying with
+        // `fatal: '<path>' already exists`. Anything resembling user data,
+        // or a path git still tracks (a real collision against a different
+        // branch), is left untouched so git fails loudly as before.
+        if is_reclaimable_orphan_worktree(repo_path, &worktree_path) {
+            std::fs::remove_dir_all(&worktree_path).map_err(|e| {
+                format!("Failed to reclaim leftover worktree directory '{path_str}': {e}")
+            })?;
+            // A registration may still claim this branch from a now-missing
+            // path; prune so `worktree add` starts clean. Permissive: a
+            // repo with no stale entries is a no-op.
+            let _ = run_git_permissive(repo_path, &["worktree", "prune"]);
+        }
     }
 
     if new_branch {
@@ -3153,6 +3220,94 @@ C  source.txt -> copy.txt";
             !existing_worktree_matches(&repo, "/tmp/nonexistent-path", "main"),
             "no registered worktrees => no match"
         );
+    }
+
+    #[test]
+    fn worktree_create_reclaims_orphan_leftover_dir() {
+        // Regression: a previous worktree for this branch was pruned from
+        // git's registry but its directory was left on disk (a stray
+        // `.codemux/` and nothing else). Re-creating the worktree must
+        // reclaim that orphan instead of dying with
+        // `fatal: '<path>' already exists` — the exact failure seen when
+        // spinning up a workspace from an already-worked (often closed)
+        // issue branch.
+        let (_dir, repo) = setup_test_repo();
+        let branch = unique_branch("orphan");
+        run_git(&repo, &["branch", &branch]).expect("create branch");
+
+        // Materialize the worktree, then drop ONLY its registration + dir
+        // (the branch survives) — this is the exact path git will derive.
+        let wt_path =
+            git_create_worktree(&repo, &branch, false, None, None).expect("first create");
+        run_git(&repo, &["worktree", "remove", "--force", &wt_path])
+            .expect("remove worktree, keep branch");
+        assert!(!PathBuf::from(&wt_path).exists(), "dir gone after remove");
+
+        // Recreate the orphan leftover: dir back on disk holding only
+        // Codemux metadata, with no git registration behind it.
+        let orphan = PathBuf::from(&wt_path);
+        std::fs::create_dir_all(orphan.join(".codemux")).expect("mk .codemux");
+        std::fs::write(orphan.join(".codemux").join("index.json"), "{}").expect("write metadata");
+
+        // Create must now reclaim the orphan and produce a real worktree.
+        let again = git_create_worktree(&repo, &branch, false, None, None)
+            .expect("must reclaim orphan, not error with 'already exists'");
+        assert_eq!(again, wt_path, "reclaimed path matches the original");
+        assert!(
+            PathBuf::from(&again).join(".git").is_file(),
+            "reclaimed dir is now a real linked worktree"
+        );
+
+        git_remove_worktree(Path::new(&again), Some(&branch), true).expect("cleanup");
+    }
+
+    #[test]
+    fn is_reclaimable_orphan_worktree_distinguishes_safe_from_unsafe() {
+        let (_dir, repo) = setup_test_repo();
+        let tmp = TempDir::new().expect("tmp");
+
+        // Empty dir → reclaimable.
+        let empty = tmp.path().join("empty");
+        std::fs::create_dir_all(&empty).unwrap();
+        assert!(is_reclaimable_orphan_worktree(&repo, &empty), "empty dir is reclaimable");
+
+        // Only Codemux metadata → reclaimable.
+        let meta_only = tmp.path().join("meta");
+        std::fs::create_dir_all(meta_only.join(".codemux")).unwrap();
+        std::fs::write(meta_only.join(".codemux").join("index.json"), "{}").unwrap();
+        assert!(
+            is_reclaimable_orphan_worktree(&repo, &meta_only),
+            "Codemux-metadata-only dir is reclaimable"
+        );
+
+        // Contains user data → NOT reclaimable.
+        let with_user = tmp.path().join("userdata");
+        std::fs::create_dir_all(&with_user).unwrap();
+        std::fs::write(with_user.join("main.rs"), "fn main() {}").unwrap();
+        assert!(
+            !is_reclaimable_orphan_worktree(&repo, &with_user),
+            "a dir with user files must never be reclaimed"
+        );
+
+        // Contains a `.git` → NOT reclaimable (looks like a real checkout).
+        let with_git = tmp.path().join("hasgit");
+        std::fs::create_dir_all(&with_git).unwrap();
+        std::fs::write(with_git.join(".git"), "gitdir: /somewhere").unwrap();
+        assert!(
+            !is_reclaimable_orphan_worktree(&repo, &with_git),
+            "a dir with a .git entry must never be reclaimed"
+        );
+
+        // A live registered worktree → NOT reclaimable even though its
+        // only non-tracked content might look disposable.
+        let branch = unique_branch("registered");
+        run_git(&repo, &["branch", &branch]).unwrap();
+        let wt = git_create_worktree(&repo, &branch, false, None, None).unwrap();
+        assert!(
+            !is_reclaimable_orphan_worktree(&repo, Path::new(&wt)),
+            "a registered worktree must never be reclaimed"
+        );
+        git_remove_worktree(Path::new(&wt), Some(&branch), true).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/remote/git.rs
+++ b/src-tauri/src/remote/git.rs
@@ -198,6 +198,48 @@ fn existing_worktree_matches(repo_root: &Path, target: &Path, branch: &str) -> b
     matched
 }
 
+/// True when `git worktree list` reports a worktree registered at
+/// `target` for ANY branch — i.e. git still tracks this directory, so
+/// reclaiming it would corrupt that worktree.
+fn path_is_registered_worktree(repo_root: &Path, target: &Path) -> bool {
+    let Ok(output) = run_git(repo_root, &["worktree", "list", "--porcelain"]) else {
+        return false;
+    };
+    output.lines().any(|line| {
+        line.trim()
+            .strip_prefix("worktree ")
+            .map(|p| Path::new(p) == target)
+            .unwrap_or(false)
+    })
+}
+
+/// Decide whether the directory already at a would-be worktree path is a
+/// safe-to-remove leftover: an orphaned Codemux worktree dir whose git
+/// registration is gone, holding nothing but Codemux's own metadata.
+/// Returns true ONLY when deleting it can't lose user data or corrupt a
+/// live worktree. Mirrors the desktop's `git_create_worktree` policy so a
+/// remote-host agent reclaiming a stale issue-branch dir behaves the same.
+fn is_reclaimable_orphan_worktree(repo_root: &Path, path: &Path) -> bool {
+    if path_is_registered_worktree(repo_root, path) {
+        return false;
+    }
+    if path.join(".git").exists() {
+        return false;
+    }
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return false;
+    };
+    const CODEMUX_METADATA: &[&str] = &[".codemux"];
+    for entry in entries {
+        let Ok(entry) = entry else { return false };
+        match entry.file_name().to_str() {
+            Some(name) if CODEMUX_METADATA.contains(&name) => continue,
+            _ => return false,
+        }
+    }
+    true
+}
+
 /// Create (or reuse) a git worktree for `branch` off `repo_path`.
 ///
 /// - `new_branch = true`: create a new branch `branch` based on `base`
@@ -244,6 +286,17 @@ pub fn create_worktree(
             repo_root,
             branch: branch.to_string(),
         });
+    }
+
+    // Path exists but isn't our registered worktree. Reclaim it when it's
+    // a safe orphan — a leftover Codemux dir whose registration is gone —
+    // so `worktree add` doesn't die with `fatal: '<path>' already exists`.
+    // `worktree prune` below only drops registrations whose dir is MISSING,
+    // so it can't clear an on-disk orphan; this can.
+    if worktree_path.exists() && is_reclaimable_orphan_worktree(&repo_root, &worktree_path) {
+        std::fs::remove_dir_all(&worktree_path).map_err(|e| {
+            format!("failed to reclaim leftover worktree dir '{}': {e}", worktree_path.display())
+        })?;
     }
 
     // Prune stale worktree registrations before adding. Without this, a
@@ -351,6 +404,31 @@ mod tests {
         let again = create_worktree(home.path(), repo.path(), "feature-x", true, Some("main"))
             .expect("reuse worktree");
         assert_eq!(again.worktree_path, created.worktree_path);
+    }
+
+    #[test]
+    fn create_worktree_reclaims_orphan_leftover_dir() {
+        // Daemon parity with the desktop fix: a worktree dir left on disk
+        // after its git registration was pruned (holding only a stray
+        // `.codemux/`) must be reclaimed, not error with "already exists".
+        let repo = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        init_repo(repo.path());
+
+        // The path create_worktree will derive for this branch.
+        let repo_name = git_root(repo.path()).unwrap();
+        let repo_name = repo_name.file_name().unwrap().to_string_lossy();
+        let orphan = conventional_worktree_path(home.path(), &repo_name, "feature-orphan");
+        std::fs::create_dir_all(orphan.join(".codemux")).unwrap();
+        std::fs::write(orphan.join(".codemux").join("index.json"), "{}").unwrap();
+        assert!(orphan.exists() && !orphan.join(".git").exists(), "orphan precondition");
+
+        let created =
+            create_worktree(home.path(), repo.path(), "feature-orphan", true, Some("main"))
+                .expect("must reclaim orphan, not error");
+        assert_eq!(created.worktree_path, orphan);
+        assert!(created.worktree_path.join(".git").is_file(), "now a real worktree");
+        assert!(created.worktree_path.join("README.md").exists(), "populated checkout");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Opening a new workspace by linking a GitHub issue could fail with:

```
git worktree failed: Preparing worktree (checking out 'feature/95-empty-project-dialog-not-opening')
fatal: '/home/.../.codemux/worktrees/codemux/feature-95-empty-project-dialog-not-opening' already exists
```

The issue's **closed** state is a red herring — Codemux doesn't gate linking on issue state. The real cause: linking an issue auto-suggests a deterministic `feature/<n>-<slug>` branch name, and a worktree directory from a *previous* round of work on that branch was still sitting on disk. Its git worktree registration had been pruned (so it doesn't appear in `git worktree list`), but the folder — holding nothing but a stray `.codemux/` — was left behind. `git worktree add` refuses to write into an existing path, so creation died with its raw error.

The existing reuse-detection only short-circuits for a path git **registers** as a worktree for the same branch; an orphan folder failed that check and fell straight through to git's failure.

## Fix

`git_create_worktree` (desktop) and `create_worktree` (headless daemon) now detect a **safe orphan** before `git worktree add` and remove it first:

- the path is **not** registered as a worktree for any branch (a real collision against a different registered branch still fails loudly), **and**
- it has no `.git` entry (not a real/mid-teardown checkout), **and**
- every top-level entry is Codemux-owned metadata (`.codemux/`), or the dir is empty.

Anything resembling user data is left untouched, so genuinely surprising collisions still surface git's diagnostic. Shared helper: `is_reclaimable_orphan_worktree`.

## Tests

- `git::tests::worktree_create_reclaims_orphan_leftover_dir` — reproduces the exact scenario (orphan dir with `.codemux/index.json`, registration pruned) and asserts creation reclaims it into a real linked worktree.
- `git::tests::is_reclaimable_orphan_worktree_distinguishes_safe_from_unsafe` — empty/metadata-only → reclaimable; user files / `.git` / live registered worktree → not.
- `remote::git::tests::create_worktree_reclaims_orphan_leftover_dir` — daemon parity.

All `git` (166) and `remote::git` (10) module tests pass. Docs updated in `docs/features/workspace-creation.md`.