### PR TITLE
feat(hosts): "Reinstall agent on host" button (#24)

### DIFF
--- a/docs/features/remote-hosts.md
+++ b/docs/features/remote-hosts.md
@@ -420,6 +420,7 @@ The pane built in 2a now uses the real probe + bootstrap:
 
 - **Test connection** → calls `hosts_test_connection`, surfaces the result inline.
 - **Install button** appears when the probe reports `needs_install: true`. Opens a `window.confirm` modal that names the binary, says it's ~8MB and runs in the user's account (no root), and links to the source repo. On confirm → calls `hosts_bootstrap_install` and surfaces the result.
+- **Reinstall agent** (issue #24) → always-visible card on the host detail pane. Calls `hosts_reinstall_remote`, which force-reinstalls `codemux-remote` regardless of the installed version and restarts its pty-daemon, then fires a success/error toast. This is the dev-workflow escape hatch: rebuilding `codemux-remote` from a branch keeps the version string the same, so the push-time version check (`ensure_remote_binary_current`) sees a match and skips the upgrade — leaving the host on a stale binary. The command reuses the proven `force_reinstall_remote_binary` helper (uname probe → `pkill -f 'codemux-remote pty-daemon'` → scp + chmod + verify → restart `serve`), the same body the push-time upgrade runs after its version check. No prior Test connection is required — the backend re-probes the uname itself. Replaces the manual `scp` + `pkill` workaround.
 
 ## Test coverage
 
@@ -448,7 +449,7 @@ Landed since the original 2b–2d cut: **"Push workspace to host" action** (`8c7
 ## Important Touch Points
 
 - `src-tauri/src/state/state_impl.rs` — `WorkspaceSnapshot.host_id`, `set_workspace_host_id`.
-- `src-tauri/src/commands/hosts.rs` — `set_workspace_host`, `hosts_test_connection` (real impl), `hosts_bootstrap_install`.
+- `src-tauri/src/commands/hosts.rs` — `set_workspace_host`, `hosts_test_connection` (real impl), `hosts_bootstrap_install`, `hosts_reinstall_remote` (issue #24 — force reinstall + daemon restart, shares `force_reinstall_remote_binary` with the push-time `ensure_remote_binary_current`).
 - `src-tauri/src/commands/workspace.rs` — `close_workspace` / `close_workspace_with_worktree` capture `host_id` and tear down the tunnel supervisor + cached client on close (post-`v0.7.6`).
 - `src-tauri/src/bin/codemux_remote.rs` — binary entry point. Subcommands: `version`, `pty-daemon`, `scheduler`, `serve` (+ `status`, `stop`), `mcp`, `workspace register`, `workspace list` (reads the daemon SQLite directly for the host-inventory poller). Unix-only — Windows builds a no-op stub.
 - `src-tauri/src/remote/` — headless MCP daemon module: `manifest.rs` (atomic write + pid liveness), `auth.rs` (bearer-token axum middleware), `identity.rs` (`Local | Cloud { user_id, org_id, role }`), `workspace.rs` (self-contained SQLite registry with nullable `owner_id`), `pty.rs` (portable-pty wrapper + 1 MiB ring buffer), `server.rs` (axum routes), `mcp.rs` (stdio JSON-RPC bridge), `mcp_register.rs` (auto-write into agent configs on startup), `tools/mod.rs` (12-tool catalog), `git.rs` (`worktree_create` + adoption worktree recreate), `config.rs` (state-dir resolution).
@@ -458,7 +459,7 @@ Landed since the original 2b–2d cut: **"Push workspace to host" action** (`8c7
 - `src/stores/tunnel-status-store.ts` / `src/hooks/use-tunnel-status-events.ts` / `src/tauri/events.ts` — frontend tunnel-health store + app-root event hook + `TunnelStatus` wire type; `sidebar-workspace-row.tsx` renders the "Reconnecting…" / "Connection lost — re-push" pill.
 - `src/components/hosts/device-picker.tsx` — shared pill component.
 - `src/components/overlays/new-workspace-dialog.tsx` — DevicePicker wired into bottom bar.
-- `src/components/settings/hosts-section.tsx` — uses real probe + bootstrap modal.
+- `src/components/settings/hosts-section.tsx` — uses real probe + bootstrap modal + "Reinstall agent" card (`hosts-section.test.tsx` covers the reinstall wiring: success toast, error-result toast, thrown-error toast).
 - `src/tauri/commands.ts` — new bindings: `setWorkspaceHost`, `hostsBootstrapInstall`, `HostBootstrapResult`.
 - `Cargo.toml` — `[[bin]] codemux-remote`; embedded `axum`, `tower`, `rusqlite`, `portable-pty` for the headless daemon.
 - `scripts/codemux-remote.service.example` — sample systemd user unit (used both by manual install and `provision_serve`).

--- a/src-tauri/src/commands/hosts.rs
+++ b/src-tauri/src/commands/hosts.rs
@@ -424,6 +424,59 @@ pub struct HostBootstrapResult {
     pub message: String,
 }
 
+/// Force-reinstall `codemux-remote` on a host regardless of the version
+/// already installed there, and restart its pty-daemon so the fresh
+/// binary takes effect immediately.
+///
+/// This is the dev-workflow escape hatch behind the "Reinstall agent on
+/// host" button in Settings → Hosts. Rebuilding `codemux-remote` from a
+/// branch keeps the version string the same, so the push-time version
+/// check (`ensure_remote_binary_current`) sees a match and skips the
+/// upgrade — leaving the host running a stale binary. This command always
+/// re-uploads the freshly built bits (and kills the running pty-daemon),
+/// so the next push uses them. No manual `scp` + `pkill` needed.
+///
+/// Unix-only — the SSH bootstrap path is `#[cfg(unix)]`. On Windows we
+/// return a clear "not implemented" message.
+#[tauri::command]
+pub async fn hosts_reinstall_remote(
+    app: tauri::AppHandle,
+    db: State<'_, DatabaseStore>,
+    id: i64,
+) -> Result<HostBootstrapResult, String> {
+    let host = db
+        .list_hosts()
+        .into_iter()
+        .find(|h| h.id == id)
+        .ok_or_else(|| format!("Host not found: {id}"))?;
+
+    #[cfg(unix)]
+    {
+        Ok(match force_reinstall_remote_binary(&app, &host).await {
+            Ok(version) => HostBootstrapResult {
+                ok: true,
+                message: format!(
+                    "codemux-remote v{version} reinstalled on {} — daemon restarted; \
+                     the next push uses the fresh binary.",
+                    host.name
+                ),
+            },
+            Err(reason) => HostBootstrapResult {
+                ok: false,
+                message: format!("Reinstall failed: {reason}"),
+            },
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (&app, host);
+        Ok(HostBootstrapResult {
+            ok: false,
+            message: "SSH transport is Unix-only for now.".into(),
+        })
+    }
+}
+
 /// Push a workspace to a remote host.
 ///
 /// Atomic contract: `host_id` is set on the workspace ONLY when the
@@ -1443,7 +1496,34 @@ async fn ensure_remote_binary_current(
         host.name, remote_version
     );
 
-    // Step 2: figure out the remote uname so we can pick the right
+    // Version differs — re-upload + restart. Shared with the manual
+    // "Reinstall agent" button (`hosts_reinstall_remote`), which runs
+    // the same steps but skips the version check above.
+    force_reinstall_remote_binary(app, host).await.map(|_| ())
+}
+
+/// Force a freshly built `codemux-remote` onto a host and restart it,
+/// *without* the version-skip check in `ensure_remote_binary_current`.
+///
+/// This is the dev-workflow primitive behind the "Reinstall agent on
+/// host" button. Rebuilding `codemux-remote` from a branch keeps the
+/// version string the same (e.g. `0.9.5`), so the push-time version
+/// check sees a match and never re-uploads — leaving the host running a
+/// stale binary. Forcing the reinstall is the only way to get freshly
+/// built bits onto the host during development.
+///
+/// Steps: probe uname → kill the SSH-spawned pty-daemon → scp + chmod +
+/// verify the bundled binary → restart the headless `serve` daemon.
+/// Returns the reported version on success.
+#[cfg(unix)]
+async fn force_reinstall_remote_binary(
+    app: &tauri::AppHandle,
+    host: &crate::database::HostRecord,
+) -> Result<String, String> {
+    use std::process::Stdio;
+    use tokio::process::Command;
+
+    // Step 1: figure out the remote uname so we can pick the right
     // bundled binary.
     let uname_output = Command::new("ssh")
         .arg("-o")
@@ -1460,13 +1540,13 @@ async fn ensure_remote_binary_current(
         return Err("uname probe returned empty string".into());
     }
 
-    // Step 3: kill any running pty-daemon. Otherwise the freshly-bootstrapped
+    // Step 2: kill any running pty-daemon. Otherwise the freshly-bootstrapped
     // binary won't actually be used until the next SSH-spawn cycle, and
     // a stale daemon still bound to the workspace's Unix socket would
     // make that next spawn fail with "address in use." The narrow `-f`
     // pattern only matches the SSH-spawned pty-daemon — user-launched
     // `codemux-remote mcp` or `serve` invocations are spared. `serve`
-    // is restarted via systemctl in step 5 instead.
+    // is restarted via systemctl in step 4 instead.
     let _ = Command::new("ssh")
         .arg("-o")
         .arg("BatchMode=yes")
@@ -1475,18 +1555,19 @@ async fn ensure_remote_binary_current(
         .status()
         .await;
 
-    // Step 4: bootstrap (upload binary + verify version).
+    // Step 3: bootstrap (upload binary + verify version).
     use crate::ssh::bootstrap::{bootstrap_remote, BootstrapOptions, BootstrapResult};
     let outcome = bootstrap_remote(
         BootstrapOptions::new(&host.ssh_target, &uname).with_app(app),
     )
     .await;
-    match outcome {
+    let reported_version = match outcome {
         BootstrapResult::Installed { reported_version } => {
             eprintln!(
                 "[hosts] bootstrapped {} → codemux-remote {reported_version}",
                 host.name
             );
+            reported_version
         }
         BootstrapResult::BinaryNotBundled { wanted_target } => {
             return Err(format!(
@@ -1499,9 +1580,9 @@ async fn ensure_remote_binary_current(
         BootstrapResult::PostInstallProbeFailed { reason } => {
             return Err(format!("verify: {reason}"));
         }
-    }
+    };
 
-    // Step 5: re-provision the headless `serve` daemon. This is
+    // Step 4: re-provision the headless `serve` daemon. This is
     // idempotent — it rewrites the systemd unit (so a unit-content
     // change in this Codemux version takes effect immediately), runs
     // daemon-reload, and **restarts** the unit (not just `enable
@@ -1512,7 +1593,7 @@ async fn ensure_remote_binary_current(
     // confuse anyone debugging "why doesn't my new MCP tool show up
     // after I updated Codemux."
     //
-    // Best-effort: a failure here doesn't fail the upgrade. The
+    // Best-effort: a failure here doesn't fail the reinstall. The
     // binary is current; the user can `systemctl --user restart
     // codemux-remote` themselves if needed.
     if let Err(error) = crate::ssh::bootstrap::provision_serve(
@@ -1523,14 +1604,14 @@ async fn ensure_remote_binary_current(
     .await
     {
         eprintln!(
-            "[hosts] re-provisioning serve on {} after upgrade failed (continuing): {error}",
+            "[hosts] re-provisioning serve on {} after reinstall failed (continuing): {error}",
             host.name
         );
     } else {
         eprintln!("[hosts] re-provisioned codemux-remote.service on {}", host.name);
     }
 
-    Ok(())
+    Ok(reported_version)
 }
 
 /// Stash the synced OpenCode session id into the adapter captures of the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1686,6 +1686,7 @@ pub fn run() {
             commands::hosts_delete,
             commands::hosts_test_connection,
             commands::hosts_bootstrap_install,
+            commands::hosts_reinstall_remote,
             commands::set_workspace_host,
             commands::workspace_push_to_host,
             commands::workspace_pull_back,

--- a/src/components/settings/hosts-section.test.tsx
+++ b/src/components/settings/hosts-section.test.tsx
@@ -1,0 +1,137 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import type { HostView } from "@/tauri/commands";
+
+// `hosts_reinstall_remote` is the dev-workflow escape hatch (issue #24):
+// it re-uploads codemux-remote and restarts its daemon regardless of the
+// version already installed. These tests pin the UI wiring — the right
+// command is called for the selected host, and the outcome surfaces as a
+// success/error toast.
+vi.mock("@/tauri/commands", async (importActual) => {
+  const actual = (await importActual()) as Record<string, unknown>;
+  return {
+    ...actual,
+    hostsList: vi.fn(),
+    hostsReinstallRemote: vi.fn(),
+    hostsTestConnection: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/toast", () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn(),
+    custom: vi.fn(),
+  },
+}));
+
+import { HostsSection } from "./hosts-section";
+import { hostsList, hostsReinstallRemote } from "@/tauri/commands";
+import { toast } from "@/lib/toast";
+
+const hostsListMock = hostsList as unknown as ReturnType<typeof vi.fn>;
+const hostsReinstallRemoteMock =
+  hostsReinstallRemote as unknown as ReturnType<typeof vi.fn>;
+
+function makeHost(overrides: Partial<HostView> = {}): HostView {
+  return {
+    id: 1,
+    server_id: null,
+    name: "homelab",
+    ssh_target: "deus@homelab.local",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    dirty: false,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("HostsSection — Reinstall agent", () => {
+  it("reinstalls the selected host and shows a success toast", async () => {
+    hostsListMock.mockResolvedValue([makeHost()]);
+    hostsReinstallRemoteMock.mockResolvedValue({
+      ok: true,
+      message:
+        "codemux-remote v0.9.5 reinstalled on homelab — daemon restarted; " +
+        "the next push uses the fresh binary.",
+    });
+
+    render(<HostsSection />);
+
+    const button = await screen.findByRole("button", { name: /^reinstall$/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      // The first (and only) host is auto-selected on load, so the
+      // reinstall targets its id.
+      expect(hostsReinstallRemoteMock).toHaveBeenCalledWith(1);
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "Agent reinstalled",
+        expect.objectContaining({
+          description: expect.stringContaining("reinstalled"),
+        }),
+      );
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast when the reinstall fails", async () => {
+    hostsListMock.mockResolvedValue([makeHost()]);
+    hostsReinstallRemoteMock.mockResolvedValue({
+      ok: false,
+      message: "Reinstall failed: upload: connection refused",
+    });
+
+    render(<HostsSection />);
+
+    const button = await screen.findByRole("button", { name: /^reinstall$/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Reinstall failed",
+        expect.objectContaining({
+          description: expect.stringContaining("upload"),
+        }),
+      );
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a thrown command error as an error toast", async () => {
+    hostsListMock.mockResolvedValue([makeHost()]);
+    hostsReinstallRemoteMock.mockRejectedValue("ssh: host key verification failed");
+
+    render(<HostsSection />);
+
+    const button = await screen.findByRole("button", { name: /^reinstall$/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Reinstall failed",
+        expect.objectContaining({
+          description: expect.stringContaining("host key verification"),
+        }),
+      );
+    });
+  });
+});

--- a/src/components/settings/hosts-section.tsx
+++ b/src/components/settings/hosts-section.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   Pencil,
   Plus,
+  RefreshCw,
   Server,
   Trash2,
   X,
@@ -17,11 +18,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { toast } from "@/lib/toast";
 import {
   hostsAdd,
   hostsBootstrapInstall,
   hostsDelete,
   hostsList,
+  hostsReinstallRemote,
   hostsTestConnection,
   hostsUpdate,
   type HostTestResult,
@@ -115,6 +118,7 @@ export function HostsSection() {
   );
   const [testingId, setTestingId] = useState<number | null>(null);
   const [installingId, setInstallingId] = useState<number | null>(null);
+  const [reinstallingId, setReinstallingId] = useState<number | null>(null);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -296,6 +300,31 @@ export function HostsSection() {
     },
     [],
   );
+
+  // Force a fresh codemux-remote onto the host and restart its daemon.
+  // The dev-workflow escape hatch (issue #24): rebuilding the agent
+  // keeps the version string the same, so the push-time version check
+  // skips the upgrade and the host keeps running the stale binary. This
+  // re-uploads the freshly built bits unconditionally, so the next push
+  // uses them — no manual scp + pkill needed. Unlike Install, this needs
+  // no prior Test connection: the backend re-probes the uname itself.
+  const handleReinstallRemote = useCallback(async (host: HostView) => {
+    setReinstallingId(host.id);
+    try {
+      const result = await hostsReinstallRemote(host.id);
+      if (result.ok) {
+        toast.success("Agent reinstalled", { description: result.message });
+      } else {
+        toast.error("Reinstall failed", { description: result.message });
+      }
+    } catch (err) {
+      toast.error("Reinstall failed", {
+        description: typeof err === "string" ? err : String(err),
+      });
+    } finally {
+      setReinstallingId(null);
+    }
+  }, []);
 
   if (loading) {
     return (
@@ -653,6 +682,44 @@ export function HostsSection() {
                     )}
                 </div>
               )}
+            </div>
+
+            {/* Reinstall agent — dev-workflow escape hatch (issue #24).
+                The push-time version check skips the upgrade when the
+                version string is unchanged (which it always is across
+                local rebuilds), so this re-uploads the freshly built
+                codemux-remote and restarts its daemon unconditionally. */}
+            <div className="rounded-lg border border-border/60 bg-muted/30 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[13px] font-medium text-foreground">Reinstall agent</p>
+                  <p className="text-[11.5px] text-muted-foreground/75 leading-relaxed mt-0.5">
+                    Re-upload codemux-remote and restart it on the host. Use after
+                    rebuilding the agent locally — pushes skip the update when the
+                    version string is unchanged.
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 text-[12px] gap-1.5 shrink-0"
+                  disabled={reinstallingId === selected.id}
+                  onClick={() => void handleReinstallRemote(selected)}
+                >
+                  {reinstallingId === selected.id ? (
+                    <>
+                      <Loader2 className="size-3.5 animate-spin" />
+                      Reinstalling…
+                    </>
+                  ) : (
+                    <>
+                      <RefreshCw className="size-3.5" />
+                      Reinstall
+                    </>
+                  )}
+                </Button>
+              </div>
             </div>
 
             <div className="flex items-center justify-between pt-4 border-t border-border/40">

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -814,7 +814,53 @@ const handlers: Record<string, Handler> = {
   list_incoming_prs: () => [],
 
   // ── Hosts (remote devices) ──
-  hosts_list: () => [],
+  //
+  // Seed one host so the Settings → Hosts detail pane (Test connection,
+  // Reinstall agent, Edit/Remove) renders in the browser dev runtime.
+  // The mutating commands echo back plausible payloads — nothing here
+  // touches a real SSH target.
+  hosts_list: () => [
+    {
+      id: 1,
+      server_id: null,
+      name: "homelab",
+      ssh_target: "deus@homelab.local",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      dirty: false,
+    },
+  ],
+  hosts_add: (a) => ({
+    id: Date.now(),
+    server_id: null,
+    name: String(a.name ?? "new-device"),
+    ssh_target: String(a.sshTarget ?? "user@host"),
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    dirty: true,
+  }),
+  hosts_update: (a) => ({
+    id: Number(a.id ?? 1),
+    server_id: null,
+    name: String(a.name ?? "homelab"),
+    ssh_target: String(a.sshTarget ?? "deus@homelab.local"),
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    dirty: true,
+  }),
+  hosts_delete: () => undefined,
+  hosts_test_connection: () => ({
+    ok: true,
+    message: "Connected. codemux-remote v0.9.5 is installed (Linux x86_64)",
+    needs_install: false,
+    uname: null,
+  }),
+  hosts_reinstall_remote: () => ({
+    ok: true,
+    message:
+      "codemux-remote v0.9.5 reinstalled on homelab — daemon restarted; " +
+      "the next push uses the fresh binary.",
+  }),
 
   // ── MCP runtime ──
   get_mcp_runtime_status: () => ({ servers: [], running: false }),

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1652,6 +1652,16 @@ export const hostsTestConnection = (id: number) =>
 export const hostsBootstrapInstall = (id: number, uname: string) =>
   invoke<HostBootstrapResult>("hosts_bootstrap_install", { id, uname });
 
+/** Force-reinstall `codemux-remote` on a host regardless of the version
+ *  already installed, and restart its pty-daemon so the fresh binary
+ *  takes effect immediately. The dev-workflow escape hatch: rebuilding
+ *  `codemux-remote` keeps the version string the same, so the push-time
+ *  version check would otherwise skip the upgrade and leave the host on
+ *  a stale binary. The backend re-probes the uname itself, so no prior
+ *  Test connection is required. */
+export const hostsReinstallRemote = (id: number) =>
+  invoke<HostBootstrapResult>("hosts_reinstall_remote", { id });
+
 // ── Automations (scheduled agent runs) ──
 //
 // An automation is a named prompt + agent + recurrence. `schedule` is a


### PR DESCRIPTION
Closes #24.

## What

Adds a **Reinstall agent** button to Settings → Hosts that force-reinstalls `codemux-remote` on a host regardless of the installed version and restarts its daemon — the dev-workflow escape hatch.

### Why

PR #15's auto-update compares the laptop's `codemux-remote` version against the host's and re-bootstraps on a mismatch. Production users get fresh binaries for free, but **dev users are stuck**: rebuilding `codemux-remote` from a branch keeps the version string the same, so the push-time check (`ensure_remote_binary_current`) sees a match and skips the upgrade — the host keeps running the stale binary. The only prior workaround was a manual `scp` + `pkill`.

## Changes

**Backend** (`src-tauri/src/commands/hosts.rs`)
- Extracted `force_reinstall_remote_binary` from `ensure_remote_binary_current` (uname probe → `pkill -f 'codemux-remote pty-daemon'` → scp + chmod + verify → restart `serve`). The push path keeps its version-skip check and delegates to the helper — no behavior change to push.
- Added `hosts_reinstall_remote` command that calls the helper directly (skips the version check). Re-probes the uname itself, so no prior Test connection is required. Registered in `lib.rs`.

**Frontend**
- `hostsReinstallRemote` binding in `src/tauri/commands.ts`.
- "Reinstall agent" card in `hosts-section.tsx` (mirrors the Test connection card) with a spinner state and success/error toast.
- Dev mock now seeds a host + add/update/delete/test/reinstall handlers so the pane is exercisable under `npm run dev`.

**Tests & docs**
- New `hosts-section.test.tsx`: success-result, error-result, and thrown-error toast paths.
- `docs/features/remote-hosts.md` documents the button and the shared helper.

## Verification

- `cargo check` ✅, `cargo test commands::hosts` ✅ (7 pass)
- `npm run check` (tsc) ✅, full `npm run test` ✅ (1954 pass, +3 new)
- Visual: booted the dev runtime, opened Settings → Devices, the card renders and clicking **Reinstall** fires the success toast.

## Note

The uploaded binary is whatever `bundled_binary_path` resolves — the staged `src-tauri/binaries/codemux-remote-<target>` (refreshed by `scripts/build-codemux-remote.sh` on each `tauri:dev` start) takes precedence over the freshly-built `target/debug` one. This is the same resolution all bootstrap callers use; kept faithful to the issue's "reuse `hosts_bootstrap_install`" framing and its "auto-detect dev mode — out of scope" note. Couldn't run the literal SSH end-to-end (no live host configured), but the SSH mechanics are the already-production-tested push-path code; the new command only bypasses the version check.