### PR TITLE
fix(chat): eliminate scroll jitter in long agent chat threads

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -209,15 +209,20 @@ Contract preserved from the pre-redesign renderer:
   their `items` array each build, as the old tool-group rows did; the
   stable `run:<first-id>` key keeps the scroller row from remounting as
   the run grows and transitions working → settled.)
-- **Stick-to-bottom.** Pinned-ness is tracked from real scroll events
-  (≤ 80 px from the bottom); after every transcript change (or
-  streaming-marker toggle), if pinned, it snaps to the tail. Content
-  growth alone never unpins, so auto-scroll never fights a user
-  reading history. This is implemented directly in `MessageList.tsx`
-  (mount tail-snap with a bounded settle loop + pinned-follow effect)
-  because `content-visibility` rows expose only estimated heights
-  until rendered — the engine's own mount positioning and smooth
-  `scrollToEnd` land short on large hydrated transcripts.
+- **Stick-to-bottom.** The shadcn scroller engine
+  (`MessageScrollerProvider autoScroll`) is the single owner of
+  tail-tracking: its `following-bottom` state machine re-scrolls to
+  the end whenever a ResizeObserver/MutationObserver detects content
+  growth while following, unpins on a real user gesture (wheel /
+  touch / keydown), and re-pins once the reader scrolls back within
+  its `scrollEdgeThreshold` (default 8px) of the bottom. `MessageList`
+  no longer runs a competing hand-rolled pin/snap loop — an earlier
+  version did (direct `scrollTop` writes on a separate 80px
+  threshold), which produced visible jitter fighting the engine in
+  the 8–80px band; that machinery was deleted. The viewport also sets
+  `overflow-anchor: none` so native browser scroll anchoring can't
+  fight the engine's programmatic scrolls while `content-visibility`
+  rows settle from estimated to real heights.
 - **Turn anchoring is deliberately OFF** (`scrollAnchor={false}` on
   every row): with hundreds of pre-hydrated rows the engine's anchor
   handling scrolls the viewport to a stale early anchor when new items
@@ -227,9 +232,10 @@ Contract preserved from the pre-redesign renderer:
   scroller row (both the step list and per-step inline detail); the
   browser re-derives sizes as rows materialize.
 - **Streaming marker** (shimmer status) renders as the last row inside
-  the scroller content (not a footer) so the tail snap keeps it
-  visible while streaming; the jump-to-latest pill is the restyled
-  `MessageScrollerButton` with a direct-DOM snap fallback. **A working
+  the scroller content (not a footer) so the engine's following-bottom
+  tracking keeps it visible while streaming; the jump-to-latest pill is
+  the restyled `MessageScrollerButton` (its own `scrollToEnd`, which
+  also re-enters following-bottom mode). **A working
   Activity block already shows the single live line, so the marker is
   suppressed when one is the transcript tail** — `MessageList` passes
   the thread `streaming` flag into `buildTranscriptSlots`, and the
@@ -323,9 +329,10 @@ already Beta-gated pane and simply hides on short threads.
   cold jump across thousands of estimated pixels lands the target well off
   (and re-calling `scrollToMessage` reproduces the same wrong offset), so
   the loop instead nudges `scrollTop` by the target row's *measured* offset
-  error each frame until it rests near the top (same spirit as
-  `MessageList`'s own mount settle loop). Jumping up fires real scroll
-  events, so the `#77` `pinnedRef` unpins itself — no extra coordination.
+  error each frame until it rests near the top (its own settle loop,
+  independent of the transcript's tail-tracking). Jumping up fires real
+  scroll events, so the scroller engine's `following-bottom` mode unpins
+  itself on the gesture — no extra coordination needed.
   The rail overlays the viewport's left gutter but is its **sibling**, so
   its `<nav>` forwards `onWheel` to the viewport's `scrollTop` — otherwise
   wheeling over that 28px strip would be a dead zone. Ticks are real `<button>`s (`Enter`/`Space`,

--- a/src/components/chat/ChatTranscript.tsx
+++ b/src/components/chat/ChatTranscript.tsx
@@ -32,10 +32,9 @@ interface Props {
 }
 
 /**
- * Transcript shell. The scroll container, stick-to-bottom pinning and
- * row windowing all live inside the virtualized `MessageList` (the
- * virtualizer must own its scroller to map scroll offsets onto the
- * rendered window) — this layer just sizes it and derives the
+ * Transcript shell. The scroll container and stick-to-bottom tracking
+ * (owned by the shadcn scroller engine inside `MessageList`) both live
+ * inside `MessageList` — this layer just sizes it and derives the
  * thinking-pulse flag.
  */
 export function ChatTranscript({

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,12 +1,5 @@
 import { ArrowDown } from "lucide-react";
-import {
-  memo,
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  type CSSProperties,
-} from "react";
+import { memo, useCallback, useMemo, type CSSProperties } from "react";
 
 import {
   MessageScroller,
@@ -86,10 +79,18 @@ interface Props {
  * Transcript body on the shadcn **MessageScroller** (design D2). The
  * scroller provides the viewport/rows/jump-button anatomy and
  * `content-visibility:auto` row containment (thousands of turns stay
- * cheap; the reducer's 5,000-message cap bounds the worst case), while
- * tail tracking uses the preserved stick-to-bottom contract implemented
- * below (mount snap + pinned follow) — the engine's turn anchoring is
- * disabled because it mis-scrolls against fully hydrated transcripts.
+ * cheap; the reducer's 5,000-message cap bounds the worst case). The
+ * engine (`MessageScrollerProvider autoScroll`) is the SINGLE owner of
+ * stick-to-bottom: its `following-bottom` state machine re-scrolls to
+ * the end on every ResizeObserver/MutationObserver-detected content
+ * change while following, unpins on user wheel/touch/keydown gestures,
+ * and re-pins once the reader scrolls back within its 8px edge
+ * threshold. The viewport also disables native browser scroll
+ * anchoring (`overflow-anchor: none`) so `content-visibility:auto`'s
+ * estimated-then-real row height settling can't fight the engine's
+ * programmatic scrolls. Per-item turn anchoring is still off (see
+ * `scrollAnchor={false}` below) — that remains a deliberate,
+ * independent setting.
  *
  * Layout is derived by the pure `buildTranscriptSlots` (turn grouping,
  * tool-run folding, avatar/turn-boundary metadata). Each slot is one
@@ -181,73 +182,7 @@ export function MessageList({
   const tailIsWorkingActivity =
     tailBody?.kind === "activity" && tailBody.working;
 
-  // --- Tail snap ------------------------------------------------------
-  // `content-visibility:auto` rows expose only ESTIMATED heights until
-  // they render, so the engine's mount-time "end" positioning (and a
-  // smooth scrollToEnd across tens of thousands of estimated pixels)
-  // can land far from the real tail. Direct scrollTop assignment is
-  // reliable — the browser re-clamps as row sizes materialise — so we
-  // snap the DOM directly: once on first mount (re-snapping across a
-  // few frames until the viewport actually rests at the bottom), and on
-  // every jump-button press.
-  const shellRef = useRef<HTMLDivElement | null>(null);
-  const snapToTail = useCallback(() => {
-    const viewport = shellRef.current?.querySelector<HTMLElement>(
-      '[data-slot="message-scroller-viewport"]',
-    );
-    if (viewport) viewport.scrollTop = viewport.scrollHeight;
-  }, []);
-  const hasContent = slots.length > 0;
-  const initialSnapDoneRef = useRef(false);
-  useLayoutEffect(() => {
-    if (!hasContent || initialSnapDoneRef.current) return;
-    initialSnapDoneRef.current = true;
-    snapToTail();
-    let tries = 0;
-    let frame = 0;
-    const settle = () => {
-      const viewport = shellRef.current?.querySelector<HTMLElement>(
-        '[data-slot="message-scroller-viewport"]',
-      );
-      if (!viewport) return;
-      const distance =
-        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
-      if (distance > 4 && tries < 20) {
-        tries += 1;
-        viewport.scrollTop = viewport.scrollHeight;
-        frame = requestAnimationFrame(settle);
-      }
-    };
-    frame = requestAnimationFrame(settle);
-    return () => cancelAnimationFrame(frame);
-  }, [hasContent, snapToTail]);
-
-  // --- Pinned follow ---------------------------------------------------
-  // The preserved stick-to-bottom contract (issue #77 semantics):
-  // pinned-ness is tracked from REAL scroll events (≤80px from the
-  // bottom counts as pinned); after every transcript change, if pinned,
-  // snap to the tail. Content growth alone never fires a scroll event,
-  // so streaming can never unpin a reader who scrolled up.
-  const pinnedRef = useRef(true);
-  useLayoutEffect(() => {
-    const viewport = shellRef.current?.querySelector<HTMLElement>(
-      '[data-slot="message-scroller-viewport"]',
-    );
-    if (!viewport) return;
-    const onScroll = () => {
-      const distance =
-        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
-      pinnedRef.current = distance <= PIN_THRESHOLD_PX;
-    };
-    viewport.addEventListener("scroll", onScroll, { passive: true });
-    return () => viewport.removeEventListener("scroll", onScroll);
-  }, []);
-  useLayoutEffect(() => {
-    if (pinnedRef.current) snapToTail();
-  }, [slots, showThinking, snapToTail]);
-
   return (
-    <div ref={shellRef} style={SHELL_STYLE}>
     <MessageScrollerProvider autoScroll>
       <MessageScroller>
         {/* Navigation trail — a turn rail in the left gutter (inside the
@@ -270,7 +205,8 @@ export function MessageList({
                 // the engine's anchor handling scrolls the viewport to
                 // a stale early anchor when new items register mid-
                 // stream, which breaks the stick-to-bottom contract.
-                // The pinned-follow effect below owns tail tracking.
+                // The scroller engine's `following-bottom` mode owns
+                // tail tracking (see the file-top doc comment).
                 scrollAnchor={false}
                 className={slot.turnStart ? "mt-5" : "mt-[13px]"}
               >
@@ -320,7 +256,6 @@ export function MessageList({
           behavior="auto"
           variant="secondary"
           size="sm"
-          onClick={snapToTail}
           className="bottom-4 h-8 w-auto gap-1.5 rounded-full border border-border bg-card px-3.5 text-[11.5px] font-semibold text-muted-foreground shadow-lg hover:bg-card hover:text-foreground"
         >
           Jump to latest
@@ -328,17 +263,8 @@ export function MessageList({
         </MessageScrollerButton>
       </MessageScroller>
     </MessageScrollerProvider>
-    </div>
   );
 }
-
-/** Layout-transparent wrapper so the tail-snap logic can reach the
- *  scroller viewport without adding a real box to the flex chain. */
-const SHELL_STYLE: CSSProperties = { display: "contents" };
-
-/** Distance from the bottom (px) still counted as "pinned to the tail"
- *  — matches the pre-redesign transcript contract. */
-const PIN_THRESHOLD_PX = 80;
 
 /** Viewport edge fade (design `wsFade`): dissolve content at the top/bottom
  *  of the scroll surface. A mask, not an overlay, so it works over any

--- a/src/components/ui/message-scroller.tsx
+++ b/src/components/ui/message-scroller.tsx
@@ -40,7 +40,7 @@ function MessageScrollerViewport({
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
+        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content [overflow-anchor:none] [scrollbar-gutter:stable] data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
         className
       )}
       {...props}


### PR DESCRIPTION
## Problem

With Agent Chat enabled, scrolling up/down in a long thread glitched — the viewport jumped up and down instead of scrolling smoothly.

## Root cause

Two competing auto-scroll systems were writing to the same transcript viewport:

1. **The shadcn MessageScroller engine** (`autoScroll` on the provider) — its `following-bottom` state machine re-scrolls to the end on every ResizeObserver/MutationObserver content change, with an **8px** at-bottom threshold, gesture-based unpin, and a programmatic-scroll guard.
2. **MessageList's hand-rolled stick-to-bottom** — direct `scrollTop = scrollHeight` writes on every streaming token with an **80px** threshold, plus a 20-frame rAF settle loop on mount.

In the 8–80px-from-bottom band the two disagreed about whether the reader was pinned: one snapped the viewport down while the other held position — the visible jitter. Native browser scroll anchoring (never disabled) and `content-visibility: auto` estimated row heights added further correction actors.

This mirrors how other agent-chat UIs solved the same bug: they enforce a **single scroll owner** and explicitly set `overflow-anchor: none` on the chat timeline so nothing fights the programmatic follow.

## Fix

- **MessageList.tsx** — delete the manual scroll machinery (`snapToTail`, mount settle loop, `pinnedRef` scroll listener, per-token snap effect, `PIN_THRESHOLD_PX`). The engine is now the single stick-to-bottom owner. Jump-to-latest uses the engine's own `scrollToEnd` (which also re-enters `following-bottom`).
- **message-scroller.tsx** — add `[overflow-anchor:none]` (native anchoring can no longer fight the engine) and `[scrollbar-gutter:stable]` (no width reflow when the scrollbar toggles) to the viewport.
- Doc-comment corrections in `ChatTranscript.tsx` (stale "virtualized" wording) and `docs/features/agent-chat.md`.

Net: **−109/+41 lines.** The left MessageTrail turn rail and the regular right scrollbar are untouched.

## Verification

- `npm run check` ✅
- `npm run test` ✅ (162 files / 2,320 tests)
- Live browser probes against the 220-turn seeded transcript (~87,000px scroll height):
  - Opens landing exactly at the tail (0px off) without the old settle loop
  - Resting mid-thread: 0px drift over 1.5s
  - Wheel-scrolling up: perfectly monotonic, no downward yanks — including in the former 8–80px glitch band
  - Simulated streaming growth while pinned: follows every step, stays at 0px
  - Scrolled up while content grows: position holds exactly (no yank); scrolling back to bottom re-pins and follows again
  - Jump-to-latest lands at exactly 0px from bottom