### PR TITLE
refactor(cloud-push): gate verbose push-to-host trace logs behind CODEMUX_TRACE_CLOUD_PUSH

### DIFF
--- a/docs/features/observability.md
+++ b/docs/features/observability.md
@@ -69,6 +69,35 @@ Support surface:
   Codemux drives zenity itself (`src-tauri/src/dialog_fallback.rs`,
   sanitized env + timeout) rather than relying on rfd's portal path.
 
+## Cloud-Push Diagnostic Tracing (`CODEMUX_TRACE_CLOUD_PUSH`)
+
+The push-to-host spawn path (SSH tunnel → remote PTY daemon → agent
+relaunch) is wired with detailed per-step tracing that was essential to
+finding the original cross-machine bug stack. In normal operation those
+lines are pure noise — a single 4-pane push would otherwise emit dozens
+of `[trace:session-id] …`, `[client_for_workspace:…]`, and
+`[tunnel-supervisor] …` lines — so they are gated behind an environment
+variable instead of printed unconditionally.
+
+- **Default (unset):** a normal 4-pane push emits fewer than ten lines of
+  cloud-push logs, and the ones that remain are actionable — errors
+  (`tunnel did not come up`, `daemon list failed`), agent-not-installed
+  preflight, the connection landmarks (`[tunnel-supervisor] start` /
+  `published Connected`, `daemon reached: pid=… version=…`), and the
+  per-pane relaunch landmark (`remote relaunch for X: claude --resume Y`).
+- **Re-enabling:** set `CODEMUX_TRACE_CLOUD_PUSH` to any value (e.g.
+  `CODEMUX_TRACE_CLOUD_PUSH=1`) in the environment of the process whose
+  stderr you want to inspect — the desktop app for the laptop-side trace,
+  or the `codemux-remote` daemon for the host-side `[daemon::spawn]`
+  trace. No recompile and no code change required; the full diagnostic
+  trace returns.
+
+Implementation: `src-tauri/src/trace.rs` defines `cloud_push_enabled()`
+(a process-wide cached env check) and the `trace_cloud_push!` macro — an
+`eprintln!`-compatible wrapper that emits only when the gate is on. Gated
+call sites live in `terminal/daemon_backed.rs`, `ssh/registry.rs`,
+`ssh/tunnel_supervisor.rs`, and `pty_daemon/server.rs`.
+
 ## Important Touch Points
 
 - `src-tauri/src/observability.rs`:
@@ -76,6 +105,7 @@ Support surface:
   - Store: `ObservabilityStore::default`, `snapshot`, `log`, `increment_metric`, `set_feature_flags`, `set_permission_policy`, `set_safety_config`, `add_replay_record`
   - Persistence: `load_observability_store`, `save_snapshot`, `snapshot_path`, `trim_logs`, `trim_replays`, `default_snapshot`
 - `src-tauri/src/commands/mod.rs` — Tauri commands: `get_observability_snapshot`, `add_structured_log`, `update_feature_flags`, `update_permission_policy`, `update_safety_config`, `add_replay_record`
+- `src-tauri/src/trace.rs` — `cloud_push_enabled()` + the `trace_cloud_push!` macro (`CODEMUX_TRACE_CLOUD_PUSH` gate for cloud-push diagnostics)
 - `src/stores/observability-store.ts` — Zustand store consuming the snapshot
 - `src-tauri/src/openflow/orchestrator.rs` — reads `PermissionPolicy` and `SafetyConfig` to gate risky actions and enforce run budgets
 - Persisted file: `dirs::data_dir() / codemux / observability.json` (platform-specific: `~/.local/share/codemux/observability.json` on Linux, `%APPDATA%\codemux\observability.json` on Windows, `~/Library/Application Support/codemux/observability.json` on macOS)

--- a/docs/features/remote-hosts.md
+++ b/docs/features/remote-hosts.md
@@ -475,3 +475,6 @@ Landed since the original 2b–2d cut: **"Push workspace to host" action** (`8c7
 
 **Tunnel says "ssh exited before tunnel came up":**
 - Usually a `-L` bind failure: the local socket already exists from a stale prior tunnel, OR the remote socket dir doesn't exist + can't be created. The tunnel command's `rm -f` + `mkdir -p` covers most of this; if it still fails, check the SSH stderr from the captured error message.
+
+**A push spawns blank/wrong panes and the kept stderr landmarks aren't enough:**
+- Restore the full per-step cloud-push trace (`[trace:…]`, `[client_for_workspace:…]`, per-attempt tunnel/socket polling, `[daemon::spawn]`) by setting `CODEMUX_TRACE_CLOUD_PUSH=1` in the environment of the process you want to inspect — the desktop app for the laptop-side trace, the `codemux-remote` daemon for the host-side trace. No recompile needed. Details + the kept-vs-gated breakdown: `docs/features/observability.md` (§ Cloud-Push Diagnostic Tracing).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,6 +77,9 @@ pub mod state;
 pub mod hooks;
 pub mod stream_input;
 pub mod terminal;
+// Opt-in cloud-push diagnostic tracing. Defines the crate-wide
+// `trace_cloud_push!` macro (gated on `CODEMUX_TRACE_CLOUD_PUSH`).
+pub mod trace;
 
 /// Save window dimensions and position to SQLite before close.
 fn save_window_state(handle: &tauri::AppHandle) {

--- a/src-tauri/src/pty_daemon/server.rs
+++ b/src-tauri/src/pty_daemon/server.rs
@@ -725,7 +725,7 @@ async fn spawn_pty(
     // where we know the local HOME.
     let resolved_cwd = crate::project::expand_tilde(&cwd);
     let cwd_exists = std::path::Path::new(&resolved_cwd).exists();
-    eprintln!(
+    crate::trace_cloud_push!(
         "[daemon::spawn] session={session_id} input_cwd={cwd:?} \
          resolved_cwd={resolved_cwd:?} exists={cwd_exists} \
          HOME={:?}",

--- a/src-tauri/src/ssh/registry.rs
+++ b/src-tauri/src/ssh/registry.rs
@@ -92,7 +92,7 @@ pub async fn install_supervisor(
     let map = registry().await;
     let mut guard = map.lock().await;
     let prev = guard.insert(workspace_id.to_string(), supervisor);
-    eprintln!(
+    crate::trace_cloud_push!(
         "[registry] install_supervisor({workspace_id}, replaced_existing={})",
         prev.is_some()
     );
@@ -112,7 +112,7 @@ pub async fn get_supervisor(
     let map = registry().await;
     let guard = map.lock().await;
     let result = guard.get(workspace_id).cloned();
-    eprintln!(
+    crate::trace_cloud_push!(
         "[registry] get_supervisor({workspace_id}) -> {} (registry has {} entries: {:?})",
         if result.is_some() { "FOUND" } else { "MISS" },
         guard.len(),
@@ -292,7 +292,7 @@ pub async fn client_for_workspace(
     // iteration to pick up changes between awaits.
     let initial_status = rx.borrow_and_update().clone();
     let deadline = Instant::now() + tunnel_wait;
-    eprintln!(
+    crate::trace_cloud_push!(
         "[client_for_workspace:{workspace_id}] waiting for tunnel local-socket bind \
          (initial supervisor status: {initial_status:?})"
     );
@@ -304,13 +304,13 @@ pub async fn client_for_workspace(
         // Log every iteration for the first few + every ~5s after
         // so the log doesn't drown but we see the polling alive.
         if iter <= 3 || iter % 10 == 0 {
-            eprintln!(
+            crate::trace_cloud_push!(
                 "[client_for_workspace:{workspace_id}] poll iter={iter} status={status:?}"
             );
         }
         match status {
             TunnelStatus::Connected { ssh_pid } => {
-                eprintln!(
+                crate::trace_cloud_push!(
                     "[client_for_workspace:{workspace_id}] tunnel local-socket bound, ssh_pid={ssh_pid}"
                 );
                 break;

--- a/src-tauri/src/ssh/tunnel_supervisor.rs
+++ b/src-tauri/src/ssh/tunnel_supervisor.rs
@@ -167,7 +167,7 @@ async fn run_supervisor(
             remote_binary: &remote_binary,
         };
         let argv = build_tunnel_argv(&opts);
-        eprintln!("[tunnel-supervisor] attempt {} argv: ssh {}", attempt + 1, argv.join(" "));
+        crate::trace_cloud_push!("[tunnel-supervisor] attempt {} argv: ssh {}", attempt + 1, argv.join(" "));
         let mut cmd = Command::new("ssh");
         for arg in &argv {
             cmd.arg(arg);
@@ -179,7 +179,7 @@ async fn run_supervisor(
         let spawn_res = cmd.spawn();
         let mut child = match spawn_res {
             Ok(c) => {
-                eprintln!(
+                crate::trace_cloud_push!(
                     "[tunnel-supervisor] ssh spawned ok, pid={:?}",
                     c.id()
                 );
@@ -294,7 +294,7 @@ async fn wait_for_socket(
 ) -> Result<(), String> {
     let start = Instant::now();
     let mut last_log_at_secs: u64 = 0;
-    eprintln!(
+    crate::trace_cloud_push!(
         "[tunnel-supervisor] waiting for local socket {:?} (deadline {:?})",
         local_socket, deadline
     );
@@ -313,7 +313,7 @@ async fn wait_for_socket(
         if local_socket.exists() {
             // Tiny grace beat so the daemon's listener is fully up.
             tokio::time::sleep(Duration::from_millis(50)).await;
-            eprintln!(
+            crate::trace_cloud_push!(
                 "[tunnel-supervisor] local socket appeared after {:?}",
                 start.elapsed()
             );
@@ -322,7 +322,7 @@ async fn wait_for_socket(
         let elapsed_secs = start.elapsed().as_secs();
         if elapsed_secs > last_log_at_secs {
             // Per-second progress so we know the loop is alive.
-            eprintln!(
+            crate::trace_cloud_push!(
                 "[tunnel-supervisor] still waiting for socket (elapsed {}s, ssh alive)",
                 elapsed_secs
             );

--- a/src-tauri/src/terminal/daemon_backed.rs
+++ b/src-tauri/src/terminal/daemon_backed.rs
@@ -274,7 +274,7 @@ pub async fn spawn_pty_for_agent_via_daemon(
     };
 
     let pid = if let Some(existing) = existing {
-        eprintln!(
+        crate::trace_cloud_push!(
             "[codemux::terminal::daemon_backed] reattaching to live daemon session \
              {session_id} pid={}",
             existing.pid
@@ -414,7 +414,7 @@ pub async fn spawn_pty_for_agent_via_daemon(
             }
             queue_or_send_output(&read_sessions, &read_session_id, chunk);
         }
-        eprintln!(
+        crate::trace_cloud_push!(
             "[codemux::terminal::daemon_backed] read loop ended for session {read_session_id}"
         );
         // Only emit Exited if WE'RE still the runtime's daemon client.
@@ -452,7 +452,7 @@ pub async fn spawn_pty_for_session_via_daemon(
     session_id: String,
 ) -> Result<(), String> {
     let entry_ts = std::time::Instant::now();
-    eprintln!(
+    crate::trace_cloud_push!(
         "[trace:{session_id}] spawn_via_daemon ENTRY t=0ms"
     );
     let terminal_state: State<'_, PtyState> = app.state();
@@ -460,7 +460,7 @@ pub async fn spawn_pty_for_session_via_daemon(
     let sessions = terminal_state.sessions.clone();
 
     if !super::try_reserve_session_spawn(&sessions, &session_id) {
-        eprintln!(
+        crate::trace_cloud_push!(
             "[trace:{session_id}] try_reserve FAILED at t={}ms",
             entry_ts.elapsed().as_millis()
         );
@@ -549,7 +549,7 @@ pub async fn spawn_pty_for_session_via_daemon(
     // keep using the local cwd as before.
     let mut effective_cwd = if is_remote {
         let computed = remote_spawn_cwd(owning_ws);
-        eprintln!(
+        crate::trace_cloud_push!(
             "[codemux::terminal::daemon_backed] remote cwd for {session_id}: \
              {computed} (owning_ws={}, attach_only={}, remote_cwd={:?}, \
              project_root={:?}, git_branch={:?})",
@@ -672,13 +672,13 @@ pub async fn spawn_pty_for_session_via_daemon(
                 );
                 auto_resume_command = Some(cmd);
             } else if has_evidence {
-                eprintln!(
+                crate::trace_cloud_push!(
                     "[codemux::terminal::daemon_backed] remote respawn for {session_id} \
                      has no original_command (was a plain shell, or preset wasn't yet \
                      applied) — spawning bare bash"
                 );
             } else {
-                eprintln!(
+                crate::trace_cloud_push!(
                     "[codemux::terminal::daemon_backed] skipping remote in-memory synthesis \
                      for {session_id}: no disk_meta and no captured agent session id — \
                      treating as a fresh preset launch (apply_preset owns the PTY write)"
@@ -732,7 +732,7 @@ pub async fn spawn_pty_for_session_via_daemon(
                     meta,
                     &adapter_state,
                 ) {
-                    eprintln!(
+                    crate::trace_cloud_push!(
                         "[codemux::terminal::daemon_backed] local restore via \
                          disk_meta+adapter for {session_id} at {ws_id}/{pane_id}"
                     );
@@ -780,7 +780,7 @@ pub async fn spawn_pty_for_session_via_daemon(
                         auto_resume_command = Some(cmd);
                     }
                 } else {
-                    eprintln!(
+                    crate::trace_cloud_push!(
                         "[codemux::terminal::daemon_backed] skipping in-memory synthesis for \
                          {session_id}: no disk_meta and no captured agent session id — \
                          treating as a fresh preset launch (apply_preset owns the PTY write)"
@@ -859,7 +859,7 @@ pub async fn spawn_pty_for_session_via_daemon(
             .collect::<Vec<_>>()
             .join(",")
     });
-    eprintln!(
+    crate::trace_cloud_push!(
         "[trace:{session_id}] daemon.list() at t={}ms returned: [{}]",
         entry_ts.elapsed().as_millis(),
         list_snapshot.unwrap_or_else(|| "ERR".to_string())
@@ -871,7 +871,7 @@ pub async fn spawn_pty_for_session_via_daemon(
     let reattached;
     let pid = if let Some(existing) = existing {
         reattached = true;
-        eprintln!(
+        crate::trace_cloud_push!(
             "[trace:{session_id}] DECISION=reattach pid={} at t={}ms",
             existing.pid,
             entry_ts.elapsed().as_millis()
@@ -879,7 +879,7 @@ pub async fn spawn_pty_for_session_via_daemon(
         existing.pid
     } else {
         reattached = false;
-        eprintln!(
+        crate::trace_cloud_push!(
             "[trace:{session_id}] DECISION=fresh_spawn at t={}ms",
             entry_ts.elapsed().as_millis()
         );
@@ -930,7 +930,7 @@ pub async fn spawn_pty_for_session_via_daemon(
     // message bug). Only write on fresh_spawn where the new bash
     // genuinely needs the agent launched.
     let auto_resume_clone = if reattached {
-        eprintln!(
+        crate::trace_cloud_push!(
             "[trace:{session_id}] reattached — suppressing auto-write of resume command"
         );
         None
@@ -1111,7 +1111,7 @@ pub async fn spawn_pty_for_session_via_daemon(
             }
             queue_or_send_output(&read_sessions, &read_session_id, chunk);
         }
-        eprintln!(
+        crate::trace_cloud_push!(
             "[codemux::terminal::daemon_backed] shell read loop ended for {read_session_id}"
         );
         // Skip emit if this is a stale read task whose session was

--- a/src-tauri/src/trace.rs
+++ b/src-tauri/src/trace.rs
@@ -1,0 +1,69 @@
+//! Opt-in cloud-push diagnostic tracing.
+//!
+//! The push-to-host spawn path is wired with detailed per-step tracing
+//! that was essential to finding the original cross-machine bug stack
+//! (reattach guard, race suppression, stale-`Exited` guard, cwd
+//! close-then-respawn). In normal operation those lines are pure noise —
+//! a single 4-pane push emits dozens of them — so they are gated behind
+//! the `CODEMUX_TRACE_CLOUD_PUSH` environment variable.
+//!
+//! Set `CODEMUX_TRACE_CLOUD_PUSH` to any value (e.g. `=1`) and every
+//! `trace_cloud_push!` line prints to stderr again. Unset (the default),
+//! each call is a single cached bool check and emits nothing. No
+//! recompile and no code change is required to restore the full trace, so
+//! if a future bug surfaces in the same area the diagnostics are one env
+//! var away instead of forcing a re-discovery of what to log.
+//!
+//! The gate is process-wide and read from the environment, so it works
+//! for both the desktop app and the headless `codemux-remote` daemon:
+//! export the var before launching the process whose stderr you want to
+//! inspect.
+
+use std::sync::OnceLock;
+
+/// Returns `true` when `CODEMUX_TRACE_CLOUD_PUSH` is present in the
+/// environment. The result is cached on first read because the
+/// environment is fixed for a process's lifetime, so hot spawn paths pay
+/// the lookup cost exactly once.
+pub fn cloud_push_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("CODEMUX_TRACE_CLOUD_PUSH").is_some())
+}
+
+/// `eprintln!`-compatible macro that only emits when cloud-push tracing
+/// is enabled (see [`cloud_push_enabled`]).
+///
+/// Use it for per-spawn-step lifecycle logs — `spawn_via_daemon ENTRY`,
+/// `DECISION=`, tunnel poll iterations, cwd dumps — that are noise in
+/// normal operation but invaluable when debugging push-to-host. Keep
+/// plain `eprintln!` for actionable errors and once-per-event landmarks
+/// (relaunch commands, "tunnel did not come up", agent-not-installed).
+#[macro_export]
+macro_rules! trace_cloud_push {
+    ($($arg:tt)*) => {
+        if $crate::trace::cloud_push_enabled() {
+            eprintln!($($arg)*);
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabled_reflects_env_presence() {
+        // The cached read is process-wide; this test only asserts the
+        // function is callable and returns a stable bool (the value
+        // depends on the ambient env, which `cargo test` does not set).
+        let first = cloud_push_enabled();
+        let second = cloud_push_enabled();
+        assert_eq!(first, second, "gate must be stable within a process");
+    }
+
+    #[test]
+    fn macro_compiles_and_is_silent_by_default() {
+        // Exercising the macro must never panic regardless of the gate.
+        trace_cloud_push!("trace probe {}", 1 + 1);
+    }
+}


### PR DESCRIPTION
Closes #21.

## Problem

The push-to-host spawn path was instrumented with detailed per-step `[trace:…]`, `[client_for_workspace:…]`, `[tunnel-supervisor]`, and `[daemon::spawn]` logging while chasing the cross-machine bug stack in PR #15. Essential then, but noise now — a normal 4-pane push emitted ~30 stderr lines in normal operation.

## Approach

Rather than *delete* the trace lines (and lose the diagnostic value the issue warns about), gate them behind a runtime switch so the full trace returns with no recompile and no code change.

**New gate — `src-tauri/src/trace.rs`:**
- `cloud_push_enabled()` — process-wide, once-cached check of the `CODEMUX_TRACE_CLOUD_PUSH` env var.
- `trace_cloud_push!` — an `eprintln!`-compatible macro that emits only when the gate is on (with unit tests).

**Categorization (per the issue's three buckets):**
- **`terminal/daemon_backed.rs`** — gated 14 lines (all `[trace:…]` ENTRY/DECISION/list, cwd dump, read-loop-ended, skipping-synthesis diagnostics); kept 5 (daemon-list-failed, remote + local relaunch command landmarks, agent-not-installed preflight, DaemonWriter failure).
- **`ssh/registry.rs`** — gated the `[registry]` + `[client_for_workspace:…]` polling/waiting lines; kept the `daemon reached: pid version` handshake landmark.
- **`ssh/tunnel_supervisor.rs`** — gated verbose argv/spawn/socket-polling lines; kept `start`, `published Connected`, `ssh exited`, and both error paths ("keep most").
- **`pty_daemon/server.rs`** — gated only the `[daemon::spawn]` dump; kept all errors/warnings/landmarks.

## Acceptance criteria

- ✅ Normal 4-pane push now emits **~7** cloud-push stderr lines (tunnel `start` + `Connected`, `daemon reached`, ≤4 per-pane relaunch landmarks) — down from ~30, under the <10 bar.
- ✅ Remaining lines are all actionable — errors, connection landmarks, and the per-pane relaunch command.
- ✅ Detailed tracing re-enables via `CODEMUX_TRACE_CLOUD_PUSH=1` (env var, no recompile, no code change).
- ✅ PR #15 regression tests left untouched; logging not restructured app-wide.

## Docs

Added a "Cloud-Push Diagnostic Tracing" section to `docs/features/observability.md` and a troubleshooting cross-reference in `docs/features/remote-hosts.md`.

## Verification

`cargo check --manifest-path src-tauri/Cargo.toml` clean; `cargo test --lib trace::` passes (2/2).