### PR TITLE
fix(chat): let native scroll anchoring stabilize unpinned transcript scrolling

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -219,10 +219,28 @@ Contract preserved from the pre-redesign renderer:
   no longer runs a competing hand-rolled pin/snap loop — an earlier
   version did (direct `scrollTop` writes on a separate 80px
   threshold), which produced visible jitter fighting the engine in
-  the 8–80px band; that machinery was deleted. The viewport also sets
-  `overflow-anchor: none` so native browser scroll anchoring can't
-  fight the engine's programmatic scrolls while `content-visibility`
-  rows settle from estimated to real heights.
+  the 8–80px band; that machinery was deleted. Scroll stability is
+  **split by ownership**: native browser scroll anchoring owns
+  free-scroll — while the reader scrolls history it absorbs the
+  `content-visibility:auto` estimated-then-real height settling of rows
+  above the viewport (the mechanism the content-visibility spec relies
+  on) — and the engine owns following-bottom. They never fight because
+  the viewport disables anchoring by default (`[overflow-anchor:none]` —
+  pinned/following, the engine owns the tail snap) and re-enables it
+  **only while the reader is away from the bottom**
+  (`data-[scrollable~=end]:[overflow-anchor:auto]`; the engine keeps
+  `end` in the viewport's `data-scrollable` attribute exactly while the
+  user is unpinned in history, and updates it promptly on scroll
+  commits). Do NOT scope this off `data-autoscrolling` instead: that
+  attribute is only rewritten on engine state commits and measured stale
+  — still set minutes after the user scrolled up and went idle — which
+  would leave anchoring off exactly when the reader needs it. Per-slot
+  `contain-intrinsic-size` estimates
+  (`intrinsicSizeClass` in `MessageList`, keyed off the slot body kind)
+  keep each first-reveal settle small so anchoring's corrections stay
+  imperceptible in both scroll directions. (An earlier build set a blanket
+  `overflow-anchor: none`, which disabled anchoring everywhere and let
+  those settles drift the viewport hundreds of px per wheel batch.)
 - **Turn anchoring is deliberately OFF** (`scrollAnchor={false}` on
   every row): with hundreds of pre-hydrated rows the engine's anchor
   handling scrolls the viewport to a stale early anchor when new items

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -13,6 +13,7 @@ import type {
   ChatViewItem,
   PermissionRequestItem,
 } from "@/lib/agent-chat/types";
+import { cn } from "@/lib/utils";
 import { useAppStore } from "@/stores/app-store";
 import { useFeatureFlags } from "@/stores/feature-flags";
 import type { ApprovalDecision } from "@/tauri/events";
@@ -32,7 +33,11 @@ import { isTaskSummaryTool, TaskSummaryCard } from "./TaskSummaryCard";
 import { ToolCallCard } from "./ToolCallCard";
 import { UserMessage } from "./UserMessage";
 import { WorkflowRunCard } from "./WorkflowRunCard";
-import { buildTranscriptSlots, type ActivityStep } from "./transcript-slots";
+import {
+  buildTranscriptSlots,
+  type ActivityStep,
+  type TranscriptSlot,
+} from "./transcript-slots";
 
 interface Props {
   messages: ChatViewItem[];
@@ -85,12 +90,24 @@ interface Props {
  * the end on every ResizeObserver/MutationObserver-detected content
  * change while following, unpins on user wheel/touch/keydown gestures,
  * and re-pins once the reader scrolls back within its 8px edge
- * threshold. The viewport also disables native browser scroll
- * anchoring (`overflow-anchor: none`) so `content-visibility:auto`'s
- * estimated-then-real row height settling can't fight the engine's
- * programmatic scrolls. Per-item turn anchoring is still off (see
- * `scrollAnchor={false}` below) — that remains a deliberate,
- * independent setting.
+ * threshold. Scroll stability is split by ownership: native browser
+ * scroll anchoring owns free-scroll (while the reader scrolls history it
+ * absorbs the `content-visibility:auto` estimated-then-real height
+ * settling of rows above the viewport); the engine owns following-bottom.
+ * The two never fight because the viewport disables anchoring by default
+ * (`[overflow-anchor:none]` — pinned/following, the engine owns the tail
+ * snap) and re-enables it only while the reader is away from the bottom
+ * (`data-[scrollable~=end]:[overflow-anchor:auto]` — the engine keeps
+ * "end" in the viewport's `data-scrollable` attribute exactly while the
+ * user is unpinned in history, updated promptly on scroll commits). Do
+ * NOT scope this off `data-autoscrolling`: that attribute is only
+ * rewritten on engine state commits and stays stale — set — indefinitely
+ * after the user scrolls up and goes idle, which is precisely when
+ * anchoring is needed. Per-item turn anchoring is still off (see
+ * `scrollAnchor={false}` below) — that remains a deliberate, independent
+ * setting. Per-slot `contain-intrinsic-size` estimates
+ * (`intrinsicSizeClass`) keep each first-reveal settle small so
+ * anchoring's corrections stay imperceptible.
  *
  * Layout is derived by the pure `buildTranscriptSlots` (turn grouping,
  * tool-run folding, avatar/turn-boundary metadata). Each slot is one
@@ -208,7 +225,10 @@ export function MessageList({
                 // The scroller engine's `following-bottom` mode owns
                 // tail tracking (see the file-top doc comment).
                 scrollAnchor={false}
-                className={slot.turnStart ? "mt-5" : "mt-[13px]"}
+                className={cn(
+                  slot.turnStart ? "mt-5" : "mt-[13px]",
+                  intrinsicSizeClass(slot),
+                )}
               >
                 {slot.body.kind === "activity" ? (
                   <ActivityRowMemo
@@ -321,6 +341,41 @@ function subagentNameFor(
 ): string | null {
   if (item.kind !== "permission_request" || !item.subagent_id) return null;
   return subagentNames.get(item.subagent_id) ?? "subagent";
+}
+
+/**
+ * Per-slot `content-visibility` first-reveal estimate. Each row is
+ * `[content-visibility:auto]`, so before it first paints the browser lays
+ * it out at the `contain-intrinsic-size` estimate and only measures the
+ * real height on reveal. When the user scrolls up through cold history the
+ * difference between estimate and real height is exactly the correction the
+ * browser's native scroll anchoring has to absorb — so the closer the
+ * estimate is to a row-type's typical height, the smaller (and less
+ * visible) that correction is in BOTH scroll directions. Keying the
+ * estimate off the slot's body kind gets us most of that accuracy for free
+ * without any measurement, observers, or JS scroll compensation. Rows with
+ * no strong typical height fall through to the `MessageScrollerItem`
+ * default (`auto_6rem`); tailwind-merge lets the per-row estimate here win
+ * over that default (last arbitrary-property wins).
+ */
+function intrinsicSizeClass(slot: TranscriptSlot): string {
+  // Folded mechanical-step runs (reasoning + tool calls) render a multi-row
+  // Activity block, so they're taller than a single step.
+  if (slot.body.kind === "activity") return "[contain-intrinsic-size:auto_8rem]";
+  switch (slot.body.item.kind) {
+    case "user_message":
+      return "[contain-intrinsic-size:auto_3.5rem]";
+    case "assistant_message":
+      return "[contain-intrinsic-size:auto_7rem]";
+    case "tool_call":
+    case "reasoning":
+      return "[contain-intrinsic-size:auto_5rem]";
+    case "subagent_run":
+    case "workflow_run":
+      return "[contain-intrinsic-size:auto_14rem]";
+    default:
+      return "";
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/ui/message-scroller.tsx
+++ b/src/components/ui/message-scroller.tsx
@@ -40,7 +40,7 @@ function MessageScrollerViewport({
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content [overflow-anchor:none] [scrollbar-gutter:stable] data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
+        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content [overflow-anchor:none] data-[scrollable~=end]:[overflow-anchor:auto] data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
         className
       )}
       {...props}
@@ -71,7 +71,7 @@ function MessageScrollerItem({
       data-slot="message-scroller-item"
       scrollAnchor={scrollAnchor}
       className={cn(
-        "min-w-0 shrink-0 [contain-intrinsic-size:auto_10rem] [content-visibility:auto]",
+        "min-w-0 shrink-0 [contain-intrinsic-size:auto_6rem] [content-visibility:auto]",
         className
       )}
       {...props}

--- a/src/components/ui/message-scroller.tsx
+++ b/src/components/ui/message-scroller.tsx
@@ -40,7 +40,7 @@ function MessageScrollerViewport({
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content [overflow-anchor:none] data-[scrollable~=end]:[overflow-anchor:auto] data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
+        "size-full min-h-0 min-w-0 scroll-fade-b scrollbar-thin scrollbar-gutter-stable overflow-y-auto overscroll-contain contain-content [overflow-anchor:none] [scrollbar-gutter:stable] data-[scrollable~=end]:[overflow-anchor:auto] data-autoscrolling:scrollbar-thumb-transparent data-autoscrolling:scrollbar-track-transparent",
         className
       )}
       {...props}


### PR DESCRIPTION
## Problem

PR #141 (v0.13.0) correctly made the shadcn scroller engine the single stick-to-bottom owner, but it also set a blanket `overflow-anchor: none` on the transcript viewport. Transcript rows use `content-visibility: auto` with estimated heights, and the engine writes **no** scroll corrections while the reader is unpinned (its ResizeObserver only acts in `following-bottom` mode). So when scrolling up through cold history, rows above the viewport settle from the flat 10rem estimate to their real heights and nothing holds the reading position — native scroll anchoring, the browser mechanism designed for exactly this (see CSSWG #9833), was disabled.

**Measured** in the seeded 490-row `agent-chat-demo` thread with frame-by-frame viewport instrumentation: 4 visual jumps of **217–607px** across 4 wheel batches while scrolling up (drift exactly equals the above-viewport `scrollHeight` delta, `scrollTop` unchanged).

## Fix

- **Scope anchoring instead of disabling it**: `[overflow-anchor:none] data-[scrollable~=end]:[overflow-anchor:auto]` — anchoring stays off while pinned at the tail (engine owns the snap; #141 contract preserved) and turns on the moment the reader is away from the bottom, letting the browser absorb above-viewport height settling. The engine's `data-autoscrolling` attribute was evaluated first but measured stale between state commits (stays set indefinitely after the user scrolls up and idles); `data-scrollable~=end` updates reliably.
- **Per-row-type `contain-intrinsic-size` estimates** (user 3.5rem, tool/reasoning 5rem, assistant 7rem, activity 8rem, subagent/workflow cards 14rem, default 6rem) replace the flat 10rem, shrinking first-reveal settle deltas in both scroll directions.
- Drop a duplicate `scrollbar-gutter` declaration; update `MessageList` doc comment and `docs/features/agent-chat.md`.

## Verification (end-to-end, dev mock + browser instrumentation)

| Check | Before | After |
|---|---|---|
| Uncompensated jumps, scroll up through cold history | 4 (max 607px) | **0** (compensation within 0.1px; worst single-frame residual ~9px) |
| Height-settle churn per pass | 1750px | 652px |
| Scroll down / re-scroll jumps | — | 0 |
| Stick-to-bottom while streaming | — | pinned, 0px deviation across 2192 frames |
| Scroll up mid-stream | — | position holds exactly, no yank-back |
| Jump-to-latest | — | lands at bottom, anchoring hands back to engine |

`cargo check` + `cargo test` (1965/27/37), `npm run check`, and all 2358 frontend tests pass (`event_ordering_across_rapid_bursts` flaked once, passes 4/4 on rerun; unrelated — this diff is frontend-only).

Note: verified in the Chromium-based dev browser pane. On webviews without `overflow-anchor` support the anchoring half is a no-op and behavior degrades to today's baseline improved by the estimate accuracy (~4× smaller jumps), so there is no regression path.