### PR TITLE
fix(dialog): make file pickers work on portal-less Linux sessions (#95)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -312,10 +312,28 @@ pub async fn pick_folder_dialog<R: Runtime>(
     use tauri_plugin_dialog::DialogExt;
     use tokio::sync::oneshot;
 
-    // Fail loudly when no dialog backend exists (issue #95) — without
-    // this the portal-only backend resolves `None` exactly like a user
-    // cancel and the UI silently does nothing.
-    crate::dialog_preflight::ensure_file_picker_backend().await?;
+    // Decide the dialog backend up front (issue #95). On Linux, when
+    // the portal is unusable but zenity exists, drive zenity ourselves
+    // with a sanitized env + timeout instead of letting rfd inherit the
+    // broken session environment (which hangs the picker).
+    #[cfg(target_os = "linux")]
+    {
+        match crate::dialog_preflight::select_backend().await {
+            crate::dialog_preflight::Backend::Portal => {}
+            crate::dialog_preflight::Backend::Zenity(zenity) => {
+                let dialog_title = title.clone().unwrap_or_else(|| "Choose folder".to_string());
+                return Ok(crate::dialog_fallback::pick_folder(&zenity, &dialog_title)
+                    .await?
+                    .map(|path| path.to_string_lossy().into_owned()));
+            }
+            crate::dialog_preflight::Backend::None(message) => {
+                return Err(format!(
+                    "{}: {message}",
+                    crate::dialog_preflight::NO_BACKEND_MARKER
+                ));
+            }
+        }
+    }
 
     let (tx, rx) = oneshot::channel();
 
@@ -345,8 +363,27 @@ pub async fn pick_files_dialog<R: Runtime>(
     use tauri_plugin_dialog::DialogExt;
     use tokio::sync::oneshot;
 
-    // See pick_folder_dialog — same silent-failure guard (issue #95).
-    crate::dialog_preflight::ensure_file_picker_backend().await?;
+    // See pick_folder_dialog — same backend decision (issue #95).
+    #[cfg(target_os = "linux")]
+    {
+        match crate::dialog_preflight::select_backend().await {
+            crate::dialog_preflight::Backend::Portal => {}
+            crate::dialog_preflight::Backend::Zenity(zenity) => {
+                let dialog_title = title.clone().unwrap_or_else(|| "Attach files".to_string());
+                return Ok(crate::dialog_fallback::pick_files(&zenity, &dialog_title)
+                    .await?
+                    .into_iter()
+                    .map(|path| path.to_string_lossy().into_owned())
+                    .collect());
+            }
+            crate::dialog_preflight::Backend::None(message) => {
+                return Err(format!(
+                    "{}: {message}",
+                    crate::dialog_preflight::NO_BACKEND_MARKER
+                ));
+            }
+        }
+    }
 
     let (tx, rx) = oneshot::channel();
 
@@ -388,8 +425,31 @@ pub async fn pick_save_file_dialog<R: Runtime>(
     use tauri_plugin_dialog::DialogExt;
     use tokio::sync::oneshot;
 
-    // See pick_folder_dialog — same silent-failure guard (issue #95).
-    crate::dialog_preflight::ensure_file_picker_backend().await?;
+    // See pick_folder_dialog — same backend decision (issue #95).
+    #[cfg(target_os = "linux")]
+    {
+        match crate::dialog_preflight::select_backend().await {
+            crate::dialog_preflight::Backend::Portal => {}
+            crate::dialog_preflight::Backend::Zenity(zenity) => {
+                let dialog_title = title.clone().unwrap_or_else(|| "Save as".to_string());
+                return Ok(crate::dialog_fallback::save_file(
+                    &zenity,
+                    &dialog_title,
+                    default_filename.as_deref(),
+                    filter_name.as_deref(),
+                    filter_extensions.as_deref(),
+                )
+                .await?
+                .map(|path| path.to_string_lossy().into_owned()));
+            }
+            crate::dialog_preflight::Backend::None(message) => {
+                return Err(format!(
+                    "{}: {message}",
+                    crate::dialog_preflight::NO_BACKEND_MARKER
+                ));
+            }
+        }
+    }
 
     let (tx, rx) = oneshot::channel();
 
@@ -433,8 +493,30 @@ pub async fn pick_open_file_dialog<R: Runtime>(
     use tauri_plugin_dialog::DialogExt;
     use tokio::sync::oneshot;
 
-    // See pick_folder_dialog — same silent-failure guard (issue #95).
-    crate::dialog_preflight::ensure_file_picker_backend().await?;
+    // See pick_folder_dialog — same backend decision (issue #95).
+    #[cfg(target_os = "linux")]
+    {
+        match crate::dialog_preflight::select_backend().await {
+            crate::dialog_preflight::Backend::Portal => {}
+            crate::dialog_preflight::Backend::Zenity(zenity) => {
+                let dialog_title = title.clone().unwrap_or_else(|| "Open".to_string());
+                return Ok(crate::dialog_fallback::pick_open_file(
+                    &zenity,
+                    &dialog_title,
+                    filter_name.as_deref(),
+                    filter_extensions.as_deref(),
+                )
+                .await?
+                .map(|path| path.to_string_lossy().into_owned()));
+            }
+            crate::dialog_preflight::Backend::None(message) => {
+                return Err(format!(
+                    "{}: {message}",
+                    crate::dialog_preflight::NO_BACKEND_MARKER
+                ));
+            }
+        }
+    }
 
     let (tx, rx) = oneshot::channel();
 

--- a/src-tauri/src/dialog_fallback.rs
+++ b/src-tauri/src/dialog_fallback.rs
@@ -1,0 +1,178 @@
+//! Direct zenity fallback for Linux file dialogs (issue #95).
+//!
+//! The dialog plugin is compiled portal-only (`tauri-plugin-dialog`
+//! with the `xdg-portal` feature → rfd → ashpd). rfd *does* fall back
+//! to spawning `zenity`, but only when the portal call returns an
+//! error. On minimal window-manager sessions the portal frequently
+//! *hangs* instead (the preflight catches that via timeout), so rfd's
+//! own fallback never runs — and when it does run, rfd spawns zenity
+//! with the inherited session environment, the very environment that
+//! broke the portal in the first place (a stale/dead D-Bus session
+//! bus, or a GTK module that blocks `gtk_init`), so zenity hangs too.
+//!
+//! This module is the escape hatch: when the preflight decides the
+//! portal is unusable but a `zenity` binary exists, the dialog command
+//! calls in here instead of rfd. We spawn zenity ourselves with
+//!
+//! 1. a **sanitized environment** — the vars that hang GTK clients on
+//!    broken sessions are cleared, and the accessibility bridge (a
+//!    classic source of multi-second `gtk_init` stalls) is disabled;
+//! 2. a **hard timeout** — a wedged zenity can never leave the picker
+//!    button dead forever; it resolves as a cancel-with-error instead.
+//!
+//! Non-Linux platforms never use this module: their native dialogs
+//! need no external process.
+
+#![cfg(target_os = "linux")]
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+/// Environment variables cleared for the zenity subprocess. On a
+/// healthy desktop these are harmless to keep; we only ever reach this
+/// module when the portal is already broken, which strongly correlates
+/// with the session environment below being the cause.
+///
+/// - `DBUS_SESSION_BUS_ADDRESS`: when it points at a dead or wedged bus
+///   (e.g. a greeter's address that outlived its bus), GTK blocks
+///   talking to it during init. Clearing it lets GTK autolaunch a
+///   private session bus, or run without one — either way it no longer
+///   hangs.
+/// - `GTK_MODULES` / `GTK3_MODULES`: a module that blocks (a stale
+///   accessibility bridge is the usual culprit) stalls `gtk_init`.
+const SANITIZE_VARS: &[&str] = &["DBUS_SESSION_BUS_ADDRESS", "GTK_MODULES", "GTK3_MODULES"];
+
+/// Default safety timeout. Generous enough that a user genuinely
+/// browsing the filesystem is never cut off, but bounded so a zenity
+/// wedged at init eventually releases the dialog. Overridable via
+/// `CODEMUX_ZENITY_TIMEOUT_MS` (used by tests, and as an operational
+/// escape hatch).
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
+
+fn timeout() -> Duration {
+    std::env::var("CODEMUX_ZENITY_TIMEOUT_MS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_TIMEOUT)
+}
+
+/// A zenity command pre-seeded with the sanitized environment.
+fn base_command(zenity: &Path) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new(zenity);
+    cmd.arg("--no-markup");
+    for var in SANITIZE_VARS {
+        cmd.env_remove(var);
+    }
+    // Disable the at-spi accessibility bridge for this child. Without a
+    // running a11y bus, GTK clients can block for many seconds during
+    // init waiting for it; the file picker needs none of it.
+    cmd.env("NO_AT_BRIDGE", "1");
+    cmd.env("GTK_A11Y", "none");
+    cmd.kill_on_drop(true);
+    cmd
+}
+
+/// Apply rfd-compatible `--file-filter NAME | *.ext *.ext` arguments.
+fn add_filters(cmd: &mut tokio::process::Command, name: Option<&str>, extensions: Option<&[String]>) {
+    if let (Some(name), Some(exts)) = (name, extensions) {
+        if !exts.is_empty() {
+            let globs: Vec<String> = exts.iter().map(|ext| format!("*.{ext}")).collect();
+            cmd.arg("--file-filter");
+            cmd.arg(format!("{name} | {}", globs.join(" ")));
+        }
+    }
+}
+
+/// Run a prepared zenity command to completion under the timeout.
+///
+/// Returns `Ok(Some(stdout))` when the user confirmed a selection
+/// (zenity exits 0 with output), `Ok(None)` on cancel (exit 1 / empty),
+/// and `Err(msg)` when zenity could not be run or timed out.
+async fn run(mut cmd: tokio::process::Command) -> Result<Option<String>, String> {
+    let child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|err| format!("could not launch zenity: {err}"))?;
+
+    match tokio::time::timeout(timeout(), child.wait_with_output()).await {
+        // Timed out: the future is dropped here, and `kill_on_drop`
+        // reaps the wedged zenity so it can't linger.
+        Err(_) => Err("zenity timed out (no dialog appeared)".to_string()),
+        Ok(Err(err)) => Err(format!("zenity failed: {err}")),
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let trimmed = stdout.trim();
+            if output.status.success() && !trimmed.is_empty() {
+                Ok(Some(trimmed.to_string()))
+            } else {
+                // Non-zero exit or empty output == user cancelled.
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// Folder picker. `Ok(None)` on cancel.
+pub async fn pick_folder(zenity: &Path, title: &str) -> Result<Option<PathBuf>, String> {
+    let mut cmd = base_command(zenity);
+    cmd.args(["--file-selection", "--directory", "--title", title]);
+    Ok(run(cmd).await?.map(PathBuf::from))
+}
+
+/// Multi-file picker. Returns an empty vec on cancel.
+pub async fn pick_files(zenity: &Path, title: &str) -> Result<Vec<PathBuf>, String> {
+    let mut cmd = base_command(zenity);
+    // Newline separator so paths containing the default `|` don't split
+    // incorrectly.
+    cmd.args([
+        "--file-selection",
+        "--multiple",
+        "--separator",
+        "\n",
+        "--title",
+        title,
+    ]);
+    Ok(run(cmd)
+        .await?
+        .map(|out| out.lines().map(PathBuf::from).collect())
+        .unwrap_or_default())
+}
+
+/// Single-file open dialog with an optional filter. `Ok(None)` on cancel.
+pub async fn pick_open_file(
+    zenity: &Path,
+    title: &str,
+    filter_name: Option<&str>,
+    filter_extensions: Option<&[String]>,
+) -> Result<Option<PathBuf>, String> {
+    let mut cmd = base_command(zenity);
+    cmd.args(["--file-selection", "--title", title]);
+    add_filters(&mut cmd, filter_name, filter_extensions);
+    Ok(run(cmd).await?.map(PathBuf::from))
+}
+
+/// Save-as dialog. `Ok(None)` on cancel.
+pub async fn save_file(
+    zenity: &Path,
+    title: &str,
+    default_filename: Option<&str>,
+    filter_name: Option<&str>,
+    filter_extensions: Option<&[String]>,
+) -> Result<Option<PathBuf>, String> {
+    let mut cmd = base_command(zenity);
+    cmd.args([
+        "--file-selection",
+        "--save",
+        "--confirm-overwrite",
+        "--title",
+        title,
+    ]);
+    if let Some(name) = default_filename {
+        cmd.args(["--filename", name]);
+    }
+    add_filters(&mut cmd, filter_name, filter_extensions);
+    Ok(run(cmd).await?.map(PathBuf::from))
+}

--- a/src-tauri/src/dialog_preflight.rs
+++ b/src-tauri/src/dialog_preflight.rs
@@ -92,6 +92,48 @@ async fn portal_file_chooser_version() -> Result<u32, String> {
         .map_err(|_| "timed out talking to the desktop portal".to_string())?
 }
 
+/// Build a cause-specific, actionable remediation message from the
+/// portal probe's failure reason. In the branch this is used from,
+/// zenity is always absent (a present zenity would have satisfied the
+/// preflight), so every variant also points at the zenity fallback.
+///
+/// The important distinction is "portal not installed" vs "portal
+/// installed but not starting": the latter is the common minimal-WM
+/// case (issue #95) where reinstalling packages does nothing and the
+/// real fix is exporting the session environment to D-Bus. Telling
+/// those users to `pacman -S` again just sends them in circles.
+#[cfg(target_os = "linux")]
+pub fn no_backend_remediation(portal_error: &str) -> String {
+    let zenity_fallback =
+        "Alternatively, install zenity and Codemux will use it as a fallback file picker.";
+
+    if portal_error.contains("timed out") {
+        // Reached a live session bus, but the portal never answered:
+        // the service failed to activate/start. Almost always a bare
+        // window-manager session that never exported its environment
+        // to D-Bus, so xdg-desktop-portal comes up with no display /
+        // no backend and hangs.
+        format!(
+            "The xdg-desktop-portal is installed but is not starting in this session. \
+             This is common on minimal window managers (i3, dwm, ...) when the session \
+             environment is not exported to D-Bus. Export it and make sure \
+             XDG_CURRENT_DESKTOP is set, then restart Codemux \
+             (see https://wiki.archlinux.org/title/XDG_Desktop_Portal#Portal_does_not_start). \
+             {zenity_fallback}"
+        )
+    } else if portal_error.contains("session bus") {
+        format!(
+            "No D-Bus session bus is available, so the xdg-desktop-portal cannot run. \
+             Start your session under a D-Bus session bus (for example via dbus-run-session) \
+             and restart Codemux. {zenity_fallback}"
+        )
+    } else {
+        // "FileChooser interface not provided", proxy setup failure,
+        // etc.: treat as a genuinely absent backend.
+        INSTALL_HINT.to_string()
+    }
+}
+
 /// `Err(actionable message)` when no file-dialog backend can possibly
 /// work, `Ok(())` otherwise. Called by every dialog command before
 /// the dialog is built.
@@ -108,9 +150,8 @@ pub async fn ensure_file_picker_backend() -> Result<(), String> {
                 "no file picker backend: portal probe failed ({portal_error}); zenity not on PATH"
             );
             return Err(format!(
-                "{NO_BACKEND_MARKER}: cannot open a file dialog. \
-                 The XDG desktop portal is unavailable ({portal_error}) \
-                 and zenity is not installed. {INSTALL_HINT}"
+                "{NO_BACKEND_MARKER}: {}",
+                no_backend_remediation(&portal_error)
             ));
         }
     }

--- a/src-tauri/src/dialog_preflight.rs
+++ b/src-tauri/src/dialog_preflight.rs
@@ -134,6 +134,51 @@ pub fn no_backend_remediation(portal_error: &str) -> String {
     }
 }
 
+/// Which backend a dialog command should drive, decided once up front
+/// so we never call rfd's portal path on a session where it hangs.
+#[cfg(target_os = "linux")]
+pub enum Backend {
+    /// The portal answered; let rfd (tauri-plugin-dialog) handle it.
+    Portal,
+    /// The portal is unusable but a `zenity` binary exists; drive it
+    /// ourselves with a sanitized environment + timeout
+    /// (`dialog_fallback`) instead of relying on rfd inheriting the
+    /// broken session env.
+    Zenity(std::path::PathBuf),
+    /// Nothing can open a dialog; `String` is the actionable message
+    /// (already prefixed-free; the caller adds the marker).
+    None(String),
+}
+
+/// Probe once and decide. Linux-only; other platforms always use their
+/// native dialog via rfd.
+#[cfg(target_os = "linux")]
+pub async fn select_backend() -> Backend {
+    let diagnosis = diagnose().await;
+    if diagnosis.portal.is_ok() {
+        return Backend::Portal;
+    }
+    let portal_error = diagnosis
+        .portal
+        .err()
+        .unwrap_or_else(|| "portal unavailable".to_string());
+    match diagnosis.zenity {
+        Some(path) => {
+            log::warn!(
+                "desktop portal unusable ({portal_error}); falling back to zenity at {}",
+                path.display()
+            );
+            Backend::Zenity(path)
+        }
+        None => {
+            log::error!(
+                "no file picker backend: portal probe failed ({portal_error}); zenity not on PATH"
+            );
+            Backend::None(no_backend_remediation(&portal_error))
+        }
+    }
+}
+
 /// `Err(actionable message)` when no file-dialog backend can possibly
 /// work, `Ok(())` otherwise. Called by every dialog command before
 /// the dialog is built.

--- a/src-tauri/src/doctor.rs
+++ b/src-tauri/src/doctor.rs
@@ -63,7 +63,11 @@ pub async fn run() {
             println!("  [ok]   file dialogs should work");
         } else {
             println!("  [FAIL] file dialogs cannot open on this system.");
-            println!("         {}", crate::dialog_preflight::INSTALL_HINT);
+            let reason = diagnosis.portal.as_ref().err().cloned().unwrap_or_default();
+            println!(
+                "         {}",
+                crate::dialog_preflight::no_backend_remediation(&reason)
+            );
         }
         println!();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ pub mod github;
 pub mod github_cache;
 pub mod control;
 pub mod diagnostics;
+pub mod dialog_fallback;
 pub mod dialog_preflight;
 pub mod app_logs;
 pub mod doctor;

--- a/src-tauri/tests/dialog_fallback.rs
+++ b/src-tauri/tests/dialog_fallback.rs
@@ -1,0 +1,88 @@
+//! Integration tests for the direct zenity fallback (issue #95).
+//!
+//! Like `dialog_preflight.rs`, this lives in its own test binary and
+//! runs everything in a single test: the checks mutate process-global
+//! env (PATH-independent here, but `CODEMUX_ZENITY_TIMEOUT_MS` and the
+//! hostile session vars), and cargo runs each tests/*.rs as its own
+//! process, so nothing else races them.
+
+#![cfg(target_os = "linux")]
+
+use codemux_lib::dialog_fallback;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+/// Fake zenity that records the session vars it actually received, then
+/// "selects" a path. Proves our spawn sanitizes the environment.
+const RECORDING_ZENITY: &str = r#"#!/bin/sh
+{
+  echo "DBUS=${DBUS_SESSION_BUS_ADDRESS-<unset>}"
+  echo "GTK3=${GTK3_MODULES-<unset>}"
+  echo "NOAT=${NO_AT_BRIDGE-<unset>}"
+} > "$FAKE_ZENITY_DUMP"
+printf '/picked/dir'
+exit 0
+"#;
+
+fn write_exec(path: &std::path::Path, body: &str) {
+    std::fs::write(path, body).expect("write fake zenity");
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+}
+
+#[tokio::test]
+async fn fallback_sanitizes_env_returns_selection_and_times_out() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // ── 1. Sanitized environment + selection round-trip ──────────
+    let dump = dir.path().join("env_dump");
+    let recording = dir.path().join("zenity");
+    write_exec(&recording, RECORDING_ZENITY);
+    std::env::set_var("FAKE_ZENITY_DUMP", &dump);
+
+    // Poison the env exactly the way a broken minimal-WM session does:
+    // a dead session bus address and a blocking GTK module. Both would
+    // hang a real zenity; our spawn must strip them.
+    std::env::set_var(
+        "DBUS_SESSION_BUS_ADDRESS",
+        "unix:path=/nonexistent/codemux-dead-bus",
+    );
+    std::env::set_var("GTK3_MODULES", "some-blocking-module");
+
+    let picked = dialog_fallback::pick_folder(&recording, "Choose folder")
+        .await
+        .expect("fallback should run the fake zenity");
+    assert_eq!(picked, Some(PathBuf::from("/picked/dir")));
+
+    let seen = std::fs::read_to_string(&dump).expect("env dump written");
+    assert!(
+        seen.contains("DBUS=<unset>"),
+        "DBUS_SESSION_BUS_ADDRESS must be cleared for the child, got:\n{seen}"
+    );
+    assert!(
+        seen.contains("GTK3=<unset>"),
+        "GTK3_MODULES must be cleared for the child, got:\n{seen}"
+    );
+    assert!(
+        seen.contains("NOAT=1"),
+        "NO_AT_BRIDGE must be set for the child, got:\n{seen}"
+    );
+
+    // ── 2. A wedged zenity is bounded by the timeout ─────────────
+    let hung = dir.path().join("hung-zenity");
+    write_exec(&hung, "#!/bin/sh\nsleep 60\n");
+    std::env::set_var("CODEMUX_ZENITY_TIMEOUT_MS", "300");
+
+    let start = Instant::now();
+    let result = dialog_fallback::pick_folder(&hung, "Choose folder").await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "a zenity that never returns must surface an error, got: {result:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "the timeout must release the dialog promptly, took {elapsed:?}"
+    );
+}

--- a/src/lib/file-dialog.test.ts
+++ b/src/lib/file-dialog.test.ts
@@ -41,11 +41,12 @@ describe("pickFolder", () => {
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
-  it("turns the missing-backend rejection into an actionable toast and resolves null", async () => {
-    // The Rust preflight rejects with this marker when neither the
-    // XDG portal nor zenity exists (issue #95).
+  it("surfaces the cause-specific backend message as the toast description", async () => {
+    // The Rust preflight rejects with the marker plus a cause-specific
+    // remediation (issue #95). The wrapper must surface that detail
+    // verbatim, not a fixed "install packages" hint.
     mockPickFolderDialog.mockRejectedValue(
-      `${NO_FILE_PICKER_BACKEND}: cannot open a file dialog. The XDG desktop portal is unavailable and zenity is not installed.`,
+      `${NO_FILE_PICKER_BACKEND}: The xdg-desktop-portal is installed but is not starting in this session. Export it to D-Bus and restart Codemux. Alternatively, install zenity and Codemux will use it as a fallback file picker.`,
     );
 
     await expect(pickFolder("Open project")).resolves.toBeNull();
@@ -53,6 +54,9 @@ describe("pickFolder", () => {
     expect(mockToastError).toHaveBeenCalledTimes(1);
     const [headline, opts] = mockToastError.mock.calls[0];
     expect(headline).toMatch(/file picker/i);
+    // The marker prefix is stripped; the actionable detail survives.
+    expect(opts?.description).not.toContain(NO_FILE_PICKER_BACKEND);
+    expect(opts?.description).toMatch(/not starting in this session/);
     expect(opts?.description).toMatch(/xdg-desktop-portal/);
     expect(opts?.description).toMatch(/zenity/);
   });

--- a/src/lib/file-dialog.ts
+++ b/src/lib/file-dialog.ts
@@ -30,8 +30,19 @@ function describeError(err: unknown): string {
 function surfaceDialogError(err: unknown): void {
   const message = describeError(err);
   if (message.includes(NO_FILE_PICKER_BACKEND)) {
-    toast.error("No file picker available on this system", {
+    // The Rust preflight builds a cause-specific, actionable message
+    // (portal not installed vs installed-but-not-starting, plus the
+    // zenity fallback). Surface it verbatim instead of a fixed
+    // "install packages" hint that's wrong when the packages are
+    // already there but the portal just isn't starting (issue #95).
+    const markerAt = message.indexOf(NO_FILE_PICKER_BACKEND);
+    const detail = message
+      .slice(markerAt + NO_FILE_PICKER_BACKEND.length)
+      .replace(/^[:\s]+/, "")
+      .trim();
+    toast.error("Can't open a file picker on this system", {
       description:
+        detail ||
         "Install xdg-desktop-portal and xdg-desktop-portal-gtk, then restart your session. Installing zenity also works.",
     });
   } else {


### PR DESCRIPTION
Follow-up to #97. A reporter on Arch + i3 had `xdg-desktop-portal`, the gtk backend, and `zenity` all installed and the file picker still never opened. Two layers were wrong.

## What was actually happening

- The XDG portal was **installed but not starting** in his session (the probe *timed out* rather than coming back missing). On minimal window managers the portal can't start because the session environment isn't exported to D-Bus. Reinstalling packages does nothing for this.
- rfd's built-in zenity fallback couldn't save it either: it only falls back when the portal call *errors*, but here it *hangs*; and when it does spawn zenity it inherits the same broken session env (dead/stale D-Bus session bus, at-spi bridge blocking `gtk_init`), so zenity hangs too. He confirmed zenity only displayed after unsetting those vars by hand.

## Changes

**1. Cause-specific guidance.** The preflight classifies the portal failure instead of collapsing everything into "install xdg-desktop-portal / zenity":
- timed out → portal is installed but not starting; point at exporting the session env to D-Bus / setting `XDG_CURRENT_DESKTOP`, with the Arch wiki reference.
- no session bus → start the session under a D-Bus session bus.
- otherwise → the original install hint.

The Rust side builds the message; the frontend surfaces it verbatim (marker stripped) and `codemux doctor` prints the same remediation.

**2. A zenity fallback we control.** `dialog_preflight::select_backend()` decides up front: portal answers → keep using rfd; portal unusable but zenity present → drive zenity ourselves (`dialog_fallback`) with
- a **sanitized environment** — clear `DBUS_SESSION_BUS_ADDRESS` / `GTK*_MODULES`, set `NO_AT_BRIDGE=1` / `GTK_A11Y=none` so a broken bus or a11y bridge can't stall init;
- a **hard timeout** (`CODEMUX_ZENITY_TIMEOUT_MS`, default 180s) so a wedged zenity releases the dialog instead of leaving the button dead.

This means a portal-less session with zenity installed now just works, no session config required.

## Verification

- `tests/dialog_fallback.rs` (deterministic, fake zenity): asserts the env is sanitized, the selection round-trips, and a hung picker hits the timeout.
- `tests/dialog_preflight.rs`, the frontend `file-dialog.test.ts`, and the full suites stay green (`cargo check`, `tsc`, 1914 vitest tests).
- Reproduced on a portal-less Arch container running **real zenity 4.2.2** under Xvfb: the reporter's broken session (dead bus + atk-bridge) hangs the picker at startup; applying this exact transformation makes it open and return a selection.

Note: this covers users who have zenity (shipped as an optdepend). A session with neither a working portal nor zenity still can't open a picker, but now gets the precise, actionable message rather than a silent no-op.
