### PR TITLE
Show resolved model version and blurb in the chat model picker

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -91,6 +91,20 @@ The chat pane stack:
     child (`kill_on_drop`, generated `OPENCODE_SERVER_PASSWORD`).
   - All three render in a single 2-column picker (provider rail + searchable
     model list); favorites persist via zustand + `localStorage`.
+  - **Model rows show the resolved version + blurb** (like the terminal
+    `/model` picker): when `ChatModelInfo.description` is present the row
+    subtitle renders `<driver> · <description>` (truncated, full text in a
+    `title` tooltip), e.g. `Claude · Opus 4.8 with 1M context · Best for
+    everyday, complex tasks`; the trigger pill mirrors label + description
+    into its tooltip. Backend guarantees every Claude row carries a
+    description: SDK-provided string verbatim when the CLI supplies one →
+    maintained blurb for known full ids (blurb-only; the label already
+    carries the version) → alias backfill (`ALIAS_CANONICAL_IDS` in
+    `src-tauri/src/agent_provider/claude/capabilities.rs` maps
+    `default`/`opus`/`fable`/`sonnet`/`haiku` to canonical maintained ids and
+    synthesizes `<Version>[ with 1M context] · <blurb>`). Model *selection*
+    itself passes the picked id through unchanged; alias ids are resolved to
+    the latest concrete model by the Claude CLI/SDK, not by Codemux.
 - **Streaming chat UX**: Streamdown-rendered messages, tool approvals
   (per-tool body rendering), collapsible reasoning blocks (thinking
   deltas reduce into a `reasoning` ChatViewItem that seals on any

--- a/src-tauri/src/agent_provider/claude/capabilities.rs
+++ b/src-tauri/src/agent_provider/claude/capabilities.rs
@@ -122,7 +122,7 @@ fn models() -> Vec<ChatModelInfo> {
         ChatModelInfo {
             id: "claude-opus-4-7".into(),
             label: "Claude Opus 4.7".into(),
-            description: None,
+            description: Some("Previous Opus generation".into()),
             effort_levels: vec![
                 "low".into(),
                 "medium".into(),
@@ -144,7 +144,7 @@ fn models() -> Vec<ChatModelInfo> {
         ChatModelInfo {
             id: "claude-opus-4-6".into(),
             label: "Claude Opus 4.6".into(),
-            description: None,
+            description: Some("Previous Opus generation".into()),
             effort_levels: vec![
                 "low".into(),
                 "medium".into(),
@@ -165,7 +165,7 @@ fn models() -> Vec<ChatModelInfo> {
         ChatModelInfo {
             id: "claude-opus-4-5".into(),
             label: "Claude Opus 4.5".into(),
-            description: None,
+            description: Some("Previous Opus generation".into()),
             effort_levels: vec![
                 "low".into(),
                 "medium".into(),
@@ -766,6 +766,64 @@ fn build_capabilities_from_sdk(
     }
 }
 
+/// The deployed CLI's `supportedModels()` reports its curated roster
+/// under short *alias* ids (`default`, `opus`, `fable`, `sonnet`,
+/// `haiku`) rather than the full versioned id, and some deployed CLIs
+/// give those alias rows no `description`. This table maps each alias to
+/// the canonical full id in the maintained [`models`] table so an alias
+/// row can borrow the canonical entry's resolved version + blurb when
+/// the SDK reports no description of its own. `default` is the CLI's
+/// recommended default and resolves like `opus`. Keeping the mapping in
+/// one place means a future model bump is a one-line edit.
+const ALIAS_CANONICAL_IDS: &[(&str, &str)] = &[
+    ("default", "claude-opus-4-8"),
+    ("opus", "claude-opus-4-8"),
+    ("fable", "claude-fable-5"),
+    ("sonnet", "claude-sonnet-4-6"),
+    ("haiku", "claude-haiku-4-5"),
+];
+
+/// Resolve an alias id (`default` / `opus` / `fable` / `sonnet` /
+/// `haiku`) to its canonical full id. Case-insensitive; returns `None`
+/// for a full id or an unknown id (both fall through to the normal
+/// lookup / inference path).
+fn canonical_id_for_alias(id: &str) -> Option<&'static str> {
+    let lower = id.to_ascii_lowercase();
+    ALIAS_CANONICAL_IDS
+        .iter()
+        .find(|(alias, _)| *alias == lower)
+        .map(|(_, canonical)| *canonical)
+}
+
+/// Build a version-bearing description for an alias row from its
+/// canonical maintained entry, per the picker contract:
+/// `"<Version>[ with 1M context] · <blurb>"` — e.g.
+/// `"Opus 4.8 with 1M context · Best for everyday, complex tasks"`.
+///
+/// The version is the canonical label with the leading `"Claude "`
+/// stripped (`"Claude Opus 4.8"` → `"Opus 4.8"`); `" with 1M context"`
+/// is appended only when the canonical model *defaults* to a 1M context
+/// window; the blurb is the canonical entry's own description. Returns
+/// `None` when the canonical entry carries no blurb, so nothing empty is
+/// ever synthesized.
+fn alias_description_from_canonical(canonical: &ChatModelInfo) -> Option<String> {
+    let blurb = canonical.description.as_deref()?;
+    let version = canonical
+        .label
+        .strip_prefix("Claude ")
+        .unwrap_or(canonical.label.as_str());
+    let defaults_to_1m = canonical
+        .context_window_options
+        .iter()
+        .any(|o| o.is_default && o.value == "1m");
+    let prefix = if defaults_to_1m {
+        format!("{version} with 1M context")
+    } else {
+        version.to_string()
+    };
+    Some(format!("{prefix} · {blurb}"))
+}
+
 /// Merge a single SDK model record with hand-maintained metadata. The
 /// SDK is authoritative for the live model id, display name, and
 /// effort vocabulary (since the deployed CLI is sometimes ahead of
@@ -835,10 +893,25 @@ fn merge_sdk_with_maintained(
     } else {
         sdk.display_name
     };
-    let description = if sdk.description.trim().is_empty() {
-        known.as_ref().and_then(|k| k.description.clone())
-    } else {
+    // Description precedence:
+    //   1. SDK verbatim — the deployed CLI packs the resolved version +
+    //      blurb into `description` (exactly what the terminal `/model`
+    //      picker renders), so prefer it untouched.
+    //   2. Maintained blurb for a known full id — the row's label already
+    //      carries the version (e.g. "Claude Opus 4.8"), so the blurb
+    //      stands alone with no version duplication.
+    //   3. Alias backfill — an alias row (default/opus/fable/sonnet/haiku)
+    //      the SDK gave no description for gets a version-bearing
+    //      description synthesized from its canonical maintained entry, so
+    //      the picker still shows what the alias actually resolves to.
+    let description = if !sdk.description.trim().is_empty() {
         Some(sdk.description)
+    } else if let Some(known_desc) = known.as_ref().and_then(|k| k.description.clone()) {
+        Some(known_desc)
+    } else {
+        canonical_id_for_alias(&base_id)
+            .and_then(|cid| maintained.get(cid))
+            .and_then(alias_description_from_canonical)
     };
 
     ChatModelInfo {
@@ -1228,11 +1301,10 @@ mod tests {
 
     #[test]
     fn merge_uses_maintained_metadata_for_known_ids() {
-        // The maintained Opus 4.7 entry has `description: None` (demoted
-        // from flagship). An inferred Opus would carry no description
-        // either, so we discriminate by the precise label — maintained
-        // is "Claude Opus 4.7", and the api `display_name` we feed is
-        // deliberately different to prove maintained wins.
+        // Discriminate maintained-vs-inferred by the precise label: the
+        // maintained entry is "Claude Opus 4.7", and the api
+        // `display_name` we feed is deliberately different to prove
+        // maintained metadata wins over the live payload.
         let live = vec![ApiModel {
             id: "claude-opus-4-7".into(),
             display_name: "DIFFERENT NAME".into(),
@@ -1568,5 +1640,159 @@ mod tests {
             caps.default_permission_mode.as_deref(),
             Some("bypassPermissions")
         );
+    }
+
+    // ── Description backfill (resolved-version blurbs) ────────────────
+
+    #[test]
+    fn every_maintained_model_has_a_description() {
+        // Contract: no current Claude model may serve `description: None`
+        // to the picker — the frontend renders it in the row subtitle.
+        for model in models() {
+            assert!(
+                model.description.as_deref().is_some_and(|d| !d.trim().is_empty()),
+                "{} must carry a non-empty description",
+                model.id
+            );
+        }
+    }
+
+    #[test]
+    fn sdk_merge_alias_rows_backfill_version_bearing_description() {
+        // The deployed CLI reports its roster under alias ids with short
+        // display names and — on some builds — no `description`. Each
+        // alias row must backfill a resolved-version + blurb description
+        // from its canonical maintained entry so the picker shows what
+        // the alias actually runs. `default` resolves like `opus`.
+        let live = vec![
+            sdk_model(
+                "default",
+                "Default (recommended)",
+                &["low", "medium", "high", "xhigh", "max"],
+                Some(true),
+                Some(true),
+            ),
+            sdk_model(
+                "opus",
+                "Opus",
+                &["low", "medium", "high", "xhigh", "max"],
+                Some(true),
+                None,
+            ),
+            sdk_model(
+                "fable",
+                "Fable",
+                &["low", "medium", "high", "xhigh", "max"],
+                Some(true),
+                None,
+            ),
+            sdk_model("sonnet", "Sonnet", &["low", "medium", "high"], Some(true), None),
+            sdk_model("haiku", "Haiku", &[], None, None),
+        ];
+        let caps = build_capabilities_from_sdk(live);
+        let desc = |id: &str| {
+            caps.models
+                .iter()
+                .find(|m| m.id == id)
+                .unwrap_or_else(|| panic!("{id} row must exist"))
+                .description
+                .clone()
+                .unwrap_or_else(|| panic!("{id} row must carry a description"))
+        };
+        // `default` and `opus` both resolve to Opus 4.8, which defaults to
+        // the 1M context window → the "with 1M context" qualifier.
+        assert_eq!(
+            desc("default"),
+            "Opus 4.8 with 1M context · Best for everyday, complex tasks"
+        );
+        assert_eq!(
+            desc("opus"),
+            "Opus 4.8 with 1M context · Best for everyday, complex tasks"
+        );
+        // Fable/Sonnet also default to the 1M window in the maintained
+        // table, so they carry the qualifier too.
+        assert_eq!(
+            desc("fable"),
+            "Fable 5 with 1M context · Most capable for the hardest, longest-running tasks"
+        );
+        assert_eq!(desc("sonnet"), "Sonnet 4.6 with 1M context · Fast and capable");
+        // Haiku has no context-window options → no qualifier, blurb only.
+        assert_eq!(desc("haiku"), "Haiku 4.5 · Fastest and cheapest");
+    }
+
+    #[test]
+    fn sdk_merge_full_id_rows_keep_blurb_only_description() {
+        // A full-id row's label already carries the version
+        // ("Claude Opus 4.8"), so its description must stay the bare
+        // blurb — no version duplication.
+        let live = vec![
+            sdk_model(
+                "claude-opus-4-8",
+                "Claude Opus 4.8",
+                &["low", "medium", "high", "xhigh", "max"],
+                Some(true),
+                None,
+            ),
+            sdk_model(
+                "claude-opus-4-7",
+                "Claude Opus 4.7",
+                &["low", "medium", "high", "xhigh", "max"],
+                Some(true),
+                None,
+            ),
+        ];
+        let caps = build_capabilities_from_sdk(live);
+        let opus48 = caps.models.iter().find(|m| m.id == "claude-opus-4-8").unwrap();
+        assert_eq!(
+            opus48.description.as_deref(),
+            Some("Best for everyday, complex tasks")
+        );
+        let opus47 = caps.models.iter().find(|m| m.id == "claude-opus-4-7").unwrap();
+        assert_eq!(opus47.description.as_deref(), Some("Previous Opus generation"));
+    }
+
+    #[test]
+    fn sdk_description_wins_verbatim_over_backfill() {
+        // When the deployed CLI supplies its own description (the common
+        // case — it packs the resolved version + blurb in there), that
+        // string wins verbatim over any maintained / alias backfill.
+        let sdk = SdkModelInfo {
+            value: "opus".into(),
+            display_name: "Opus".into(),
+            description: "Opus 4.9 with 1M context · Freshest blurb from the CLI".into(),
+            supported_effort_levels: vec!["low".into(), "high".into()],
+            supports_adaptive_thinking: Some(true),
+            supports_fast_mode: None,
+        };
+        let caps = build_capabilities_from_sdk(vec![sdk]);
+        let opus = caps.models.iter().find(|m| m.id == "opus").unwrap();
+        assert_eq!(
+            opus.description.as_deref(),
+            Some("Opus 4.9 with 1M context · Freshest blurb from the CLI")
+        );
+    }
+
+    #[test]
+    fn canonical_id_for_alias_maps_every_alias_and_ignores_full_ids() {
+        assert_eq!(canonical_id_for_alias("default"), Some("claude-opus-4-8"));
+        assert_eq!(canonical_id_for_alias("opus"), Some("claude-opus-4-8"));
+        assert_eq!(canonical_id_for_alias("fable"), Some("claude-fable-5"));
+        assert_eq!(canonical_id_for_alias("sonnet"), Some("claude-sonnet-4-6"));
+        assert_eq!(canonical_id_for_alias("haiku"), Some("claude-haiku-4-5"));
+        // Case-insensitive.
+        assert_eq!(canonical_id_for_alias("OPUS"), Some("claude-opus-4-8"));
+        // Full ids and unknown ids are not aliases.
+        assert_eq!(canonical_id_for_alias("claude-opus-4-8"), None);
+        assert_eq!(canonical_id_for_alias("mystery"), None);
+        // Every alias must resolve to an id that exists in the maintained
+        // table, so backfill can never point at a missing entry.
+        let maintained: std::collections::HashSet<String> =
+            models().into_iter().map(|m| m.id).collect();
+        for (alias, canonical) in ALIAS_CANONICAL_IDS {
+            assert!(
+                maintained.contains(*canonical),
+                "alias {alias} maps to unknown canonical id {canonical}",
+            );
+        }
     }
 }

--- a/src/components/chat/pickers/ModelPicker.test.tsx
+++ b/src/components/chat/pickers/ModelPicker.test.tsx
@@ -17,10 +17,24 @@ vi.mock("@/assets/preset-icons/codex.svg", () => ({
 // minimal payload that mirrors the Rust `capabilities.rs` data the
 // real store would return, so the test's label assertions keep
 // matching reality.
-const CLAUDE_MODELS_STUB = [
-  { id: "claude-opus-4-7", label: "Claude Opus 4.7" },
-  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+const CLAUDE_MODELS_STUB: Array<{
+  id: string;
+  label: string;
+  description: string | null;
+}> = [
+  {
+    id: "claude-opus-4-7",
+    label: "Claude Opus 4.7",
+    description: "Opus 4.8 with 1M context · Best for everyday, complex tasks",
+  },
+  {
+    id: "claude-sonnet-4-6",
+    label: "Claude Sonnet 4.6",
+    description: "Sonnet 5 · Efficient for routine tasks",
+  },
+  // Kept without a description so the "no subtitle" rendering path
+  // stays covered.
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", description: null },
 ];
 const CODEX_MODELS_STUB = [
   { id: "gpt-5.4", label: "GPT-5.4 (Codex)" },
@@ -32,7 +46,7 @@ const capsState = {
     models: CLAUDE_MODELS_STUB.map((m) => ({
       id: m.id,
       label: m.label,
-      description: null,
+      description: m.description,
       effort_levels: [],
       default_effort: null,
       prompt_injected_effort_levels: [],
@@ -187,6 +201,47 @@ describe("ModelPicker — interaction", () => {
       expect(img).not.toBeNull();
       expect(img!.getAttribute("data-provider")).toBe("claude");
     }
+  });
+
+  it("renders the model description as a row subtitle when present", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <TooltipProvider>
+        <ModelPicker provider="claude" value={null} onChange={vi.fn()} />
+      </TooltipProvider>,
+    );
+    await user.click(container.querySelector("button") as HTMLElement);
+    const options = await screen.findAllByRole("option");
+    const opus = options.find((o) =>
+      o.textContent?.includes("Claude Opus 4.7"),
+    );
+    expect(opus).toBeDefined();
+    const subtitle = opus!.querySelector("[title]") as HTMLElement | null;
+    expect(subtitle).not.toBeNull();
+    expect(subtitle!.textContent).toBe(
+      "Opus 4.8 with 1M context · Best for everyday, complex tasks",
+    );
+    expect(subtitle!).toHaveAttribute(
+      "title",
+      "Opus 4.8 with 1M context · Best for everyday, complex tasks",
+    );
+  });
+
+  it("omits the subtitle for a model without a description", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <TooltipProvider>
+        <ModelPicker provider="claude" value={null} onChange={vi.fn()} />
+      </TooltipProvider>,
+    );
+    await user.click(container.querySelector("button") as HTMLElement);
+    const options = await screen.findAllByRole("option");
+    const haiku = options.find((o) =>
+      o.textContent?.includes("Claude Haiku 4.5"),
+    );
+    expect(haiku).toBeDefined();
+    // No description → no subtitle element carrying a `title`.
+    expect(haiku!.querySelector("[title]")).toBeNull();
   });
 
   it("clicking a row calls onChange with that model id", async () => {

--- a/src/components/chat/pickers/ModelPicker.tsx
+++ b/src/components/chat/pickers/ModelPicker.tsx
@@ -37,7 +37,7 @@ export const defaultModelForProvider = defaultModelId;
 
 export function modelsForProvider(
   provider: AgentChatProviderKind,
-): Array<{ id: string; label: string }> {
+): Array<{ id: string; label: string; description: string | null }> {
   return modelsForProviderFromCaps(provider);
 }
 
@@ -101,13 +101,26 @@ export function ModelPicker({ provider, value, onChange, disabled }: Props) {
                     onChange(model.id);
                     setOpen(false);
                   }}
-                  className="h-9 gap-2 text-xs"
+                  className="min-h-9 gap-2 text-xs"
                 >
-                  <ProviderLogo provider={provider} className="h-3.5 w-3.5" />
-                  <span className="flex-1 min-w-0 truncate">{model.label}</span>
+                  <ProviderLogo
+                    provider={provider}
+                    className="h-3.5 w-3.5 shrink-0"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate">{model.label}</div>
+                    {model.description ? (
+                      <div
+                        className="mt-0.5 truncate text-[11px] text-muted-foreground/70"
+                        title={model.description}
+                      >
+                        {model.description}
+                      </div>
+                    ) : null}
+                  </div>
                   <Check
                     className={cn(
-                      "h-3.5 w-3.5 text-muted-foreground",
+                      "h-3.5 w-3.5 shrink-0 text-muted-foreground",
                       current === model.id ? "opacity-100" : "opacity-0",
                     )}
                   />

--- a/src/components/chat/pickers/MultiProviderModelPicker.test.tsx
+++ b/src/components/chat/pickers/MultiProviderModelPicker.test.tsx
@@ -45,7 +45,14 @@ function makeCaps(models: ChatModelInfo[]): ProviderChatCapabilities {
 }
 
 const CLAUDE_CAPS = makeCaps([
-  makeModel({ id: "claude-opus-4-7", label: "Claude Opus 4.7" }),
+  // Opus carries the resolved-version + blurb the backend now serves
+  // for Claude rows; Haiku keeps `description: null` so we still cover
+  // the unchanged (subtitle == driver label) rendering.
+  makeModel({
+    id: "claude-opus-4-7",
+    label: "Claude Opus 4.7",
+    description: "Opus 4.8 with 1M context · Best for everyday, complex tasks",
+  }),
   makeModel({ id: "claude-haiku-4-5", label: "Claude Haiku 4.5" }),
 ]);
 
@@ -170,6 +177,68 @@ describe("MultiProviderModelPicker — trigger", () => {
     expect(
       screen.queryByPlaceholderText("Search models..."),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("MultiProviderModelPicker — model descriptions", () => {
+  it("appends the description to the row subtitle after the driver label", async () => {
+    const user = userEvent.setup();
+    renderPicker({ provider: "claude", model: "claude-opus-4-7" });
+    await openPicker(user);
+
+    const rows = screen.getAllByTestId("multi-provider-model-row");
+    const opusRow = rows.find((r) =>
+      r.textContent?.includes("Claude Opus 4.7"),
+    );
+    expect(opusRow).toBeDefined();
+    // Subtitle reads "Claude · <description>" on a single line, with
+    // the full text mirrored into the title tooltip.
+    const subtitle = opusRow!.querySelector(
+      "span[title]",
+    ) as HTMLElement | null;
+    expect(subtitle).not.toBeNull();
+    expect(subtitle!.textContent).toBe(
+      "Claude · Opus 4.8 with 1M context · Best for everyday, complex tasks",
+    );
+    expect(subtitle!).toHaveAttribute(
+      "title",
+      "Claude · Opus 4.8 with 1M context · Best for everyday, complex tasks",
+    );
+  });
+
+  it("leaves the subtitle as the driver label when description is null", async () => {
+    const user = userEvent.setup();
+    renderPicker({ provider: "claude", model: "claude-opus-4-7" });
+    await openPicker(user);
+
+    const rows = screen.getAllByTestId("multi-provider-model-row");
+    const haikuRow = rows.find((r) =>
+      r.textContent?.includes("Claude Haiku 4.5"),
+    );
+    expect(haikuRow).toBeDefined();
+    const subtitle = haikuRow!.querySelector(
+      "span[title]",
+    ) as HTMLElement | null;
+    expect(subtitle).not.toBeNull();
+    expect(subtitle!.textContent).toBe("Claude");
+    expect(subtitle!).toHaveAttribute("title", "Claude");
+  });
+
+  it("surfaces the active model's description in the trigger tooltip", () => {
+    renderPicker({ provider: "claude", model: "claude-opus-4-7" });
+    expect(
+      screen.getByTestId("multi-provider-model-picker-trigger"),
+    ).toHaveAttribute(
+      "title",
+      "Claude Opus 4.7 · Opus 4.8 with 1M context · Best for everyday, complex tasks",
+    );
+  });
+
+  it("trigger tooltip is just the label when the active model has no description", () => {
+    renderPicker({ provider: "claude", model: "claude-haiku-4-5" });
+    expect(
+      screen.getByTestId("multi-provider-model-picker-trigger"),
+    ).toHaveAttribute("title", "Claude Haiku 4.5");
   });
 });
 

--- a/src/components/chat/pickers/MultiProviderModelPicker.tsx
+++ b/src/components/chat/pickers/MultiProviderModelPicker.tsx
@@ -327,6 +327,22 @@ export function MultiProviderModelPicker({
     return caps?.models.find((m) => m.id === model)?.sub_provider ?? null;
   }, [provider, model, claudeCaps, codexCaps, opencodeCaps]);
 
+  // The active model's resolved-version blurb, surfaced only in the
+  // trigger's tooltip so the pill itself stays compact. Combines the
+  // visible label with the description (e.g.
+  // "Opus · Opus 4.8 with 1M context · Best for everyday, complex tasks").
+  const triggerTitle = useMemo(() => {
+    const caps =
+      provider === "claude"
+        ? claudeCaps
+        : provider === "codex"
+        ? codexCaps
+        : opencodeCaps;
+    const description =
+      caps?.models.find((m) => m.id === model)?.description ?? null;
+    return description ? `${triggerLabel} · ${description}` : triggerLabel;
+  }, [provider, model, claudeCaps, codexCaps, opencodeCaps, triggerLabel]);
+
   return (
     <Popover open={open} onOpenChange={(v) => !disabled && setOpen(v)}>
       <PopoverTrigger asChild>
@@ -334,6 +350,7 @@ export function MultiProviderModelPicker({
           type="button"
           disabled={disabled}
           data-testid="multi-provider-model-picker-trigger"
+          title={triggerTitle}
           className={cn(
             // Composer footer pill: bordered card chip on the base
             // surface (design's model/effort/permission pills), the
@@ -640,9 +657,19 @@ function ModelRow({
 }) {
   const { model, provider } = row;
   const driverLabel = providerDisplayLabel(provider);
-  const subtitle = model.sub_provider
+  // Base subtitle: driver label, plus the federated `sub_provider`
+  // hint for OpenCode rows. When the backend supplies a resolved
+  // `description` (e.g. Claude alias rows carry
+  // "Opus 4.8 with 1M context · Best for everyday, complex tasks"),
+  // append it after another dot so the row reads
+  // "Claude · Opus 4.8 with 1M context · Best…" — single line,
+  // truncated, with the full text in the `title` tooltip.
+  const subtitleBase = model.sub_provider
     ? `${driverLabel} · ${model.sub_provider}`
     : driverLabel;
+  const subtitle = model.description
+    ? `${subtitleBase} · ${model.description}`
+    : subtitleBase;
   return (
     <CommandItem
       value={`${provider}::${model.id}`}
@@ -664,7 +691,9 @@ function ModelRow({
             provider={provider}
             className="h-2.5 w-2.5 shrink-0"
           />
-          <span className="truncate">{subtitle}</span>
+          <span className="truncate" title={subtitle}>
+            {subtitle}
+          </span>
         </div>
       </div>
       {model.is_free ? (

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -269,7 +269,10 @@ const EMPTY_CAPABILITIES: ProviderChatCapabilities = {
 const MOCK_CHAT_MODEL: ChatModelInfo = {
   id: "mock-sonnet",
   label: "Mock Sonnet",
-  description: "Simulated model served by the dev mock",
+  // Mirrors the resolved-version + blurb the real backend now serves
+  // for Claude rows so `npm run dev` visually exercises the picker's
+  // description subtitle.
+  description: "Sonnet 5 with 1M context · Efficient for routine tasks",
   effort_levels: [],
   default_effort: null,
   prompt_injected_effort_levels: [],

--- a/src/lib/agent-chat/capability-defaults.test.ts
+++ b/src/lib/agent-chat/capability-defaults.test.ts
@@ -80,16 +80,20 @@ describe("capability-defaults", () => {
   });
 
   describe("modelsForProvider", () => {
-    it("returns a [{id, label}] projection of the capabilities list", () => {
+    it("returns a [{id, label, description}] projection of the capabilities list", () => {
       useProviderCapabilities.setState({
         claude: makeClaudeCaps([
           makeModel({ id: "a", label: "Alpha" }),
-          makeModel({ id: "b", label: "Beta" }),
+          makeModel({
+            id: "b",
+            label: "Beta",
+            description: "Beta 2 · Fast and capable",
+          }),
         ]),
       });
       expect(modelsForProvider("claude")).toEqual([
-        { id: "a", label: "Alpha" },
-        { id: "b", label: "Beta" },
+        { id: "a", label: "Alpha", description: null },
+        { id: "b", label: "Beta", description: "Beta 2 · Fast and capable" },
       ]);
     });
 

--- a/src/lib/agent-chat/capability-defaults.ts
+++ b/src/lib/agent-chat/capability-defaults.ts
@@ -42,17 +42,27 @@ export function defaultModelId(provider: AgentChatProviderKind): string {
   return caps?.models[0]?.id ?? FALLBACK_DEFAULT_MODEL_BY_PROVIDER[provider];
 }
 
-/** List the provider's models as `{ id, label }` for picker rendering.
- *  Returns `[]` when capabilities aren't hydrated — the picker
- *  renders its CommandEmpty state in that case. */
+/** List the provider's models as `{ id, label, description }` for
+ *  picker rendering. `description` carries the backend's resolved
+ *  version + blurb (e.g. Claude's
+ *  "Opus 4.8 with 1M context · Best for everyday, complex tasks"),
+ *  `null` when none was supplied. Returns `[]` when capabilities
+ *  aren't hydrated — the picker renders its CommandEmpty state in
+ *  that case. */
 export function modelsForProvider(
   provider: AgentChatProviderKind,
-): Array<{ id: string; label: string }> {
+): Array<{ id: string; label: string; description: string | null }> {
   const caps = selectCapabilities(
     useProviderCapabilities.getState(),
     provider,
   );
-  return caps?.models.map((m) => ({ id: m.id, label: m.label })) ?? [];
+  return (
+    caps?.models.map((m) => ({
+      id: m.id,
+      label: m.label,
+      description: m.description,
+    })) ?? []
+  );
 }
 
 /** Look up a model's display label by id. Falls back to the raw id


### PR DESCRIPTION
## Problem

The Agent Chat model picker showed Claude models as bare aliases ("Opus", "Fable", "Sonnet", "Haiku") with only "Claude" as the row subtitle. There was no way to tell which version an alias actually runs, while the Claude Code terminal `/model` picker shows e.g. "Opus 4.8 with 1M context · Best for everyday, complex tasks".

Investigation confirmed model *selection* itself works correctly — alias ids pass through intact and the Claude CLI/SDK resolves them to the latest concrete model. The gap was purely display: `ChatModelInfo.description` existed in the backend but was never rendered by any picker, and alias rows harvested from the CLI missed the metadata backfill (keyed on full ids only).

## Changes

**Backend** (`src-tauri/src/agent_provider/claude/capabilities.rs`)
- SDK-provided per-model descriptions now pass through verbatim (same strings the terminal picker shows).
- New `ALIAS_CANONICAL_IDS` table (`default`/`opus`/`fable`/`sonnet`/`haiku` → canonical maintained id, pattern borrowed from t3code's alias table) synthesizes a version-bearing description — `"<Version>[ with 1M context] · <blurb>"` — for alias rows the SDK reports without one.
- Backfilled missing blurbs so every Claude model always serves a description.
- 5 new unit tests: precedence (SDK verbatim > maintained blurb > alias backfill), alias mapping, no-empty-description guarantee.

**Frontend**
- `MultiProviderModelPicker` + legacy `ModelPicker` render the description in the row subtitle: **"Claude · Opus 4.8 with 1M context · Best for everyday, complex tasks"** (truncated, full text in a `title` tooltip). Composer pill mirrors label + description into its tooltip. Rows without a description render exactly as before.
- Dev-mock seed data gains realistic descriptions so `npm run dev` shows the new subtitles.

**Docs**: `docs/features/agent-chat.md` updated with the new picker behavior and description precedence.

## New-model behavior

No manual work needed for a new model to appear: the picker list is harvested live from the deployed CLI, and SDK-reported labels/descriptions/effort levels win over the maintained table. The maintained table + alias map are enrichment/fallback only; bumping them when a generation ships is a one-line cosmetic edit.

## Verification

- `npm run check` + `npm run test`: 148 files, 2143 tests, 0 failures
- `cargo check` + `cargo test`: 1930 lib tests passed, 0 failed (44 in the capabilities module, incl. the 5 new ones)
- Visual check in the browser pane (dev mock): picker row renders "Claude · Sonnet 5 with 1M context · Efficient for routine tasks"
- Caveat: the SDK-verbatim path couldn't be exercised against a logged-in CLI in this sandbox; worth one glance at the real picker. The alias fallback guarantees a version is shown either way.