### PR TITLE
fix(sidebar): disambiguate duplicate project names by host

### DIFF
--- a/src/components/automations/automations-section.tsx
+++ b/src/components/automations/automations-section.tsx
@@ -253,13 +253,16 @@ export function AutomationsSection() {
   // and editing an automation keeps its saved path via custom mode.
   const openWorkspaces = useAppStore((s) => s.appState?.workspaces);
   const homeDir = useHomeDir();
-  const projects = useMemo<ProjectOption[]>(
-    () =>
-      groupWorkspacesByProject(openWorkspaces ?? [], homeDir)
-        .map((g) => ({ name: g.projectName, path: g.projectPath }))
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    [openWorkspaces, homeDir],
-  );
+  const projects = useMemo<ProjectOption[]>(() => {
+    // Disambiguate a project that lives both locally and on a remote
+    // host by host name (local stays clean, remote gets " · <host>"),
+    // consistent with the sidebar. `hosts` may be empty until the
+    // first load resolves — the memo recomputes when it arrives.
+    const hostNameById = new Map(hosts.map((h) => [h.id, h.name] as const));
+    return groupWorkspacesByProject(openWorkspaces ?? [], homeDir, hostNameById)
+      .map((g) => ({ name: g.projectName, path: g.projectPath }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [openWorkspaces, homeDir, hosts]);
 
   // `null` = not editing. A draft with no matching automation = create.
   const [draft, setDraft] = useState<FormDraft | null>(null);

--- a/src/components/layout/sidebar-workspace-list.tsx
+++ b/src/components/layout/sidebar-workspace-list.tsx
@@ -9,6 +9,7 @@ import {
   useProjectGroupedWorkspaces,
 } from "@/stores/app-store";
 import { useUIStore } from "@/stores/ui-store";
+import { useHosts } from "@/stores/hosts-store";
 import { SidebarProjectGroup } from "./sidebar-project-group";
 import { computeWorkspaceReorder } from "./workspace-reorder";
 import { NewWorkspaceDialog } from "@/components/overlays/new-workspace-dialog";
@@ -31,7 +32,13 @@ export function SidebarWorkspaceList() {
   // any other project now; `groupWorkspacesByProject` labels them as
   // "Home" when their `project_root` matches the cached $HOME.
   const homeDir = useHomeDir();
-  const projectGroups = useProjectGroupedWorkspaces(allWorkspaces, homeDir);
+  // Pass the configured hosts so duplicate project names that span
+  // machines (a local repo and the same repo on a remote host) are
+  // disambiguated by host name — local stays clean, remote gets a
+  // " · <host>" suffix — instead of both collapsing to an identical
+  // parent-path label.
+  const hosts = useHosts();
+  const projectGroups = useProjectGroupedWorkspaces(allWorkspaces, homeDir, hosts);
   const activeWorkspaceId = appState?.active_workspace_id ?? "";
   const showDialog = useUIStore((s) => s.showNewWorkspaceDialog);
   const setShowDialog = useUIStore((s) => s.setShowNewWorkspaceDialog);

--- a/src/components/overlays/project-picker.tsx
+++ b/src/components/overlays/project-picker.tsx
@@ -20,6 +20,7 @@ import {
   useProjectGroupedWorkspaces,
 } from "@/stores/app-store";
 import { useUIStore } from "@/stores/ui-store";
+import { useHosts } from "@/stores/hosts-store";
 import { basename } from "@/lib/path";
 import { dbGetRecentProjects, dbGetUiState } from "@/tauri/commands";
 import { useProjectActions } from "@/hooks/use-project-actions";
@@ -61,7 +62,11 @@ export function ProjectPicker({ value, onChange }: ProjectPickerProps) {
 
   const workspaces = useAppStore((s) => s.appState?.workspaces ?? []);
   const homeDir = useHomeDir();
-  const projectGroups = useProjectGroupedWorkspaces(workspaces, homeDir);
+  // Pass hosts so a project that exists both locally and on a remote
+  // host is disambiguated by host name (local stays clean, remote gets
+  // a " · <host>" suffix) — matching the sidebar's labels.
+  const hosts = useHosts();
+  const projectGroups = useProjectGroupedWorkspaces(workspaces, homeDir, hosts);
 
   // Load recent projects plus each project's avatar (accent color + custom
   // image + favicon cache-bust token) when the popover opens, so the picker

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -22,3 +22,9 @@ export function tailSegments(path: string, n: number): string {
   const parts = path.split(SEP).filter(Boolean);
   return parts.slice(-n).join("/");
 }
+
+/** Number of non-empty segments in a path. Used to bound how far the
+ *  duplicate-label disambiguation can grow the trailing tail. */
+export function segmentCount(path: string): number {
+  return path.split(SEP).filter(Boolean).length;
+}

--- a/src/stores/app-store.test.ts
+++ b/src/stores/app-store.test.ts
@@ -218,6 +218,109 @@ describe("project grouping", () => {
     const names = groups.map((g) => g.projectName).sort();
     expect(names).toEqual(["personal/app", "work/app"]);
   });
+
+  it("grows the path tail until duplicate labels are actually unique", () => {
+    // Both roots end in the same two segments (`projects/app`), so a
+    // fixed 2-segment tail would leave them identical. The tail must
+    // grow to three segments to disambiguate.
+    const workspaces = [
+      makeWs({ workspace_id: "ws-1", project_root: "/home/alice/projects/app" }),
+      makeWs({ workspace_id: "ws-2", project_root: "/home/bob/projects/app" }),
+    ];
+
+    const groups = groupWorkspacesByProject(workspaces, null);
+
+    const names = groups.map((g) => g.projectName).sort();
+    expect(names).toEqual(["alice/projects/app", "bob/projects/app"]);
+    // Crucially, the broken identical "projects/app" label never appears.
+    expect(names).not.toContain("projects/app");
+  });
+
+  it("tags the remote copy with its host and keeps the local copy clean", () => {
+    // Same repo basename on two machines: local `/home/zeus/...` and the
+    // remote `/home/deus/...` on host id 7 ("pandora"). Local must stay
+    // "partpilot"; the remote gets a " · pandora" suffix.
+    const workspaces = [
+      makeWs({
+        workspace_id: "ws-local",
+        project_root: "/home/zeus/projects/partpilot",
+        host_id: null,
+      }),
+      makeWs({
+        workspace_id: "ws-remote",
+        project_root: "/home/deus/projects/partpilot",
+        host_id: 7,
+      }),
+    ];
+
+    const groups = groupWorkspacesByProject(
+      workspaces,
+      null,
+      new Map([[7, "pandora"]]),
+    );
+
+    const byName = new Map(groups.map((g) => [g.projectName, g]));
+    expect(byName.has("partpilot")).toBe(true);
+    expect(byName.get("partpilot")!.projectPath).toBe(
+      "/home/zeus/projects/partpilot",
+    );
+    expect(byName.has("partpilot · pandora")).toBe(true);
+    expect(byName.get("partpilot · pandora")!.projectPath).toBe(
+      "/home/deus/projects/partpilot",
+    );
+    // The old broken "projects/partpilot" label is gone.
+    expect(groups.map((g) => g.projectName)).not.toContain(
+      "projects/partpilot",
+    );
+  });
+
+  it("falls back to path tails when host names are unavailable", () => {
+    // host_id is set but no name map is provided — disambiguation can't
+    // use the host, so it must still produce unique path-based labels.
+    const workspaces = [
+      makeWs({
+        workspace_id: "ws-local",
+        project_root: "/home/zeus/projects/partpilot",
+        host_id: null,
+      }),
+      makeWs({
+        workspace_id: "ws-remote",
+        project_root: "/home/deus/projects/partpilot",
+        host_id: 7,
+      }),
+    ];
+
+    const groups = groupWorkspacesByProject(workspaces, null);
+
+    const names = groups.map((g) => g.projectName).sort();
+    expect(names).toEqual(["deus/projects/partpilot", "zeus/projects/partpilot"]);
+  });
+
+  it("disambiguates two same-named projects on the same remote host by path", () => {
+    // Both remote on host 7: host alone can't tell them apart, so we
+    // grow the path tail. Neither should keep a bare "app" label.
+    const workspaces = [
+      makeWs({
+        workspace_id: "ws-1",
+        project_root: "/home/deus/work/app",
+        host_id: 7,
+      }),
+      makeWs({
+        workspace_id: "ws-2",
+        project_root: "/home/deus/personal/app",
+        host_id: 7,
+      }),
+    ];
+
+    const groups = groupWorkspacesByProject(
+      workspaces,
+      null,
+      new Map([[7, "pandora"]]),
+    );
+
+    const names = groups.map((g) => g.projectName).sort();
+    expect(names).toEqual(["personal/app", "work/app"]);
+  });
 });
 
 describe("groupWorkspacesByProject — Home labelling (Stage A)", () => {

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -6,7 +6,8 @@ import type {
   WorkspaceSnapshot,
   SurfaceSnapshot,
 } from "@/tauri/types";
-import { basename, tailSegments } from "@/lib/path";
+import { basename, tailSegments, segmentCount } from "@/lib/path";
+import type { HostView } from "@/tauri/commands";
 
 interface AppStore {
   appState: AppStateSnapshot | null;
@@ -294,9 +295,26 @@ export function resolveProjectRoot(ws: WorkspaceSnapshot): string {
  * stops filtering out `workspace_type === "home"` workspaces, so this
  * label rule is what surfaces them correctly in the sidebar.
  */
+/**
+ * The single host a group's workspaces live on, or `null` when they're
+ * local. Returns `undefined` when the group is empty or its workspaces
+ * straddle multiple hosts — in that case the host can't disambiguate
+ * the group and we fall back to path tails.
+ */
+function groupHostId(workspaces: WorkspaceSnapshot[]): number | null | undefined {
+  let hostId: number | null | undefined = undefined;
+  for (const ws of workspaces) {
+    const h = ws.host_id ?? null;
+    if (hostId === undefined) hostId = h;
+    else if (hostId !== h) return undefined; // mixed → ambiguous
+  }
+  return hostId;
+}
+
 export function groupWorkspacesByProject(
   workspaces: WorkspaceSnapshot[],
   homeDir: string | null,
+  hostNameById?: ReadonlyMap<number, string> | null,
 ): ProjectGroup[] {
   const groups = new Map<string, { name: string; path: string; workspaces: WorkspaceSnapshot[] }>();
 
@@ -319,18 +337,49 @@ export function groupWorkspacesByProject(
     workspaces: g.workspaces,
   }));
 
-  // Disambiguate duplicate project names by adding parent path. The
-  // "Home" group is always unique (single homeDir path), so this
-  // never rewrites it.
-  const nameCounts = new Map<string, number>();
+  // Disambiguate duplicate project names. Two project roots can share a
+  // basename when the same repo lives on different machines (e.g. a
+  // local `~/projects/app` and the same `app` on a remote host) or in
+  // sibling directories. We prefer the host as the distinguishing tag:
+  // the local copy keeps its clean basename and each remote copy is
+  // suffixed with " · <host>". When the host can't tell the copies
+  // apart (both local, both on the same host, or host names
+  // unavailable) we fall back to appending just enough trailing path
+  // segments to make every colliding label unique. The "Home" group is
+  // always unique (single homeDir path), so this never rewrites it.
+  const byName = new Map<string, typeof result>();
   for (const g of result) {
-    nameCounts.set(g.projectName, (nameCounts.get(g.projectName) || 0) + 1);
+    const list = byName.get(g.projectName);
+    if (list) list.push(g);
+    else byName.set(g.projectName, [g]);
   }
-  for (const g of result) {
-    if ((nameCounts.get(g.projectName) || 0) > 1) {
-      const tail = tailSegments(g.projectPath, 2);
-      if (tail.includes("/")) {
-        g.projectName = tail;
+
+  for (const colliding of byName.values()) {
+    if (colliding.length < 2) continue;
+
+    // Pass 1 — tag remote groups with their host name; locals (and
+    // groups whose host we can't name) keep the clean basename.
+    for (const g of colliding) {
+      const hostId = groupHostId(g.workspaces);
+      const hostName = hostId != null ? hostNameById?.get(hostId) ?? null : null;
+      if (hostName) g.projectName = `${g.projectName} · ${hostName}`;
+    }
+
+    const unique = (gs: typeof colliding) =>
+      new Set(gs.map((g) => g.projectName)).size === gs.length;
+    if (unique(colliding)) continue;
+
+    // Pass 2 — fall back to trailing path segments, growing the tail
+    // until every label is unique. Group keys are distinct absolute
+    // paths, so this always converges by the longest path's depth.
+    const maxSegments = Math.max(...colliding.map((g) => segmentCount(g.projectPath)));
+    for (let n = 2; n <= maxSegments; n++) {
+      const tails = colliding.map((g) => tailSegments(g.projectPath, n));
+      if (new Set(tails).size === colliding.length) {
+        colliding.forEach((g, i) => {
+          if (tails[i].includes("/")) g.projectName = tails[i];
+        });
+        break;
       }
     }
   }
@@ -341,9 +390,12 @@ export function groupWorkspacesByProject(
 export function useProjectGroupedWorkspaces(
   workspaces: WorkspaceSnapshot[],
   homeDir: string | null,
+  hosts?: HostView[],
 ): ProjectGroup[] {
-  return useMemo(
-    () => groupWorkspacesByProject(workspaces, homeDir),
-    [workspaces, homeDir],
-  );
+  return useMemo(() => {
+    const hostNameById = hosts
+      ? new Map(hosts.map((h) => [h.id, h.name] as const))
+      : null;
+    return groupWorkspacesByProject(workspaces, homeDir, hostNameById);
+  }, [workspaces, homeDir, hosts]);
 }


### PR DESCRIPTION
## Problem

Adding a project that already exists on another machine made the sidebar suddenly label it `projects/partpilot` instead of `partpilot` — on **both** copies.

Root cause: the same repo basename existed in two project roots — a local `~/projects/partpilot` and the same repo on a remote host (`deus@pandora:/home/deus/projects/partpilot`). The sidebar disambiguates duplicate project names by appending the **last two path segments**. Both roots end in `projects/partpilot`, so both got that identical label — no real disambiguation, just an ugly parent-dir prefix.

## Fix

Prefer the **host** as the distinguishing tag:

- Local copy keeps its clean basename → `partpilot`
- Each remote copy is suffixed with its host → `partpilot · pandora`

When the host can't tell copies apart (both local, same host, or host names unavailable), fall back to **growing the trailing path tail until every label is unique** instead of a fixed two segments — which also fixes a latent case where two same-named local projects could collapse to an identical label.

## Surfaces wired

| Surface | Behavior |
|---|---|
| Sidebar project groups | Host-aware labels |
| Project picker (project switcher) | Host-aware labels |
| Automations project dropdown | Host-aware labels |

Worktree/derivative pickers and `AgentChatPane`'s direct call only look up groups by `projectPath` (never render the name), and the workspaces overview already has its own device-bucket host display — all left on the improved path-tail fallback to avoid double-tagging. Backward-compatible: callers that don't pass hosts get the better path-tail labels.

## Tests

- 4 new unit tests in `app-store.test.ts` covering the local-vs-remote case, tail-growth-until-unique, no-host fallback, and same-host collision.
- Full suite green: **1967/1967**; `tsc --noEmit` clean.