### PR TITLE
fix: stop worktree auto-naming from silently falling back to random names

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -976,8 +976,12 @@ sends the first message. The shared naming/creation helper is
 `createDeferredWorktree` (exported from
 `src/lib/agent-chat/materialize.ts`): name precedence is trimmed
 `worktreeName` verbatim → `generateBranchName(firstMessage,
-projectPath)` (the CLI's AI first-message naming) →
-`generateRandomBranchName(projectPath)` on error/empty, then
+projectPath)` (the CLI's AI first-message naming, backed by
+`branch_name.rs::generate_ai_name`; the underlying `claude --print` call
+is bounded by a 30s timeout, and any failure — spawn error, timeout,
+non-zero exit, empty output — is logged via `log::warn!` to the native
+log instead of failing silently) → `generateRandomBranchName(projectPath)`
+on error/empty, then
 `createWorktreeWorkspace` off the row's `baseBranch` with the `"empty"`
 layout. The two surfaces route it differently:
 

--- a/src-tauri/src/branch_name.rs
+++ b/src-tauri/src/branch_name.rs
@@ -119,10 +119,15 @@ pub async fn generate_ai_name(prompt: &str, repo_path: &Path) -> String {
     );
 
     // Try claude first
-    if let Some(name) = try_ai_cli("claude", &["--print"], &meta_prompt).await {
-        let sanitized = sanitize_branch_name(&name);
-        if !sanitized.is_empty() {
-            return deconflict_branch_name(&sanitized, repo_path);
+    match try_ai_cli("claude", &["--print"], &meta_prompt).await {
+        Ok(name) => {
+            let sanitized = sanitize_branch_name(&name);
+            if !sanitized.is_empty() {
+                return deconflict_branch_name(&sanitized, repo_path);
+            }
+        }
+        Err(reason) => {
+            log::warn!("AI branch naming failed, falling back to random name: {reason}");
         }
     }
 
@@ -130,14 +135,31 @@ pub async fn generate_ai_name(prompt: &str, repo_path: &Path) -> String {
     generate_random_name(repo_path)
 }
 
-async fn try_ai_cli(binary: &str, args: &[&str], prompt: &str) -> Option<String> {
+/// AI naming timeout. Warm `claude --print` calls measured at 5-9s on this
+/// machine; 30s gives real headroom for cold starts / network latency while
+/// still bounding a hung CLI (the child is killed on timeout, see
+/// `kill_on_drop` below).
+const AI_CLI_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Number of stderr bytes to keep in failure logs (claude CLI's error
+/// reasons are usually short; this avoids dumping huge output into logs).
+const STDERR_EXCERPT_LEN: usize = 200;
+
+/// Run an AI CLI with `prompt` on stdin. Returns the trimmed stdout on
+/// success, or `Err(reason)` describing why it failed (spawn error, timeout,
+/// non-zero exit, empty output) so callers can log a diagnosable reason.
+async fn try_ai_cli(binary: &str, args: &[&str], prompt: &str) -> Result<String, String> {
     let mut cmd = tokio::process::Command::new(binary);
     cmd.args(args);
     cmd.stdin(std::process::Stdio::piped());
     cmd.stdout(std::process::Stdio::piped());
-    cmd.stderr(std::process::Stdio::null());
+    cmd.stderr(std::process::Stdio::piped());
+    // Reap the child if we time out below, rather than leaking it.
+    cmd.kill_on_drop(true);
 
-    let mut child = cmd.spawn().ok()?;
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("failed to spawn `{binary}`: {e}"))?;
 
     // Write prompt to stdin
     if let Some(mut stdin) = child.stdin.take() {
@@ -146,15 +168,33 @@ async fn try_ai_cli(binary: &str, args: &[&str], prompt: &str) -> Option<String>
         drop(stdin);
     }
 
-    let result = tokio::time::timeout(Duration::from_secs(10), child.wait_with_output()).await;
+    let result = tokio::time::timeout(AI_CLI_TIMEOUT, child.wait_with_output()).await;
 
-    match result {
-        Ok(Ok(output)) if output.status.success() => {
-            let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if text.is_empty() { None } else { Some(text) }
+    let output = match result {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => return Err(format!("`{binary}` process error: {e}")),
+        Err(_) => {
+            return Err(format!(
+                "`{binary}` timed out after {}s",
+                AI_CLI_TIMEOUT.as_secs()
+            ));
         }
-        _ => None,
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let excerpt: String = stderr.trim().chars().take(STDERR_EXCERPT_LEN).collect();
+        return Err(format!(
+            "`{binary}` exited with {}: {excerpt}",
+            output.status
+        ));
     }
+
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() {
+        return Err(format!("`{binary}` produced empty output"));
+    }
+    Ok(text)
 }
 
 /// Escape a string for safe embedding in double-quoted shell arguments.
@@ -436,6 +476,22 @@ mod tests {
             "path\\\\\\nline2"
         );
         // bash $'path\\\\\\nline2' → path\ + newline + line2
+    }
+
+    #[tokio::test]
+    async fn try_ai_cli_reports_spawn_failure_reason() {
+        // No network/real-CLI dependency: this binary should never exist.
+        let result = try_ai_cli(
+            "codemux-definitely-not-a-real-binary",
+            &["--print"],
+            "prompt",
+        )
+        .await;
+        let err = result.expect_err("nonexistent binary must fail to spawn");
+        assert!(
+            err.contains("failed to spawn"),
+            "expected spawn-failure reason, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Leaving the worktree name empty on the Agent Chat first-send scope row is supposed to auto-derive the name from the first message ("like the CLI does" — Thread Scope, #142). In practice it frequently produced random adjective-noun names like `lazy-arch` instead.

## Root cause

`generate_ai_name` (`src-tauri/src/branch_name.rs`) shells out to `claude --print` with a **10s hard timeout**, but warm invocations already measure **5–9s** — any cold start or network latency exceeded the bound. On timeout (or any other failure) `try_ai_cli` returned `None` with stderr nulled and nothing logged, so the random fallback fired silently and the failure was undiagnosable.

## Fix

- Raise the AI-naming timeout to **30s** (`AI_CLI_TIMEOUT` const) — typical 5–9s calls now succeed with real headroom while still bounding a hung CLI
- Add `kill_on_drop(true)` so a timed-out `claude` child is reaped instead of leaking
- Capture stderr and restructure `try_ai_cli` to return reason-carrying errors: spawn failure, timeout (with duration), non-zero exit (with a 200-char stderr excerpt), empty output
- `generate_ai_name` logs the reason via `log::warn!` (routed by `tauri_plugin_log` to the native log / `codemux logs`) before falling back to the random name — public behavior unchanged: it always returns a usable name
- New unit test `try_ai_cli_reports_spawn_failure_reason` (no real CLI / network dependency)
- `docs/features/agent-chat.md` § Thread Scope updated to document the bound + logging

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml` — clean
- `cargo test --manifest-path src-tauri/Cargo.toml` — 1975 passed / 0 failed (38/38 in `branch_name`, incl. the new test)
- Frontend untouched (name-precedence logic in `materialize.ts` unchanged)