### PR TITLE
Docked live subagent activity bar for Agent Chat

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -431,7 +431,10 @@ turn — see [Sidebar status indicators](#sidebar-status-indicators).
   activity line while running / muted result when done, mono
   `elapsed · N tools` meta, Enter button, chevron), an inline "Recent
   activity" peek (last 3 child tool rows + "Enter subagent"), and the
-  footer note.
+  footer note. The card root carries `data-subagent-card={item.id}` so
+  the docked activity bar (below) can locate + scroll to + flash-
+  highlight it by plain DOM query — no prop plumbing through
+  `MessageList`/`ChatTranscript` needed.
 - `SubagentView.tsx` + `SubagentBreadcrumb.tsx` — the read-only drill-in:
   a `← Orchestrator › ⟨ordinal⟩ Name` breadcrumb with model chip and
   right-aligned blinking status, a tone-tinted read-only banner, the
@@ -441,11 +444,59 @@ turn — see [Sidebar status indicators](#sidebar-status-indicators).
   state; entering swaps the transcript body and the sub-header for the
   breadcrumb, Esc / back returns, and the composer stays parent-bound
   with the placeholder "Steering goes to the orchestrator…".
-  `AgentChatPaneHeader.tsx` shows an amber blinking "N subagents running"
-  pill while any subagent runs. All tones consume design-system tokens
-  (running = `status-working`, completed = `status-open`, failed =
-  `status-attention`); `.cm-blink` in `globals.css` honors
-  reduced-motion.
+
+### Docked live activity bar (`SubagentActivityBar.tsx`)
+
+Replaces the old pane-header / title-bar "N subagents running" pills
+(removed — they read as a broken tab strip entry once the drill-in and
+orchestration card already say the same thing). One docked bar per
+thread, mounted in `AgentChatPane.tsx` between the transcript and the
+composer, hidden while `enteredSubagentId` is set (design: the bar only
+shows in the conversation view) and rendered as `null` entirely while
+idle — no resting state.
+
+- **Whole-thread rollup.** `runningSubagentEntries` (`subagents.ts`)
+  flattens every `running`/`pending` subagent across **every**
+  `subagent_run` card in the thread, tagging each with its card id and a
+  `from task N` label (omitted when the thread has only one card — there
+  is nothing to disambiguate). The bar's count and expand-list both key
+  off this list, so scattered work from different replies still reads as
+  one signal.
+- **1 running** → the whole bar is one click target labelled "View";
+  clicking jumps straight to that subagent's card.
+- **>1 running** → the action chip reads "Show all" / "Hide" with a
+  rotating caret; clicking the bar toggles an expand list that opens
+  upward (`rise-in` class) above the bar: a header
+  ("N subagents running · across this thread · tap one to jump") and one
+  row per running subagent (spinner, name, shimmering activity, mono
+  elapsed, `from <label>`, chevron) — clicking a row collapses the list
+  and jumps to that subagent's card.
+- **Just finished** (the running count is observed transitioning from
+  `>0` to `0` — never on initial mount or a thread hydrate): the bar
+  flashes green for ~2.5s (check icon, "Subagents finished", muted mono
+  "all tasks complete · results are in the thread"), then unmounts. The
+  flash is itself clickable (design gallery "Jump" CTA): it jumps to the
+  card of the last subagent that was still running before the
+  transition.
+- **Jump + highlight.** `AgentChatPane.tsx`'s `handleJumpToSubagentCard`
+  queries the pane's own DOM subtree (via a `paneRootRef`, so split panes
+  each jump within their own transcript) for
+  `[data-slot="message-scroller-viewport"]` and the target
+  `[data-subagent-card]`, applies the `subagent-card-highlight` class
+  (ember `box-shadow` ring, ~1100ms, token-driven per the design-system
+  no-hardcoded-color rule) via plain `classList`, and runs a bounded rAF
+  correction loop (mirroring `MessageTrail.tsx`'s own jump — `content-
+  visibility:auto` rows only expose estimated heights until they render)
+  to settle the scroll position. Plain DOM query works because
+  `MessageList` renders every slot (no windowing — see "Transcript
+  scroller" above), so the target node always exists even off-screen.
+  The bar itself never touches the DOM directly — it calls the `onJump`
+  callback prop and lets the pane do the query, since the bar is mounted
+  outside the `MessageScroller` provider tree.
+- All tones consume design-system tokens (running = `status-working`,
+  finished flash = `status-open`, highlight ring = `accent-ember`); the
+  top-edge sweep animation (`cm-sweep` in `globals.css`) and `.cm-blink`
+  (still used by the breadcrumb's status dot) honor reduced-motion.
 
 The dev mock seeds one subagent turn in the demo transcript and exposes
 `window.__codemuxChatMock.streamSubagents()` for a live two-subagent
@@ -849,8 +900,10 @@ lives in `ChatHomeLanding.tsx`.
 **GUI chrome suppression.** When the Beta flag is on and the chat pane is
 the **sole root** of its surface (not a split), `AgentChatPaneHeader` does
 NOT render — the title bar absorbs the tab, its session-history dropdown,
-close, "Restore checkpoint", and the "N subagents running" pill (`PaneNode`
-gates on `isSurfaceRoot`). In split layouts the per-pane header still
+close, and "Restore checkpoint" (`PaneNode` gates on `isSurfaceRoot`);
+subagent status now lives in the docked activity bar (see "Docked live
+activity bar" above), not either header, so there is no "N subagents
+running" pill left to absorb. In split layouts the per-pane header still
 renders, so split/close/drag keep working. The session-switch orchestration
 (stop → hydrate → resume), the checkpoint-restore state, and the grouped
 session list were extracted into shared pieces so the legacy per-pane header

--- a/docs/features/gui-chrome.md
+++ b/docs/features/gui-chrome.md
@@ -44,8 +44,10 @@ sidebar boundary so tabs start where the content pane starts (design:
   workspace's backend-owned tabs as compact pills (h-7, rounded-lg) with a
   per-tab status dot (highest-priority `pane_statuses` across the tab's panes),
   a chat-bubble / terminal / kind icon, and a hover/active-revealed close `X`.
-  The **active chat tab** grows a chevron opening the session-history dropdown
-  and renders the live "N subagents running" pill inline beside it.
+  The **active chat tab** grows a chevron opening the session-history dropdown.
+  (The inline "N subagents running" pill that used to ride beside it was
+  removed in favor of the docked `SubagentActivityBar` above the composer —
+  see `docs/features/agent-chat.md` "Docked live activity bar".)
   Activation/close route through the existing `activateTab` / `closeTab`
   commands. Pills cap at `max-w-[130px]` and the strip scrolls
   horizontally (wheel → horizontal translation, hidden scrollbar) instead
@@ -93,8 +95,11 @@ titlebar tab share one implementation (see "Important Touch Points").
   run-start checkpoint exists).
 - `+` launcher covering GUI chat presets, CLI agents (with Shift-split),
   Terminal/Browser panes, and Manage presets.
-- Inline ember chat favorite; rehomed right-panel toggle + RunButton; the "N
-  subagents running" status pill kept alive next to the active chat tab.
+- Inline ember chat favorite; rehomed right-panel toggle + RunButton. (The
+  "N subagents running" status pill that originally rehomed next to the
+  active chat tab was later removed — subagent status now lives in the
+  docked `SubagentActivityBar` above the composer; see
+  `docs/features/agent-chat.md` "Docked live activity bar".)
 - Tab drag-reorder via a pointer-based drag (pointerdown on a pill body +
   ~5px movement threshold → drag mode, drop index computed from tab
   midpoints, same `reorder_tabs` backend command and insertion-indicator

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -562,6 +562,25 @@ describe("AgentChatPane subagent drill-in (viewMode swap)", () => {
     expect(container.querySelector('[data-testid="transcript"]')).toBeNull();
     expect(container.querySelector('[data-testid="composer"]')).not.toBeNull();
   });
+
+  it("hides the docked subagent activity bar while drilled into a subagent, and shows it again on Esc", () => {
+    const { container } = render(<AgentChatPane pane={pane} />);
+    // Orchestrator mode: one live subagent — the bar is up.
+    expect(
+      container.querySelector('[data-testid="subagent-activity-bar"]'),
+    ).not.toBeNull();
+
+    fireEvent.click(container.querySelector('[data-testid="enter-subagent"]')!);
+    // Design: the docked bar only shows in the conversation view.
+    expect(
+      container.querySelector('[data-testid="subagent-activity-bar"]'),
+    ).toBeNull();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(
+      container.querySelector('[data-testid="subagent-activity-bar"]'),
+    ).not.toBeNull();
+  });
 });
 
 describe("AgentChatPane hydrate-on-mount (workspace swap recovery)", () => {

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -92,6 +92,7 @@ import type {
 import { ChatTranscript } from "./ChatTranscript";
 import { ChatHomeLanding } from "./ChatHomeLanding";
 import { Composer } from "./Composer";
+import { SubagentActivityBar } from "./SubagentActivityBar";
 import { SubagentBreadcrumb } from "./SubagentBreadcrumb";
 import { SubagentView } from "./SubagentView";
 import { DebugCleanupBanner } from "./DebugCleanupBanner";
@@ -163,6 +164,19 @@ export function detectAnimatedGif(buffer: ArrayBuffer): boolean {
   }
   return false;
 }
+
+// Jump-to-card correction-loop tuning for the docked SubagentActivityBar
+// (see `handleJumpToSubagentCard` below). Mirrors MessageTrail.tsx's own
+// jump constants: `content-visibility:auto` rows only expose estimated
+// heights until they render, so a single scrollTop computation can land
+// off; a few corrective rAF passes converge on the real offset.
+const JUMP_SCROLL_MARGIN_PX = 16;
+const JUMP_SETTLE_TOLERANCE_PX = 2;
+const JUMP_SETTLE_STABLE_FRAMES = 3;
+const JUMP_SETTLE_MAX_FRAMES = 40;
+/** How long the ember ring highlight stays on a jumped-to card (design:
+ *  "flashes `box-shadow` ... for ~1100ms"). */
+const JUMP_HIGHLIGHT_MS = 1100;
 
 export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   const initialProvider: AgentChatProviderKind = pane.provider ?? "claude";
@@ -463,6 +477,101 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [enteredSubagentId]);
+  // Scoped to this pane's own subtree (not `document`) so split panes each
+  // jump within their own transcript. Plain DOM query rather than the
+  // MessageScroller engine's `scrollToMessage`: the docked bar lives
+  // outside the scroller's provider tree, and MessageList renders every
+  // slot (no windowing — see docs/features/agent-chat.md "Transcript
+  // scroller"), so a direct query by `data-subagent-card` always finds the
+  // node.
+  const paneRootRef = useRef<HTMLDivElement>(null);
+  // Live handles for an in-flight jump (rAF settle loop + highlight
+  // timeout), cancelled on a re-jump, a thread switch, and unmount — the
+  // same hygiene as MessageList's / MessageTrail's own settle loops.
+  const jumpFrameRef = useRef<number | null>(null);
+  const jumpHighlightRef = useRef<{
+    timer: number;
+    card: HTMLElement;
+  } | null>(null);
+  const cancelJump = useCallback(() => {
+    if (jumpFrameRef.current != null) {
+      cancelAnimationFrame(jumpFrameRef.current);
+      jumpFrameRef.current = null;
+    }
+    if (jumpHighlightRef.current != null) {
+      window.clearTimeout(jumpHighlightRef.current.timer);
+      jumpHighlightRef.current.card.classList.remove(
+        "subagent-card-highlight",
+      );
+      jumpHighlightRef.current = null;
+    }
+  }, []);
+  // Cleanup-only effect: cancels any in-flight jump when the thread
+  // changes and on unmount.
+  useEffect(() => cancelJump, [cancelJump, threadId]);
+  const handleJumpToSubagentCard = useCallback(
+    (cardId: string) => {
+      const root = paneRootRef.current;
+      if (!root) return;
+      const viewport = root.querySelector<HTMLElement>(
+        '[data-slot="message-scroller-viewport"]',
+      );
+      if (!viewport) return;
+      const findCard = () => {
+        const nodes = viewport.querySelectorAll<HTMLElement>(
+          "[data-subagent-card]",
+        );
+        for (const node of Array.from(nodes)) {
+          if (node.dataset.subagentCard === cardId) return node;
+        }
+        return null;
+      };
+      let card = findCard();
+      if (!card) return;
+
+      // A jump already in flight (or a lingering highlight on another
+      // card) is superseded by this one.
+      cancelJump();
+
+      card.classList.add("subagent-card-highlight");
+      jumpHighlightRef.current = {
+        card,
+        timer: window.setTimeout(() => {
+          jumpHighlightRef.current?.card.classList.remove(
+            "subagent-card-highlight",
+          );
+          jumpHighlightRef.current = null;
+        }, JUMP_HIGHLIGHT_MS),
+      };
+
+      let frames = 0;
+      let stableFrames = 0;
+      const settle = () => {
+        jumpFrameRef.current = null;
+        if (!card?.isConnected) card = findCard();
+        if (!card) return;
+        const top =
+          card.getBoundingClientRect().top -
+          viewport.getBoundingClientRect().top;
+        const delta = top - JUMP_SCROLL_MARGIN_PX;
+        if (Math.abs(delta) > JUMP_SETTLE_TOLERANCE_PX) {
+          viewport.scrollTop += delta;
+          stableFrames = 0;
+        } else {
+          stableFrames += 1;
+        }
+        frames += 1;
+        if (
+          stableFrames < JUMP_SETTLE_STABLE_FRAMES &&
+          frames < JUMP_SETTLE_MAX_FRAMES
+        ) {
+          jumpFrameRef.current = requestAnimationFrame(settle);
+        }
+      };
+      jumpFrameRef.current = requestAnimationFrame(settle);
+    },
+    [cancelJump],
+  );
   const activeTurnId = slice?.activeTurnId ?? null;
   const model = slice?.model ?? null;
   const permissionMode =
@@ -2284,7 +2393,10 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     ) : null;
 
   return (
-    <div className="flex h-full w-full flex-col bg-background">
+    <div
+      ref={paneRootRef}
+      className="flex h-full w-full flex-col bg-background"
+    >
       {messages.length === 0 ? (
         <ChatHomeLanding composer={composerEl} />
       ) : (
@@ -2318,6 +2430,19 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
               onEnterSubagent={handleEnterSubagent}
               workspaceId={workspaceIdForPane}
             />
+          )}
+          {/* Docked live subagent activity bar (design "A living status,
+              docked by the composer"): one bar for the whole thread,
+              hidden while drilled into a subagent (the design only shows
+              it in the conversation view) and hidden entirely while idle. */}
+          {!enteredSubagent && (
+            <div className="px-7 pt-2.5">
+              <SubagentActivityBar
+                messages={messages}
+                threadId={threadId}
+                onJump={handleJumpToSubagentCard}
+              />
+            </div>
           )}
           {/* Composer region (design D10): a hairline lifts the whole
               composer column — AskUserQuestion panel, debug banner, and

--- a/src/components/chat/AgentChatPaneHeader.tsx
+++ b/src/components/chat/AgentChatPaneHeader.tsx
@@ -5,8 +5,6 @@ import { SessionSelector } from "@/components/chat/SessionSelector";
 import { Button } from "@/components/ui/button";
 import { useAgentChatCheckpointRestore } from "@/hooks/use-agent-chat-checkpoint-restore";
 import { useAgentChatSessionActions } from "@/hooks/use-agent-chat-session-actions";
-import { countRunningSubagents } from "@/lib/agent-chat/subagents";
-import { selectThread, useAgentChatStore } from "@/stores/agent-chat-store";
 import { findWorkspaceIdForPane, useAppStore } from "@/stores/app-store";
 import { closePane, splitPane } from "@/tauri/commands";
 import type { PaneNodeSnapshot } from "@/tauri/types";
@@ -52,14 +50,6 @@ export function AgentChatPaneHeader({ pane, isActive, onPointerDown }: Props) {
     restoring,
     handleRestoreConfirmed,
   } = useAgentChatCheckpointRestore(pane.thread_id ?? null);
-  // Orchestrator-mode pane sub-header pill: how many subagents are live
-  // in this thread right now. Store-driven off the reduced transcript
-  // (backend-state-driven), so it reflects hydrate + live events alike.
-  const runningSubagents = useAgentChatStore((s) => {
-    const slice = pane.thread_id ? selectThread(pane.thread_id)(s) : null;
-    return slice ? countRunningSubagents(slice.messages) : 0;
-  });
-
   const handleSplit = (direction: "horizontal" | "vertical") => {
     splitPane(pane.pane_id, direction).catch(console.error);
   };
@@ -94,20 +84,6 @@ export function AgentChatPaneHeader({ pane, isActive, onPointerDown }: Props) {
           <span className="px-1.5 text-xs text-muted-foreground">Agent Chat</span>
         )}
       </div>
-      {/* "N subagents running" pill (design) — amber, blinking dot,
-          always visible while any subagent in this thread is live. */}
-      {runningSubagents > 0 && (
-        <span
-          className="mr-1 inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold text-status-working"
-          data-testid="subagents-running-pill"
-        >
-          <span
-            className="cm-blink h-1.5 w-1.5 rounded-full bg-status-working"
-            aria-hidden
-          />
-          {runningSubagents} subagent{runningSubagents === 1 ? "" : "s"} running
-        </span>
-      )}
       {/* Match the muted-at-rest / lift-on-hover dialect the rest of
           the app's pane headers landed in c11a3fc + e96619e: 28px hit
           target, 14px glyph, drop close to destructive-foreground when

--- a/src/components/chat/SubagentActivityBar.test.tsx
+++ b/src/components/chat/SubagentActivityBar.test.tsx
@@ -1,0 +1,212 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { ChatViewItem, SubagentRunItem, SubagentView } from "@/lib/agent-chat/types";
+
+import { SubagentActivityBar } from "./SubagentActivityBar";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function subagent(overrides: Partial<SubagentView>): SubagentView {
+  return {
+    id: "s1",
+    name: "Subagent",
+    status: "running",
+    items: [],
+    toneIndex: 0,
+    ...overrides,
+  };
+}
+
+function card(id: string, subagents: SubagentView[]): SubagentRunItem {
+  return {
+    kind: "subagent_run",
+    id,
+    seq: 0,
+    turn_id: "t1",
+    subagents,
+  };
+}
+
+describe("SubagentActivityBar", () => {
+  it("renders nothing when no subagent is running", () => {
+    const messages: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", status: "completed" })]),
+    ];
+    const { container } = render(
+      <SubagentActivityBar messages={messages} threadId="t1" onJump={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("single running: shows the count + View, and clicking the bar jumps to its card", () => {
+    const onJump = vi.fn();
+    const messages: ChatViewItem[] = [
+      card("run-1", [
+        subagent({
+          id: "a",
+          name: "Verify",
+          status: "running",
+          activity: "reading diff for timing regressions…",
+        }),
+      ]),
+    ];
+    render(<SubagentActivityBar messages={messages} threadId="t1" onJump={onJump} />);
+
+    expect(screen.getByText("1 subagent running")).toBeInTheDocument();
+    expect(screen.getByText("View")).toBeInTheDocument();
+    expect(
+      screen.getByText("Verify · reading diff for timing regressions…"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("subagent-activity-bar"));
+    expect(onJump).toHaveBeenCalledWith("run-1");
+    // No expand list for a single running subagent.
+    expect(screen.queryByTestId("subagent-activity-bar-list")).toBeNull();
+  });
+
+  it("multi running: shows the count + Show all, toggles the expand list, and a row jump collapses + fires with its own card id", () => {
+    const onJump = vi.fn();
+    const messages: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", name: "Explore", status: "running" })]),
+      card("run-2", [subagent({ id: "b", name: "Implement", status: "running" })]),
+    ];
+    render(<SubagentActivityBar messages={messages} threadId="t1" onJump={onJump} />);
+
+    expect(screen.getByText("2 subagents running")).toBeInTheDocument();
+    expect(screen.getByText("Show all")).toBeInTheDocument();
+    expect(screen.queryByTestId("subagent-activity-bar-list")).toBeNull();
+    expect(screen.getByTestId("subagent-activity-bar")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+
+    fireEvent.click(screen.getByTestId("subagent-activity-bar"));
+    expect(screen.getByTestId("subagent-activity-bar-list")).toBeInTheDocument();
+    expect(screen.getByText("Hide")).toBeInTheDocument();
+    expect(screen.getByTestId("subagent-activity-bar")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    // Two-card thread: rows carry a from-label to disambiguate.
+    expect(screen.getByText("from task 1")).toBeInTheDocument();
+    expect(screen.getByText("from task 2")).toBeInTheDocument();
+
+    const rows = screen.getAllByTestId("subagent-activity-bar-row");
+    expect(rows).toHaveLength(2);
+    fireEvent.click(rows[1]);
+
+    expect(onJump).toHaveBeenCalledWith("run-2");
+    // Collapses back after a row jump.
+    expect(screen.queryByTestId("subagent-activity-bar-list")).toBeNull();
+  });
+
+  it("does not auto-reopen the list when the count dips to 1 and climbs back (stale open reset)", () => {
+    const two: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", name: "Explore", status: "running" })]),
+      card("run-2", [subagent({ id: "b", name: "Implement", status: "running" })]),
+    ];
+    const one: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", name: "Explore", status: "completed" })]),
+      card("run-2", [subagent({ id: "b", name: "Implement", status: "running" })]),
+    ];
+    const twoAgain: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", name: "Explore", status: "completed" })]),
+      card("run-2", [subagent({ id: "b", name: "Implement", status: "running" })]),
+      card("run-3", [subagent({ id: "c", name: "Verify", status: "running" })]),
+    ];
+    const { rerender } = render(
+      <SubagentActivityBar messages={two} threadId="t1" onJump={() => {}} />,
+    );
+
+    // Open the expand list while two are running.
+    fireEvent.click(screen.getByTestId("subagent-activity-bar"));
+    expect(screen.getByTestId("subagent-activity-bar-list")).toBeInTheDocument();
+
+    // One finishes: single-running state, list hidden by design.
+    rerender(
+      <SubagentActivityBar messages={one} threadId="t1" onJump={() => {}} />,
+    );
+    expect(screen.queryByTestId("subagent-activity-bar-list")).toBeNull();
+
+    // A new subagent starts (back to 2): the list must NOT pop open with
+    // no click — the stale `open` was reset on the multi → single drop.
+    rerender(
+      <SubagentActivityBar messages={twoAgain} threadId="t1" onJump={() => {}} />,
+    );
+    expect(screen.queryByTestId("subagent-activity-bar-list")).toBeNull();
+    expect(screen.getByText("Show all")).toBeInTheDocument();
+  });
+
+  it("flashes green then disappears when the running count transitions to zero, and the flash is a clickable jump", () => {
+    vi.useFakeTimers();
+    const onJump = vi.fn();
+    const running: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", status: "running" })]),
+    ];
+    const finished: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", status: "completed" })]),
+    ];
+    const { rerender, queryByTestId, getByTestId } = render(
+      <SubagentActivityBar messages={running} threadId="t1" onJump={onJump} />,
+    );
+    expect(getByTestId("subagent-activity-bar")).toHaveAttribute(
+      "data-tone",
+      "running",
+    );
+
+    rerender(
+      <SubagentActivityBar messages={finished} threadId="t1" onJump={onJump} />,
+    );
+    expect(getByTestId("subagent-activity-bar")).toHaveAttribute(
+      "data-tone",
+      "finished",
+    );
+    expect(screen.getByText("Subagents finished")).toBeInTheDocument();
+    expect(
+      screen.getByText("all tasks complete · results are in the thread"),
+    ).toBeInTheDocument();
+
+    // Design gallery gives the finished state a "Jump" CTA: clicking the
+    // green flash jumps to the card of the last subagent that finished.
+    fireEvent.click(getByTestId("subagent-activity-bar"));
+    expect(onJump).toHaveBeenCalledWith("run-1");
+
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
+    expect(queryByTestId("subagent-activity-bar")).toBeNull();
+  });
+
+  it("does not flash on initial mount / thread hydrate even when the thread has no running subagents", () => {
+    const messages: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", status: "completed" })]),
+    ];
+    render(<SubagentActivityBar messages={messages} threadId="t1" onJump={() => {}} />);
+    expect(screen.queryByTestId("subagent-activity-bar")).toBeNull();
+    expect(screen.queryByText("Subagents finished")).toBeNull();
+  });
+
+  it("does not flash when switching to a different thread with zero running subagents", () => {
+    const runningThreadA: ChatViewItem[] = [
+      card("run-1", [subagent({ id: "a", status: "running" })]),
+    ];
+    const idleThreadB: ChatViewItem[] = [
+      card("run-2", [subagent({ id: "b", status: "completed" })]),
+    ];
+    const { rerender, queryByTestId } = render(
+      <SubagentActivityBar messages={runningThreadA} threadId="thread-a" onJump={() => {}} />,
+    );
+    expect(queryByTestId("subagent-activity-bar")).not.toBeNull();
+
+    rerender(
+      <SubagentActivityBar messages={idleThreadB} threadId="thread-b" onJump={() => {}} />,
+    );
+    // Different thread — this is a hydrate, not an observed transition.
+    expect(queryByTestId("subagent-activity-bar")).toBeNull();
+  });
+});

--- a/src/components/chat/SubagentActivityBar.tsx
+++ b/src/components/chat/SubagentActivityBar.tsx
@@ -1,0 +1,328 @@
+import { Check, ChevronDown, ChevronRight, LoaderCircle } from "lucide-react";
+import { memo, useEffect, useId, useRef, useState } from "react";
+
+import {
+  formatElapsed,
+  runningSubagentEntries,
+  subagentActivityLine,
+  subagentElapsedMs,
+  type RunningSubagentEntry,
+} from "@/lib/agent-chat/subagents";
+import type { ChatViewItem } from "@/lib/agent-chat/types";
+import { cn } from "@/lib/utils";
+
+/** How long the green "just finished" flash stays up before the bar
+ *  disappears entirely (design "for ~2.5s, then disappears"). */
+const FINISHED_FLASH_MS = 2500;
+
+/**
+ * Docked live subagent activity bar (design "A living status, docked by
+ * the composer"). One bar for the whole thread: counts every live
+ * (running|pending) subagent across every `subagent_run` card, no matter
+ * which reply spawned it. Mounted between the transcript and the
+ * composer; renders nothing while idle — no resting state, and this
+ * replaces the old pane-header / title-bar "N subagents running" pills
+ * (design note: "no tab-strip pill... looks like a broken tab").
+ *
+ * - 1 running -> action chip is "View"; clicking the bar jumps straight
+ *   to that subagent's card.
+ * - >1 running -> action chip is "Show all" / "Hide"; clicking the bar
+ *   toggles an expand list (opens upward) with one row per running
+ *   subagent, each jumping to its own card.
+ * - Just finished (running count observed transitioning >0 -> 0): the
+ *   bar flashes green for {@link FINISHED_FLASH_MS}, then unmounts.
+ *   The flash itself is clickable (design gallery "Jump" CTA) and jumps
+ *   to the card of the last subagent that was still running.
+ *
+ * Self-contained: owns its own open/finished-flash state and the 1s
+ * elapsed-time tick. The actual transcript scroll + highlight is done by
+ * the caller (`onJump`) since that requires DOM access scoped to the
+ * owning pane (see `AgentChatPane.tsx`'s jump handler).
+ */
+export const SubagentActivityBar = memo(function SubagentActivityBar({
+  messages,
+  threadId,
+  onJump,
+}: {
+  messages: ChatViewItem[];
+  threadId: string | null;
+  onJump: (cardId: string) => void;
+}) {
+  const entries = runningSubagentEntries(messages);
+  const count = entries.length;
+  const now = useNow(count > 0);
+
+  const listId = useId();
+  const [open, setOpen] = useState(false);
+  const [finishedFlash, setFinishedFlash] = useState(false);
+  const prevCountRef = useRef(count);
+  const prevThreadRef = useRef(threadId);
+  // Card of the most recent still-running subagent, captured every render
+  // while anything runs — by the time the >0 → 0 transition is observed,
+  // `entries` is already empty, so this ref is what the finished flash's
+  // "jump" click targets (the design gallery gives the finished state a
+  // Jump CTA).
+  const lastRunningCardIdRef = useRef<string | null>(null);
+  if (count > 0) {
+    lastRunningCardIdRef.current = entries[entries.length - 1].cardId;
+  }
+
+  useEffect(() => {
+    // A thread switch is not an "observed transition" — reset silently so
+    // hydrating into a thread that happens to have zero running subagents
+    // never flashes green (design: "No flash on initial mount/thread
+    // hydrate, only on an observed transition").
+    if (threadId !== prevThreadRef.current) {
+      prevThreadRef.current = threadId;
+      prevCountRef.current = count;
+      lastRunningCardIdRef.current = null;
+      setFinishedFlash(false);
+      setOpen(false);
+      return;
+    }
+
+    const wasRunning = prevCountRef.current > 0;
+    prevCountRef.current = count;
+
+    if (wasRunning && count === 0) {
+      setFinishedFlash(true);
+      const timer = window.setTimeout(() => {
+        setFinishedFlash(false);
+      }, FINISHED_FLASH_MS);
+      return () => window.clearTimeout(timer);
+    }
+
+    // The expand list only exists in the multi (>1) state. Reset `open`
+    // whenever the count falls out of it — otherwise a stale `open=true`
+    // (list open → one finishes → another starts) would pop the list back
+    // open with no click.
+    if (count <= 1) setOpen(false);
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deliberately
+    // keyed only on count/threadId; prevCountRef/prevThreadRef are refs.
+  }, [count, threadId]);
+
+  if (count === 0 && !finishedFlash) return null;
+
+  if (count === 0 && finishedFlash) {
+    const finishedCardId = lastRunningCardIdRef.current;
+    const jumpToFinished = () => {
+      if (finishedCardId) onJump(finishedCardId);
+    };
+    return (
+      <div className="mx-auto w-full max-w-[760px]">
+        <div
+          data-testid="subagent-activity-bar"
+          data-tone="finished"
+          role="button"
+          tabIndex={0}
+          onClick={jumpToFinished}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              jumpToFinished();
+            }
+          }}
+          title="Jump to the Subagents card"
+          className="flex h-11 cursor-pointer items-center gap-2.5 rounded-xl border border-status-open/30 bg-status-open/10 px-3.5 hover:bg-status-open/[0.15]"
+        >
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+            <Check
+              className="h-[19px] w-[19px] text-status-open"
+              strokeWidth={1.8}
+              aria-hidden
+            />
+          </span>
+          <span className="shrink-0 whitespace-nowrap text-[12.5px] font-bold text-foreground">
+            Subagents finished
+          </span>
+          <span className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-muted-foreground">
+            all tasks complete · results are in the thread
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const multi = count > 1;
+  const primary = entries[0];
+  const primaryName =
+    primary.subagent.name ?? primary.subagent.agentType ?? "Subagent";
+  const primaryActivity = subagentActivityLine(primary.subagent);
+  const primaryElapsedMs = subagentElapsedMs(primary.subagent, now);
+
+  const handleBarClick = () => {
+    if (multi) {
+      setOpen((cur) => !cur);
+    } else {
+      onJump(primary.cardId);
+    }
+  };
+  const handleBarKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleBarClick();
+    }
+  };
+  const handleRowJump = (entry: RunningSubagentEntry) => {
+    setOpen(false);
+    onJump(entry.cardId);
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-[760px]">
+      {multi && open && (
+        <div
+          id={listId}
+          data-testid="subagent-activity-bar-list"
+          className="rise-in mb-2 overflow-hidden rounded-xl border border-border bg-popover shadow-lg"
+        >
+          <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2.5">
+            <span className="whitespace-nowrap text-[11.5px] font-bold text-foreground">
+              {count} subagents running
+            </span>
+            <span className="text-[11px] text-muted-foreground">
+              across this thread · tap one to jump
+            </span>
+          </div>
+          <div className="p-1.5">
+            {entries.map((entry) => (
+              <SubagentActivityBarRow
+                key={entry.subagent.id}
+                entry={entry}
+                now={now}
+                onJump={() => handleRowJump(entry)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div
+        data-testid="subagent-activity-bar"
+        data-tone="running"
+        role="button"
+        tabIndex={0}
+        aria-expanded={multi ? open : undefined}
+        aria-controls={multi && open ? listId : undefined}
+        onClick={handleBarClick}
+        onKeyDown={handleBarKeyDown}
+        title={
+          multi ? "Show all running subagents" : "Jump to the Subagents card"
+        }
+        className="relative flex h-11 cursor-pointer items-center gap-2.5 overflow-hidden rounded-xl border border-status-working/30 bg-status-working/10 py-0 pl-3.5 pr-1.5 hover:bg-status-working/[0.15]"
+      >
+        <div className="absolute inset-x-0 top-0 h-0.5 overflow-hidden bg-status-working/15">
+          <div className="cm-sweep absolute top-0 h-0.5 w-[38%] rounded-full bg-status-working" />
+        </div>
+        <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+          <LoaderCircle
+            className="h-[17px] w-[17px] animate-spin text-status-working"
+            strokeWidth={1.9}
+            aria-hidden
+          />
+        </span>
+        <span className="shrink-0 whitespace-nowrap text-[12.5px] font-bold text-foreground">
+          {count} subagent{count === 1 ? "" : "s"} running
+        </span>
+        <span
+          className="h-[3px] w-[3px] shrink-0 rounded-full bg-muted-foreground"
+          aria-hidden
+        />
+        <span className="shimmer min-w-0 flex-1 truncate font-mono text-[11.5px]">
+          {primaryName} · {primaryActivity}
+        </span>
+        <span className="shrink-0 whitespace-nowrap font-mono text-[10.5px] text-muted-foreground">
+          {primaryElapsedMs != null ? formatElapsed(primaryElapsedMs) : ""}
+        </span>
+        <span className="flex h-[30px] shrink-0 items-center gap-1.5 rounded-lg bg-foreground/[0.08] px-2.5 text-[11px] font-semibold text-muted-foreground">
+          {multi ? (open ? "Hide" : "Show all") : "View"}
+          {multi ? (
+            <ChevronDown
+              className={cn(
+                "h-3 w-3 transition-transform",
+                open && "rotate-180",
+              )}
+              strokeWidth={1.8}
+              aria-hidden
+            />
+          ) : (
+            <ChevronRight className="h-3 w-3" strokeWidth={1.8} aria-hidden />
+          )}
+        </span>
+      </div>
+    </div>
+  );
+});
+
+function SubagentActivityBarRow({
+  entry,
+  now,
+  onJump,
+}: {
+  entry: RunningSubagentEntry;
+  now: number;
+  onJump: () => void;
+}) {
+  const { subagent, fromLabel } = entry;
+  const name = subagent.name ?? subagent.agentType ?? "Subagent";
+  const activity = subagentActivityLine(subagent);
+  const elapsedMs = subagentElapsedMs(subagent, now);
+
+  return (
+    <div
+      data-testid="subagent-activity-bar-row"
+      data-subagent-id={subagent.id}
+      role="button"
+      tabIndex={0}
+      onClick={onJump}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onJump();
+        }
+      }}
+      className="flex cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 hover:bg-foreground/[0.06]"
+    >
+      <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center">
+        <LoaderCircle
+          className="h-[15px] w-[15px] animate-spin text-status-working"
+          strokeWidth={1.9}
+          aria-hidden
+        />
+      </span>
+      <span className="w-20 shrink-0 truncate text-[12px] font-bold text-foreground">
+        {name}
+      </span>
+      <span className="shimmer min-w-0 flex-1 truncate font-mono text-[11px]">
+        {activity}
+      </span>
+      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+        {elapsedMs != null ? formatElapsed(elapsedMs) : ""}
+      </span>
+      {fromLabel && (
+        <span className="shrink-0 text-[10px] font-semibold text-muted-foreground">
+          from {fromLabel}
+        </span>
+      )}
+      <ChevronRight
+        className="h-3 w-3 shrink-0 text-muted-foreground"
+        strokeWidth={1.7}
+        aria-hidden
+      />
+    </div>
+  );
+}
+
+/** 1s tick while `active`, so derived elapsed times advance without a
+ *  provider `duration_ms`. Frozen (no interval) when nothing is running.
+ *  Mirrors `SubagentsCard.tsx`'s local `useNow`. */
+function useNow(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [active]);
+  return now;
+}

--- a/src/components/chat/SubagentsCard.tsx
+++ b/src/components/chat/SubagentsCard.tsx
@@ -30,6 +30,11 @@ import { cn } from "@/lib/utils";
  * mutates only this card's `item` reference, so exactly this row
  * re-renders (issue #77 scroller contract preserved). A local 1s tick
  * refreshes the derived elapsed time while any subagent is running.
+ *
+ * The root carries `data-subagent-card={item.id}` so the docked
+ * {@link SubagentActivityBar} can locate + scroll to + flash-highlight
+ * this card by plain DOM query, without any new prop plumbing through
+ * MessageList/ChatTranscript.
  */
 export const SubagentsCard = memo(function SubagentsCard({
   item,
@@ -50,7 +55,10 @@ export const SubagentsCard = memo(function SubagentsCard({
   const activeCount = subs.filter((s) => isRunning(s)).length;
 
   return (
-    <div className="overflow-hidden rounded-[13px] border border-border bg-foreground/[0.025]">
+    <div
+      data-subagent-card={item.id}
+      className="overflow-hidden rounded-[13px] border border-border bg-foreground/[0.025]"
+    >
       {/* Aggregate header */}
       <div className="flex items-center gap-2.5 border-b border-border/60 px-3.5 py-3">
         <span className="flex h-5 w-5 shrink-0 items-center justify-center">

--- a/src/components/layout/title-bar-tabs.tsx
+++ b/src/components/layout/title-bar-tabs.tsx
@@ -25,10 +25,8 @@ import { PresetIcon } from "@/components/icons/preset-icon";
 import { StatusIndicator } from "@/components/ui/status-indicator";
 import { useAgentChatCheckpointRestore } from "@/hooks/use-agent-chat-checkpoint-restore";
 import { useAgentChatSessionActions } from "@/hooks/use-agent-chat-session-actions";
-import { countRunningSubagents } from "@/lib/agent-chat/subagents";
 import { getHighestPriorityStatus } from "@/lib/pane-status";
 import { cn } from "@/lib/utils";
-import { selectThread, useAgentChatStore } from "@/stores/agent-chat-store";
 import { useAppStore } from "@/stores/app-store";
 import { activateTab, closeTab, reorderTabs } from "@/tauri/commands";
 import type {
@@ -287,9 +285,11 @@ function useTabReorder(workspace: WorkspaceSnapshot) {
 /**
  * Workspace tabs merged into the title bar for GUI chrome. Each tab is a
  * compact pill; the active chat tab grows a chevron that opens the shared
- * session-history dropdown, and a live "N subagents running" pill rides
- * alongside it. Tabs stay backend-owned — activation/close/reorder go
- * through the existing commands. Reorder is a pointer-driven drag (see
+ * session-history dropdown. Live subagent status no longer rides an
+ * inline pill here — it lives in the docked `SubagentActivityBar` above
+ * the composer (see `docs/features/agent-chat.md` "Docked live activity
+ * bar"). Tabs stay backend-owned — activation/close/reorder go through
+ * the existing commands. Reorder is a pointer-driven drag (see
  * `useTabReorder` below) rather than the legacy TabBar's HTML5 DnD.
  */
 export function TitleBarTabs({ workspace }: TitleBarTabsProps) {
@@ -491,11 +491,6 @@ function ActiveChatTab({
     restoring,
     handleRestoreConfirmed,
   } = useAgentChatCheckpointRestore(pane.thread_id);
-  const runningSubagents = useAgentChatStore((s) => {
-    const slice = pane.thread_id ? selectThread(pane.thread_id)(s) : null;
-    return slice ? countRunningSubagents(slice.messages) : 0;
-  });
-
   const handleClose = (e: React.MouseEvent) => {
     e.stopPropagation();
     closeTab(workspaceId, tab.tab_id).catch(console.error);
@@ -567,21 +562,6 @@ function ActiveChatTab({
           <X className="h-3 w-3" />
         </button>
       </div>
-
-      {/* "N subagents running" — status signal that used to sit on the
-          pane sub-header; kept alive inline next to the active chat tab. */}
-      {runningSubagents > 0 && (
-        <span
-          className="inline-flex shrink-0 items-center gap-1.5 pl-0.5 text-[11px] font-semibold text-status-working"
-          data-testid="titlebar-subagents-pill"
-        >
-          <span
-            className="cm-blink h-1.5 w-1.5 rounded-full bg-status-working"
-            aria-hidden
-          />
-          {runningSubagents} subagent{runningSubagents === 1 ? "" : "s"} running
-        </span>
-      )}
 
       <RestoreCheckpointDialog
         open={confirmOpen}

--- a/src/globals.css
+++ b/src/globals.css
@@ -459,9 +459,12 @@ body.pane-resizing iframe {
   }
 }
 
-/* Blinking status dot for the "N subagents running" pill and the
- * subagent breadcrumb (design wsBlink). Opacity pulse only, so it reads
- * over any tint; honours reduced-motion. Apply via `cm-blink`. */
+/* Blinking status dot (design wsBlink) shared by several live-status
+ * indicators — the subagent breadcrumb, the background-browser chip, the
+ * right-panel tab, the workspace context bar. Formerly also used by the
+ * now-removed "N subagents running" pane-header / title-bar pills,
+ * replaced by the docked SubagentActivityBar. Opacity pulse only, so it
+ * reads over any tint; honours reduced-motion. Apply via `cm-blink`. */
 @keyframes cm-blink {
   0%,
   100% {
@@ -478,5 +481,38 @@ body.pane-resizing iframe {
   .cm-blink {
     animation: none;
   }
+}
+
+/* Top-edge "sweep" progress segment on the docked SubagentActivityBar
+ * (design wsSweep) — a thin bar-within-a-bar that slides left→right while
+ * any subagent runs, reading as ambient progress rather than a discrete
+ * loading percentage. Honours reduced-motion. Apply via `cm-sweep` to the
+ * absolutely-positioned inner segment (the outer track just clips it). */
+@keyframes cm-sweep {
+  0% {
+    left: -38%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+.cm-sweep {
+  animation: cm-sweep 1.7s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cm-sweep {
+    animation: none;
+  }
+}
+
+/* Temporary jump-highlight applied to a Subagents orchestration card
+ * when the docked SubagentActivityBar scrolls the transcript to it
+ * (design: ember ring flash, ~1100ms, added/removed by JS — see
+ * AgentChatPane's jump handler). Token-driven so it reads in both
+ * palettes; no keyframe needed since it's a single add/remove, but the
+ * transition softens the moment it's cleared. */
+.subagent-card-highlight {
+  box-shadow: 0 0 0 2px var(--accent-ember);
+  transition: box-shadow 0.3s ease;
 }
 

--- a/src/lib/agent-chat/subagents.test.ts
+++ b/src/lib/agent-chat/subagents.test.ts
@@ -11,6 +11,7 @@ import {
   mergeStatus,
   newSubagentView,
   recentToolCalls,
+  runningSubagentEntries,
   subagentActivityLine,
   subagentElapsedMs,
   subagentMetaLine,
@@ -216,5 +217,29 @@ describe("whole-thread lookups", () => {
     expect(toneIndexForId("abc")).toBe(toneIndexForId("abc"));
     expect(toneIndexForId("abc")).toBeGreaterThanOrEqual(0);
     expect(toneIndexForId("abc")).toBeLessThan(5);
+  });
+
+  it("flattens running subagents with no from-label when there is one card", () => {
+    const entries = runningSubagentEntries(messages);
+    expect(entries.map((e) => e.subagent.id)).toEqual(["a", "c"]);
+    expect(entries.every((e) => e.cardId === "run-1")).toBe(true);
+    expect(entries.every((e) => e.fromLabel === null)).toBe(true);
+  });
+
+  it("labels each running subagent with its originating card once several cards exist", () => {
+    const cardTwo: SubagentRunItem = {
+      kind: "subagent_run",
+      id: "run-2",
+      seq: 1,
+      turn_id: "t2",
+      subagents: [view({ id: "d", status: "running" })],
+    };
+    const multi: ChatViewItem[] = [...messages, cardTwo];
+    const entries = runningSubagentEntries(multi);
+    expect(entries.map((e) => [e.subagent.id, e.cardId, e.fromLabel])).toEqual([
+      ["a", "run-1", "task 1"],
+      ["c", "run-1", "task 1"],
+      ["d", "run-2", "task 2"],
+    ]);
   });
 });

--- a/src/lib/agent-chat/subagents.ts
+++ b/src/lib/agent-chat/subagents.ts
@@ -302,7 +302,7 @@ export function subagentRunItems(messages: ChatViewItem[]): SubagentRunItem[] {
 }
 
 /** Count of currently-running subagents across the whole thread — feeds
- *  the pane sub-header "N subagents running" pill. */
+ *  the docked {@link SubagentActivityBar}. */
 export function countRunningSubagents(messages: ChatViewItem[]): number {
   let n = 0;
   for (const card of subagentRunItems(messages)) {
@@ -333,4 +333,45 @@ export function subagentOrdinal(messages: ChatViewItem[], id: string): number {
     if (idx >= 0) return idx + 1;
   }
   return 0;
+}
+
+/** One currently-running subagent, flattened out of its card, with enough
+ *  context to render a docked-bar row and jump back to the card it came
+ *  from. */
+export interface RunningSubagentEntry {
+  subagent: SubagentView;
+  /** The `subagent_run` card id — the jump target (design "from
+   *  <reply>"). */
+  cardId: string;
+  /** 1-based position of the card among the thread's `subagent_run`
+   *  cards. */
+  cardIndex: number;
+  /** "task N" label for the expand-list row, or null when the thread has
+   *  only one card (the design allows omitting "from" in that case —
+   *  there is nothing to disambiguate). */
+  fromLabel: string | null;
+}
+
+/** Every currently-running subagent across every `subagent_run` card in
+ *  the thread, no matter which reply spawned it (design "one bar for the
+ *  whole thread"). Feeds the docked {@link SubagentActivityBar}: its
+ *  `.length` is the bar's count, and each entry carries the "from"
+ *  label + jump target for the expand list. */
+export function runningSubagentEntries(
+  messages: ChatViewItem[],
+): RunningSubagentEntry[] {
+  const cards = subagentRunItems(messages);
+  const entries: RunningSubagentEntry[] = [];
+  cards.forEach((card, cardIdx) => {
+    for (const sub of card.subagents) {
+      if (!isRunning(sub)) continue;
+      entries.push({
+        subagent: sub,
+        cardId: card.id,
+        cardIndex: cardIdx + 1,
+        fromLabel: cards.length > 1 ? `task ${cardIdx + 1}` : null,
+      });
+    }
+  });
+  return entries;
 }

--- a/src/lib/agent-chat/workflows.ts
+++ b/src/lib/agent-chat/workflows.ts
@@ -135,8 +135,11 @@ export function latestWorkflowRun(messages: ChatViewItem[]): WorkflowRunItem | n
 }
 
 /** Count of currently-running agents across every workflow run in the
- *  thread — feeds the pane sub-header pill alongside
- *  `countRunningSubagents`. */
+ *  thread — the workflow-side counterpart of `countRunningSubagents`.
+ *  (The pane sub-header pill both used to feed was removed in favor of
+ *  the docked `SubagentActivityBar`, which covers plain subagent runs;
+ *  workflow surfaces track their own status via `WorkflowRunCard` /
+ *  the Orchestration panel.) */
 export function countRunningWorkflowAgents(messages: ChatViewItem[]): number {
   let n = 0;
   for (const item of workflowRunItems(messages)) {


### PR DESCRIPTION
## Summary

Implements the new Subagents design revision (claude.ai/design `Subagents.dc.html`): subagent activity moves out of the tab-strip/header pills and into a **live activity bar docked above the composer**.

- **Thread-wide rollup** — the bar counts every running subagent across all Subagents cards in the thread, no matter which reply spawned it
- **One running** → "View" chip; clicking jumps to that subagent's card and flash-highlights it (ember ring, rAF settle pass for `content-visibility` rows)
- **Several running** → "Show all"/"Hide" toggles an upward expand list; each row shows spinner, name, shimmering live activity, elapsed, "from task N", and jumps to its card
- **Just finished** → green "Subagents finished" flash for ~2.5s (clickable, jumps to the last card), then the bar disappears — no resting state
- **Pills removed** — both the pane-header and title-bar "N subagents running" pills are replaced by the bar (design note: the tab-strip pill "looks like a broken tab")
- Hidden while drilled into a subagent; reappears on exit

## Implementation

- New `SubagentActivityBar.tsx` (self-contained, memoized), mounted in `AgentChatPane` between transcript and composer
- New `runningSubagentEntries()` pure helper in `subagents.ts`
- New `cm-sweep` keyframe + `.subagent-card-highlight` in `globals.css` — token-driven (`status-working`/`status-open`/`accent-ember`), `prefers-reduced-motion` guarded
- `SubagentsCard` gains only a `data-subagent-card` jump anchor; card/drill-in visuals untouched
- Docs updated: `agent-chat.md` subagent-view section, stale pill refs in `gui-chrome.md` and `workflows.ts`

## Testing

- `npm run check` — clean; `npm run test` — 163 files, 2330 tests passing
- New `SubagentActivityBar.test.tsx`: hidden-when-idle, single-running View+jump, multi-running toggle/rows/row-jump, `aria-expanded`, finished-flash (fake timers) incl. clickable jump, no-flash-on-mount/thread-switch, and a 2→1→2 stale-open regression
- Visually verified in the dev mock (`npm run dev` + browser pane): single/multi bar states, expand list, jump + ember highlight all match the design

## Notes

- Accepted deviations from the design mock: "from task N" labels (the wire model has no per-reply prose labels) and no recency sort for the collapsed bar's headline agent
- Multi-agent live-stream mock (`streamSubagents()`) doesn't deliver events in the sandboxed dev browser — pre-existing environment issue (also affects the untouched `streamReply()`); multi state verified via seed + unit tests