### PR TITLE
fix: launch deferred-worktree chat sessions in the worktree, restore Context Row issue chip

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -985,11 +985,12 @@ layout. The two surfaces route it differently:
   `worktreeProjectPath` (resolved by `DraftChatSurface`:
   `target.projectPath` for a `project` target, the resolved
   `existingWorkspaceProjectRoot` for `existing_workspace`); it creates
-  the worktree, re-resolves the pane/session cwd to the new worktree's
-  real cwd (read back from the app-store), and continues down the
-  existing create-pane → mark-materialized → seed-slice →
-  start-session → send-turn ordering (shared `thread_id` throughout, so
-  the first send can't hit `session_not_found`).
+  the worktree, resolves the pane/session cwd to the new worktree's real
+  cwd via `waitForWorkspaceCwd` (see the cwd-resolution invariant
+  below), and continues down the existing create-pane →
+  mark-materialized → seed-slice → start-session → send-turn ordering
+  (shared `thread_id` throughout, so the first send can't hit
+  `session_not_found`).
 - **Pane empty state** — `AgentChatPane`'s `handleDeferredWorktreeSubmit`
   intercepts the composer submit ONLY while `messages.length === 0 &&
   checkoutMode === "worktree"` (everything else stays on the unmodified
@@ -1004,10 +1005,32 @@ layout. The two surfaces route it differently:
   the turn; the chip UI stays behind and is cleared), appends the
   optimistic user bubble to the new thread, clears this pane's
   composer, and activates the new workspace. The stale GitHub-detail
-  re-fetch pass is deliberately skipped on this path. If the prestart
-  returns `null` (workspace not yet in the store), the text stays in
-  the old composer, a warning toast fires, and the new workspace is
-  activated anyway.
+  re-fetch pass is deliberately skipped on this path. `prestartWorktreeSession`
+  resolves its cwd via `waitForWorkspaceCwd` too, so it now succeeds on
+  first send instead of returning `null` on a routine store miss; it
+  keeps the `null` contract only for a genuine timeout, in which case
+  the text stays in the old composer, a warning toast fires, and the new
+  workspace is activated anyway.
+
+**CWD-resolution invariant.** A freshly-created worktree
+workspace only reaches the Zustand app-store via the async
+`app-state-changed` Tauri event, which has essentially never been
+processed by the time `create_worktree_workspace`'s `invoke` promise
+resolves. The previous synchronous read-back (`useAppStore.getState()`
+right after the invoke) therefore missed ~always and silently left the
+pane + agent session launching at the PARENT checkout cwd (the project
+root) — so agents committed into the user's real working copy. Both
+surfaces now share `waitForWorkspaceCwd(workspaceId, timeoutMs = 5000)`
+(`src/lib/agent-chat/wait-for-workspace-cwd.ts`): it awaits the
+workspace landing in the store with a non-empty `cwd`, racing the
+store subscription (`app-state-changed`) against a polled direct
+`get_app_state` fetch (written back into the store) so a
+dropped/reordered event can't strand it. **Hard invariant:** a
+`checkoutMode === "worktree"` submit must NEVER create the pane or start
+the session at the parent/project-root cwd — on timeout,
+`materializeAndSend` fails the send via `markSendFailed` (draft text
+preserved) rather than proceeding, and `prestartWorktreeSession` returns
+`null` (mount-effect fallback).
 
 `checkoutMode === "current"` (the default) is unchanged from before the
 redesign on both surfaces — no worktree, no new Tauri calls.
@@ -1092,6 +1115,13 @@ one). It renders:
 - a **PR chip** (`#N`, tone-tinted via `PR_CHIP_TONE` — the single
   shared map in `src/components/github/pr-status-icon.tsx`, also used
   by `WorkspaceContextBar`) that opens `pr_url` on click;
+- a **linked-issue chip** (`Issue #N`) — the shared
+  `IssueDetailPopover` (chip variant, `side="top" align="end"`,
+  `src/components/github/issue-detail-popover.tsx`) the old bar used,
+  reused verbatim so a thread's linked issue stays visible after PR #144
+  relocated the bar's content here. Unlike the git chips it renders
+  independent of the branch, so a branch-less workspace with only a
+  linked issue shows the Issue chip alone;
 - a **workspace-details button** (window icon + chevron-up) that opens
   a `~290px` popover (`side="top" align="end"`) with:
   - a header — workspace title, then `project · device` in
@@ -1101,18 +1131,21 @@ one). It renders:
     since `WorkspaceSnapshot` doesn't carry it; omitted on fetch
     failure), Behind base (warning tone, if any), Ahead (success tone,
     if any), Uncommitted (`+A −D`, if any), Pull request (`#N ·
-    <state>`, tone-tinted via `prStatusTextClass`), Location (`this
-    device` or the resolved host name);
+    <state>`, tone-tinted via `prStatusTextClass`), Issue (`#N ·
+    <state>`, only with a `linked_issue` — `text-success` when Open else
+    `text-muted-foreground`, the same tone the sidebar/issue components
+    use), Location (`this device` or the resolved host name);
   - a footer with up to two quick actions: **View PR #N** (only with a
     `pr_url`) and **Sync ↓N** (only while `git_behind > 0` — calls
     `gitPullChanges(cwd)` with a busy label + an error toast on
     failure, mirroring `changes-panel.tsx`'s `handlePull`).
 
-Renders `null` with no active workspace, or with neither a `git_branch`
-nor a background browser session. The git chips + details popover
-additionally require the branch, so a git-less workspace with a live
-background browser shows the Browser pill alone — matching the old
-bar's "browser indicator alone" case.
+Renders `null` with no active workspace, or with neither a `git_branch`,
+a background browser session, nor a `linked_issue`. The git chips +
+details popover additionally require the branch, so a git-less workspace
+with a live background browser shows the Browser pill alone, and one
+with only a linked issue shows the Issue chip alone — matching the old
+bar's visibility set (`hasGit || prState || linked_issue || browser`).
 
 **Bottom bar interaction.** While an Agent Chat pane is the active pane
 of the active surface in GUI chrome, `WorkspaceContextBar` renders

--- a/docs/features/workspace-context-bar.md
+++ b/docs/features/workspace-context-bar.md
@@ -32,7 +32,12 @@ Left → right:
   disabled without a URL.
 - **Issue chip** — `IssueDetailPopover` in its `chip` variant
   (`Issue #40` with state dot); the detail popover opens upward
-  (`side="top"`).
+  (`side="top"`). Shown while `workspace.linked_issue` is set, and part
+  of the bar's "something to show" visibility set. The same chip (same
+  props) also lives in the Context Row's `WorkspaceStatusCluster`, so
+  when the bar hides for an active agent-chat pane the linked issue
+  stays visible there (see `docs/features/agent-chat.md` § "Context
+  Row"); its details popover additionally carries an Issue row.
 - **Device** — laptop icon + "This device", or cloud icon + host name
   (resolved from `useHosts()` by `host_id`) for remote workspaces.
 - **Background browser indicator** (GUI mode only — `docs/features/browser.md`
@@ -110,7 +115,7 @@ new data plumbing.
 - `src/stores/browser-peek-store.ts` — the indicator's click target (opens the peek)
 - `src/dev/tauri-mock.ts` — `get_github_issue` mock for the popover
 - `src/components/layout/workspace-context-bar.test.tsx` — unit tests
-- `src/components/chat/WorkspaceStatusCluster.tsx` — the Context Row's relocated version of this bar's git/PR detail + browser indicator (see `docs/features/agent-chat.md`)
+- `src/components/chat/WorkspaceStatusCluster.tsx` — the Context Row's relocated version of this bar's git/PR/issue detail + browser indicator (PR chip, linked-issue chip, background-browser indicator, details popover; see `docs/features/agent-chat.md`)
 
 ## Notes
 

--- a/src/components/chat/WorkspaceStatusCluster.test.tsx
+++ b/src/components/chat/WorkspaceStatusCluster.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type {
   AgentBrowserSession,
+  GitHubIssue,
   PullRequestInfo,
   WorkspaceSnapshot,
 } from "@/tauri/types";
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   hosts: [] as Array<{ id: number; name: string }>,
   openUrl: vi.fn().mockResolvedValue(undefined),
   getGithubPrByPath: vi.fn().mockResolvedValue(null as PullRequestInfo | null),
+  getGithubIssue: vi.fn().mockResolvedValue(null as GitHubIssue | null),
   gitPullChanges: vi.fn().mockResolvedValue(undefined),
   agentBrowserSessions: [] as AgentBrowserSession[],
 }));
@@ -36,6 +38,7 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
 }));
 vi.mock("@/tauri/commands", () => ({
   getGithubPrByPath: (...args: unknown[]) => mocks.getGithubPrByPath(...args),
+  getGithubIssue: (...args: unknown[]) => mocks.getGithubIssue(...args),
   gitPullChanges: (...args: unknown[]) => mocks.gitPullChanges(...args),
 }));
 vi.mock("@/lib/toast", () => ({
@@ -101,6 +104,7 @@ beforeEach(() => {
   mocks.hosts = [];
   mocks.openUrl.mockClear();
   mocks.getGithubPrByPath.mockReset().mockResolvedValue(null);
+  mocks.getGithubIssue.mockReset().mockResolvedValue(null);
   mocks.gitPullChanges.mockReset().mockResolvedValue(undefined);
   mocks.agentBrowserSessions = [];
   vi.mocked(toast.error).mockClear();
@@ -345,5 +349,72 @@ describe("WorkspaceStatusCluster", () => {
     expect(
       screen.getByRole("button", { name: "Workspace details" }),
     ).toBeInTheDocument();
+  });
+
+  // ── Linked-issue chip ──
+  // Relocated from the old bottom WorkspaceContextBar (which hides while
+  // an agent-chat pane is active) — same shared `IssueDetailPopover`
+  // (chip variant, opening upward), so a thread's linked issue stays
+  // visible on the Context Row (regression from PR #144).
+
+  const LINKED_ISSUE = {
+    number: 146,
+    title: "Context Row loses the linked-issue chip",
+    state: "Open" as const,
+    labels: [],
+  };
+
+  it("renders the linked-issue chip and opens the detail popover upward", async () => {
+    mocks.workspace = makeWorkspace({ linked_issue: LINKED_ISSUE });
+    render(<WorkspaceStatusCluster />);
+    const chip = screen.getByText("Issue #146").closest("button")!;
+    expect(chip).toBeInTheDocument();
+    await userEvent.click(chip);
+    const content = await waitFor(() => {
+      const el = document.querySelector(
+        "[data-testid='issue-detail-content']",
+      );
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    // The popover opens upward (`side="top"`, mirroring the old bar).
+    expect(content.closest("[data-side]")).toHaveAttribute("data-side", "top");
+    expect(mocks.getGithubIssue).toHaveBeenCalledWith("ws-1", 146);
+  });
+
+  it("renders the issue chip alone (no git chips / details button) for a branch-less workspace with a linked issue", () => {
+    mocks.workspace = makeWorkspace({
+      git_branch: null,
+      linked_issue: LINKED_ISSUE,
+    });
+    const { container } = render(<WorkspaceStatusCluster />);
+    expect(container).not.toBeEmptyDOMElement();
+    expect(screen.getByText("Issue #146")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Workspace details" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders no issue chip when the workspace has no linked issue", () => {
+    mocks.workspace = makeWorkspace({ linked_issue: null });
+    render(<WorkspaceStatusCluster />);
+    expect(screen.queryByText(/^Issue #/)).not.toBeInTheDocument();
+  });
+
+  it("shows the Issue row in the details popover when a linked issue is present", async () => {
+    mocks.workspace = makeWorkspace({ linked_issue: LINKED_ISSUE });
+    const user = userEvent.setup();
+    render(<WorkspaceStatusCluster />);
+    await user.click(screen.getByRole("button", { name: "Workspace details" }));
+    expect(screen.getByText("Issue")).toBeInTheDocument();
+    expect(screen.getByText("#146 · Open")).toBeInTheDocument();
+  });
+
+  it("omits the Issue row from the details popover without a linked issue", async () => {
+    mocks.workspace = makeWorkspace({ linked_issue: null });
+    const user = userEvent.setup();
+    render(<WorkspaceStatusCluster />);
+    await user.click(screen.getByRole("button", { name: "Workspace details" }));
+    expect(screen.queryByText("Issue")).not.toBeInTheDocument();
   });
 });

--- a/src/components/chat/WorkspaceStatusCluster.tsx
+++ b/src/components/chat/WorkspaceStatusCluster.tsx
@@ -21,6 +21,7 @@ import {
   BackgroundBrowserIndicator,
   useBackgroundBrowserSession,
 } from "@/components/browser/background-browser-indicator";
+import { IssueDetailPopover } from "@/components/github/issue-detail-popover";
 import { getGithubPrByPath, gitPullChanges } from "@/tauri/commands";
 import type { PullRequestInfo } from "@/tauri/types";
 
@@ -39,9 +40,13 @@ import type { PullRequestInfo } from "@/tauri/types";
  *    its upstream,
  *  - a PR chip (#N, tone-tinted per state) that opens the PR on
  *    GitHub,
+ *  - a linked-issue chip (Issue #N) that opens the issue detail
+ *    popover upward — the same `IssueDetailPopover` (chip variant) the
+ *    old bar rendered, so a thread's linked issue stays visible on the
+ *    Context Row,
  *  - a "workspace details" button that opens a compact popover with
  *    the full picture (branch, base, behind, ahead, uncommitted diff,
- *    PR, device) plus quick View PR / Sync actions.
+ *    PR, issue, device) plus quick View PR / Sync actions.
  *
  * Self-contained: reads the active workspace directly. This only ever
  * renders from inside an `AgentChatPane`, and `PaneContainer` only
@@ -53,10 +58,12 @@ import type { PullRequestInfo } from "@/tauri/types";
  * OpenFlow workspaces never route through `PaneContainer`.)
  *
  * Renders nothing when there is no active workspace, or there is
- * neither a git branch nor a background browser session (nothing
- * passive to report). The git chips + details popover additionally
- * require the branch, so a git-less workspace with a live background
- * browser shows the Browser pill alone — matching the old bar.
+ * neither a git branch, a background browser session, nor a linked
+ * issue (nothing passive to report). The git chips + details popover
+ * additionally require the branch, so a git-less workspace with a live
+ * background browser shows the Browser pill alone, and one with only a
+ * linked issue shows the Issue chip alone — matching the old bar's
+ * visibility set (`hasGit || prState || linked_issue || browser`).
  */
 export function WorkspaceStatusCluster() {
   const workspace = useActiveWorkspace();
@@ -92,7 +99,8 @@ export function WorkspaceStatusCluster() {
 
   if (!workspace) return null;
   const gitBranch = workspace.git_branch;
-  if (!gitBranch && !backgroundBrowserSession) return null;
+  if (!gitBranch && !backgroundBrowserSession && !workspace.linked_issue)
+    return null;
 
   const prState = normalizePrState(workspace.pr_state);
   const prHumanState = humanizePrState(workspace.pr_state);
@@ -109,6 +117,21 @@ export function WorkspaceStatusCluster() {
   const deviceLabel = isRemote ? (hostName ?? "Remote host") : "this device";
 
   const projectName = basename(workspace.project_root ?? workspace.cwd);
+
+  /* Linked-issue chip — opens the issue detail popover upward. Mirrors
+     the old bottom bar's usage (chip variant, `side="top"`). Rendered
+     right after the PR chip (the old bar's ordering); unlike the git
+     chips it does not require a branch, so a branch-less workspace with
+     a linked issue still shows it (standalone render below). */
+  const issueChip = workspace.linked_issue ? (
+    <IssueDetailPopover
+      workspaceId={workspace.workspace_id}
+      issue={workspace.linked_issue}
+      variant="chip"
+      side="top"
+      align="end"
+    />
+  ) : null;
 
   const handlePrClick = () => {
     if (workspace.pr_url) openUrl(workspace.pr_url).catch(console.error);
@@ -172,6 +195,8 @@ export function WorkspaceStatusCluster() {
             </button>
           )}
 
+          {issueChip}
+
           <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
               <button
@@ -233,6 +258,17 @@ export function WorkspaceStatusCluster() {
                     valueClassName={prStatusTextClass(workspace.pr_state) ?? undefined}
                   />
                 )}
+                {workspace.linked_issue && (
+                  <DetailRow
+                    label="Issue"
+                    value={`#${workspace.linked_issue.number} · ${workspace.linked_issue.state}`}
+                    valueClassName={
+                      workspace.linked_issue.state === "Open"
+                        ? "text-success"
+                        : "text-muted-foreground"
+                    }
+                  />
+                )}
                 <DetailRow label="Location" value={deviceLabel} muted />
               </div>
               {(workspace.pr_url || showBehind) && (
@@ -262,6 +298,10 @@ export function WorkspaceStatusCluster() {
           </Popover>
         </>
       )}
+
+      {/* Branch-less workspace with a linked issue: the git block above
+          didn't render, so show the Issue chip standalone. */}
+      {!gitBranch && issueChip}
     </div>
   );
 }

--- a/src/dev/mock-fixtures.ts
+++ b/src/dev/mock-fixtures.ts
@@ -284,6 +284,17 @@ const ISSUE_MOCK: LinkedIssue = {
   labels: ["enhancement"],
 };
 
+/** Linked to the agent-chat-demo workspace so the Context Row's
+ *  linked-issue chip (relocated from the old bottom bar) is visible and
+ *  clickable under `npm run dev` — the mock's `get_github_issue`
+ *  expands this into a full issue for the popover. */
+const ISSUE_CHAT: LinkedIssue = {
+  number: 146,
+  title: "Context Row loses the linked-issue chip on agent-chat surfaces",
+  state: "Open",
+  labels: ["bug", "regression"],
+};
+
 // ── Workspaces ──────────────────────────────────────────────────────
 //
 // Project 1 — codemux: 1 primary (repo root) + 4 worktrees, covering
@@ -321,6 +332,9 @@ const wsCodemuxChat: WorkspaceSnapshot = (() => {
     pr_number: 172,
     pr_state: "open",
     pr_url: "https://github.com/example/codemux/pull/172",
+    // Linked issue so the Context Row's relocated linked-issue chip
+    // (PR #144 dropped it from agent-chat surfaces) is demoable here.
+    linked_issue: ISSUE_CHAT,
     git_ahead: 2,
     git_behind: 5,
     git_additions: 9,

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -51,7 +51,10 @@ import type {
   ChatModelInfo,
   CliToolInfo,
   FeatureFlags,
+  PaneNodeSnapshot,
   PresetStoreSnapshot,
+  SurfaceSnapshot,
+  TabSnapshot,
   TerminalPreset,
   ProviderChatCapabilities,
   ResourceMetricsSnapshot,
@@ -1555,6 +1558,51 @@ const handlers: Record<string, Handler> = {
   save_terminal_scrollback: () => undefined,
   flush_scrollback_cache: () => 0,
 
+  // ── Deferred worktree first-send (Thread Scope) ──
+  //
+  // Faithfully reproduces the async race the fix targets: the new
+  // worktree workspace is RETURNED synchronously from the invoke, but
+  // only reaches the app-store via an ASYNCHRONOUS `app-state-changed`
+  // emit (a macrotask later) — so a synchronous store read-back right
+  // after the invoke resolves misses, exactly like the real Tauri
+  // runtime. The workspace carries a DISTINCT cwd (the sibling worktree
+  // path, not the repo root) so root-vs-worktree is observable in dev.
+  generate_branch_name: (a) => {
+    const slug = String(a.prompt ?? "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .split("-")
+      .slice(0, 4)
+      .join("-");
+    return slug || "mock-branch";
+  },
+  generate_random_branch_name: () =>
+    `mock-worktree-${Math.random().toString(36).slice(2, 8)}`,
+  create_worktree_workspace: (a) => {
+    const ws = buildWorktreeWorkspace(
+      String(a.repoPath ?? `${MOCK_HOME_DIR}/projects/codemux`),
+      String(a.branch ?? "mock-branch"),
+    );
+    // ASYNC emit — the workspace lands in the store only AFTER this
+    // invoke's promise has already resolved (macrotask), mirroring the
+    // real runtime's event ordering that the bug depended on.
+    setTimeout(() => {
+      appState = { ...appState, workspaces: [...appState.workspaces, ws] };
+      emitAppState();
+    }, 0);
+    return ws.workspace_id;
+  },
+  agent_chat_create_pane: (a) => {
+    // The deferred worktree workspace already carries a fresh
+    // agent_chat pane (empty thread); bind the session to it. Falls
+    // back to a synthetic id for any other workspace.
+    const ws = findWorkspace(a.workspaceId);
+    const root = ws?.surfaces?.[0]?.root;
+    if (root && root.kind === "agent_chat") return root.pane_id;
+    return `pane-mock-${Date.now()}`;
+  },
+
   // ── Mutators: patch in-memory state + re-emit ──
   activate_workspace: (a) => {
     if (findWorkspace(a.workspaceId)) {
@@ -1582,6 +1630,83 @@ const handlers: Record<string, Handler> = {
   close_workspace: (a) => removeWorkspace(a.workspaceId),
   close_workspace_with_worktree: (a) => removeWorkspace(a.workspaceId),
 };
+
+/** Build a `worktree`-kind workspace with a fresh (thread-less)
+ *  agent_chat pane and a DISTINCT sibling-worktree cwd, mirroring the
+ *  real `create_worktree_workspace` with the `"empty"` layout. Kept
+ *  self-contained (mock-fixtures' builders aren't exported) so the
+ *  deferred-worktree first-send path is exercisable end-to-end in
+ *  `npm run dev`. */
+let deferredWorktreeSeq = 0;
+function buildWorktreeWorkspace(
+  repoPath: string,
+  branch: string,
+): WorkspaceSnapshot {
+  const n = ++deferredWorktreeSeq;
+  const repoName = repoPath.split("/").filter(Boolean).pop() ?? "repo";
+  // Sibling worktree path — NOT the repo root — so a caller can tell the
+  // worktree cwd apart from the parent checkout.
+  const cwd = `${MOCK_HOME_DIR}/.codemux/worktrees/${repoName}/${branch}`;
+  const paneId = `pane-deferred-wt-${n}`;
+  const surfaceId = `surface-deferred-wt-${n}`;
+  const tabId = `tab-deferred-wt-${n}`;
+
+  const pane: PaneNodeSnapshot = {
+    kind: "agent_chat",
+    pane_id: paneId,
+    title: branch,
+    thread_id: null,
+    provider: "claude",
+    cwd,
+  };
+  const surface: SurfaceSnapshot = {
+    surface_id: surfaceId,
+    title: branch,
+    root: pane,
+    active_pane_id: paneId,
+  };
+  const tab: TabSnapshot = {
+    tab_id: tabId,
+    kind: "terminal",
+    title: branch,
+    surface_id: surfaceId,
+    browser_id: null,
+    icon: null,
+  };
+
+  return {
+    workspace_id: `ws-deferred-worktree-${n}`,
+    title: branch,
+    workspace_type: "standard",
+    cwd,
+    git_branch: branch,
+    git_ahead: 0,
+    git_behind: 0,
+    git_additions: 0,
+    git_deletions: 0,
+    git_changed_files: 0,
+    notification_count: 0,
+    latest_agent_state: null,
+    worktree_path: cwd,
+    project_root: repoPath,
+    project_uid: null,
+    workspace_kind: "worktree",
+    protected: false,
+    divergent_copy: false,
+    pr_number: null,
+    pr_state: null,
+    pr_url: null,
+    linked_issue: null,
+    notifications_muted: false,
+    tabs: [tab],
+    active_tab_id: tabId,
+    active_surface_id: surfaceId,
+    surfaces: [surface],
+    host_id: null,
+    remote_cwd: null,
+    attach_only: false,
+  };
+}
 
 /** Drop a workspace from the in-memory snapshot, reassigning the active
  *  workspace if it was the one closed, then re-emit. */

--- a/src/lib/agent-chat/materialize.test.ts
+++ b/src/lib/agent-chat/materialize.test.ts
@@ -879,6 +879,7 @@ describe("materializeAndSend", () => {
         null,
         null,
         [],
+        [],
         "/projects/foo",
       );
 
@@ -940,6 +941,7 @@ describe("materializeAndSend", () => {
         actions,
         null,
         null,
+        [],
         [],
         "/projects/foo",
       );

--- a/src/lib/agent-chat/materialize.test.ts
+++ b/src/lib/agent-chat/materialize.test.ts
@@ -22,6 +22,19 @@ vi.mock("@/tauri/commands", () => ({
   generateRandomBranchName: vi.fn().mockResolvedValue("random-branch"),
   getHomeDir: vi.fn().mockResolvedValue("/home/user"),
   renameWorkspace: vi.fn().mockResolvedValue(undefined),
+  // `waitForWorkspaceCwd` (worktree arm) polls this on its direct-fetch
+  // fallback path. Return the store's current snapshot so a poll never
+  // clobbers seeded state; the worktree tests drive resolution via the
+  // store subscription instead.
+  getAppState: vi.fn(() =>
+    Promise.resolve(
+      useAppStore.getState().appState ?? {
+        schema_version: 1,
+        active_workspace_id: "",
+        workspaces: [],
+      },
+    ),
+  ),
 }));
 
 import {
@@ -826,6 +839,117 @@ describe("materializeAndSend", () => {
       );
       expect(agentChatCreatePane).not.toHaveBeenCalled();
       expect(agentChatStartSession).not.toHaveBeenCalled();
+    });
+
+    it("waits for the app-store to hydrate the worktree AFTER a delay, then launches at the WORKTREE cwd", async () => {
+      // Reproduce the real race (PR #142 deferred-worktree cwd bug): the store does NOT yet
+      // hold the new worktree when `create_worktree_workspace` resolves.
+      // The app-state event lands ~asynchronously; the pane + session
+      // must still launch inside the worktree, never the project root.
+      useAppStore.setState({
+        homeDir: "/home/user",
+        appState: {
+          schema_version: 1,
+          active_workspace_id: "ws-codemux-main",
+          workspaces: [{ workspace_id: "ws-codemux-main", cwd: "/projects/foo" }],
+        } as never,
+      });
+      const actions = makeActions();
+      const draft = makeDraft({
+        target: { kind: "project", projectPath: "/projects/foo" },
+        checkoutMode: "worktree",
+        worktreeName: "",
+        baseBranch: "main",
+      });
+
+      const promise = materializeAndSend(
+        draft,
+        "fix the login bug",
+        "/projects/foo",
+        actions,
+        null,
+        null,
+        [],
+        "/projects/foo",
+      );
+
+      // The worktree workspace only reaches the store after a tick —
+      // exactly like the async `app-state-changed` Tauri event.
+      setTimeout(() => {
+        useAppStore.setState({
+          appState: {
+            schema_version: 1,
+            active_workspace_id: "ws-worktree",
+            workspaces: [
+              { workspace_id: "ws-codemux-main", cwd: "/projects/foo" },
+              {
+                workspace_id: "ws-worktree",
+                cwd: "/projects/foo-ai-named-branch",
+              },
+            ],
+          } as never,
+        });
+      }, 20);
+
+      const result = await promise;
+
+      expect(result.success).toBe(true);
+      // NEVER the parent `/projects/foo`.
+      expect(agentChatCreatePane).toHaveBeenCalledWith(
+        "ws-worktree",
+        "claude",
+        "/projects/foo-ai-named-branch",
+      );
+      const [, , startInput] = vi.mocked(agentChatStartSession).mock.calls[0];
+      expect(startInput.cwd).toBe("/projects/foo-ai-named-branch");
+    });
+
+    it("HARD INVARIANT: never hydrates → fails the send safely, session NEVER started at the project root", async () => {
+      vi.useFakeTimers();
+      // Store never gains the worktree workspace — the app-state event
+      // is dropped/never delivered.
+      useAppStore.setState({
+        homeDir: "/home/user",
+        appState: {
+          schema_version: 1,
+          active_workspace_id: "ws-codemux-main",
+          workspaces: [{ workspace_id: "ws-codemux-main", cwd: "/projects/foo" }],
+        } as never,
+      });
+      const actions = makeActions();
+      const draft = makeDraft({
+        target: { kind: "project", projectPath: "/projects/foo" },
+        checkoutMode: "worktree",
+        worktreeName: "",
+        baseBranch: "main",
+      });
+
+      const promise = materializeAndSend(
+        draft,
+        "fix the login bug",
+        "/projects/foo",
+        actions,
+        null,
+        null,
+        [],
+        "/projects/foo",
+      );
+      // Drive past the resolver's timeout (default 5s).
+      await vi.advanceTimersByTimeAsync(6_000);
+      const result = await promise;
+      vi.useRealTimers();
+
+      expect(result.success).toBe(false);
+      expect(actions.markSendFailed).toHaveBeenCalledWith(
+        "draft-1",
+        expect.stringContaining("worktree"),
+      );
+      // The invariant: the pane is never created and the session is
+      // never started — so it can NEVER launch at the parent
+      // `/projects/foo`.
+      expect(agentChatCreatePane).not.toHaveBeenCalled();
+      expect(agentChatStartSession).not.toHaveBeenCalled();
+      expect(agentChatSendTurn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/agent-chat/materialize.ts
+++ b/src/lib/agent-chat/materialize.ts
@@ -21,6 +21,7 @@ import type { TerminalPreset } from "@/tauri/types";
 
 import { deriveTitleFromFirstMessage } from "./derive-title";
 import { applyAllPrefixes } from "./mode-prefix";
+import { waitForWorkspaceCwd } from "./wait-for-workspace-cwd";
 
 /**
  * Mutations performed as `materializeAndSend` progresses. Kept as a bag
@@ -145,6 +146,15 @@ export async function materializeAndSend(
   //    resolved cwd and is swapped for the freshly-created worktree's
   //    real cwd below so the pane + session launch inside the new
   //    worktree, not the original checkout.
+  //
+  //    HARD INVARIANT: a `"worktree"` submit must NEVER
+  //    create the pane or start the session at the parent/project-root
+  //    cwd. The new worktree workspace only reaches the app-store via
+  //    the async `app-state-changed` event, so a synchronous read-back
+  //    ~always missed and silently launched the agent in the user's
+  //    real checkout. `waitForWorkspaceCwd` awaits the store landing the
+  //    workspace; on timeout we fail the send (draft text preserved via
+  //    the existing markSendFailed pathway) rather than proceeding.
   let workspaceId: string;
   let effectiveCwd = cwd;
   try {
@@ -155,10 +165,14 @@ export async function materializeAndSend(
         draft.baseBranch ?? "",
         text,
       );
-      const createdWorkspace = useAppStore
-        .getState()
-        .appState?.workspaces.find((w) => w.workspace_id === workspaceId);
-      if (createdWorkspace?.cwd) effectiveCwd = createdWorkspace.cwd;
+      const worktreeCwd = await waitForWorkspaceCwd(workspaceId);
+      if (!worktreeCwd) {
+        const message =
+          "Timed out resolving the new worktree's location. Please send again.";
+        actions.markSendFailed(draft.draftId, message);
+        return { success: false, error: message };
+      }
+      effectiveCwd = worktreeCwd;
     } else {
       switch (draft.target.kind) {
         case "home": {

--- a/src/lib/agent-chat/prestart-worktree-session.test.ts
+++ b/src/lib/agent-chat/prestart-worktree-session.test.ts
@@ -10,13 +10,14 @@ vi.mock("@/tauri/commands", () => ({
   agentChatStartSession: (...args: unknown[]) => startSessionMock(...args),
 }));
 
-let workspacesSnapshot: Array<{ workspace_id: string; cwd: string }> = [];
-vi.mock("@/stores/app-store", () => ({
-  useAppStore: {
-    getState: () => ({
-      appState: { workspaces: workspacesSnapshot },
-    }),
-  },
+// The cwd-resolution race lives in `./wait-for-workspace-cwd` and has
+// its own dedicated tests (`wait-for-workspace-cwd.test.ts`). Here we
+// mock it so these tests exercise prestart's own logic in isolation:
+// a resolved cwd → full prestart; a `null` (genuine timeout) → the
+// mount-effect fallback contract.
+const waitForWorkspaceCwdMock = vi.fn();
+vi.mock("./wait-for-workspace-cwd", () => ({
+  waitForWorkspaceCwd: (...args: unknown[]) => waitForWorkspaceCwdMock(...args),
 }));
 
 const ensureThreadMock = vi.fn();
@@ -45,7 +46,10 @@ import { prestartWorktreeSession } from "./prestart-worktree-session";
 
 describe("prestartWorktreeSession", () => {
   beforeEach(() => {
-    workspacesSnapshot = [];
+    waitForWorkspaceCwdMock.mockReset();
+    // Default: the worktree cwd resolves. Individual tests override the
+    // resolved value or set it to `null` to exercise the timeout path.
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/worktree-feat");
     createPaneMock.mockReset();
     startSessionMock.mockReset();
     ensureThreadMock.mockReset();
@@ -63,7 +67,7 @@ describe("prestartWorktreeSession", () => {
     // Regression: passing null leaves `pane.cwd` null and makes the
     // mount-effect's `if (!cwd) return` guard fire, which is the
     // original race that produced session_not_found.
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/worktree-feat" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/worktree-feat");
     await prestartWorktreeSession("ws-new");
     expect(createPaneMock).toHaveBeenCalledTimes(1);
     expect(createPaneMock).toHaveBeenCalledWith(
@@ -78,7 +82,7 @@ describe("prestartWorktreeSession", () => {
     // adapter's HashMap holds the thread_id. Callers activate the
     // workspace afterward so AgentChatPane mounts with a live
     // session already in place.
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/worktree-feat" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/worktree-feat");
     await prestartWorktreeSession("ws-new");
     expect(startSessionMock).toHaveBeenCalledTimes(1);
     const [paneId, provider, input] = startSessionMock.mock.calls[0];
@@ -104,7 +108,7 @@ describe("prestartWorktreeSession", () => {
       events.push("start_session");
       return "thread-echo";
     });
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/w" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/w");
     await prestartWorktreeSession("ws-new");
     expect(events).toEqual(["create_pane", "start_session"]);
   });
@@ -113,7 +117,7 @@ describe("prestartWorktreeSession", () => {
     // AgentChatPane's mount-effect adopts pane.thread_id and calls
     // ensureThread; pickers read from the slice. Seeding here means
     // the live pane mounts against a populated slice, not a bare one.
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/w" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/w");
     await prestartWorktreeSession("ws-new");
     expect(ensureThreadMock).toHaveBeenCalledTimes(1);
     expect(setPermissionModeMock).toHaveBeenCalledTimes(1);
@@ -130,7 +134,7 @@ describe("prestartWorktreeSession", () => {
   });
 
   it("reuses the SAME thread_id across start_session and the slice seed", async () => {
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/w" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/w");
     await prestartWorktreeSession("ws-new");
     const startInput = startSessionMock.mock.calls[0][2];
     const seededThreadId = ensureThreadMock.mock.calls[0][0];
@@ -138,12 +142,12 @@ describe("prestartWorktreeSession", () => {
   });
 
   it("defers to the mount-effect path when the workspace isn't in the store yet (fallback)", async () => {
-    // Edge case: Tauri event delivery hasn't landed the new
-    // workspace by the time we run. Rather than fabricating a bad
-    // cwd (sidecar would spawn in the wrong directory), we skip and
+    // Edge case: the cwd never reached the store within the timeout
+    // (`waitForWorkspaceCwd` resolves null). Rather than fabricating a
+    // bad cwd (sidecar would spawn in the wrong directory), we skip and
     // let AgentChatPane's mount-effect handle it. No worse than the
     // pre-fix behavior.
-    workspacesSnapshot = [];
+    waitForWorkspaceCwdMock.mockResolvedValue(null);
     await prestartWorktreeSession("ws-missing");
     expect(createPaneMock).not.toHaveBeenCalled();
     expect(startSessionMock).not.toHaveBeenCalled();
@@ -151,7 +155,7 @@ describe("prestartWorktreeSession", () => {
   });
 
   it("propagates backend errors from agent_chat_start_session (so the caller can log)", async () => {
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/w" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/w");
     startSessionMock.mockRejectedValueOnce(new Error("sidecar spawn failed"));
     await expect(prestartWorktreeSession("ws-new")).rejects.toThrow(
       "sidecar spawn failed",
@@ -165,20 +169,20 @@ describe("prestartWorktreeSession", () => {
   // ── Thread Scope deferred-worktree extensions ──
 
   it("returns { paneId, threadId } matching the created pane + session (and null on the store fallback)", async () => {
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/w" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/w");
     const result = await prestartWorktreeSession("ws-new");
     expect(result).not.toBeNull();
     expect(result!.paneId).toBe("pane-1");
     const startInput = startSessionMock.mock.calls[0][2];
     expect(result!.threadId).toBe(startInput.thread_id);
 
-    workspacesSnapshot = [];
+    waitForWorkspaceCwdMock.mockResolvedValue(null);
     const missing = await prestartWorktreeSession("ws-missing");
     expect(missing).toBeNull();
   });
 
   it("plumbs the optional config into start_session and the slice seed", async () => {
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/w" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/w");
     const result = await prestartWorktreeSession("ws-new", {
       model: "claude-opus-4-7",
       permissionMode: "plan",
@@ -200,8 +204,29 @@ describe("prestartWorktreeSession", () => {
     expect(setSessionLaunchModeMock).toHaveBeenCalledWith(tid, "plan");
   });
 
+  it("first-send succeeds with the worktree cwd even when it resolves after a delay", async () => {
+    // Regression (PR #142 deferred-worktree cwd bug): the store often hasn't landed the new
+    // worktree by the time prestart runs. `waitForWorkspaceCwd` awaits
+    // it; prestart must then launch the pane + session at the WORKTREE
+    // cwd, not return null on a routine store miss.
+    waitForWorkspaceCwdMock.mockImplementationOnce(
+      () =>
+        new Promise((r) => setTimeout(() => r("/tmp/worktree-delayed"), 10)),
+    );
+    const result = await prestartWorktreeSession("ws-new");
+    expect(waitForWorkspaceCwdMock).toHaveBeenCalledWith("ws-new");
+    expect(result).not.toBeNull();
+    expect(createPaneMock).toHaveBeenCalledWith(
+      "ws-new",
+      "claude",
+      "/tmp/worktree-delayed",
+    );
+    const [, , input] = startSessionMock.mock.calls[0];
+    expect(input.cwd).toBe("/tmp/worktree-delayed");
+  });
+
   it("omitted config keeps the legacy defaults and skips the optional slice setters", async () => {
-    workspacesSnapshot = [{ workspace_id: "ws-new", cwd: "/tmp/w" }];
+    waitForWorkspaceCwdMock.mockResolvedValue("/tmp/w");
     await prestartWorktreeSession("ws-new");
     const [, , input] = startSessionMock.mock.calls[0];
     expect(input.model).toBeNull();

--- a/src/lib/agent-chat/prestart-worktree-session.ts
+++ b/src/lib/agent-chat/prestart-worktree-session.ts
@@ -3,11 +3,12 @@ import {
   useAgentChatStore,
   type ChatMode,
 } from "@/stores/agent-chat-store";
-import { useAppStore } from "@/stores/app-store";
 import {
   agentChatCreatePane,
   agentChatStartSession,
 } from "@/tauri/commands";
+
+import { waitForWorkspaceCwd } from "./wait-for-workspace-cwd";
 
 /** Optional session config carried from the surface that triggered the
  *  prestart (Thread Scope deferred-worktree submit) so the new
@@ -62,27 +63,27 @@ export interface PrestartedWorktreeSession {
  * ## CWD resolution
  *
  * The worktree path is only known to the backend after
- * `git_create_worktree` runs. We read it from the app-store after
- * `create_worktree_workspace` returns — `emit_app_state` fires
- * synchronously inside that Tauri command before the `Ok()` return,
- * so the event is on the frontend's IPC queue ahead of the invoke
- * response. In the degenerate case where the workspace still isn't
- * in the store (e.g. event delivery reordering), we skip the
- * pre-start entirely and fall back to the mount-effect path — not
- * ideal, but strictly no worse than today's buggy behavior.
+ * `git_create_worktree` runs, and the new workspace reaches the
+ * app-store only via the async `app-state-changed` event — which has
+ * essentially never been processed by the time `create_worktree_workspace`
+ * resolves (the PR #142 deferred-worktree cwd regression). Rather than
+ * a single synchronous read-back
+ * (which ~always missed and returned null on first send), we
+ * `waitForWorkspaceCwd` — awaiting the store landing the workspace,
+ * racing the event against a direct `get_app_state` fetch. Only a
+ * genuine timeout returns `null`, at which point we fall back to the
+ * AgentChatPane mount-effect path — strictly no worse than the pre-fix
+ * behavior, but now rare instead of routine.
  */
 export async function prestartWorktreeSession(
   workspaceId: string,
   config: PrestartSessionConfig = {},
 ): Promise<PrestartedWorktreeSession | null> {
-  const ws = useAppStore
-    .getState()
-    .appState?.workspaces.find((w) => w.workspace_id === workspaceId);
-  const cwd = ws?.cwd;
+  const cwd = await waitForWorkspaceCwd(workspaceId);
   if (!cwd) {
     console.warn(
-      "[prestart-worktree-session] workspace not yet in store; deferring " +
-        "session start to AgentChatPane mount-effect",
+      "[prestart-worktree-session] workspace cwd never reached the store; " +
+        "deferring session start to AgentChatPane mount-effect",
       { workspaceId },
     );
     return null;

--- a/src/lib/agent-chat/wait-for-workspace-cwd.test.ts
+++ b/src/lib/agent-chat/wait-for-workspace-cwd.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Only `getAppState` is needed by the resolver; mock it so we can drive
+// the direct-fetch fallback path deterministically.
+const getAppStateMock = vi.fn();
+vi.mock("@/tauri/commands", () => ({
+  getAppState: (...args: unknown[]) => getAppStateMock(...args),
+}));
+
+import { waitForWorkspaceCwd } from "./wait-for-workspace-cwd";
+// The REAL app-store — the resolver races its subscription against the
+// mocked direct fetch.
+import { useAppStore } from "@/stores/app-store";
+
+function seed(workspaces: Array<{ workspace_id: string; cwd: string }>) {
+  useAppStore.setState({
+    appState: {
+      schema_version: 1,
+      active_workspace_id: workspaces[0]?.workspace_id ?? "",
+      workspaces,
+    } as never,
+  });
+}
+
+describe("waitForWorkspaceCwd", () => {
+  beforeEach(() => {
+    getAppStateMock.mockReset();
+    // Default: the direct fetch keeps missing, so tests that don't
+    // exercise the fallback rely purely on the subscription.
+    getAppStateMock.mockResolvedValue({
+      schema_version: 1,
+      active_workspace_id: "",
+      workspaces: [],
+    });
+    useAppStore.setState({ appState: null });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fast path: resolves synchronously when the workspace is already in the store", async () => {
+    seed([{ workspace_id: "w1", cwd: "/wt/one" }]);
+    const cwd = await waitForWorkspaceCwd("w1");
+    expect(cwd).toBe("/wt/one");
+    // No fetch needed — the store already had it.
+    expect(getAppStateMock).not.toHaveBeenCalled();
+  });
+
+  it("subscription path: resolves when the app-state event lands the workspace after a delay", async () => {
+    seed([]);
+    const promise = waitForWorkspaceCwd("w2");
+    // Mimic the async `app-state-changed` event arriving late.
+    setTimeout(() => seed([{ workspace_id: "w2", cwd: "/wt/two" }]), 15);
+    expect(await promise).toBe("/wt/two");
+  });
+
+  it("direct-fetch fallback: resolves from a polled get_app_state when the event never fires", async () => {
+    seed([]);
+    // The event never updates the store; only the polled fetch sees it.
+    getAppStateMock.mockResolvedValue({
+      schema_version: 1,
+      active_workspace_id: "w3",
+      workspaces: [{ workspace_id: "w3", cwd: "/wt/three" }],
+    });
+    const cwd = await waitForWorkspaceCwd("w3");
+    expect(cwd).toBe("/wt/three");
+    expect(getAppStateMock).toHaveBeenCalled();
+    // The fetched snapshot was hydrated into the store for the rest of
+    // the UI to catch up.
+    expect(
+      useAppStore
+        .getState()
+        .appState?.workspaces.find((w) => w.workspace_id === "w3")?.cwd,
+    ).toBe("/wt/three");
+  });
+
+  it("timeout: resolves null when the workspace never appears", async () => {
+    vi.useFakeTimers();
+    seed([]);
+    const promise = waitForWorkspaceCwd("missing", 1_000);
+    await vi.advanceTimersByTimeAsync(1_200);
+    expect(await promise).toBeNull();
+  });
+});

--- a/src/lib/agent-chat/wait-for-workspace-cwd.ts
+++ b/src/lib/agent-chat/wait-for-workspace-cwd.ts
@@ -1,0 +1,96 @@
+import { getAppState } from "@/tauri/commands";
+import { useAppStore } from "@/stores/app-store";
+
+/** How long to wait for a freshly-created workspace's real cwd to reach
+ *  the app-store before giving up. Worktree creation itself
+ *  (`git worktree add` + optional setup) already resolved by the time we
+ *  call this — we're only waiting for the async `app-state-changed`
+ *  event to propagate the new workspace into the Zustand store, which is
+ *  normally a single IPC tick. 5s is generous headroom for a cold repo /
+ *  a briefly backed-up event queue while still failing fast enough that a
+ *  genuinely stuck create surfaces to the user instead of hanging. */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/** Interval between direct `get_app_state` fetches on the fallback path. */
+const POLL_INTERVAL_MS = 200;
+
+/** Read a workspace's cwd from the current app-store snapshot, or `null`
+ *  when the workspace isn't present yet (or is present but has no cwd). */
+function readCwd(workspaceId: string): string | null {
+  const ws = useAppStore
+    .getState()
+    .appState?.workspaces.find((w) => w.workspace_id === workspaceId);
+  return ws?.cwd || null;
+}
+
+/**
+ * Resolve a just-created workspace's real cwd, waiting for it to appear
+ * in the app-store.
+ *
+ * Motivation (root cause of the PR #142 deferred-worktree cwd
+ * regression): a deferred worktree workspace only
+ * reaches the Zustand store via the async `app-state-changed` Tauri
+ * event, which has essentially never been processed by the time
+ * `create_worktree_workspace`'s `invoke` promise resolves. A synchronous
+ * `useAppStore.getState()` read therefore misses ~always, which silently
+ * left the pane + agent session launching at the PARENT checkout cwd
+ * (the project root) instead of the new worktree — so agents committed
+ * into the user's real working copy.
+ *
+ * Resolution strategy — race two sources so this returns as soon as
+ * either lands the workspace:
+ *   1. `useAppStore.subscribe` — fires when the `app-state-changed`
+ *      event updates the store (the normal, fast path).
+ *   2. A polled direct `get_app_state` fetch — a fallback for the case
+ *      where event delivery is reordered/dropped. Each fetch is written
+ *      back into the store via `setAppState`, so it both unblocks us and
+ *      lets the rest of the UI catch up; the write also wakes the
+ *      subscription above, keeping the resolve logic in one place.
+ *
+ * @returns the workspace's cwd, or `null` if it never appears within
+ *   `timeoutMs`. Callers MUST treat `null` as a hard failure and must
+ *   NOT fall back to a parent/project-root cwd.
+ */
+export async function waitForWorkspaceCwd(
+  workspaceId: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<string | null> {
+  // Fast path: already in the store (e.g. a synchronous emit, or a retry
+  // after the event already landed).
+  const immediate = readCwd(workspaceId);
+  if (immediate) return immediate;
+
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (value: string | null): void => {
+      if (settled) return;
+      settled = true;
+      unsubscribe();
+      clearTimeout(timer);
+      clearInterval(poll);
+      resolve(value);
+    };
+
+    // 1. Store subscription — the normal `app-state-changed` path.
+    const unsubscribe = useAppStore.subscribe(() => {
+      const cwd = readCwd(workspaceId);
+      if (cwd) finish(cwd);
+    });
+
+    // 2. Direct-fetch fallback — poll `get_app_state` and hydrate the
+    //    store so a dropped/reordered event can't strand us. Writing the
+    //    fresh snapshot back wakes the subscription above, which does the
+    //    actual resolve.
+    const poll = setInterval(() => {
+      void getAppState()
+        .then((snapshot) => {
+          if (!settled) useAppStore.getState().setAppState(snapshot);
+        })
+        .catch(() => {
+          /* transient fetch failure — the next tick retries */
+        });
+    }, POLL_INTERVAL_MS);
+
+    const timer = setTimeout(() => finish(null), timeoutMs);
+  });
+}


### PR DESCRIPTION
## Problem

Two regressions from the Thread Scope / Context Row redesign (#142 / #144):

### 1. Deferred-worktree threads ran in the project root (the big one)

Since #142, a first send with checkout mode **New worktree** created the worktree correctly — but launched the agent session with `cwd` = the **parent project root**. Evidence from the live app: every worktree-scoped session in `agent_chat_sessions` since the redesign had `cwd = ~/projects/codemux` while its workspace pointed at `~/.codemux/worktrees/codemux/<branch>`.

Consequences observed in production use:
- agents created branches and committed **in the user's real checkout** (the repo root got flipped onto `fix/126-reap-agent-browser-sessions`, later `fix/deferred-worktree-auto-naming`);
- their PRs (#145, #146) attached to the repo-root workspace's context row instead of the thread's workspace;
- the thread's own workspace showed no PR chip and no sidebar PR icon (its branch genuinely had none);
- new drafts on the root workspace seeded "from `<agent branch>`" because that *was* now the root's checked-out branch.

**Root cause:** the new workspace only reaches the Zustand store via the async `app-state-changed` event, which has essentially never been processed by the time `create_worktree_workspace`'s invoke resolves. `materializeAndSend`'s synchronous read-back therefore missed ~always, and a silent `if (createdWorkspace?.cwd)` fallback kept the parent cwd. Pre-#142 this couldn't happen: worktree creation was an earlier, separate click, and the only cwd resolver (`prestartWorktreeSession`) aborted on a store miss instead of falling back.

### 2. Context Row lost the linked-issue chip

`WorkspaceStatusCluster` never rendered `workspace.linked_issue`, and #144 hides the bottom bar while an agent-chat pane is active — so linked issues disappeared entirely from chat surfaces.

## Fix

- **`waitForWorkspaceCwd(workspaceId, timeoutMs = 5000)`** (new, `src/lib/agent-chat/wait-for-workspace-cwd.ts`) — resolves the created workspace's cwd by racing the store subscription against a polled direct `get_app_state` fetch (written back to the store), so a dropped/reordered event can't strand it.
- **`materializeAndSend`** — hard invariant: a `checkoutMode === "worktree"` submit never creates the pane or starts the session at the parent cwd. On timeout the send fails safely (`markSendFailed`, draft text preserved) instead of proceeding.
- **`prestartWorktreeSession`** — shares the resolver, so the pane empty-state path now succeeds on first send; `null` remains only for a genuine timeout.
- **Context Row** — linked-issue chip restored (same `IssueDetailPopover` chip the old bar used, opens upward, placed right after the PR chip) + an `Issue #N · <state>` row in the workspace-details popover; cluster visibility extended so a branch-less workspace with a linked issue still shows the chip. PR chip, behind chip, and background-browser indicator untouched.
- **Dev mock** — `create_worktree_workspace` now mirrors the real async event ordering (workspace lands in the store a macrotask after the invoke resolves) with a distinct sibling-worktree cwd, plus `generate_branch_name` / `agent_chat_create_pane` handlers, so the whole flow is exercisable in `npm run dev`. `agent-chat-demo` seeds a linked issue for the chip.
- Docs updated (`agent-chat.md`, `workspace-context-bar.md`).

## Verification

- `npm run check` clean; `npm run test` **2370/2370** (new tests: delayed store hydration → session gets the worktree cwd; store never hydrates → send fails and no session is ever started at the parent cwd; pane-path first send; issue chip/row render + visibility).
- End-to-end in the browser dev runtime: drove draft → codemux → New worktree → first send. Instrumented run showed `parentCwd: /home/dev/projects/codemux → effectiveCwd: /home/dev/.codemux/worktrees/codemux/add-dark-mode-toggle`; auto-naming from the first message worked; thread routed into the new workspace. Issue #146 chip, upward popover, and details-popover Issue row verified on screen.
- No Rust changes.