### PR TITLE
feat(new-workspace): enlarge dialog and prompt input

### DIFF
--- a/src/components/overlays/new-workspace-dialog.tsx
+++ b/src/components/overlays/new-workspace-dialog.tsx
@@ -387,7 +387,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     setPrompt(e.target.value);
     const ta = e.target;
     ta.style.height = "auto";
-    ta.style.height = `${Math.min(Math.max(ta.scrollHeight, 40), 192)}px`;
+    ta.style.height = `${Math.min(Math.max(ta.scrollHeight, 96), 192)}px`;
   };
 
   // Accept clipboard images alongside the paperclip-attach flow.
@@ -758,7 +758,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="sm:max-w-[560px] max-h-[min(70vh,600px)] !top-[calc(50%-min(35vh,300px))] !-translate-y-0 bg-popover p-0 gap-0 overflow-visible"
+        className="sm:max-w-2xl max-h-[min(70vh,600px)] !top-[calc(50%-min(35vh,300px))] !-translate-y-0 bg-popover p-0 gap-0 overflow-visible"
         onKeyDown={handleKeyDown}
       >
         <DialogHeader className="sr-only">
@@ -799,7 +799,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
               onChange={handleTextareaChange}
               onPaste={handlePasteImage}
               placeholder="What do you want to do?"
-              className="min-h-10 max-h-48 resize-none border-0 bg-transparent dark:bg-transparent shadow-none focus-visible:ring-0 text-sm px-4 pt-3 pb-1"
+              className="min-h-24 max-h-48 resize-none border-0 bg-transparent dark:bg-transparent shadow-none focus-visible:ring-0 text-sm px-4 pt-3 pb-1"
               rows={1}
             />
 


### PR DESCRIPTION
## What

Make the **New workspace** dialog a bit larger so the primary prompt input reads as the main field instead of a single-line search box.

| Element | Before | After |
|---|---|---|
| Dialog width | `560px` (`sm:max-w-[560px]`) | `672px` (`sm:max-w-2xl`) |
| Prompt resting height | `40px` (`min-h-10`, ~1 line) | `96px` (`min-h-24`, ~5 lines) |
| Auto-resize floor (JS) | `40` | `96` (max unchanged at 192px) |

## Why

The prompt ("What do you want to do?") is the dialog's primary action, but at one line tall it looked like a minor field. Giving it ~5 lines of resting height matches its importance, and the extra width de-crowds the device/project/branch picker row. The code comment already documented the intended "min 96px = ~5 lines" — this restores that intent (it had been shrunk to 40px).

## Scope

Purely visual — resting size of two fields. **No functional changes:** all fields, pickers, the agent selector, attach/send buttons, and the Ctrl+Enter shortcut are untouched. Also switched the width from an arbitrary value to the standard `max-w-2xl` token.

## Verification

- `npm run check` (tsc --noEmit) passes.
- Verified live in the browser pane — dialog renders wider with a comfortable multi-line prompt; every control still present and functional.