### PR TITLE
Richer attachment chips in the new-workspace composer

### DIFF
--- a/docs/features/workspace-creation.md
+++ b/docs/features/workspace-creation.md
@@ -58,7 +58,7 @@ After onboarding: scripts saved to project config, worktree workspace created, w
 - Manual branch name editing (stops auto-generation)
 - GitHub issue linking with branch name suggestion and prompt context injection
 - PR linking with branch auto-fill
-- File attachment (paths appended to prompt)
+- File attachment (paths appended to prompt) — staged as bordered chips (`workspace-attachment-chip.tsx`) with a per-type leading badge: image files show a real thumbnail (Tauri asset protocol, falling back to a glyph if it can't load), other files a file glyph, and clipboard pastes a friendly "Pasted image" label (full path on hover)
 - Agent preset selection from pinned presets
 - Package manager detection (npm, bun, pnpm, yarn, cargo, pip, uv, poetry, go, bundle, etc.)
 - Setup/teardown script configuration with environment variables

--- a/src/components/overlays/new-workspace-dialog.test.tsx
+++ b/src/components/overlays/new-workspace-dialog.test.tsx
@@ -857,8 +857,10 @@ describe("Clipboard image paste", () => {
     );
     firePaste(textarea);
 
-    // The chip renders the trailing filename component (the existing
-    // attachment-strip logic lifts it via `.split("/").pop()`).
+    // Pasted clipboard images carry a `paste-<uuid>` temp filename
+    // that's noise to the user, so the chip shows a friendly "Pasted
+    // image" label and keeps the real path in the hover title (which is
+    // what the submit flow consumes).
     //
     // The default 1000ms waitFor isn't enough on a busy Windows CI
     // runner: paste → await mock → setAttachments → React commit can
@@ -867,11 +869,15 @@ describe("Clipboard image paste", () => {
     // so we widen the budget rather than pushing on a real bug.
     await waitFor(
       () => {
-        const chips = within(dialog).getAllByText("paste-xyz.png");
+        const chips = within(dialog).getAllByText("Pasted image");
         expect(chips.length).toBeGreaterThan(0);
       },
       { timeout: 5000 },
     );
+    const chip = within(dialog)
+      .getByText("Pasted image")
+      .closest("[title]");
+    expect(chip?.getAttribute("title")).toContain("paste-xyz.png");
   });
 
   it("stays silent when the OS clipboard has no image", async () => {
@@ -895,10 +901,10 @@ describe("Clipboard image paste", () => {
       expect(pasteClipboardImageToFile).toHaveBeenCalled();
     });
 
-    // No chip should appear. Probe by the paste-* filename pattern
+    // No chip should appear. Probe by the friendly pasted-image label
     // so the test isn't sensitive to other chip text.
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(within(dialog).queryByText(/paste-.*\.png/)).toBeNull();
+    expect(within(dialog).queryByText("Pasted image")).toBeNull();
   });
 
   it("does not double-add the same path on repeated paste", async () => {
@@ -919,7 +925,7 @@ describe("Clipboard image paste", () => {
     );
     firePaste(textarea);
     await waitFor(() => {
-      expect(within(dialog).getAllByText("paste-dupe.png").length).toBe(1);
+      expect(within(dialog).getAllByText("Pasted image").length).toBe(1);
     });
 
     firePaste(textarea);
@@ -927,6 +933,6 @@ describe("Clipboard image paste", () => {
       expect(pasteClipboardImageToFile).toHaveBeenCalledTimes(2);
     });
     // Still exactly one chip.
-    expect(within(dialog).getAllByText("paste-dupe.png").length).toBe(1);
+    expect(within(dialog).getAllByText("Pasted image").length).toBe(1);
   });
 });

--- a/src/components/overlays/new-workspace-dialog.tsx
+++ b/src/components/overlays/new-workspace-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { basename } from "@/lib/path";
 import { BranchPicker } from "./branch-picker";
+import { WorkspaceAttachmentChip } from "./workspace-attachment-chip";
 import { DevicePicker } from "@/components/hosts/device-picker";
 import {
   Tooltip,
@@ -1050,21 +1051,31 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
 
             {/* Attachment chips + linked issue chip */}
             {(attachments.length > 0 || linkedIssue) && (
-              <div className="flex flex-wrap gap-1.5 px-4 pb-2">
+              <div className="flex flex-wrap gap-2 px-4 pb-2.5">
                 {/* Linked issue chip */}
                 {linkedIssue && (
-                  <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-0.5 text-[11px] text-muted-foreground">
+                  <span
+                    className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/50 py-0.5 pl-1 pr-1 text-[11px] text-foreground"
+                    title={`#${linkedIssue.number} ${linkedIssue.title}`}
+                  >
                     <span
                       className={cn(
-                        "size-1.5 rounded-full shrink-0",
-                        linkedIssue.state === "Open" ? "bg-success" : "bg-muted-foreground",
+                        "flex size-5 shrink-0 items-center justify-center rounded",
+                        linkedIssue.state === "Open"
+                          ? "bg-success/15 text-success"
+                          : "bg-foreground/10 text-muted-foreground",
                       )}
-                    />
-                    <span className="font-mono tabular-nums">#{linkedIssue.number}</span>
-                    <span className="max-w-[180px] truncate">{linkedIssue.title}</span>
+                    >
+                      <CircleDot className="h-3 w-3" />
+                    </span>
+                    <span className="font-mono tabular-nums text-muted-foreground">
+                      #{linkedIssue.number}
+                    </span>
+                    <span className="max-w-[160px] truncate">{linkedIssue.title}</span>
                     <button
                       type="button"
-                      className="ml-0.5 rounded-full p-0.5 hover:bg-foreground/10 transition-colors"
+                      aria-label={`Remove issue #${linkedIssue.number}`}
+                      className="ml-0.5 rounded-full p-0.5 text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground"
                       onClick={() => {
                         setLinkedIssue(null);
                         if (branchAutoFilled) {
@@ -1078,24 +1089,13 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
                   </span>
                 )}
                 {attachments.map((file) => (
-                  <span
+                  <WorkspaceAttachmentChip
                     key={file}
-                    className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-0.5 text-[11px] text-muted-foreground"
-                  >
-                    <Paperclip className="h-2.5 w-2.5" />
-                    <span className="max-w-[160px] truncate">
-                      {basename(file)}
-                    </span>
-                    <button
-                      type="button"
-                      className="ml-0.5 rounded-full p-0.5 hover:bg-foreground/10 transition-colors"
-                      onClick={() =>
-                        setAttachments((prev) => prev.filter((f) => f !== file))
-                      }
-                    >
-                      <X className="h-2.5 w-2.5" />
-                    </button>
-                  </span>
+                    path={file}
+                    onRemove={() =>
+                      setAttachments((prev) => prev.filter((f) => f !== file))
+                    }
+                  />
                 ))}
               </div>
             )}

--- a/src/components/overlays/workspace-attachment-chip.tsx
+++ b/src/components/overlays/workspace-attachment-chip.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import { FileText, Image as ImageIcon, X } from "lucide-react";
+import { basename } from "@/lib/path";
+
+const IMAGE_EXTS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "bmp",
+  "avif",
+  "ico",
+]);
+
+/** Image attachments get a thumbnail; everything else a typed glyph. */
+function isImagePath(path: string): boolean {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  return IMAGE_EXTS.has(ext);
+}
+
+/** Pasted clipboard images land in a dedicated temp dir
+ *  (`codemux-clipboard-images/paste-<uuid>.<ext>`). Surfacing the raw
+ *  UUID is noise — show a friendly label and keep the real path in the
+ *  hover title. The dir marker is the reliable signal (cross-platform,
+ *  not fooled by a user file that happens to start with `paste-`). */
+function attachmentLabel(path: string, isImage: boolean): string {
+  const name = basename(path);
+  if (isImage && path.includes("codemux-clipboard-images")) {
+    return "Pasted image";
+  }
+  return name;
+}
+
+interface Props {
+  /** Absolute filesystem path of the attached file. */
+  path: string;
+  onRemove: () => void;
+}
+
+/** Chip for a staged file/image attachment in the new-workspace composer.
+ *  Images render a real thumbnail (via the Tauri asset protocol); other
+ *  files fall back to a typed glyph. Mirrors the footer pill vocabulary
+ *  (bordered, muted) so the attachment strip reads as a sibling of the
+ *  agent/model pills below it. */
+export function WorkspaceAttachmentChip({ path, onRemove }: Props) {
+  const [thumbErrored, setThumbErrored] = useState(false);
+  const isImage = isImagePath(path);
+  const showThumb = isImage && !thumbErrored;
+  const label = attachmentLabel(path, isImage);
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/50 py-0.5 pl-1 pr-1 text-[11px] text-foreground"
+      title={path}
+    >
+      {showThumb ? (
+        <img
+          src={convertFileSrc(path)}
+          alt=""
+          aria-hidden
+          className="size-5 shrink-0 rounded object-cover"
+          onError={() => setThumbErrored(true)}
+        />
+      ) : (
+        <span className="flex size-5 shrink-0 items-center justify-center rounded bg-foreground/10 text-muted-foreground">
+          {isImage ? (
+            <ImageIcon className="h-3 w-3" />
+          ) : (
+            <FileText className="h-3 w-3" />
+          )}
+        </span>
+      )}
+      <span className="max-w-[160px] truncate">{label}</span>
+      <button
+        type="button"
+        aria-label={`Remove ${label}`}
+        className="ml-0.5 rounded-full p-0.5 text-muted-foreground/70 transition-colors hover:bg-foreground/10 hover:text-foreground"
+        onClick={onRemove}
+      >
+        <X className="h-2.5 w-2.5" />
+      </button>
+    </span>
+  );
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -79,3 +79,15 @@ vi.mock('@tauri-apps/api/window', () => ({
     requestUserAttention: () => Promise.resolve(),
   }),
 }));
+
+// `convertFileSrc()` from `@tauri-apps/api/core` reads
+// `window.__TAURI_INTERNALS__.convertFileSrc`, which only exists under the
+// Tauri runtime. Components that render local-file thumbnails (e.g. image
+// attachment chips) call it during render, so without a stub they crash
+// under jsdom. Override only `convertFileSrc` and keep the module's other
+// exports (notably `invoke`, used by the real command wrapper) intact —
+// tests that assert on the resolved URL still override this themselves.
+vi.mock('@tauri-apps/api/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tauri-apps/api/core')>();
+  return { ...actual, convertFileSrc: (filePath: string) => filePath };
+});


### PR DESCRIPTION
## What

Polishes how staged attachments (files, pasted images, linked issues) render in the new-workspace composer.

Before, chips used a flat muted fill on the muted textarea — so they blended into the background — and every file (including pasted images) got a generic paperclip icon and the raw filename (e.g. `paste-858a3b9c-…png`).

## Changes

- **New `WorkspaceAttachmentChip`** with a per-type leading badge:
  - **Image files** → a real rounded **thumbnail** via the Tauri asset protocol (same `convertFileSrc` path as `ImageViewer`), with a glyph fallback if it can't load.
  - **Other files** → a file glyph.
  - **Clipboard pastes** → a friendly **"Pasted image"** label (detected by the `codemux-clipboard-images` temp dir; full path preserved on hover).
- **Restyled the linked-issue chip** to match: green `CircleDot` badge for open / muted for closed, a bordered-pill surface consistent with the agent/model pills, and proper `aria-label`s.
- All chips now read as discrete, lifted objects using the dialog's existing pill vocabulary (`border-border` + `bg-muted/50`).

## Testing

- Visually verified all chip states in the dev-mock browser.
- Added a global `convertFileSrc` mock in `vitest.setup.ts` (spreads the actual module so `invoke` and other exports stay intact) so thumbnail components don't crash under jsdom; updated the paste tests for the new label.
- `tsc` clean; full frontend suite green (131 files / 1942 tests). Rust untouched.
- Updated `docs/features/workspace-creation.md`.