### PR TITLE
Bug fixes: correctness, stability & smoothness (panes, terminal, browser, sync, MCP)

### DIFF
--- a/src-tauri/src/agent_browser.rs
+++ b/src-tauri/src/agent_browser.rs
@@ -1344,6 +1344,21 @@ fn make_request_id() -> String {
     )
 }
 
+/// Truncate a string to at most `max_bytes`, backing off to a UTF-8 char
+/// boundary. agent-browser output is arbitrary page/DOM text (often multibyte),
+/// so a raw byte-index slice for a log preview would panic when the cut lands
+/// inside a character.
+fn truncate_on_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 fn execute_agent_browser_action(browser_id: &str, action: &str, params: serde_json::Value, stream_port: u16) -> Result<BrowserAutomationResult, String> {
     let session = session_name(browser_id);
 
@@ -1386,9 +1401,9 @@ fn execute_agent_browser_action(browser_id: &str, action: &str, params: serde_js
 
     // Debug logging for snapshot commands
     if action == "snapshot" || action == "accessibility_snapshot" {
-        eprintln!("[codemux::browser] Snapshot stdout ({} bytes): {}", stdout.len(), &stdout[..stdout.len().min(200)]);
+        eprintln!("[codemux::browser] Snapshot stdout ({} bytes): {}", stdout.len(), truncate_on_boundary(&stdout, 200));
         if !stderr.is_empty() {
-            eprintln!("[codemux::browser] Snapshot stderr: {}", &stderr[..stderr.len().min(200)]);
+            eprintln!("[codemux::browser] Snapshot stderr: {}", truncate_on_boundary(&stderr, 200));
         }
     }
 
@@ -1398,7 +1413,7 @@ fn execute_agent_browser_action(browser_id: &str, action: &str, params: serde_js
 
     // For snapshot: detect useless ARIA result and fall back to DOM-based query
     if action == "snapshot" || action == "accessibility_snapshot" {
-        eprintln!("[codemux::browser] Snapshot raw stdout for fallback check: {:?}", &stdout[..stdout.len().min(300)]);
+        eprintln!("[codemux::browser] Snapshot raw stdout for fallback check: {:?}", truncate_on_boundary(&stdout, 300));
     }
     if (action == "snapshot" || action == "accessibility_snapshot") && needs_dom_fallback(&stdout) {
         eprintln!("[codemux::browser] ARIA snapshot empty, falling back to DOM query");
@@ -2178,6 +2193,21 @@ impl AgentBrowserManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_on_boundary_never_splits_a_multibyte_char() {
+        // 67×'技' = 201 bytes; byte 200 is inside the 67th char (198..201),
+        // so a raw `&s[..200]` would panic. The helper backs off to byte 198.
+        let s = "技".repeat(67);
+        let out = truncate_on_boundary(&s, 200);
+        assert_eq!(out, "技".repeat(66));
+        assert!(out.len() <= 200);
+        // Shorter-than-limit and ASCII inputs pass through / cut cleanly.
+        assert_eq!(truncate_on_boundary("hello", 200), "hello");
+        assert_eq!(truncate_on_boundary("hello", 3), "hel");
+        // A cut exactly on a boundary keeps the whole char.
+        assert_eq!(truncate_on_boundary("a技b", 4), "a技");
+    }
 
     // ── External-process timeout guard (issue #96) ───────────────────
     //

--- a/src-tauri/src/automations/recurrence.rs
+++ b/src-tauri/src/automations/recurrence.rs
@@ -91,6 +91,28 @@ mod tests {
     }
 
     #[test]
+    fn next_occurrence_preserves_wall_clock_time_across_dst() {
+        // A daily 06:00 America/Los_Angeles rule must keep firing at 06:00
+        // local wall-clock time across the spring-forward (Sun 2026-03-08,
+        // 02:00 PST → 03:00 PDT). The UTC instant therefore shifts by an hour:
+        // 06:00 PST = 14:00 UTC before, 06:00 PDT = 13:00 UTC after. (Superset's
+        // hand-rolled scheduler drifted here; codemux delegates to the rrule
+        // crate + a TZID-anchored DTSTART, which the UI builder emits.)
+        let schedule =
+            "DTSTART;TZID=America/Los_Angeles:20260301T060000\nRRULE:FREQ=DAILY";
+        let before_dst =
+            next_occurrence(schedule, Utc.with_ymd_and_hms(2026, 3, 7, 0, 0, 0).unwrap())
+                .unwrap()
+                .unwrap();
+        assert_eq!(before_dst, Utc.with_ymd_and_hms(2026, 3, 7, 14, 0, 0).unwrap());
+        let after_dst =
+            next_occurrence(schedule, Utc.with_ymd_and_hms(2026, 3, 9, 0, 0, 0).unwrap())
+                .unwrap()
+                .unwrap();
+        assert_eq!(after_dst, Utc.with_ymd_and_hms(2026, 3, 9, 13, 0, 0).unwrap());
+    }
+
+    #[test]
     fn validate_rejects_a_rule_without_a_dtstart() {
         // `RRULE` alone is not a valid `RRuleSet` — it has no anchor.
         assert!(validate("RRULE:FREQ=DAILY").is_err());

--- a/src-tauri/src/branch_name.rs
+++ b/src-tauri/src/branch_name.rs
@@ -53,8 +53,17 @@ pub fn sanitize_branch_name(raw: &str) -> String {
         }
     }
 
-    // Trim leading/trailing hyphens and dots
-    name.trim_matches(|c| c == '-' || c == '.').to_string()
+    // Trim leading/trailing hyphens and dots.
+    let mut name = name.trim_matches(|c| c == '-' || c == '.').to_string();
+
+    // Git rejects refs ending in ".lock", so strip any such suffix and
+    // re-trim any separator it exposes (loop handles e.g. "foo.lock.lock").
+    while let Some(stripped) = name.strip_suffix(".lock") {
+        name = stripped
+            .trim_end_matches(|c| c == '-' || c == '.')
+            .to_string();
+    }
+    name
 }
 
 /// Check name against a set of existing branches, appending -2..-99 on conflict.
@@ -243,6 +252,16 @@ mod tests {
     fn sanitize_trims_leading_trailing() {
         assert_eq!(sanitize_branch_name("-foo-bar-"), "foo-bar");
         assert_eq!(sanitize_branch_name(".foo.bar."), "foo.bar");
+    }
+
+    #[test]
+    fn sanitize_strips_trailing_lock_suffix() {
+        // Git forbids refs ending in ".lock".
+        assert_eq!(sanitize_branch_name("update.lock"), "update");
+        assert_eq!(sanitize_branch_name("hotfix.lock.lock"), "hotfix");
+        assert!(!sanitize_branch_name("release.lock").ends_with(".lock"));
+        // Only the trailing suffix is stripped — ".lock" elsewhere stays.
+        assert_eq!(sanitize_branch_name("my.lockfile"), "my.lockfile");
     }
 
     #[test]

--- a/src-tauri/src/commands/workspaces_sync.rs
+++ b/src-tauri/src/commands/workspaces_sync.rs
@@ -148,9 +148,15 @@ fn adopt_worktree_landing_via_repo(
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or(project_name);
-    crate::workspace_paths::expand_tilde(
-        &crate::workspace_paths::conventional_remote_path(root_basename, branch),
-    )
+    // Predict git_create_worktree's path EXACTLY: it lands the worktree at
+    // ~/.codemux/worktrees/<root_basename>/<sanitize_branch_for_worktree_path(branch)>.
+    // conventional_remote_path's sanitize_segment is stricter on the branch
+    // (e.g. it maps '+' -> '-'), so routing the branch through it would predict
+    // a directory that differs from where the worktree actually lands.
+    let branch_seg = crate::git::sanitize_branch_for_worktree_path(branch);
+    crate::workspace_paths::expand_tilde(&std::path::PathBuf::from(format!(
+        "~/.codemux/worktrees/{root_basename}/{branch_seg}"
+    )))
     .to_string_lossy()
     .to_string()
 }
@@ -2086,6 +2092,24 @@ mod landing_tests {
             n.ends_with(&format!("/worktrees/{FIXTURE}/feature-x")),
             "got {n}"
         );
+    }
+
+    #[test]
+    fn worktree_via_repo_landing_matches_git_create_worktree_branch_sanitizer() {
+        // git_create_worktree only maps the Windows-forbidden set, so a branch
+        // like `feat+ui` keeps its `+`. The preview must predict the same dir —
+        // conventional_remote_path's sanitize_segment would wrongly map it to
+        // `feat-ui`, so the dialog (and its path-in-use check) would point at a
+        // directory the workspace never lands in.
+        let branch = "feat+ui";
+        let landing = adopt_worktree_landing_via_repo(Some(UID_A), FIXTURE, branch);
+        let expected_seg = crate::git::sanitize_branch_for_worktree_path(branch);
+        assert_eq!(expected_seg, "feat+ui");
+        assert!(
+            landing.ends_with(&format!("/{expected_seg}")),
+            "preview landing must match git_create_worktree's branch dir; got {landing}"
+        );
+        assert!(!landing.ends_with("/feat-ui"), "got {landing}");
     }
 
     #[test]

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -763,8 +763,14 @@ async fn dispatch_request(app: &AppHandle, request: ControlRequest) -> ControlRe
         "notify" => {
             let state: State<'_, AppStateStore> = app.state();
             let message = request.params.get("message").and_then(Value::as_str).unwrap_or("Attention needed");
+            let level = request.params.get("level").and_then(Value::as_str).unwrap_or("attention");
             state
-                .add_notification(None, None, message.to_string(), crate::state::NotificationLevel::Attention)
+                .add_notification(
+                    None,
+                    None,
+                    message.to_string(),
+                    crate::state::NotificationLevel::from_str_or_attention(level),
+                )
                 .map(|notification_id| {
                     crate::state::emit_app_state(app);
                     serde_json::json!({ "notification_id": notification_id })

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -889,6 +889,31 @@ fn parse_porcelain_status(output: &str) -> Vec<GitFileStatus> {
     results
 }
 
+/// Extract the destination path from a `git diff --numstat` path field,
+/// handling git's compact rename forms so the key matches what
+/// `git diff --name-status` reports (and stats attach correctly):
+///   "old => new"        -> "new"
+///   "dir/{old => new}"  -> "dir/new"
+///   "{old => new}/file" -> "new/file"
+///   "a/{old => new}/b"  -> "a/new/b"
+/// Non-rename paths are returned unchanged.
+fn numstat_new_path(raw: &str) -> String {
+    if !raw.contains(" => ") {
+        return raw.to_string();
+    }
+    if let (Some(open), Some(close)) = (raw.find('{'), raw.find('}')) {
+        if open < close {
+            let prefix = &raw[..open];
+            let inside = &raw[open + 1..close];
+            let suffix = &raw[close + 1..];
+            let new_part = inside.split(" => ").nth(1).unwrap_or(inside);
+            return format!("{prefix}{new_part}{suffix}");
+        }
+    }
+    // No braces: the whole field is "old => new".
+    raw.split(" => ").nth(1).unwrap_or(raw).to_string()
+}
+
 fn parse_numstat_per_file(unstaged: &str, staged: &str) -> std::collections::HashMap<String, (u32, u32)> {
     let mut map = std::collections::HashMap::new();
     for line in unstaged.lines().chain(staged.lines()) {
@@ -896,7 +921,7 @@ fn parse_numstat_per_file(unstaged: &str, staged: &str) -> std::collections::Has
         if parts.len() >= 3 {
             let adds = parts[0].parse::<u32>().unwrap_or(0);
             let dels = parts[1].parse::<u32>().unwrap_or(0);
-            let path = parts[2].to_string();
+            let path = numstat_new_path(parts[2]);
             let entry = map.entry(path).or_insert((0, 0));
             entry.0 += adds;
             entry.1 += dels;
@@ -966,15 +991,9 @@ fn parse_single_numstat(output: &str) -> std::collections::HashMap<String, (u32,
         if parts.len() >= 3 {
             let adds = parts[0].parse::<u32>().unwrap_or(0);
             let dels = parts[1].parse::<u32>().unwrap_or(0);
-            // Handle renames: numstat shows "old => new" or just the path
-            let raw_path = parts[2];
-            let path = if let Some(arrow) = raw_path.find(" => ") {
-                // e.g. "{src => dest}/file.txt" or "old.txt => new.txt"
-                let after = &raw_path[arrow + 4..];
-                after.trim_matches('}').to_string()
-            } else {
-                raw_path.to_string()
-            };
+            // Handle renames: numstat shows compact forms like
+            // "src/lib/{old => new}" — reconstruct the full destination path.
+            let path = numstat_new_path(parts[2]);
             let entry = map.entry(path).or_insert((0, 0));
             entry.0 += adds;
             entry.1 += dels;
@@ -3026,6 +3045,46 @@ C  source.txt -> copy.txt";
         let (adds, dels) = parse_numstat("");
         assert_eq!(adds, 0);
         assert_eq!(dels, 0);
+    }
+
+    #[test]
+    fn numstat_new_path_handles_rename_forms() {
+        // Non-rename path is unchanged.
+        assert_eq!(numstat_new_path("src/a.txt"), "src/a.txt");
+        // Whole-path rename (no shared component).
+        assert_eq!(numstat_new_path("old.txt => new.txt"), "new.txt");
+        assert_eq!(
+            numstat_new_path("src/a.txt => dest/b.txt"),
+            "dest/b.txt"
+        );
+        // Shared prefix / suffix / both, in git's brace form.
+        assert_eq!(
+            numstat_new_path("src/lib/{old.txt => new.txt}"),
+            "src/lib/new.txt"
+        );
+        assert_eq!(
+            numstat_new_path("{src => dest}/file.txt"),
+            "dest/file.txt"
+        );
+        assert_eq!(
+            numstat_new_path("src/{a => b}/file.txt"),
+            "src/b/file.txt"
+        );
+    }
+
+    #[test]
+    fn parse_single_numstat_attaches_stats_to_renamed_path() {
+        // The key must be the full destination path so it matches
+        // `git diff --name-status` (`src/lib/new.txt`) and stats attach.
+        let map = parse_single_numstat("5\t3\tsrc/lib/{old.txt => new.txt}\n");
+        assert_eq!(map.get("src/lib/new.txt"), Some(&(5, 3)));
+        assert_eq!(map.get("new.txt"), None);
+    }
+
+    #[test]
+    fn parse_numstat_per_file_attaches_stats_to_renamed_path() {
+        let map = parse_numstat_per_file("4\t1\t{src => dest}/file.txt\n", "");
+        assert_eq!(map.get("dest/file.txt"), Some(&(4, 1)));
     }
 
     #[test]

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -636,7 +636,14 @@ pub fn suggest_branch_name(number: u64, title: &str) -> String {
     // Truncate title portion to ~60 chars, break at word boundary
     let max_title_len = 60;
     let title_slug = if trimmed.len() > max_title_len {
-        let truncated = &trimmed[..max_title_len];
+        // Back off to a char boundary so a multibyte slug (CJK, accented,
+        // Cyrillic — all kept by is_alphanumeric above) never panics on the
+        // byte-index slice. Mirrors the body-truncation sites elsewhere here.
+        let mut end = max_title_len;
+        while end > 0 && !trimmed.is_char_boundary(end) {
+            end -= 1;
+        }
+        let truncated = &trimmed[..end];
         // Find last hyphen to break at word boundary
         if let Some(pos) = truncated.rfind('-') {
             &truncated[..pos]
@@ -1617,6 +1624,17 @@ mod tests {
             suggest_branch_name(10, "Über die Straße gehen"),
             "feature/10-über-die-straße-gehen"
         );
+    }
+
+    #[test]
+    fn test_suggest_branch_name_long_multibyte_title_does_not_panic() {
+        // 'a' (1 byte) + 20×'技' (3 bytes) = 61-byte slug with no hyphens, so
+        // the truncation runs and byte 60 lands mid-character. Slicing there
+        // by raw byte index would panic; the cut must back off to a boundary.
+        let title = format!("a{}", "技".repeat(20));
+        let name = suggest_branch_name(1, &title);
+        assert!(name.starts_with("feature/1-a"), "got: {name}");
+        assert!(name.contains('技'));
     }
 
     #[test]

--- a/src-tauri/src/github_cache.rs
+++ b/src-tauri/src/github_cache.rs
@@ -56,7 +56,16 @@ fn list_key(repo_path: &Path, search: Option<&str>) -> ListKey {
 static ISSUE_LIST_CACHE: LazyLock<Mutex<HashMap<ListKey, CacheEntry<Vec<GitHubIssue>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-static ISSUE_DETAIL_CACHE: LazyLock<Mutex<HashMap<u64, CacheEntry<GitHubIssue>>>> =
+/// Detail caches key on `(repo_path, number)`. Issue/PR numbers are
+/// per-repository (every repo has an issue #1), so a bare-number key would
+/// serve repo A's issue #1 in response to repo B's issue #1 lookup.
+type IssueDetailKey = (String, u64);
+
+fn issue_detail_key(repo_path: &Path, number: u64) -> IssueDetailKey {
+    (repo_path.display().to_string(), number)
+}
+
+static ISSUE_DETAIL_CACHE: LazyLock<Mutex<HashMap<IssueDetailKey, CacheEntry<GitHubIssue>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Stage 5 — PR list cache, keyed by `(repo_path, state)` since
@@ -70,14 +79,24 @@ fn pr_list_key(repo_path: &Path, state: &str) -> PrListKey {
 static PR_LIST_CACHE: LazyLock<Mutex<HashMap<PrListKey, CacheEntry<Vec<PullRequestInfo>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-static PR_DETAIL_CACHE: LazyLock<Mutex<HashMap<u32, CacheEntry<PullRequestInfo>>>> =
+type PrDetailKey = (String, u32);
+
+fn pr_detail_key(repo_path: &Path, number: u32) -> PrDetailKey {
+    (repo_path.display().to_string(), number)
+}
+
+static PR_DETAIL_CACHE: LazyLock<Mutex<HashMap<PrDetailKey, CacheEntry<PullRequestInfo>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Diffs are bigger and shift more often than the PR header; key by
-/// `(number, full)` so a request for a name-only diff doesn't return
-/// a previously-cached full diff (or vice versa). The string is the
-/// diff body verbatim.
-type PrDiffKey = (u32, bool);
+/// `(repo_path, number, full)` so a request for a name-only diff doesn't
+/// return a previously-cached full diff (or another repo's diff). The string
+/// is the diff body verbatim.
+type PrDiffKey = (String, u32, bool);
+
+fn pr_diff_key(repo_path: &Path, number: u32, full: bool) -> PrDiffKey {
+    (repo_path.display().to_string(), number, full)
+}
 
 static PR_DIFF_CACHE: LazyLock<Mutex<HashMap<PrDiffKey, CacheEntry<String>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -111,8 +130,9 @@ pub fn cached_list_issues(
 /// longer than list TTL because a single-issue detail rarely changes
 /// during a user's chat-popup interaction.
 pub fn cached_get_issue(repo_path: &Path, number: u64) -> Result<GitHubIssue, String> {
+    let key = issue_detail_key(repo_path, number);
     if let Ok(cache) = ISSUE_DETAIL_CACHE.lock() {
-        if let Some(entry) = cache.get(&number) {
+        if let Some(entry) = cache.get(&key) {
             if entry.is_fresh(DETAIL_TTL) {
                 return Ok(entry.value.clone());
             }
@@ -121,7 +141,7 @@ pub fn cached_get_issue(repo_path: &Path, number: u64) -> Result<GitHubIssue, St
 
     let fresh = github::get_github_issue(repo_path, number)?;
     if let Ok(mut cache) = ISSUE_DETAIL_CACHE.lock() {
-        cache.insert(number, CacheEntry::fresh(fresh.clone()));
+        cache.insert(key, CacheEntry::fresh(fresh.clone()));
     }
     Ok(fresh)
 }
@@ -155,8 +175,9 @@ pub fn cached_get_pull_request(
     repo_path: &Path,
     number: u32,
 ) -> Result<PullRequestInfo, String> {
+    let key = pr_detail_key(repo_path, number);
     if let Ok(cache) = PR_DETAIL_CACHE.lock() {
-        if let Some(entry) = cache.get(&number) {
+        if let Some(entry) = cache.get(&key) {
             if entry.is_fresh(DETAIL_TTL) {
                 return Ok(entry.value.clone());
             }
@@ -165,7 +186,7 @@ pub fn cached_get_pull_request(
 
     let fresh = github::get_pull_request(repo_path, number)?;
     if let Ok(mut cache) = PR_DETAIL_CACHE.lock() {
-        cache.insert(number, CacheEntry::fresh(fresh.clone()));
+        cache.insert(key, CacheEntry::fresh(fresh.clone()));
     }
     Ok(fresh)
 }
@@ -178,7 +199,7 @@ pub fn cached_get_pr_diff(
     number: u32,
     full: bool,
 ) -> Result<String, String> {
-    let key = (number, full);
+    let key = pr_diff_key(repo_path, number, full);
     if let Ok(cache) = PR_DIFF_CACHE.lock() {
         if let Some(entry) = cache.get(&key) {
             if entry.is_fresh(DETAIL_TTL) {
@@ -202,8 +223,10 @@ pub fn cached_get_pr_diff(
 pub fn invalidate_pr_cache(number: Option<u32>) {
     if let Ok(mut cache) = PR_DETAIL_CACHE.lock() {
         match number {
+            // Number-scoped invalidation drops PR #n across every repo —
+            // over-invalidation just triggers a refetch, never a stale hit.
             Some(n) => {
-                cache.remove(&n);
+                cache.retain(|(_, num), _| *num != n);
             }
             None => cache.clear(),
         }
@@ -211,7 +234,7 @@ pub fn invalidate_pr_cache(number: Option<u32>) {
     if let Ok(mut cache) = PR_DIFF_CACHE.lock() {
         match number {
             Some(n) => {
-                cache.retain(|(k, _), _| *k != n);
+                cache.retain(|(_, num, _), _| *num != n);
             }
             None => cache.clear(),
         }
@@ -230,7 +253,7 @@ pub fn invalidate_issue_cache(number: Option<u64>) {
     if let Ok(mut cache) = ISSUE_DETAIL_CACHE.lock() {
         match number {
             Some(n) => {
-                cache.remove(&n);
+                cache.retain(|(_, num), _| *num != n);
             }
             None => cache.clear(),
         }
@@ -246,6 +269,14 @@ pub fn invalidate_issue_cache(number: Option<u64>) {
 mod tests {
     use super::*;
     use crate::github::IssueState;
+
+    /// Cache tests share global statics, and one test issues a global
+    /// `invalidate_issue_cache(None)`. Serialize the cache-state tests so that
+    /// clear can't race another test's insert→assert window.
+    fn serial() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: Mutex<()> = Mutex::new(());
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     fn fixture_issue(number: u64) -> GitHubIssue {
         GitHubIssue {
@@ -283,49 +314,83 @@ mod tests {
 
     #[test]
     fn detail_cache_round_trip() {
+        let _serial = serial();
         // Per-test unique key so parallel test runs don't stomp.
         let unique_num: u64 = 9_999_001;
+        let repo = Path::new("/repos/round-trip");
+        let key = issue_detail_key(repo, unique_num);
         let issue = fixture_issue(unique_num);
         ISSUE_DETAIL_CACHE
             .lock()
             .unwrap()
-            .insert(unique_num, CacheEntry::fresh(issue.clone()));
-        let entry = ISSUE_DETAIL_CACHE
-            .lock()
-            .unwrap()
-            .get(&unique_num)
-            .cloned();
+            .insert(key.clone(), CacheEntry::fresh(issue.clone()));
+        let entry = ISSUE_DETAIL_CACHE.lock().unwrap().get(&key).cloned();
         assert!(entry.is_some());
         let cached = entry.unwrap();
         assert_eq!(cached.value.number, unique_num);
         invalidate_issue_cache(Some(unique_num));
-        assert!(ISSUE_DETAIL_CACHE.lock().unwrap().get(&unique_num).is_none());
+        assert!(ISSUE_DETAIL_CACHE.lock().unwrap().get(&key).is_none());
+    }
+
+    #[test]
+    fn detail_cache_is_repo_scoped() {
+        let _serial = serial();
+        // Repo A caches its issue #N; repo B's issue #N must NOT hit it.
+        let n: u64 = 9_999_021;
+        let repo_a = Path::new("/repos/repo-a");
+        let repo_b = Path::new("/repos/repo-b");
+        let mut a = fixture_issue(n);
+        a.title = "Repo-A only".into();
+        ISSUE_DETAIL_CACHE
+            .lock()
+            .unwrap()
+            .insert(issue_detail_key(repo_a, n), CacheEntry::fresh(a));
+
+        let b_hit = ISSUE_DETAIL_CACHE
+            .lock()
+            .unwrap()
+            .get(&issue_detail_key(repo_b, n))
+            .map(|e| e.value.title.clone());
+        assert_eq!(b_hit, None, "repo B must not hit repo A's cached issue #N");
+        // Repo A's own lookup still hits.
+        assert!(ISSUE_DETAIL_CACHE
+            .lock()
+            .unwrap()
+            .get(&issue_detail_key(repo_a, n))
+            .is_some());
+
+        invalidate_issue_cache(Some(n));
     }
 
     #[test]
     fn targeted_invalidation_keeps_other_detail_entries() {
+        let _serial = serial();
         // Two unrelated issue numbers — invalidating one must not
         // touch the other. Unique constants keep the test isolated
         // from parallel siblings.
+        let repo = Path::new("/repos/targeted");
         let keep: u64 = 9_999_011;
         let drop: u64 = 9_999_012;
+        let keep_key = issue_detail_key(repo, keep);
+        let drop_key = issue_detail_key(repo, drop);
         ISSUE_DETAIL_CACHE
             .lock()
             .unwrap()
-            .insert(keep, CacheEntry::fresh(fixture_issue(keep)));
+            .insert(keep_key.clone(), CacheEntry::fresh(fixture_issue(keep)));
         ISSUE_DETAIL_CACHE
             .lock()
             .unwrap()
-            .insert(drop, CacheEntry::fresh(fixture_issue(drop)));
+            .insert(drop_key.clone(), CacheEntry::fresh(fixture_issue(drop)));
         invalidate_issue_cache(Some(drop));
-        assert!(ISSUE_DETAIL_CACHE.lock().unwrap().contains_key(&keep));
-        assert!(!ISSUE_DETAIL_CACHE.lock().unwrap().contains_key(&drop));
+        assert!(ISSUE_DETAIL_CACHE.lock().unwrap().contains_key(&keep_key));
+        assert!(!ISSUE_DETAIL_CACHE.lock().unwrap().contains_key(&drop_key));
         // Cleanup so we don't leak into parallel tests.
-        ISSUE_DETAIL_CACHE.lock().unwrap().remove(&keep);
+        ISSUE_DETAIL_CACHE.lock().unwrap().remove(&keep_key);
     }
 
     #[test]
     fn global_invalidation_clears_a_planted_list_entry() {
+        let _serial = serial();
         // Use a unique path so other parallel tests' global
         // invalidations don't race us between insert and assert.
         // Hold the lock across insert + read so no other thread can

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -846,6 +846,15 @@ async fn dispatch(request: JsonRpcRequest) -> Option<JsonRpcResponse> {
 // Tool call handler
 // ---------------------------------------------------------------------------
 
+/// The scroll-`amount` (ticks) value to embed in a `scroll_at` browser action,
+/// as an INTEGER JSON number. The receiver reads it with `Value::as_i64`, which
+/// returns `None` for a float-backed number — so emitting it via `as_f64`
+/// (`3.0`) silently pinned every MCP scroll to the default 3. The CLI path
+/// emits an integer; this matches it. Defaults to 3 (per the tool schema).
+fn scroll_amount_value(arguments: &Value) -> Value {
+    json!(arguments.get("amount").and_then(Value::as_i64).unwrap_or(3))
+}
+
 async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
     let tool_name = match params.get("name").and_then(Value::as_str) {
         Some(name) => name.to_string(),
@@ -940,7 +949,7 @@ async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
             let x = arguments.get("x").and_then(Value::as_f64).unwrap_or(0.0);
             let y = arguments.get("y").and_then(Value::as_f64).unwrap_or(0.0);
             let dir = arguments.get("direction").and_then(Value::as_str).unwrap_or("down");
-            let amt = arguments.get("amount").and_then(Value::as_f64).unwrap_or(3.0);
+            let amt = scroll_amount_value(&arguments);
             call_socket("browser_automation", json!({
                 "workspace_id": &workspace_id,
                 "action": { "kind": "scroll_at", "x": x, "y": y, "direction": dir, "amount": amt }
@@ -1753,6 +1762,21 @@ pub fn remove_mcp_config(workspace_dir: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn scroll_amount_reaches_receiver_as_i64() {
+        // The receiver (stream_input handle_vision_action) reads `amount` with
+        // Value::as_i64, which rejects float-backed numbers. The emitted value
+        // must therefore be an integer JSON number.
+        let v = scroll_amount_value(&json!({ "amount": 10 }));
+        assert_eq!(
+            v.as_i64(),
+            Some(10),
+            "MCP scroll amount must survive the receiver's as_i64 read"
+        );
+        // Absent → the documented default of 3.
+        assert_eq!(scroll_amount_value(&json!({})).as_i64(), Some(3));
+    }
 
     /// Helper: create a unique temp directory for a test.
     fn test_dir(name: &str) -> std::path::PathBuf {

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -855,6 +855,18 @@ fn scroll_amount_value(arguments: &Value) -> Value {
     json!(arguments.get("amount").and_then(Value::as_i64).unwrap_or(3))
 }
 
+/// The split `direction` string for the pane-split MCP tools. Matches the
+/// app-wide convention enforced by the pane renderer (PaneNode.tsx) and every
+/// in-app Split control: "horizontal" lays panes out in columns (new pane to
+/// the RIGHT), "vertical" in rows (new pane BELOW). The tools previously sent
+/// the inverted strings, so agent-driven splits went the opposite way asked.
+fn pane_split_direction(tool: &str) -> &'static str {
+    match tool {
+        "pane_split_down" => "vertical",
+        _ => "horizontal", // pane_split_right
+    }
+}
+
 async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
     let tool_name = match params.get("name").and_then(Value::as_str) {
         Some(name) => name.to_string(),
@@ -1184,11 +1196,13 @@ async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
         }
         "pane_split_right" => {
             let pane_id = arguments.get("pane_id").and_then(Value::as_str).unwrap_or_default();
-            call_socket("split_pane", json!({ "pane_id": pane_id, "direction": "vertical" })).await
+            let direction = pane_split_direction("pane_split_right");
+            call_socket("split_pane", json!({ "pane_id": pane_id, "direction": direction })).await
         }
         "pane_split_down" => {
             let pane_id = arguments.get("pane_id").and_then(Value::as_str).unwrap_or_default();
-            call_socket("split_pane", json!({ "pane_id": pane_id, "direction": "horizontal" })).await
+            let direction = pane_split_direction("pane_split_down");
+            call_socket("split_pane", json!({ "pane_id": pane_id, "direction": direction })).await
         }
 
         // -- Notification tools --
@@ -1776,6 +1790,16 @@ mod tests {
         );
         // Absent → the documented default of 3.
         assert_eq!(scroll_amount_value(&json!({})).as_i64(), Some(3));
+    }
+
+    #[test]
+    fn pane_split_tools_match_in_app_direction_convention() {
+        // PaneNode.tsx renders "horizontal" as gridTemplateColumns (new pane to
+        // the right) and "vertical" as gridTemplateRows (new pane below); every
+        // in-app Split-right control sends "horizontal". The MCP tools must
+        // match (they were inverted).
+        assert_eq!(pane_split_direction("pane_split_right"), "horizontal");
+        assert_eq!(pane_split_direction("pane_split_down"), "vertical");
     }
 
     /// Helper: create a unique temp directory for a test.

--- a/src-tauri/src/openflow/orchestrator.rs
+++ b/src-tauri/src/openflow/orchestrator.rs
@@ -200,9 +200,15 @@ impl Orchestrator {
     }
 
     pub fn parse_timestamp(timestamp_str: &str) -> Option<chrono::DateTime<chrono::Utc>> {
-        chrono::DateTime::parse_from_str(timestamp_str, "%Y-%m-%d %H:%M:%S")
+        // Comm-log timestamps are written zone-less (`chrono::Local::now()
+        // .format("%Y-%m-%d %H:%M:%S")`). DateTime::parse_from_str REQUIRES an
+        // offset and so always failed on this format, silently disabling the
+        // timestamp-based activity signal in stuck detection. Parse as naive
+        // (the activity check only compares stamps to each other, so a
+        // consistent zone is all that matters).
+        chrono::NaiveDateTime::parse_from_str(timestamp_str, "%Y-%m-%d %H:%M:%S")
             .ok()
-            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .map(|ndt| ndt.and_utc())
     }
 
     /// Parse an "ASSIGN ROLE-N: task" line and extract the instance id + task.
@@ -740,6 +746,23 @@ mod tests {
             role: role.to_string(),
             message: message.to_string(),
         }
+    }
+
+    #[test]
+    fn parse_timestamp_parses_the_comm_log_format() {
+        // The exact format the comm log is written in (zone-less).
+        let ts = Orchestrator::parse_timestamp("2026-03-18 09:30:00");
+        assert!(ts.is_some(), "comm-log timestamp must parse");
+        assert_eq!(
+            ts.unwrap().format("%Y-%m-%d %H:%M:%S").to_string(),
+            "2026-03-18 09:30:00"
+        );
+        // The activity signal relies on stamp ordering being preserved.
+        let earlier = Orchestrator::parse_timestamp("2026-03-18 09:29:59").unwrap();
+        let later = Orchestrator::parse_timestamp("2026-03-18 09:30:00").unwrap();
+        assert!(later > earlier);
+        // Garbage still rejected.
+        assert!(Orchestrator::parse_timestamp("not a timestamp").is_none());
     }
 
     #[test]

--- a/src-tauri/src/pty_daemon/server.rs
+++ b/src-tauri/src/pty_daemon/server.rs
@@ -305,9 +305,12 @@ async fn handle_connection(
     // socket. Detach removes the entry.
     let mut attached: HashMap<String, broadcast::Receiver<SessionFrame>> = HashMap::new();
 
-    let mut line = String::new();
+    // Persistent accumulation buffer for the request line currently being
+    // read. It MUST survive across loop iterations: the read below times out
+    // periodically to go drain output, and any bytes already pulled off the
+    // socket stay buffered here until the terminating newline arrives.
+    let mut pending: Vec<u8> = Vec::new();
     loop {
-        line.clear();
         // Multiplex: either read a new request line OR forward any pending
         // output from attached sessions. tokio::select! across the attach
         // receivers requires they all be polled — we sequentially poll each
@@ -368,20 +371,42 @@ async fn handle_connection(
         } else {
             std::time::Duration::from_millis(10)
         };
-        let read_result =
-            tokio::time::timeout(read_timeout, reader.read_line(&mut line)).await;
-        let read_n = match read_result {
-            Ok(Ok(n)) => n,
-            Ok(Err(error)) => return Err(format!("read_line: {error}")),
-            Err(_elapsed) => {
-                // Timeout — go back to draining.
+        // Accumulate bytes until a full newline-terminated line is available.
+        // `fill_buf` + `consume` is cancellation-safe — both the BufReader's
+        // internal buffer and `pending` persist if the timeout cancels this
+        // future — so a request that straddles the poll timeout is preserved.
+        // (`read_line` is NOT cancellation-safe: on timeout it drops the
+        // partial bytes it had already consumed, corrupting large or chunked
+        // requests such as a big paste forwarded as one `Write`.)
+        let fill = tokio::time::timeout(read_timeout, reader.fill_buf()).await;
+        let chunk = match fill {
+            Ok(Ok(buf)) => buf,
+            Ok(Err(error)) => return Err(format!("read: {error}")),
+            Err(_elapsed) => continue, // timeout — go back to draining
+        };
+        if chunk.is_empty() {
+            return Ok(()); // EOF — client closed
+        }
+        let newline = chunk.iter().position(|&b| b == b'\n');
+        let take = newline.map_or(chunk.len(), |i| i + 1);
+        pending.extend_from_slice(&chunk[..take]);
+        reader.consume(take);
+        if newline.is_none() {
+            continue; // partial line — keep accumulating across iterations
+        }
+
+        let line_bytes = std::mem::take(&mut pending);
+        let line = match std::str::from_utf8(&line_bytes) {
+            Ok(text) => text,
+            Err(_) => {
+                let frame = Frame::Response(ServerResponse::Error {
+                    request_id: 0,
+                    message: "invalid request: non-utf8 line".to_string(),
+                });
+                write_frame(&mut write_half, &frame).await?;
                 continue;
             }
         };
-        if read_n == 0 {
-            return Ok(()); // client closed cleanly
-        }
-
         let trimmed = line.trim_end_matches(['\n', '\r']);
         if trimmed.is_empty() {
             continue;
@@ -915,5 +940,54 @@ mod tests {
                 .unwrap(),
             "/tmp/codemux-ptyd-abc.sock.pid"
         );
+    }
+
+    // A request whose bytes arrive split across the server's read timeout must
+    // still be parsed (not silently corrupted). Reproduces the read_line
+    // cancellation-safety bug: the first half is consumed off the socket, the
+    // ~10ms timeout fires, and the old code dropped those bytes.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn request_split_across_read_timeout_is_not_lost() {
+        use super::{handle_connection, DaemonState};
+        use std::sync::Arc;
+        use std::time::Duration;
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        use tokio::sync::Mutex;
+
+        let state = Arc::new(Mutex::new(DaemonState::default()));
+        let (client, server) = tokio::net::UnixStream::pair().unwrap();
+        let handle = tokio::spawn(handle_connection(server, state));
+
+        let (client_read, mut client_write) = client.into_split();
+
+        // Send a valid `Hello` request in two halves, with a gap well past the
+        // server's ~10ms read timeout so the read times out mid-line.
+        client_write
+            .write_all(b"{\"type\":\"hello\",\"requ")
+            .await
+            .unwrap();
+        client_write.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        client_write.write_all(b"est_id\":7}\n").await.unwrap();
+        client_write.flush().await.unwrap();
+
+        let mut reader = BufReader::new(client_read);
+        let mut response = String::new();
+        tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut response))
+            .await
+            .expect("server did not respond in time")
+            .expect("read response");
+
+        assert!(
+            response.contains("protocol_version") && response.contains("hello"),
+            "expected a Hello response, got: {response}"
+        );
+        assert!(
+            !response.contains("invalid request"),
+            "request was corrupted by the read timeout: {response}"
+        );
+
+        handle.abort();
     }
 }

--- a/src-tauri/src/ssh/opencode_db_sync.rs
+++ b/src-tauri/src/ssh/opencode_db_sync.rs
@@ -143,15 +143,17 @@ pub(crate) fn remote_import_script(remote_cwd: &str, remote_bundle: &str) -> Str
 /// absence of the marker means "nothing to pull" (no session, or opencode
 /// not on the host), not a transport error.
 pub(crate) fn remote_extract_script(remote_cwd: &str, remote_bundle: &str) -> String {
+    // Build the query with the shared SQL helper (which SQL-escapes the
+    // directory) and pass it as a single shell-quoted argument. Splicing the
+    // path through a `$dir` shell variable into the SQL literal would break
+    // the query for any path containing an apostrophe (e.g. /Users/O'Brien/…),
+    // silently yielding "nothing to pull".
     format!(
-        "dir={cwd}\n\
-         sid=$(opencode db \"SELECT id FROM session WHERE directory = '$dir' \
-AND parent_id IS NULL ORDER BY time_updated DESC LIMIT 1\" 2>/dev/null \
-| grep -m1 '^ses_')\n\
+        "sid=$(opencode db {sql} 2>/dev/null | grep -m1 '^ses_')\n\
          if [ -n \"$sid\" ]; then\n\
            opencode export \"$sid\" > {bundle} 2>/dev/null && echo \"CMX_OC_SID=$sid\"\n\
          fi\n",
-        cwd = shell_sq(remote_cwd),
+        sql = shell_sq(&newest_session_sql(remote_cwd)),
         bundle = shell_sq(remote_bundle),
     )
 }
@@ -576,11 +578,30 @@ mod tests {
     #[test]
     fn remote_extract_script_queries_then_exports_with_marker() {
         let s = remote_extract_script("/home/me/ws", "/tmp/codemux-opencode-2.json");
-        assert!(s.contains("dir='/home/me/ws'"));
+        // The query is built by the shared SQL helper and passed as one
+        // shell-quoted argument (no raw $dir splice into the SQL literal).
+        assert!(s.contains(&shell_sq(&newest_session_sql("/home/me/ws"))));
         assert!(s.contains("opencode db"));
         assert!(s.contains("parent_id IS NULL"));
         assert!(s.contains("opencode export \"$sid\" > '/tmp/codemux-opencode-2.json'"));
         assert!(s.contains("echo \"CMX_OC_SID=$sid\""));
+    }
+
+    #[test]
+    fn remote_extract_script_sql_escapes_apostrophe_paths() {
+        // A path with an apostrophe must be SQL-escaped into the query (the
+        // apostrophe doubled), exactly like the local-side newest_session_sql —
+        // never spliced raw via a shell variable, which breaks the SQL literal.
+        let cwd = "/Users/O'Brien/ws";
+        let s = remote_extract_script(cwd, "/tmp/b.json");
+        assert!(
+            s.contains(&shell_sq(&newest_session_sql(cwd))),
+            "must embed the SQL-escaped query; got:\n{s}"
+        );
+        assert!(
+            !s.contains("'$dir'"),
+            "must not splice the raw path into the SQL string literal"
+        );
     }
 
     #[test]

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -2363,12 +2363,26 @@ impl AppStateStore {
                 // Last pane closed — remove the surface and its tab
                 let surface_id = workspace.surfaces[surface_index].surface_id.clone();
                 workspace.surfaces.remove(surface_index);
+                // Index of the tab about to be removed, so we can focus its
+                // neighbor instead of always jumping to the first tab.
+                let removed_tab_index = workspace
+                    .tabs
+                    .iter()
+                    .position(|t| t.surface_id.as_ref() == Some(&surface_id));
+                let was_active = workspace.active_surface_id == surface_id;
                 workspace.tabs.retain(|t| t.surface_id.as_ref() != Some(&surface_id));
                 if workspace.tabs.is_empty() {
                     workspace.active_tab_id = String::new();
                     workspace.active_surface_id = SurfaceId(String::new());
-                } else if workspace.active_surface_id == surface_id {
-                    let new_tab = &workspace.tabs[0];
+                } else if was_active {
+                    // Focus the adjacent tab (next, then previous) — matches
+                    // close_tab and active_id_after_removal.
+                    let new_index = match removed_tab_index {
+                        Some(idx) if idx < workspace.tabs.len() => idx,
+                        Some(idx) => idx.saturating_sub(1),
+                        None => 0,
+                    };
+                    let new_tab = &workspace.tabs[new_index];
                     workspace.active_tab_id = new_tab.tab_id.clone();
                     if let Some(ref sid) = new_tab.surface_id {
                         workspace.active_surface_id = sid.clone();
@@ -5651,6 +5665,57 @@ mod tests {
         assert_eq!(
             ws.active_tab_id, t3,
             "closing the active middle tab should select the NEXT tab, not the previous"
+        );
+    }
+
+    #[test]
+    fn closing_last_pane_of_active_middle_tab_focuses_next_tab() {
+        let store = AppStateStore::default();
+        let ws_id = store.create_workspace_with_layout(
+            PathBuf::from("/tmp/project-close-lastpane-next"),
+            WorkspacePresetLayout::Single,
+        );
+        store.activate_workspace(&ws_id.0);
+
+        // Default tab + two more → [default, t2, t3], each a single-pane tab.
+        let (t2, _) = store
+            .create_tab(&ws_id.0, TabKind::Terminal)
+            .expect("create t2");
+        let (t3, _) = store
+            .create_tab(&ws_id.0, TabKind::Terminal)
+            .expect("create t3");
+        store.activate_tab(&ws_id.0, &t2).expect("activate t2");
+
+        // The only pane in t2's surface.
+        let pane_id = {
+            let snap = store.snapshot();
+            let ws = workspace_by_id(&snap, &ws_id);
+            let sid = ws
+                .tabs
+                .iter()
+                .find(|t| t.tab_id == t2)
+                .and_then(|t| t.surface_id.clone())
+                .expect("t2 has a surface");
+            let surface = ws
+                .surfaces
+                .iter()
+                .find(|s| s.surface_id == sid)
+                .expect("surface exists");
+            first_leaf_pane_id(&surface.root).expect("a pane").0
+        };
+
+        // Closing the last pane removes the tab; focus should move to the next.
+        store.close_pane(&pane_id).expect("close pane");
+
+        let snap = store.snapshot();
+        let ws = workspace_by_id(&snap, &ws_id);
+        assert!(
+            !ws.tabs.iter().any(|t| t.tab_id == t2),
+            "t2 should be gone after closing its last pane"
+        );
+        assert_eq!(
+            ws.active_tab_id, t3,
+            "closing the last pane of the active middle tab should focus the NEXT tab"
         );
     }
 

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -3484,17 +3484,21 @@ fn remove_browser_nodes(node: &PaneNodeSnapshot) -> Option<PaneNodeSnapshot> {
             child_sizes,
             children,
         } => {
-            let remaining: Vec<_> = children
-                .iter()
-                .filter_map(remove_browser_nodes)
-                .collect();
+            let mut remaining: Vec<PaneNodeSnapshot> = Vec::new();
+            let mut kept: Vec<usize> = Vec::new();
+            for (i, child) in children.iter().enumerate() {
+                if let Some(new_child) = remove_browser_nodes(child) {
+                    remaining.push(new_child);
+                    kept.push(i);
+                }
+            }
             match remaining.len() {
                 0 => None,
                 1 => remaining.into_iter().next(),
                 _ => Some(PaneNodeSnapshot::Split {
                     pane_id: pane_id.clone(),
                     direction: direction.clone(),
-                    child_sizes: rebalance_sizes(child_sizes, remaining.len()),
+                    child_sizes: retained_sizes(child_sizes, &kept),
                     children: remaining,
                 }),
             }
@@ -3817,10 +3821,14 @@ fn remove_terminal_from_tree(
             child_sizes,
             children,
         } => {
-            let remaining_children = children
-                .iter()
-                .filter_map(|child| remove_terminal_from_tree(child, target_session_id))
-                .collect::<Vec<_>>();
+            let mut remaining_children: Vec<PaneNodeSnapshot> = Vec::new();
+            let mut kept: Vec<usize> = Vec::new();
+            for (i, child) in children.iter().enumerate() {
+                if let Some(new_child) = remove_terminal_from_tree(child, target_session_id) {
+                    remaining_children.push(new_child);
+                    kept.push(i);
+                }
+            }
 
             match remaining_children.len() {
                 0 => None,
@@ -3828,7 +3836,7 @@ fn remove_terminal_from_tree(
                 _ => Some(PaneNodeSnapshot::Split {
                     pane_id: pane_id.clone(),
                     direction: direction.clone(),
-                    child_sizes: rebalance_sizes(child_sizes, remaining_children.len()),
+                    child_sizes: retained_sizes(child_sizes, &kept),
                     children: remaining_children,
                 }),
             }
@@ -3854,10 +3862,14 @@ fn remove_terminals_from_tree(
             child_sizes,
             children,
         } => {
-            let remaining_children = children
-                .iter()
-                .filter_map(|child| remove_terminals_from_tree(child, session_ids))
-                .collect::<Vec<_>>();
+            let mut remaining_children: Vec<PaneNodeSnapshot> = Vec::new();
+            let mut kept: Vec<usize> = Vec::new();
+            for (i, child) in children.iter().enumerate() {
+                if let Some(new_child) = remove_terminals_from_tree(child, session_ids) {
+                    remaining_children.push(new_child);
+                    kept.push(i);
+                }
+            }
 
             match remaining_children.len() {
                 0 => None,
@@ -3865,7 +3877,7 @@ fn remove_terminals_from_tree(
                 _ => Some(PaneNodeSnapshot::Split {
                     pane_id: pane_id.clone(),
                     direction: direction.clone(),
-                    child_sizes: rebalance_sizes(child_sizes, remaining_children.len()),
+                    child_sizes: retained_sizes(child_sizes, &kept),
                     children: remaining_children,
                 }),
             }
@@ -3955,6 +3967,25 @@ fn rebalance_sizes(existing: &[f32], target_len: usize) -> Vec<f32> {
     }
 
     normalize_sizes(vec![1.0 / target_len as f32; target_len])
+}
+
+/// Sizes for the children that survived a removal, renormalized so their
+/// relative proportions are preserved. `kept` holds the original indices of
+/// the surviving children. Unlike resetting to equal weights, closing one
+/// pane in a custom-sized split leaves the remaining panes' ratios intact
+/// (e.g. closing the third child of a `[0.5, 0.3, 0.2]` split yields
+/// `[0.625, 0.375]`, not `[0.5, 0.5]`).
+fn retained_sizes(child_sizes: &[f32], kept: &[usize]) -> Vec<f32> {
+    let fallback = if child_sizes.is_empty() {
+        0.0
+    } else {
+        1.0 / child_sizes.len() as f32
+    };
+    let sizes: Vec<f32> = kept
+        .iter()
+        .map(|&i| child_sizes.get(i).copied().unwrap_or(fallback))
+        .collect();
+    normalize_sizes(sizes)
 }
 
 fn normalize_sizes(mut sizes: Vec<f32>) -> Vec<f32> {
@@ -4580,10 +4611,14 @@ fn remove_pane_from_tree(
             child_sizes,
             children,
         } => {
-            let remaining_children = children
-                .iter()
-                .filter_map(|child| remove_pane_from_tree(child, target_pane_id))
-                .collect::<Vec<_>>();
+            let mut remaining_children: Vec<PaneNodeSnapshot> = Vec::new();
+            let mut kept: Vec<usize> = Vec::new();
+            for (i, child) in children.iter().enumerate() {
+                if let Some(new_child) = remove_pane_from_tree(child, target_pane_id) {
+                    remaining_children.push(new_child);
+                    kept.push(i);
+                }
+            }
 
             match remaining_children.len() {
                 0 => None,
@@ -4591,7 +4626,7 @@ fn remove_pane_from_tree(
                 _ => Some(PaneNodeSnapshot::Split {
                     pane_id: pane_id.clone(),
                     direction: direction.clone(),
-                    child_sizes: rebalance_sizes(child_sizes, remaining_children.len()),
+                    child_sizes: retained_sizes(child_sizes, &kept),
                     children: remaining_children,
                 }),
             }
@@ -4793,6 +4828,77 @@ mod tests {
                 assert_eq!(session_id.0, "session-b");
             }
             _ => panic!("expected collapsed terminal node"),
+        }
+    }
+
+    fn terminal_leaf(pane: &str, session: &str) -> PaneNodeSnapshot {
+        PaneNodeSnapshot::Terminal {
+            pane_id: PaneId(pane.into()),
+            session_id: SessionId(session.into()),
+            title: pane.to_string(),
+        }
+    }
+
+    fn custom_sized_triple_split() -> PaneNodeSnapshot {
+        PaneNodeSnapshot::Split {
+            pane_id: PaneId("pane-root".into()),
+            direction: SplitDirection::Horizontal,
+            child_sizes: vec![0.5, 0.3, 0.2],
+            children: vec![
+                terminal_leaf("pane-a", "session-a"),
+                terminal_leaf("pane-b", "session-b"),
+                terminal_leaf("pane-c", "session-c"),
+            ],
+        }
+    }
+
+    #[test]
+    fn remove_pane_preserves_sibling_proportions() {
+        let tree = custom_sized_triple_split();
+
+        // Closing the last child keeps the first two at their 0.5:0.3 ratio
+        // (renormalized to 0.625:0.375), not reset to equal 0.5:0.5.
+        match remove_pane_from_tree(&tree, "pane-c").unwrap() {
+            PaneNodeSnapshot::Split { child_sizes, children, .. } => {
+                assert_eq!(children.len(), 2);
+                assert!((child_sizes[0] - 0.625).abs() < 1e-4, "got {child_sizes:?}");
+                assert!((child_sizes[1] - 0.375).abs() < 1e-4, "got {child_sizes:?}");
+            }
+            _ => panic!("expected split"),
+        }
+
+        // Closing the middle child keeps the outer two at their 0.5:0.2 ratio.
+        match remove_pane_from_tree(&tree, "pane-b").unwrap() {
+            PaneNodeSnapshot::Split { child_sizes, .. } => {
+                assert!((child_sizes[0] - 0.5 / 0.7).abs() < 1e-4, "got {child_sizes:?}");
+                assert!((child_sizes[1] - 0.2 / 0.7).abs() < 1e-4, "got {child_sizes:?}");
+            }
+            _ => panic!("expected split"),
+        }
+    }
+
+    #[test]
+    fn close_pane_preserves_sibling_proportions() {
+        // Exercise the real public close path on a live store/surface.
+        let store = AppStateStore::default();
+        let mut snap = store.snapshot();
+        {
+            let surface = &mut snap.workspaces[0].surfaces[0];
+            surface.root = custom_sized_triple_split();
+            surface.active_pane_id = PaneId("pane-a".into());
+        }
+        store.replace_snapshot(snap);
+
+        store.close_pane("pane-c").unwrap();
+
+        let snap = store.snapshot();
+        match &snap.workspaces[0].surfaces[0].root {
+            PaneNodeSnapshot::Split { child_sizes, children, .. } => {
+                assert_eq!(children.len(), 2);
+                assert!((child_sizes[0] - 0.625).abs() < 1e-4, "got {child_sizes:?}");
+                assert!((child_sizes[1] - 0.375).abs() < 1e-4, "got {child_sizes:?}");
+            }
+            _ => panic!("expected split after closing one pane"),
         }
     }
 

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -3097,7 +3097,15 @@ impl AppStateStore {
                 workspace.active_tab_id = String::new();
                 workspace.active_surface_id = SurfaceId(String::new());
             } else {
-                let new_index = if tab_index > 0 { tab_index - 1 } else { 0 };
+                // Select the next tab — after the removal it slid into
+                // tab_index — falling back to the previous tab when the closed
+                // tab was last. Mirrors active_id_after_removal and standard
+                // editor/browser tab behavior (was: always the previous tab).
+                let new_index = if tab_index < workspace.tabs.len() {
+                    tab_index
+                } else {
+                    tab_index - 1
+                };
                 let new_tab = &workspace.tabs[new_index];
                 workspace.active_tab_id = new_tab.tab_id.clone();
                 if let Some(ref sid) = new_tab.surface_id {
@@ -5617,6 +5625,35 @@ mod tests {
 
     /// Regression guard mirroring `close_workspace_result_contains_session_ids`
     /// for `close_tab`. `CloseTabResult.removed_sessions` is what the
+    #[test]
+    fn close_active_middle_tab_focuses_next_tab() {
+        let store = AppStateStore::default();
+        let ws_id = store.create_workspace_with_layout(
+            PathBuf::from("/tmp/project-close-tab-next"),
+            WorkspacePresetLayout::Single,
+        );
+        store.activate_workspace(&ws_id.0);
+
+        // Default tab + two more → order [default, t2, t3].
+        let (t2, _) = store
+            .create_tab(&ws_id.0, TabKind::Terminal)
+            .expect("create t2");
+        let (t3, _) = store
+            .create_tab(&ws_id.0, TabKind::Terminal)
+            .expect("create t3");
+
+        // Make the middle tab active, then close it.
+        store.activate_tab(&ws_id.0, &t2).expect("activate t2");
+        store.close_tab(&ws_id.0, &t2).expect("close t2");
+
+        let snap = store.snapshot();
+        let ws = workspace_by_id(&snap, &ws_id);
+        assert_eq!(
+            ws.active_tab_id, t3,
+            "closing the active middle tab should select the NEXT tab, not the previous"
+        );
+    }
+
     /// `close_tab` command hands to `terminate_pty_session` for PTY cleanup;
     /// if this list ever drops a session the corresponding PTY leaks.
     #[test]

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -266,6 +266,19 @@ pub enum NotificationLevel {
     Attention,
 }
 
+impl NotificationLevel {
+    /// Parse a level string as sent by the `notify` control command / MCP tool
+    /// (schema: "info" | "attention" | "error"). "info" → Info; "attention",
+    /// "error", and anything unrecognized → Attention (the most severe level
+    /// the enum exposes — there is no dedicated Error variant).
+    pub fn from_str_or_attention(s: &str) -> Self {
+        match s {
+            "info" => NotificationLevel::Info,
+            _ => NotificationLevel::Attention,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotificationSnapshot {
     pub notification_id: String,
@@ -5639,6 +5652,30 @@ mod tests {
 
     /// Regression guard mirroring `close_workspace_result_contains_session_ids`
     /// for `close_tab`. `CloseTabResult.removed_sessions` is what the
+    #[test]
+    fn notification_level_parses_from_string() {
+        // "info" must map to Info — the notify control handler used to drop the
+        // level and hardcode Attention, wrongly elevating info notifications.
+        assert!(matches!(
+            NotificationLevel::from_str_or_attention("info"),
+            NotificationLevel::Info
+        ));
+        assert!(matches!(
+            NotificationLevel::from_str_or_attention("attention"),
+            NotificationLevel::Attention
+        ));
+        // "error" has no dedicated variant → surfaces at Attention.
+        assert!(matches!(
+            NotificationLevel::from_str_or_attention("error"),
+            NotificationLevel::Attention
+        ));
+        // Unknown → Attention (safe default).
+        assert!(matches!(
+            NotificationLevel::from_str_or_attention("bogus"),
+            NotificationLevel::Attention
+        ));
+    }
+
     #[test]
     fn close_active_middle_tab_focuses_next_tab() {
         let store = AppStateStore::default();

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -2342,12 +2342,20 @@ impl AppStateStore {
                 .get_mut(surface_index)
                 .ok_or_else(|| "Surface disappeared while closing pane".to_string())?;
 
+            let ordered_before = collect_leaf_pane_ids(&surface.root);
+            let active_before = surface.active_pane_id.clone();
             let updated_root = remove_pane_from_tree(&surface.root, pane_id);
 
             if let Some(new_root) = updated_root {
-                // Pane removed but surface still has content
-                let next_active_pane = first_leaf_pane_id(&new_root)
-                    .ok_or_else(|| "No fallback pane available after close".to_string())?;
+                // Pane removed but surface still has content. Keep focus on the
+                // current pane when a different pane was closed; when the active
+                // pane itself was closed, move to the adjacent pane (next, then
+                // previous) rather than the leftmost leaf.
+                let next_active_pane =
+                    active_id_after_removal(&ordered_before, &active_before, pane_id)
+                        .filter(|pid| pane_tree_contains_pane(&new_root, &pid.0))
+                        .or_else(|| first_leaf_pane_id(&new_root))
+                        .ok_or_else(|| "No fallback pane available after close".to_string())?;
                 surface.root = new_root;
                 surface.active_pane_id = next_active_pane;
                 workspace.active_surface_id = surface.surface_id.clone();
@@ -4373,6 +4381,22 @@ fn first_leaf_pane_id(root: &PaneNodeSnapshot) -> Option<PaneId> {
     }
 }
 
+/// Pick the pane to focus after `removed` is closed. If a *different* pane was
+/// closed, keep the current `active` pane; if the active pane itself was
+/// closed, move to the next pane in leaf order, falling back to the previous
+/// one — instead of jumping focus to the leftmost leaf. `ordered` is the leaf
+/// order *before* removal (so `removed` is still present in it).
+fn active_id_after_removal(ordered: &[PaneId], active: &PaneId, removed: &str) -> Option<PaneId> {
+    if active.0 != removed {
+        return Some(active.clone());
+    }
+    let idx = ordered.iter().position(|p| p.0 == removed)?;
+    ordered
+        .get(idx + 1)
+        .cloned()
+        .or_else(|| idx.checked_sub(1).and_then(|prev| ordered.get(prev).cloned()))
+}
+
 fn clone_pane_node(root: &PaneNodeSnapshot, target_pane_id: &str) -> Option<PaneNodeSnapshot> {
     match root {
         PaneNodeSnapshot::Terminal { pane_id, .. }
@@ -4875,6 +4899,37 @@ mod tests {
             }
             _ => panic!("expected split"),
         }
+    }
+
+    fn close_pane_with_root(active: &str, close: &str) -> String {
+        let store = AppStateStore::default();
+        let mut snap = store.snapshot();
+        {
+            let surface = &mut snap.workspaces[0].surfaces[0];
+            surface.root = custom_sized_triple_split();
+            surface.active_pane_id = PaneId(active.into());
+        }
+        store.replace_snapshot(snap);
+        store.close_pane(close).unwrap();
+        store.snapshot().workspaces[0].surfaces[0]
+            .active_pane_id
+            .0
+            .clone()
+    }
+
+    #[test]
+    fn close_active_pane_focuses_next_then_previous() {
+        // Closing the active middle pane focuses the next (right) pane…
+        assert_eq!(close_pane_with_root("pane-b", "pane-b"), "pane-c");
+        // …and closing the active last pane focuses the previous one.
+        assert_eq!(close_pane_with_root("pane-c", "pane-c"), "pane-b");
+    }
+
+    #[test]
+    fn close_inactive_pane_keeps_focus() {
+        // Closing a different pane must not move focus off the active pane.
+        assert_eq!(close_pane_with_root("pane-b", "pane-a"), "pane-b");
+        assert_eq!(close_pane_with_root("pane-b", "pane-c"), "pane-b");
     }
 
     #[test]

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -89,32 +89,57 @@ pub(crate) fn comm_log_entry_for_chunk(role: &str, data: &[u8]) -> Option<String
 fn strip_ansi_codes(s: &str) -> String {
     let mut result = String::new();
     let mut in_escape = false;
-    let mut escape_buf = String::new();
+    let mut first = false; // next char is the byte right after ESC
+    let mut in_osc = false; // OSC (ESC ]) ends only on BEL or ST, never a letter
+    let mut osc_saw_esc = false; // inside OSC, saw ESC — awaiting '\' for ST
 
     for c in s.chars() {
-        if c == '\x1b' {
-            in_escape = true;
-            escape_buf.clear();
-        } else if in_escape {
-            if c.is_ascii_alphanumeric()
-                || c == '@'
-                || c == '['
-                || c == ']'
-                || c == ';'
-                || c == '?'
-                || c == ' '
-            {
-                escape_buf.push(c);
-                // CSI sequences end with letters, OSC with bell/ST
-                if c.is_ascii_lowercase() || c.is_ascii_uppercase() || c == '@' || c == '`' {
-                    in_escape = false;
-                }
-            } else if c == '\\' || c == '\x07' {
-                // ST (String Terminator) or BEL
-                in_escape = false;
+        if !in_escape {
+            if c == '\x1b' {
+                in_escape = true;
+                first = true;
+                in_osc = false;
+                osc_saw_esc = false;
+            } else {
+                result.push(c);
             }
-        } else {
-            result.push(c);
+            continue;
+        }
+
+        // The byte right after ESC selects the sequence type.
+        if first {
+            first = false;
+            if c == ']' {
+                in_osc = true;
+                continue;
+            }
+            // `[` (CSI) and any other escape (charset selector, ESC-letter,
+            // …) fall through to the letter-terminated heuristic below.
+        }
+
+        if in_osc {
+            // OSC command strings terminate only on BEL (0x07) or ST (ESC \),
+            // NOT on the letters in their payload (e.g. a window title).
+            if osc_saw_esc {
+                osc_saw_esc = false;
+                if c == '\\' || c == '\x07' {
+                    in_escape = false;
+                } else if c == '\x1b' {
+                    osc_saw_esc = true;
+                }
+            } else if c == '\x07' {
+                in_escape = false;
+            } else if c == '\x1b' {
+                osc_saw_esc = true;
+            }
+            continue;
+        }
+
+        // CSI / other escapes end on a final letter (or @/`), or on ST/BEL.
+        if c.is_ascii_lowercase() || c.is_ascii_uppercase() || c == '@' || c == '`' {
+            in_escape = false;
+        } else if c == '\\' || c == '\x07' {
+            in_escape = false;
         }
     }
     result
@@ -3278,6 +3303,22 @@ mod tests {
         assert!(
             comm_log_entry_for_chunk("b", b"No orchestration progress detected yet").is_none(),
         );
+    }
+
+    #[test]
+    fn strip_ansi_codes_handles_osc_sequences() {
+        // OSC window-title (ESC ] 0 ; <title> BEL) is terminated by BEL, not by
+        // the letters in its payload — the whole sequence must vanish.
+        assert_eq!(strip_ansi_codes("\x1b]0;bash\x07"), "");
+        assert_eq!(strip_ansi_codes("\x1b]0;bash\x07$ ls"), "$ ls");
+        // OSC terminated by ST (ESC \) — e.g. a hyperlink.
+        assert_eq!(strip_ansi_codes("\x1b]8;;http://x\x1b\\done"), "done");
+        // CSI and charset/ESC-letter escapes still strip correctly.
+        assert_eq!(strip_ansi_codes("\x1b[2J\x1b[Hhello"), "hello");
+        assert_eq!(strip_ansi_codes("\x1b(Bplain"), "plain");
+        assert_eq!(strip_ansi_codes("\x1bcreset"), "reset");
+        // A pure title escape is noise, exactly like the CSI-only case.
+        assert!(comm_log_entry_for_chunk("b", b"\x1b]0;bash\x07").is_none());
     }
 
     // ── Regression tests for the cross-machine push spawn bugs ────────

--- a/src/components/browser/stream-protocol.test.ts
+++ b/src/components/browser/stream-protocol.test.ts
@@ -55,13 +55,15 @@ describe("getModifiers", () => {
     ...overrides,
   });
 
-  it("encodes the CDP modifier bitmask", () => {
+  it("encodes the CDP modifier bitmask (Alt=1, Ctrl=2, Meta=4, Shift=8)", () => {
+    // Bit values are fixed by CDP and must match the Rust sender
+    // (stream_input.rs `parse_key_combo`), which drives the same daemon.
     expect(getModifiers(ev({}))).toBe(0);
-    expect(getModifiers(ev({ shiftKey: true }))).toBe(1);
+    expect(getModifiers(ev({ altKey: true }))).toBe(1);
     expect(getModifiers(ev({ ctrlKey: true }))).toBe(2);
-    expect(getModifiers(ev({ altKey: true }))).toBe(4);
-    expect(getModifiers(ev({ metaKey: true }))).toBe(8);
-    expect(getModifiers(ev({ shiftKey: true, ctrlKey: true }))).toBe(3);
+    expect(getModifiers(ev({ metaKey: true }))).toBe(4);
+    expect(getModifiers(ev({ shiftKey: true }))).toBe(8);
+    expect(getModifiers(ev({ shiftKey: true, ctrlKey: true }))).toBe(10);
   });
 });
 

--- a/src/components/browser/stream-protocol.ts
+++ b/src/components/browser/stream-protocol.ts
@@ -40,6 +40,15 @@ export function heldButtonFromButtons(buttons: number): CdpButton {
   return "none";
 }
 
+/**
+ * Encode a keyboard/mouse event's modifier keys as the CDP `modifiers`
+ * bitmask sent to the stream daemon (forwarded verbatim to Chromium's
+ * `Input.dispatch*Event`). The bit values are fixed by CDP: Alt=1, Ctrl=2,
+ * Meta/Command=4, Shift=8 — and must match the Rust sender's `parse_key_combo`
+ * (src-tauri/src/stream_input.rs), which drives the same daemon over the same
+ * `modifiers` field. (Previously Shift/Alt/Meta were on the wrong bits, so a
+ * Shift+click arrived at the page as Alt-held, etc.)
+ */
 export function getModifiers(e: {
   shiftKey: boolean;
   ctrlKey: boolean;
@@ -47,10 +56,10 @@ export function getModifiers(e: {
   metaKey: boolean;
 }): number {
   let m = 0;
-  if (e.shiftKey) m |= 1;
+  if (e.altKey) m |= 1;
   if (e.ctrlKey) m |= 2;
-  if (e.altKey) m |= 4;
-  if (e.metaKey) m |= 8;
+  if (e.metaKey) m |= 4;
+  if (e.shiftKey) m |= 8;
   return m;
 }
 

--- a/src/components/layout/sidebar-workspace-list.tsx
+++ b/src/components/layout/sidebar-workspace-list.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/stores/app-store";
 import { useUIStore } from "@/stores/ui-store";
 import { SidebarProjectGroup } from "./sidebar-project-group";
+import { computeWorkspaceReorder } from "./workspace-reorder";
 import { NewWorkspaceDialog } from "@/components/overlays/new-workspace-dialog";
 import { reorderWorkspaces } from "@/tauri/commands";
 
@@ -230,25 +231,13 @@ export function SidebarWorkspaceList() {
 
       try {
         if (ds.type === "workspace") {
-          // Reorder within project group, then rebuild flat list
-          const newIds: string[] = [];
-          for (const group of projectGroups) {
-            const groupIds = group.workspaces
-              .map((w) => w.workspace_id)
-              .filter((id) => id !== ds.id);
-
-            if (group.projectPath === ds.sourceProjectPath) {
-              const idx = Math.min(dt.index, groupIds.length);
-              groupIds.splice(idx, 0, ds.id);
-            }
-
-            newIds.push(...groupIds);
-          }
-
-          if (!newIds.includes(ds.id)) {
-            newIds.push(ds.id);
-          }
-
+          // Reorder within project group, then rebuild flat list.
+          const newIds = computeWorkspaceReorder(
+            projectGroups,
+            ds.id,
+            ds.sourceProjectPath,
+            dt.index,
+          );
           await reorderWorkspaces(newIds);
         } else if (ds.type === "project") {
           // Reorder project folders

--- a/src/components/layout/workspace-reorder.test.ts
+++ b/src/components/layout/workspace-reorder.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+
+import { computeWorkspaceReorder, type ReorderGroup } from "./workspace-reorder";
+
+const ws = (id: string) => ({ workspace_id: id });
+const group = (projectPath: string, ids: string[]): ReorderGroup => ({
+  projectPath,
+  workspaces: ids.map(ws),
+});
+
+describe("computeWorkspaceReorder", () => {
+  it("drops a downward drag at the intended slot (no off-by-one)", () => {
+    // [A, B, C], drag A, drop between B and C → dropIndex 2 (data-ws-index of
+    // B is 1, cursor below midpoint → +1). Must land [B, A, C], not [B, C, A].
+    const groups = [group("P", ["A", "B", "C"])];
+    expect(computeWorkspaceReorder(groups, "A", "P", 2)).toEqual(["B", "A", "C"]);
+  });
+
+  it("handles upward drags (no adjustment needed)", () => {
+    // [A, B, C], drag C up to between A and B → dropIndex 1.
+    const groups = [group("P", ["A", "B", "C"])];
+    expect(computeWorkspaceReorder(groups, "C", "P", 1)).toEqual(["A", "C", "B"]);
+  });
+
+  it("moves to the very top and very bottom", () => {
+    const groups = [group("P", ["A", "B", "C"])];
+    expect(computeWorkspaceReorder(groups, "C", "P", 0)).toEqual(["C", "A", "B"]);
+    expect(computeWorkspaceReorder(groups, "A", "P", 3)).toEqual(["B", "C", "A"]);
+  });
+
+  it("a no-op drop preserves order", () => {
+    const groups = [group("P", ["A", "B", "C"])];
+    // Drag B, drop back at its own slot (dropIndex 1 == sourceIdx).
+    expect(computeWorkspaceReorder(groups, "B", "P", 1)).toEqual(["A", "B", "C"]);
+  });
+
+  it("only reorders within the source group, preserving other groups", () => {
+    const groups = [
+      group("P1", ["A", "B"]),
+      group("P2", ["C", "D"]),
+    ];
+    // Reorder within P2: drag C below D (dropIndex 2) → [D, C]; P1 untouched.
+    expect(computeWorkspaceReorder(groups, "C", "P2", 2)).toEqual([
+      "A",
+      "B",
+      "D",
+      "C",
+    ]);
+  });
+});

--- a/src/components/layout/workspace-reorder.ts
+++ b/src/components/layout/workspace-reorder.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure transform behind sidebar workspace drag-reorder. Extracted from the
+ * React drop handler so it can be unit-tested without a DOM.
+ *
+ * The dragged row stays mounted during the drag (only dimmed), so `dropIndex`
+ * — derived from the rows' `data-ws-index` — is measured in the group's
+ * "with-dragged-row" index space. When the dragged workspace originally sat
+ * above the drop point, removing it shifts every later slot down by one, so a
+ * downward drop must be adjusted by -1. (The sibling project-reorder branch
+ * already does this; the workspace branch used to omit it and dropped
+ * downward drags one slot too low.)
+ */
+export interface ReorderGroup {
+  projectPath: string;
+  workspaces: ReadonlyArray<{ workspace_id: string }>;
+}
+
+export function computeWorkspaceReorder(
+  groups: ReadonlyArray<ReorderGroup>,
+  draggedId: string,
+  sourceProjectPath: string | null,
+  dropIndex: number,
+): string[] {
+  const newIds: string[] = [];
+
+  for (const group of groups) {
+    const sourceIdx = group.workspaces.findIndex(
+      (w) => w.workspace_id === draggedId,
+    );
+    const groupIds = group.workspaces
+      .map((w) => w.workspace_id)
+      .filter((id) => id !== draggedId);
+
+    if (group.projectPath === sourceProjectPath) {
+      const adjusted =
+        sourceIdx >= 0 && dropIndex > sourceIdx ? dropIndex - 1 : dropIndex;
+      groupIds.splice(Math.min(adjusted, groupIds.length), 0, draggedId);
+    }
+
+    newIds.push(...groupIds);
+  }
+
+  // Safety net: never lose the dragged id (e.g. source group not found).
+  if (!newIds.includes(draggedId)) {
+    newIds.push(draggedId);
+  }
+  return newIds;
+}

--- a/src/components/workspaces-overview/use-overview-items.test.ts
+++ b/src/components/workspaces-overview/use-overview-items.test.ts
@@ -47,7 +47,12 @@ vi.mock("@/stores/workspaces-sync-store", () => ({
   useWorkspacesSync: () => mockSyncRows,
 }));
 
-import { useOverviewItems, remoteProjectName } from "./use-overview-items";
+import {
+  useOverviewItems,
+  remoteProjectName,
+  detectDivergence,
+  type OverviewItem,
+} from "./use-overview-items";
 
 // ── Factories ─────────────────────────────────────────────────────
 
@@ -128,7 +133,91 @@ function makeHost(
   };
 }
 
+function makeRemoteItem(
+  id: number,
+  sync: Partial<WorkspaceSyncView>,
+): OverviewItem {
+  return {
+    kind: "remote",
+    key: `remote:${id}`,
+    sync: makeSync({ id, ...sync }),
+    hostServerId: sync.host_server_id ?? null,
+    projectName: null,
+    projectPath: null,
+    projectKey: null,
+  };
+}
+
 afterEach(() => cleanup());
+
+describe("detectDivergence", () => {
+  const label = (hostServerId: string | null) =>
+    hostServerId ?? "another device";
+
+  it("excludes rows with no git_head_sha from divergence", () => {
+    const items = [
+      makeRemoteItem(1, {
+        project_remote: "R",
+        git_branch: "main",
+        git_head_sha: "aaa",
+        host_server_id: "dev-a",
+      }),
+      makeRemoteItem(2, {
+        project_remote: "R",
+        git_branch: "main",
+        git_head_sha: "bbb",
+        host_server_id: "dev-b",
+      }),
+      makeRemoteItem(3, {
+        project_remote: "R",
+        git_branch: "main",
+        git_head_sha: null,
+        host_server_id: "dev-c",
+      }),
+    ];
+    const result = detectDivergence(items, label);
+    // The two rows with distinct shas diverge…
+    expect(result.has("remote:1")).toBe(true);
+    expect(result.has("remote:2")).toBe(true);
+    // …but the sha-less row can't be compared, so it gets no chip.
+    expect(result.has("remote:3")).toBe(false);
+    // And it must not inflate the fork count or the "other device" label.
+    expect(result.get("remote:1")?.forks).toBe(2);
+    expect(result.get("remote:1")?.otherLabel).toBe("dev-b");
+  });
+
+  it("does not diverge when only one sha is known", () => {
+    const items = [
+      makeRemoteItem(1, {
+        project_remote: "R",
+        git_branch: "main",
+        git_head_sha: "aaa",
+      }),
+      makeRemoteItem(2, {
+        project_remote: "R",
+        git_branch: "main",
+        git_head_sha: null,
+      }),
+    ];
+    expect(detectDivergence(items, label).size).toBe(0);
+  });
+
+  it("does not diverge when shas match", () => {
+    const items = [
+      makeRemoteItem(1, {
+        project_remote: "R",
+        git_branch: "main",
+        git_head_sha: "same",
+      }),
+      makeRemoteItem(2, {
+        project_remote: "R",
+        git_branch: "main",
+        git_head_sha: "same",
+      }),
+    ];
+    expect(detectDivergence(items, label).size).toBe(0);
+  });
+});
 
 describe("useOverviewItems", () => {
   beforeEach(() => {

--- a/src/components/workspaces-overview/use-overview-items.ts
+++ b/src/components/workspaces-overview/use-overview-items.ts
@@ -158,15 +158,19 @@ export function detectDivergence(
     groups.set(groupKey, list);
   }
 
-  // For each group with >=2 entries AND >=2 distinct shas, mark
-  // every entry in that group as diverged. Skip groups where any
-  // entry's sha is null (insufficient info).
+  // For each group with >=2 entries AND >=2 distinct shas, mark every
+  // entry as diverged. Rows with no git_head_sha are excluded entirely —
+  // we can't determine divergence without a sha on both sides, so they
+  // neither receive a chip nor count toward the fork count / device list.
   const result = new Map<string, DivergenceInfo>();
-  for (const entries of groups.values()) {
+  for (const group of groups.values()) {
+    const entries = group.filter((e): e is typeof e & { sha: string } =>
+      Boolean(e.sha),
+    );
     if (entries.length < 2) continue;
     const shas = new Set<string>();
     for (const e of entries) {
-      if (e.sha) shas.add(e.sha);
+      shas.add(e.sha);
     }
     if (shas.size < 2) continue;
     for (const entry of entries) {

--- a/src/lib/app-shortcuts.test.ts
+++ b/src/lib/app-shortcuts.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+
+import { updateAppShortcuts, isAppShortcut } from "./app-shortcuts";
+import { matchesKeyCombo } from "./keybind-utils";
+
+function keyEvent(partial: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    key: partial.key ?? "",
+    ctrlKey: partial.ctrlKey ?? false,
+    shiftKey: partial.shiftKey ?? false,
+    altKey: partial.altKey ?? false,
+  } as KeyboardEvent;
+}
+
+describe("isAppShortcut", () => {
+  it("intercepts a Space-bound app shortcut (event.key is ' ')", () => {
+    // Fresh object ref so the reference-equality guard doesn't short-circuit.
+    updateAppShortcuts({ commandPalette: "Space" });
+    const ev = keyEvent({ key: " " });
+    // The canonical matcher agrees this event IS the "Space" binding…
+    expect(matchesKeyCombo(ev, "Space")).toBe(true);
+    // …so the app-shortcut matcher must agree too.
+    expect(isAppShortcut(ev)).toBe(true);
+  });
+
+  it("still matches a normal Ctrl combo", () => {
+    updateAppShortcuts({ commandPalette: "Ctrl+K" });
+    expect(isAppShortcut(keyEvent({ key: "k", ctrlKey: true }))).toBe(true);
+    // Modifier mismatch must not match.
+    expect(isAppShortcut(keyEvent({ key: "k" }))).toBe(false);
+  });
+});

--- a/src/lib/app-shortcuts.ts
+++ b/src/lib/app-shortcuts.ts
@@ -7,7 +7,7 @@
  */
 
 import { resolveKeybinds } from "@/hooks/use-resolved-keybinds";
-import { parseKeyCombo } from "@/lib/keybind-utils";
+import { parseKeyCombo, normalizeKeyName } from "@/lib/keybind-utils";
 import { KEYBIND_REGISTRY } from "@/lib/keybind-registry";
 
 export interface AppShortcut {
@@ -55,7 +55,10 @@ updateAppShortcuts({});
  * to let the event bubble (return false) or keep it (return true).
  */
 export function isAppShortcut(event: KeyboardEvent): boolean {
-  const key = event.key.toLowerCase();
+  // Normalize the raw event key the same way the cached key was derived
+  // (via parseKeyCombo's canonical names) — otherwise Space, whose
+  // event.key is " ", never matches its cached "space" entry.
+  const key = normalizeKeyName(event.key).toLowerCase();
   return _cached.some(
     (s) =>
       s.key === key &&

--- a/src/lib/diff-parser.test.ts
+++ b/src/lib/diff-parser.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { parseDiff } from "./diff-parser";
+
+describe("parseDiff", () => {
+  it("returns nothing for empty input", () => {
+    expect(parseDiff("")).toEqual([]);
+  });
+
+  it("parses adds, dels, and context with correct line numbers", () => {
+    const diff = ["@@ -1,2 +1,2 @@", " keep", "-old", "+new"].join("\n");
+    expect(parseDiff(diff)).toEqual([
+      { type: "hunk-header", content: "@@ -1,2 +1,2 @@", oldLine: null, newLine: null },
+      { type: "context", content: "keep", oldLine: 1, newLine: 1 },
+      { type: "del", content: "old", oldLine: 2, newLine: null },
+      { type: "add", content: "new", oldLine: null, newLine: 2 },
+    ]);
+  });
+
+  it("skips file-header metadata outside a hunk", () => {
+    const diff = [
+      "diff --git a/f b/f",
+      "index 111..222 100644",
+      "--- a/f",
+      "+++ b/f",
+      "@@ -1 +1 @@",
+      "-x",
+      "+y",
+    ].join("\n");
+    const lines = parseDiff(diff);
+    // The two file-header lines must not appear as content.
+    expect(lines.filter((l) => l.type === "del")).toHaveLength(1);
+    expect(lines.filter((l) => l.type === "add")).toHaveLength(1);
+    expect(lines.find((l) => l.type === "del")?.content).toBe("x");
+    expect(lines.find((l) => l.type === "add")?.content).toBe("y");
+  });
+
+  it("keeps a deleted `-- comment` line and preserves line numbers", () => {
+    // Deleting a SQL/Lua `-- comment` line renders as `--- comment` in the
+    // unified diff — it must be parsed as a deletion, not a file header.
+    const diff = ["@@ -1,2 +1,1 @@", "--- comment: drop index", " keep this line"].join("\n");
+    const lines = parseDiff(diff);
+    const del = lines.find((l) => l.type === "del");
+    expect(del).toBeDefined();
+    expect(del?.content).toBe("-- comment: drop index");
+    expect(del?.oldLine).toBe(1);
+    // The surviving context line is original line 2, not 1.
+    const ctx = lines.find((l) => l.type === "context");
+    expect(ctx?.oldLine).toBe(2);
+  });
+
+  it("keeps an added `++ x` line", () => {
+    const diff = ["@@ -1 +1,2 @@", " keep", "++ added marker"].join("\n");
+    const lines = parseDiff(diff);
+    const add = lines.find((l) => l.type === "add");
+    expect(add).toBeDefined();
+    expect(add?.content).toBe("+ added marker");
+    expect(add?.newLine).toBe(2);
+  });
+
+  it("skips `\\ No newline at end of file` inside a hunk", () => {
+    const diff = ["@@ -1 +1 @@", "-x", "+y", "\\ No newline at end of file"].join("\n");
+    const lines = parseDiff(diff);
+    expect(lines.some((l) => l.content.includes("No newline"))).toBe(false);
+  });
+
+  it("handles a multi-file diff, resetting hunk context per file", () => {
+    const diff = [
+      "diff --git a/a.sql b/a.sql",
+      "--- a/a.sql",
+      "+++ b/a.sql",
+      "@@ -1 +1 @@",
+      "--- a comment",
+      "+-- a comment changed",
+      "diff --git a/b.txt b/b.txt",
+      "--- a/b.txt",
+      "+++ b/b.txt",
+      "@@ -1 +1 @@",
+      "-foo",
+      "+bar",
+    ].join("\n");
+    const lines = parseDiff(diff);
+    // First file: a deleted `-- a comment`, an added `-- a comment changed`.
+    // Second file: a deleted `foo`, an added `bar`. The four `--- a/...` /
+    // `+++ b/...` headers must not leak in as content.
+    const dels = lines.filter((l) => l.type === "del").map((l) => l.content);
+    const adds = lines.filter((l) => l.type === "add").map((l) => l.content);
+    expect(dels).toEqual(["-- a comment", "foo"]);
+    expect(adds).toEqual(["-- a comment changed", "bar"]);
+  });
+});

--- a/src/lib/diff-parser.ts
+++ b/src/lib/diff-parser.ts
@@ -15,11 +15,11 @@ export interface SplitLine {
   right: DiffLine | null;
 }
 
-const METADATA_PREFIXES = [
+// Structural metadata never collides with hunk content, because every
+// in-hunk content line starts with `+`, `-`, or a space. Safe to skip anywhere.
+const STRUCTURAL_PREFIXES = [
   "diff ",
   "index ",
-  "--- ",
-  "+++ ",
   "new file",
   "deleted file",
   "old mode",
@@ -29,22 +29,38 @@ const METADATA_PREFIXES = [
   "\\ No newline",
 ];
 
+// `--- ` and `+++ ` are file headers ONLY outside a hunk body. Inside a hunk
+// they are content: a deleted source line `-- x` renders as `--- x`, and an
+// added line `++ x` renders as `+++ x`. Skipping those as metadata silently
+// dropped the change and desynced every following line number.
+const FILE_HEADER_PREFIXES = ["--- ", "+++ "];
+
 /**
  * Parse unified diff text into structured lines.
- * Ported from src-old/components/diff/DiffContent.svelte.
  */
 export function parseDiff(text: string): DiffLine[] {
   if (!text) return [];
   const lines: DiffLine[] = [];
   let oldLine = 0;
   let newLine = 0;
+  let inHunk = false;
 
   for (const raw of text.split("\n")) {
-    if (METADATA_PREFIXES.some((p) => raw.startsWith(p))) {
+    // A new file's metadata block resets hunk context. In git output the
+    // `diff ` line always precedes that file's `--- `/`+++ ` headers.
+    if (raw.startsWith("diff ")) {
+      inHunk = false;
+    }
+
+    if (STRUCTURAL_PREFIXES.some((p) => raw.startsWith(p))) {
+      continue;
+    }
+    if (!inHunk && FILE_HEADER_PREFIXES.some((p) => raw.startsWith(p))) {
       continue;
     }
 
     if (raw.startsWith("@@")) {
+      inHunk = true;
       const match = raw.match(/@@ -(\d+)/);
       if (match) {
         oldLine = parseInt(match[1], 10);

--- a/src/lib/keybind-utils.test.ts
+++ b/src/lib/keybind-utils.test.ts
@@ -76,6 +76,14 @@ describe("parseKeyCombo", () => {
   it("parses Alt+Ctrl+Shift+key", () => {
     expect(parseKeyCombo("Alt+Ctrl+Shift+X")).toEqual({ alt: true, ctrl: true, shift: true, key: "X" });
   });
+
+  it("parses the '+' key itself without dropping it", () => {
+    // "+" is both the modifier delimiter and a valid key — splitting on "+"
+    // dropped the key entirely.
+    expect(parseKeyCombo("+")).toEqual({ alt: false, ctrl: false, shift: false, key: "+" });
+    expect(parseKeyCombo("Ctrl++")).toEqual({ alt: false, ctrl: true, shift: false, key: "+" });
+    expect(parseKeyCombo("Ctrl+Shift++")).toEqual({ alt: false, ctrl: true, shift: true, key: "+" });
+  });
 });
 
 describe("matchesKeyCombo", () => {
@@ -101,6 +109,14 @@ describe("matchesKeyCombo", () => {
 
   it("returns false for empty combo", () => {
     expect(matchesKeyCombo(fakeEvent({ key: "a" }), "")).toBe(false);
+  });
+
+  it("round-trips a '+' key binding (e.g. zoom in)", () => {
+    const ev = fakeEvent({ ctrlKey: true, key: "+" });
+    // The producer encodes Ctrl + "+" as "Ctrl++"; the matcher must accept it.
+    expect(normalizeKeyCombo(ev)).toBe("Ctrl++");
+    expect(matchesKeyCombo(ev, "Ctrl++")).toBe(true);
+    expect(matchesKeyCombo(fakeEvent({ key: "+" }), "+")).toBe(true);
   });
 });
 

--- a/src/lib/keybind-utils.ts
+++ b/src/lib/keybind-utils.ts
@@ -67,14 +67,29 @@ export interface ParsedKeyCombo {
 
 /** Parse a canonical combo string like "Ctrl+Shift+D" into its parts */
 export function parseKeyCombo(combo: string): ParsedKeyCombo {
-  const parts = combo.split("+");
-  const key = parts[parts.length - 1];
-  return {
-    alt: parts.includes("Alt"),
-    ctrl: parts.includes("Ctrl"),
-    shift: parts.includes("Shift"),
-    key,
-  };
+  // Strip the leading run of modifier prefixes (canonical order Alt, Ctrl,
+  // Shift). The remainder is the literal key — which may itself be "+", so we
+  // must NOT split on "+" (that dropped a "+" binding, e.g. "Ctrl++" parsed to
+  // an empty key and could never match).
+  let rest = combo;
+  let alt = false;
+  let ctrl = false;
+  let shift = false;
+  for (;;) {
+    if (rest.startsWith("Alt+")) {
+      alt = true;
+      rest = rest.slice(4);
+    } else if (rest.startsWith("Ctrl+")) {
+      ctrl = true;
+      rest = rest.slice(5);
+    } else if (rest.startsWith("Shift+")) {
+      shift = true;
+      rest = rest.slice(6);
+    } else {
+      break;
+    }
+  }
+  return { alt, ctrl, shift, key: rest };
 }
 
 /** Check if a keyboard event matches a canonical combo string */

--- a/src/lib/keybind-utils.ts
+++ b/src/lib/keybind-utils.ts
@@ -22,7 +22,7 @@ export function normalizeKeyCombo(event: KeyboardEvent): string {
 }
 
 /** Normalize a raw event.key value to canonical display form */
-function normalizeKeyName(key: string): string {
+export function normalizeKeyName(key: string): string {
   // Space is event.key " " (length 1) but should display as "Space"
   if (key === " ") return "Space";
   // Single alphabetic character → uppercase

--- a/src/lib/kitty-keyboard.test.ts
+++ b/src/lib/kitty-keyboard.test.ts
@@ -155,6 +155,14 @@ describe("scanKittySequences", () => {
     expect(scanKittySequences("\x1b[<u\x1b[<u").popCount).toBe(2);
   });
 
+  it("counts a numbered pop CSI<N u as N entries", () => {
+    expect(scanKittySequences("\x1b[<3u").popCount).toBe(3);
+  });
+
+  it("sums bare and numbered pops together", () => {
+    expect(scanKittySequences("\x1b[<u\x1b[<2u").popCount).toBe(3);
+  });
+
   it("detects DA1 query \\x1b[c", () => {
     expect(scanKittySequences("\x1b[c").hasDAQuery).toBe(true);
   });

--- a/src/lib/kitty-keyboard.ts
+++ b/src/lib/kitty-keyboard.ts
@@ -66,7 +66,13 @@ export function scanKittySequences(str: string): KittyScanResult {
     pushValues.push(parseInt(m[1], 10));
   }
 
-  const popCount = (str.match(/\x1b\[<u/g) ?? []).length;
+  // Pop op is `CSI < number u`, where `number` is how many entries to pop and
+  // defaults to 1 when omitted (Kitty keyboard protocol). Sum the counts so a
+  // numbered pop like `CSI < 3 u` removes 3 entries instead of being missed.
+  let popCount = 0;
+  for (const m of str.matchAll(/\x1b\[<([0-9]*)u/g)) {
+    popCount += m[1] ? parseInt(m[1], 10) : 1;
+  }
 
   // DA query: shell sends \x1b[c (DA1) or \x1b[>c (DA2) on startup.
   // Either form may include an explicit 0 param (\x1b[0c / \x1b[>0c).

--- a/src/lib/project-image.test.ts
+++ b/src/lib/project-image.test.ts
@@ -35,6 +35,10 @@ describe("resolveImageUrl", () => {
     const ico = "https://example.com/fav.ico?x=1";
     expect(resolveImageUrl(ico).isFavicon).toBe(false);
     expect(resolveImageUrl(ico).url).toBe(ico);
+    // …and so is one with a trailing fragment.
+    const frag = "https://example.com/logo.png#section";
+    expect(resolveImageUrl(frag).isFavicon).toBe(false);
+    expect(resolveImageUrl(frag).url).toBe(frag);
   });
 
   it("derives a favicon URL from a bare domain", () => {

--- a/src/lib/project-image.ts
+++ b/src/lib/project-image.ts
@@ -11,7 +11,10 @@
  * sites that don't expose /favicon.ico at the root.
  */
 
-const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|svg|webp|ico|avif|bmp)(\?.*)?$/i;
+// Allow an optional trailing query string (?v=1) or fragment (#section) after
+// the extension — both are valid on a direct image URL and must not cause it to
+// be misread as a website and routed through the favicon service.
+const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|svg|webp|ico|avif|bmp)([?#].*)?$/i;
 
 export interface ResolvedImage {
   /** The final URL to put on an <img src>. Empty when input is blank. */


### PR DESCRIPTION
25 verified bug fixes + 1 regression guard, found by going through the codebase and comparing against the superset reference. Every change has a unit/state test proven to **fail before and pass after** the fix (the guard confirms correct behavior), and the full suite — 1826 Rust tests + 1963 frontend tests — is green. Each commit is independent and revertable.

### Crashes / panics
- `fix(github)` no panic generating a branch name from a non-ASCII (CJK/Cyrillic) issue title — byte-index slice landed mid-character
- `fix(browser)` no panic logging multibyte snapshot output — same byte-boundary class
- (Also swept the whole codebase for byte-index slicing, `String::truncate`, and div/mod-by-zero panics — all other sites confirmed safe.)

### Terminal / PTY stability
- `fix(pty-daemon)` don't drop request bytes that straddle the read timeout — large pastes could be silently corrupted (`read_line` wasn't cancellation-safe)
- `fix(terminal)` strip OSC escape sequences fully — window-title escapes (emitted on nearly every shell prompt) leaked into the OpenFlow comm log and agent-state scanners
- `fix(terminal)` honor numbered Kitty keyboard pop (`CSI<N u`)

### Layout smoothness
- `fix(panes)` preserve sibling proportions when closing a pane (was resetting to equal)
- `fix(panes)` / `fix(tabs)` focus the **adjacent** pane/tab on close, not the leftmost/previous (3 commits across panes, tabs, and tab-via-last-pane)
- `fix(sidebar)` drag-reorder no longer drops a workspace one slot too low

### Browser & keyboard input
- `fix(browser)` encode CDP modifier bits correctly — Shift/Alt/Meta+click reached the page scrambled
- `fix(keybinds)` match a Space-bound shortcut over the terminal; don't drop the `+` key when parsing a combo

### Agent automation (MCP)
- `fix(mcp)` honor the scroll amount in `browser_scroll_at` (emitted as float, read as int → always defaulted)
- `fix(mcp)` `pane_split_right`/`down` sent inverted directions → splits always went the opposite way
- `fix(notify)` honor the notification level instead of always Attention

### Data integrity / cross-device sync
- `fix(github)` scope issue/PR detail caches by repo — one repo's issue #N served another's
- `fix(opencode-sync)` SQL-escape the workspace path in the remote query — an apostrophe path silently broke session continuity
- `fix(workspaces-sync)` predict the adopt worktree path with the real sanitizer (matched `git_create_worktree`)
- `fix(openflow)` parse comm-log timestamps so the activity signal works — `DateTime::parse_from_str` rejected the zone-less format, leaving stuck-detection's timestamp signal permanently dead

### Diff / git
- `fix(diff)` keep deleted/added lines that start with `--`/`++` (e.g. SQL comments) and preserve line numbers
- `fix(git)` keep diff stats for renamed files in subdirectories (brace-form numstat)
- `fix(workspaces-overview)` don't flag sha-less rows as diverged
- `fix(branch-name)` strip trailing `.lock` (git rejects such refs)
- `fix(project-image)` treat image URLs with a `#fragment` as direct images

### Regression guard
- `test(automations)` pin DST wall-clock preservation in recurrence — confirms codemux (unlike superset's earlier hand-rolled scheduler) keeps daily times at the right local hour across daylight-saving changes

### Approach
The highest-yield pattern was **"two implementations of the same contract that must agree but don't"** — browser modifiers, keybind round-trips, tab/pane focus, cache keys, remote-vs-local SQL, path prediction, and MCP/CLI parameter contracts — plus spec/format-grounded fixes and systematic panic-class sweeps. Strict bar throughout: only deterministically verifiable fixes, no speculative changes.