### PR TITLE
feat: opt-in desktop-size viewport for agent chat background browser peek

### DIFF
--- a/docs/features/browser.md
+++ b/docs/features/browser.md
@@ -129,6 +129,23 @@ own compact header instead. Both props are additive and default to today's
 pane behavior (`workspaceId` unset falls through to the exact prior
 `browser_id`-only lookup; `hideToolbar` defaults to showing the toolbar).
 
+**Desktop-size peek viewport (opt-in)**: by default, `BrowserPane` syncs the
+browser's real CDP viewport to its container — inside the 440×300 peek that
+means pages reflow at popover dimensions and agents end up re-sending
+`viewport` every turn. Settings → Agent → "Desktop-size background browser"
+(`UserSettings.agent_chat.background_browser_desktop_viewport`, synced
+settings, default OFF) instead pins the peek's viewport to 1280×800 —
+matching the `desktop` preset / `RESET_SPEC` in
+`src-tauri/src/browser_viewport.rs` — via a new optional `BrowserPane`
+`fixedViewport` prop. When set, the WebSocket-open handshake sends the fixed
+size instead of container dims, and the `ResizeObserver` keeps syncing the
+canvas element to the container but skips the viewport re-send, so the
+existing frame-draw letterbox scales the full-size frame down to fit. Input
+mapping needs no changes — `mapToViewport` already routes clicks through the
+canvas rect + draw rect into viewport coordinates. Applies only to the peek
+overlay; normal browser panes (and the peek with the setting off) keep the
+container-sync behavior unchanged.
+
 ## Expected Operating Model
 
 - agents control the browser programmatically

--- a/docs/features/settings-sync.md
+++ b/docs/features/settings-sync.md
@@ -47,6 +47,9 @@ UserSettings
     enabled: boolean           (default: true)
     scrollback_lines: number   (default: 10000)
     max_total_mb: number       (default: 100)
+  agent_chat
+    checkpoints_enabled: boolean                 (default: false, run-start rollback checkpoint — issue #80)
+    background_browser_desktop_viewport: boolean (default: false, pin GUI-mode background-browser peek to 1280×800 — docs/features/browser.md)
 ```
 
 ### Offline Cache

--- a/src-tauri/src/settings_sync.rs
+++ b/src-tauri/src/settings_sync.rs
@@ -124,10 +124,21 @@ pub struct FileTreeSettings {
 /// the run's changes can be rolled back. Defaults to OFF — the
 /// snapshot writes objects into the user's repo, which must be a
 /// deliberate choice.
+///
+/// `background_browser_desktop_viewport` pins a GUI-mode background
+/// browser's CDP viewport to a real desktop size (1280×800, matching
+/// the `desktop` preset / `RESET_SPEC` in `browser_viewport.rs`) when
+/// the peek popover (`BrowserPeekOverlay.tsx`) is showing it, instead
+/// of shrinking the viewport to the tiny popover's pixel size — the
+/// popover's canvas letterboxes the larger frame down to fit. Defaults
+/// to OFF so today's container-sync behavior is unchanged out of the
+/// box.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct AgentChatSettings {
     #[serde(default)]
     pub checkpoints_enabled: bool,
+    #[serde(default)]
+    pub background_browser_desktop_viewport: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -520,6 +531,7 @@ mod tests {
             },
             agent_chat: AgentChatSettings {
                 checkpoints_enabled: true,
+                background_browser_desktop_viewport: true,
             },
         };
 
@@ -542,6 +554,7 @@ mod tests {
         assert_eq!(back.session_restore.scrollback_lines, 5000);
         assert_eq!(back.session_restore.max_total_mb, 50);
         assert!(back.agent_chat.checkpoints_enabled);
+        assert!(back.agent_chat.background_browser_desktop_viewport);
     }
 
     /// A settings blob saved before the agent_chat section existed
@@ -552,6 +565,20 @@ mod tests {
         let legacy = r#"{"appearance":{"theme":"dark"}}"#;
         let parsed: UserSettings = serde_json::from_str(legacy).unwrap();
         assert!(!parsed.agent_chat.checkpoints_enabled);
+        assert!(!parsed.agent_chat.background_browser_desktop_viewport);
+    }
+
+    /// A settings blob saved before `background_browser_desktop_viewport`
+    /// existed (but with an `agent_chat` section already present) still
+    /// deserializes — the new field defaults to OFF via serde default,
+    /// not a deserialize error.
+    #[test]
+    #[serial]
+    fn missing_desktop_viewport_field_defaults_off() {
+        let legacy = r#"{"agent_chat":{"checkpoints_enabled":true}}"#;
+        let parsed: UserSettings = serde_json::from_str(legacy).unwrap();
+        assert!(parsed.agent_chat.checkpoints_enabled);
+        assert!(!parsed.agent_chat.background_browser_desktop_viewport);
     }
 
     /// Patching one section preserves all other sections when round-tripped through cache.

--- a/src/components/browser/BrowserPane.tsx
+++ b/src/components/browser/BrowserPane.tsx
@@ -50,6 +50,15 @@ interface Props {
    *  promote/close actions instead. Defaults to showing the toolbar
    *  (today's pane behavior, unchanged). */
   hideToolbar?: boolean;
+  /** Pins the browser's CDP viewport to a fixed size instead of syncing
+   *  it to the container. The canvas element still tracks the container's
+   *  pixel size — the frame-draw letterbox scales the (larger) frame down
+   *  to fit, and `mapToViewport` already maps input through the draw
+   *  rect, so clicks stay accurate. Used by the peek overlay's
+   *  "Desktop-size background browser" setting so the tiny popover
+   *  doesn't force the agent's page to reflow at popover dimensions.
+   *  Absent = today's container-sync behavior, unchanged. */
+  fixedViewport?: { width: number; height: number };
 }
 
 // Move-forwarding cadence (ms). Drags run tight for smooth text
@@ -75,11 +84,17 @@ interface PendingMove {
   modifiers: number;
 }
 
-export function BrowserPane({ browserId, focused, visible, workspaceId, hideToolbar }: Props) {
+export function BrowserPane({ browserId, focused, visible, workspaceId, hideToolbar, fixedViewport }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const viewportRef = useRef<ViewportInfo>({ width: 1280, height: 720 });
+  // Ref-mirror of the `fixedViewport` prop so the WebSocket and
+  // ResizeObserver effects can read it without listing it in their
+  // dependency arrays (an inline object literal from the caller would
+  // otherwise reconnect the stream every render).
+  const fixedViewportRef = useRef(fixedViewport);
+  fixedViewportRef.current = fixedViewport;
   const [status, setStatus] = useState<"starting" | "connecting" | "waiting" | "live" | "error">("starting");
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [hasFrame, setHasFrame] = useState(false);
@@ -282,6 +297,16 @@ export function BrowserPane({ browserId, focused, visible, workspaceId, hideTool
         ws.onopen = () => {
           if (!active) return;
           setStatus("waiting");
+
+          // Pinned viewport: ignore container dimensions entirely — the
+          // popover canvas letterboxes the larger frame down to fit.
+          const fixed = fixedViewportRef.current;
+          if (fixed && fixed.width > 10 && fixed.height > 10) {
+            viewportRef.current = { width: fixed.width, height: fixed.height };
+            agentBrowserRun(effectiveSessionId, "viewport", { width: fixed.width, height: fixed.height }).catch(() => {});
+            sendInput({ type: "resize", width: fixed.width, height: fixed.height });
+            return;
+          }
 
           // Set initial viewport to match container dimensions
           const container = containerRef.current;
@@ -815,6 +840,10 @@ export function BrowserPane({ browserId, focused, visible, workspaceId, hideTool
         canvas.width = cw;
         canvas.height = ch;
       }
+      // Pinned viewport: the canvas tracks the container (above) but the
+      // browser's viewport stays fixed — never re-send it or overwrite
+      // viewportRef with container dims.
+      if (fixedViewportRef.current) return;
       // Debounced: tell browser to resize viewport to match
       if (resizeTimer) clearTimeout(resizeTimer);
       resizeTimer = setTimeout(() => {

--- a/src/components/browser/BrowserPeekOverlay.tsx
+++ b/src/components/browser/BrowserPeekOverlay.tsx
@@ -11,7 +11,18 @@ import { useGuiChrome } from "@/hooks/use-gui-chrome";
 import { cn } from "@/lib/utils";
 import { useActiveWorkspaceId, useAppStore } from "@/stores/app-store";
 import { useBrowserPeekStore } from "@/stores/browser-peek-store";
+import {
+  selectBackgroundBrowserDesktopViewport,
+  useSyncedSettingsStore,
+} from "@/stores/synced-settings-store";
 import { createBrowserPane } from "@/tauri/commands";
+
+/** Pinned viewport for the "Desktop-size background browser" setting.
+ *  Matches the `desktop` preset / `RESET_SPEC` in
+ *  `src-tauri/src/browser_viewport.rs` (1280×800 @ 1× DPR), so the peek
+ *  shows pages at the same baseline agents get from
+ *  `codemux browser viewport reset`. */
+const DESKTOP_PEEK_VIEWPORT = { width: 1280, height: 800 };
 
 /**
  * Floating "peek" overlay for a GUI-mode background browser session
@@ -46,6 +57,9 @@ export function BrowserPeekOverlay() {
     if (!found || !found.is_active || found.pane_id) return null;
     return found;
   });
+  const desktopViewport = useSyncedSettingsStore(
+    selectBackgroundBrowserDesktopViewport,
+  );
   const panelRef = useRef<HTMLDivElement>(null);
 
   const open = guiChrome && isOpen && !!session && !!activeWorkspaceId;
@@ -157,6 +171,7 @@ export function BrowserPeekOverlay() {
           focused={false}
           visible={open}
           hideToolbar
+          fixedViewport={desktopViewport ? DESKTOP_PEEK_VIEWPORT : undefined}
         />
       </div>
     </div>

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -1971,6 +1971,22 @@ export function SettingsView() {
                       }}
                     />
                   </SettingRow>
+                  <Separator />
+                  {/* GUI-mode background browser viewport pin. Like the
+                      checkpoint toggle, only meaningful with the Agent
+                      Chat beta on — the peek popover it affects is a
+                      GUI-chrome surface. */}
+                  <SettingRow
+                    label="Desktop-size background browser"
+                    description="Start the agent's background browser at a real desktop viewport (1280×800) so pages render at full size in the peek popover, scaled to fit."
+                  >
+                    <Switch
+                      checked={syncedSettings.agent_chat?.background_browser_desktop_viewport ?? false}
+                      onCheckedChange={(checked) => {
+                        updateSyncedSetting("agent_chat", "background_browser_desktop_viewport", checked).catch(console.error);
+                      }}
+                    />
+                  </SettingRow>
                 </>
               )}
             </div>

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -248,7 +248,7 @@ const SYNCED_SETTINGS: UserSettings = {
   },
   // Checkpoints ON in the mock so the seeded chat pane exercises the
   // restore affordance (issue #80) without a real backend.
-  agent_chat: { checkpoints_enabled: true },
+  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: false },
 };
 
 const EMPTY_CAPABILITIES: ProviderChatCapabilities = {

--- a/src/stores/settings-sync-integration.test.ts
+++ b/src/stores/settings-sync-integration.test.ts
@@ -40,7 +40,7 @@ const FULL_CUSTOM: UserSettings = {
   notifications: { sound_enabled: false, desktop_enabled: false },
   file_tree: { show_hidden_files: true },
   session_restore: { enabled: false, scrollback_lines: 5000, max_total_mb: 50 },
-  agent_chat: { checkpoints_enabled: true },
+  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: true },
 };
 
 // ── Setup ──

--- a/src/stores/synced-settings-store.test.ts
+++ b/src/stores/synced-settings-store.test.ts
@@ -23,6 +23,7 @@ import {
   selectDefaultBaseBranch,
   selectNotificationSoundEnabled,
   selectDesktopNotificationsEnabled,
+  selectBackgroundBrowserDesktopViewport,
 } from "./synced-settings-store";
 import type { UserSettings } from "@/tauri/types";
 
@@ -35,7 +36,7 @@ const DARK_SETTINGS: UserSettings = {
   notifications: { sound_enabled: false, desktop_enabled: true },
   file_tree: { show_hidden_files: true },
   session_restore: { enabled: true, scrollback_lines: 10000, max_total_mb: 100 },
-  agent_chat: { checkpoints_enabled: true },
+  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: true },
 };
 
 describe("synced-settings-store", () => {
@@ -266,6 +267,15 @@ describe("synced-settings-store", () => {
 
     it("selectDesktopNotificationsEnabled returns boolean", () => {
       expect(selectDesktopNotificationsEnabled(useSyncedSettingsStore.getState())).toBe(true);
+    });
+
+    it("selectBackgroundBrowserDesktopViewport returns boolean", () => {
+      useSyncedSettingsStore.setState({ settings: DARK_SETTINGS });
+      expect(selectBackgroundBrowserDesktopViewport(useSyncedSettingsStore.getState())).toBe(true);
+    });
+
+    it("selectBackgroundBrowserDesktopViewport defaults to false", () => {
+      expect(selectBackgroundBrowserDesktopViewport(useSyncedSettingsStore.getState())).toBe(false);
     });
   });
 

--- a/src/stores/synced-settings-store.ts
+++ b/src/stores/synced-settings-store.ts
@@ -21,7 +21,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   notifications: { sound_enabled: true, desktop_enabled: true },
   file_tree: { show_hidden_files: false },
   session_restore: { enabled: true, scrollback_lines: 10_000, max_total_mb: 100 },
-  agent_chat: { checkpoints_enabled: false },
+  agent_chat: { checkpoints_enabled: false, background_browser_desktop_viewport: false },
 };
 
 export interface SyncedSettingsState {
@@ -176,3 +176,6 @@ export const selectShowResourceMonitor = (s: SyncedSettingsState): boolean =>
 
 export const selectAgentCheckpointsEnabled = (s: SyncedSettingsState): boolean =>
   s.settings.agent_chat?.checkpoints_enabled ?? false;
+
+export const selectBackgroundBrowserDesktopViewport = (s: SyncedSettingsState): boolean =>
+  s.settings.agent_chat?.background_browser_desktop_viewport ?? false;

--- a/src/tauri/types.ts
+++ b/src/tauri/types.ts
@@ -51,9 +51,14 @@ export interface SessionRestoreSettings {
 
 /** Mirrors src-tauri/src/settings_sync.rs:AgentChatSettings.
  *  `checkpoints_enabled` is the opt-in for the run-start rollback
- *  checkpoint (issue #80) — default OFF. */
+ *  checkpoint (issue #80) — default OFF.
+ *  `background_browser_desktop_viewport` pins the GUI-mode background
+ *  browser's peek popover (`BrowserPeekOverlay.tsx`) to a real desktop
+ *  viewport (1280×800) instead of shrinking to the popover's pixel
+ *  size — default OFF. */
 export interface AgentChatSyncSettings {
   checkpoints_enabled: boolean;
+  background_browser_desktop_viewport: boolean;
 }
 
 export interface UserSettings {


### PR DESCRIPTION
## Summary

The agent-chat background-browser peek popover (440×300) was force-syncing the browser's real CDP viewport to its own tiny pixel size — on stream connect and again on every resize — so pages rendered at ~440px wide and agents had to resize the viewport every turn.

This adds a settings toggle (**Settings → Agent → "Desktop-size background browser"**, default off). When enabled, the peek popover pins the viewport to **1280×800** (the existing `desktop` preset / `RESET_SPEC` in `browser_viewport.rs`) and the pane's existing letterbox rendering scales the full desktop frame down to fit the popover.

## How it works

- New synced setting `agent_chat.background_browser_desktop_viewport` — full pipeline: Rust `AgentChatSettings` (serde-default, back-compat tested) → TS types → store defaults + selector → Switch row in the Agent settings section
- `BrowserPane` gains an optional `fixedViewport` prop (ref-mirrored so it can't cause stream reconnects). When set: viewport pinned on connect; `ResizeObserver` still syncs the canvas to the container but never re-sends the viewport. Prop absent = byte-identical prior behavior
- `BrowserPeekOverlay` passes `{width: 1280, height: 800}` only when the setting is on
- No Rust browser changes and no input-mapping changes needed: frames were already letterbox-scaled into the canvas, and `mapToViewport` already maps clicks through the draw rect → viewport coordinates, so input stays accurate
- Agent-facing surface unchanged: the browser commands and system prompt are untouched — agents can still resize freely; the popover default is just already desktop-sized

## Verification

- `npm run check` ✅
- `npm run test` ✅ (2322 tests)
- `cargo check` ✅, `cargo test settings_sync` ✅ (19/19, incl. 2 new tests: round-trip + missing-field-defaults-off)
- Visual: toggle renders in Settings → Agent via the dev mock runtime

Not verified live: the pinned viewport inside the popover with a real CDP stream (dev mock has no screencast) — needs a quick `npm run tauri:dev` smoke with an agent opening a background browser.

## Docs

- `docs/features/browser.md` — new "Desktop-size peek viewport (opt-in)" paragraph
- `docs/features/settings-sync.md` — added the `agent_chat` section to the synced-settings schema