### PR TITLE
feat(keybinds): add Ctrl+Shift+B to toggle the right panel

### DIFF
--- a/docs/features/command-palette.md
+++ b/docs/features/command-palette.md
@@ -37,7 +37,7 @@ Actions are defined as `CommandItem` components organized into `CommandGroup` co
 - Search in Files (Ctrl+Shift+F)
 
 **View**
-- Toggle Right Panel
+- Toggle Right Panel (Ctrl+Shift+B)
 - Toggle Sidebar (Ctrl+B)
 - Toggle Preset Bar
 - Open Settings (Ctrl+,)

--- a/docs/reference/FEATURES.md
+++ b/docs/reference/FEATURES.md
@@ -30,7 +30,7 @@
 - Browser tabs open a full-pane embedded browser
 - Diff tabs with unified and split views, syntax highlighting, and section filtering
 - Editor tabs with CodeMirror 6, language detection, and markdown preview
-- Add tab via "+" dropdown or keyboard shortcuts (Ctrl+T, Ctrl+Shift+B, Ctrl+Shift+D)
+- Add tab via "+" dropdown or keyboard shortcuts (Ctrl+T new terminal tab, Ctrl+Shift+D split pane right)
 - Close tabs with X button or Ctrl+W (cannot close the last tab)
 - Switch tabs by clicking or Ctrl+1 through Ctrl+9
 - Tab state persists when switching between workspaces

--- a/docs/reference/SHORTCUTS.md
+++ b/docs/reference/SHORTCUTS.md
@@ -16,6 +16,7 @@ Defined in `src/hooks/use-keyboard-shortcuts.ts`, `src/lib/app-shortcuts.ts`, an
 |----------|--------|-------|
 | Ctrl+K | Command palette | Fuzzy search for any action |
 | Ctrl+B | Toggle sidebar | Collapse the left sidebar to an icon rail / expand it (see `docs/features/sidebar.md`) |
+| Ctrl+Shift+B | Toggle right panel | Show/hide the right panel (Files, Changes, Review) for the active workspace |
 | Ctrl+, | Open settings | Opens the settings panel |
 | Ctrl+Shift+? | Keyboard shortcuts | Opens Settings to the keyboard-shortcuts page (press Ctrl+Shift+/) |
 | Ctrl+O | Open project | Opens a folder picker to add an existing project |

--- a/src/components/overlays/command-palette.tsx
+++ b/src/components/overlays/command-palette.tsx
@@ -40,7 +40,8 @@ function ShortcutHint({ actionId }: { actionId: string }) {
 
 export function CommandPalette({ open, onOpenChange }: Props) {
   const appState = useAppStore((s) => s.appState);
-  const toggleRightPanel = useUIStore((s) => s.toggleRightPanel);
+  const getRightPanelTab = useUIStore((s) => s.getRightPanelTab);
+  const setRightPanelTab = useUIStore((s) => s.setRightPanelTab);
   const setShowNewWorkspaceDialog = useUIStore((s) => s.setShowNewWorkspaceDialog);
   const setShowSettings = useUIStore((s) => s.setShowSettings);
   const setShowFileSearch = useUIStore((s) => s.setShowFileSearch);
@@ -189,12 +190,15 @@ export function CommandPalette({ open, onOpenChange }: Props) {
         <CommandGroup heading="View">
           <CommandItem
             onSelect={() =>
-              run(() =>
-                ws && toggleRightPanel(ws.workspace_id, "files"),
-              )
+              run(() => {
+                if (!ws) return;
+                const current = getRightPanelTab(ws.workspace_id);
+                setRightPanelTab(ws.workspace_id, current == null ? "files" : null);
+              })
             }
           >
             Toggle Right Panel
+            <ShortcutHint actionId="toggleRightPanel" />
           </CommandItem>
           <CommandItem onSelect={() => run(toggleSidebar)}>
             Toggle Sidebar

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -191,6 +191,16 @@ export function dispatch(actionId: string, _e: KeyboardEvent): boolean {
     return true;
   }
 
+  // ── Toggle right panel ──
+  // True toggle: any open tab closes the panel; closed opens straight to
+  // Files. Mirrors the tab-bar button — using the store's by-tab-identity
+  // `toggleRightPanel` would switch tabs instead of closing.
+  if (actionId === "toggleRightPanel") {
+    const current = ui.getRightPanelTab(ws.workspace_id);
+    ui.setRightPanelTab(ws.workspace_id, current == null ? "files" : null);
+    return true;
+  }
+
   // ── New workspace in the current project (quick-create) ──
   // Mirrors the per-project "+" in the sidebar, scoped to the active
   // workspace's project. A home-rooted workspace just creates another home

--- a/src/lib/keybind-registry.ts
+++ b/src/lib/keybind-registry.ts
@@ -20,6 +20,7 @@ export const KEYBIND_REGISTRY: readonly KeybindEntry[] = [
   // ── General ──
   { id: "commandPalette", label: "Command palette", category: "general", defaultKeys: "Ctrl+K" },
   { id: "toggleSidebar", label: "Toggle sidebar", category: "general", defaultKeys: "Ctrl+B" },
+  { id: "toggleRightPanel", label: "Toggle right panel", category: "general", defaultKeys: "Ctrl+Shift+B", description: "Show/hide the right panel (Files, Changes, Review)" },
   { id: "openSettings", label: "Open settings", category: "general", defaultKeys: "Ctrl+," },
   { id: "openProject", label: "Open project", category: "general", defaultKeys: "Ctrl+O", description: "Open an existing folder as a project" },
   { id: "showShortcuts", label: "Keyboard shortcuts", category: "general", defaultKeys: "Ctrl+Shift+?", description: "Open Settings to the keyboard-shortcuts page" },


### PR DESCRIPTION
## What

Adds a keyboard shortcut to toggle the **right panel** (Files / Changes / Review). Previously the right panel could only be opened via the tab-bar button or the command palette — there was no keybinding for it, while the left sidebar already had `Ctrl+B`.

`Ctrl+Shift+B` is the natural mnemonic pairing: same base key as the left sidebar, with `Shift` denoting the secondary/right surface. Verified conflict-free against the existing registry.

## Changes

- **`keybind-registry.ts`** — new rebindable `toggleRightPanel` action → `Ctrl+Shift+B` (also appears under Settings → Keyboard shortcuts).
- **`use-keyboard-shortcuts.ts`** — dispatch handler implementing a *true toggle*: any open tab closes the panel; a closed panel opens to Files. Mirrors the tab-bar button rather than the store's by-tab-identity `toggleRightPanel` (which would switch tabs instead of closing).
- **`command-palette.tsx`** — surfaces the `Ctrl+Shift+B` hint and aligns the palette's "Toggle Right Panel" action to the same true-toggle, so button / palette / keyboard all behave identically.
- **Docs** — `SHORTCUTS.md`, `command-palette.md`; also removes a stale `Ctrl+Shift+B` reference in `FEATURES.md` that never mapped to a real binding.

## Notes

- The right panel is **per-workspace**, so the shortcut no-ops when no workspace is active — consistent with the existing button/palette behavior.

## Verification

- `npm run check` (tsc) clean; `npm run test` → 1970 passing (incl. the keybind-conflict test).
- Manually driven in the browser: `Ctrl+Shift+B` opens the right panel (Files); pressing again closes it.