### PR TITLE
feat(chat): render attached images in sent messages with click-to-open lightbox

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -134,6 +134,18 @@ The chat pane stack:
     bytes (not a temp-file path) because the chat stages bytes in
     memory. A text-only clipboard rejects the command → default paste
     runs untouched.
+  - **Attached images render in the sent bubble.** On send,
+    the staged image bytes are also turned into `data:` URLs
+    (`buildImageDisplaySources`) and stamped onto the optimistic
+    `UserMessageItem.images` — so the sent turn shows its own thumbnails,
+    not just the provider. The persisted `user_message` envelope gains an
+    optional `images: [{ path, media_type }]` (absolute fs paths written
+    backend-side); on hydrate those map onto `images[].src`.
+    `UserMessage` renders a wrapping thumbnail row (rounded, bordered,
+    ≤160px, broken-image fallback) with click-to-open lightbox
+    (`Dialog`, Esc / click-outside). `resolveAssetSrc` normalises both
+    forms: `data:` URLs (fresh optimistic send) pass through untouched,
+    absolute paths (hydrated) go through `convertFileSrc`.
 - **Slash command popup** with cross-provider parsing.
 - **Cross-provider skill system**: watcher, conflicts, disable, refined
   compat. Server-side sync (see `docs/features/skills-sync.md`).

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -1027,6 +1027,13 @@ pub async fn agent_chat_send_turn(
     let thread_id_for_persist = input.thread_id.0.clone();
     let user_text_for_persist = input.text.clone();
     let first_line = first_line_title(&input.text);
+    // Persist any attachments to disk NOW, before the provider consumes
+    // `input`. This runs for both immediate and queued sends: the bytes
+    // are in hand here and nowhere else (the deferred, dispatch-time
+    // envelope write in `forward_event` only sees `text`). Best-effort —
+    // a failed write is logged and skipped inside the helper and never
+    // blocks the turn.
+    let saved_images = save_chat_images(&thread_id_for_persist, &input.images);
     // A genuine new user turn is the authoritative, provider-agnostic
     // anchor for resetting subagent tracking. Clear the thread's tracker
     // entry here so a subagent left non-terminal by the previous turn
@@ -1067,8 +1074,25 @@ pub async fn agent_chat_send_turn(
     // this is the one chance to record them. Best-effort: a failed write
     // means resume will skip this user turn but the live conversation is
     // unaffected.
-    if result.queued_id.is_none() {
-        persist_user_message(&db, &thread_id_for_persist, &user_text_for_persist);
+    match &result.queued_id {
+        None => persist_user_message(
+            &db,
+            &thread_id_for_persist,
+            &user_text_for_persist,
+            &saved_images,
+        ),
+        // Queued: stash the (already-on-disk) image records keyed by the
+        // provider's queued_id so the deferred envelope write in
+        // `forward_event`'s `QueuedTurnDispatched` arm can attach them at
+        // real turn order. Skip the map entirely when there are no images
+        // (nothing to carry — the dispatch persist writes text only).
+        Some(queued_id) if !saved_images.is_empty() => {
+            pending_queued_images()
+                .lock()
+                .unwrap()
+                .insert(queued_id.clone(), saved_images);
+        }
+        Some(_) => {}
     }
     Ok(result)
 }
@@ -1094,14 +1118,150 @@ pub async fn agent_chat_cancel_queued_turn(
         .map_err(provider_err)
 }
 
+/// A chat image attachment that has been written to disk for the
+/// transcript. User messages (and their images) never come back through
+/// the provider event stream, so the only record of an attachment is the
+/// path we mint here plus its original MIME type — both go onto the
+/// `user_message` envelope so a resumed conversation can re-render the
+/// image the same way the live send did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PersistedChatImage {
+    /// Absolute path to the on-disk copy of the image bytes.
+    path: String,
+    /// Original media type (e.g. `"image/png"`), echoed verbatim so the
+    /// frontend can label / re-encode the attachment on hydrate.
+    media_type: String,
+}
+
+/// Map a media type to a file extension for the on-disk copy. Deliberately
+/// narrow — only the types Agent Chat actually accepts — with a `bin`
+/// fallback so an unknown/garbage MIME still round-trips to disk rather
+/// than being dropped. Case-insensitive because clients are inconsistent
+/// about MIME casing (mirrors `files::clipboard_image_extension`).
+fn chat_image_extension(media_type: &str) -> &'static str {
+    match media_type.to_ascii_lowercase().as_str() {
+        "image/png" => "png",
+        "image/jpeg" | "image/jpg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        _ => "bin",
+    }
+}
+
+/// Resolve a thread's chat-image directory:
+/// `<config>/<APP_DIR_NAME>/agent-chat/images/<thread_id>/`.
+///
+/// Mirrors how [`crate::database`] resolves its store path (config dir +
+/// app name) so images live beside the transcript DB — a durable location
+/// a resumed conversation can rely on — rather than in a temp dir the OS
+/// may reap out from under it (unlike the ephemeral clipboard-paste files
+/// in `commands::files`).
+fn chat_images_dir(thread_id: &str) -> Option<std::path::PathBuf> {
+    Some(
+        dirs::config_dir()?
+            .join(crate::APP_DIR_NAME)
+            .join("agent-chat")
+            .join("images")
+            .join(thread_id),
+    )
+}
+
+/// Write each attachment's bytes to disk under the thread's image dir and
+/// return the records to record on the transcript envelope.
+///
+/// Best-effort by contract: a failed directory-create or write logs and
+/// SKIPS that image — it must never propagate an error that would block
+/// the turn (the live send still carries the bytes to the provider). An
+/// empty input is a cheap no-op returning an empty vec, so callers can
+/// invoke it unconditionally.
+fn save_chat_images(
+    thread_id: &str,
+    images: &[crate::agent_provider::ImageInput],
+) -> Vec<PersistedChatImage> {
+    if images.is_empty() {
+        return Vec::new();
+    }
+    let Some(dir) = chat_images_dir(thread_id) else {
+        eprintln!(
+            "[codemux::agent_chat] could not resolve config dir; \
+             skipping {} chat image(s)",
+            images.len()
+        );
+        return Vec::new();
+    };
+    if let Err(error) = std::fs::create_dir_all(&dir) {
+        eprintln!(
+            "[codemux::agent_chat] failed to create chat image dir {}: {error}",
+            dir.display()
+        );
+        return Vec::new();
+    }
+    let mut saved = Vec::with_capacity(images.len());
+    for image in images {
+        let ext = chat_image_extension(&image.media_type);
+        let path = dir.join(format!("{}.{ext}", uuid::Uuid::new_v4()));
+        match std::fs::write(&path, &image.data) {
+            Ok(()) => saved.push(PersistedChatImage {
+                path: path.to_string_lossy().into_owned(),
+                media_type: image.media_type.clone(),
+            }),
+            Err(error) => eprintln!(
+                "[codemux::agent_chat] failed to write chat image {}: {error}",
+                path.display()
+            ),
+        }
+    }
+    saved
+}
+
+/// Process-wide bridge carrying a QUEUED send's on-disk image records
+/// through to the deferred user-message envelope write.
+///
+/// The provider's follow-up queue carries a queued turn's *text* to
+/// dispatch, but it has no notion of the transcript paths the command
+/// layer minted — those live only here, keyed by the same `queued_id` the
+/// provider echoes on [`ProviderRuntimeEvent::QueuedTurnDispatched`]. An
+/// immediate (non-queued) send never touches this map: its envelope is
+/// written inline in [`agent_chat_send_turn`]. Follows the same
+/// module-static idiom as [`resume_locks`] to avoid threading a new
+/// managed state through every `forward_event` test harness.
+fn pending_queued_images() -> &'static Mutex<HashMap<String, Vec<PersistedChatImage>>> {
+    static PENDING: OnceLock<Mutex<HashMap<String, Vec<PersistedChatImage>>>> =
+        OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
 /// Append the synthetic `{"type":"user_message"}` transcript envelope.
 /// Best-effort — a failed write only means resume skips this user turn.
-fn persist_user_message(db: &DatabaseStore, thread_id: &str, text: &str) {
-    let user_msg = serde_json::json!({
+///
+/// When `images` is non-empty the envelope gains an `"images"` array of
+/// `{"path","media_type"}` records; it is OMITTED entirely otherwise so
+/// older transcripts and image-less turns stay byte-identical (backward
+/// compatible — the frontend hydrate treats a missing field as "no
+/// attachments").
+fn persist_user_message(
+    db: &DatabaseStore,
+    thread_id: &str,
+    text: &str,
+    images: &[PersistedChatImage],
+) {
+    let mut user_msg = serde_json::json!({
         "type": "user_message",
         "thread_id": thread_id,
         "text": text,
     });
+    if !images.is_empty() {
+        let images_json: Vec<serde_json::Value> = images
+            .iter()
+            .map(|image| {
+                serde_json::json!({
+                    "path": image.path,
+                    "media_type": image.media_type,
+                })
+            })
+            .collect();
+        user_msg["images"] = serde_json::Value::Array(images_json);
+    }
     if let Ok(payload) = serde_json::to_string(&user_msg) {
         let _ = db.append_agent_chat_message(thread_id, &payload);
     }
@@ -1496,6 +1656,13 @@ pub async fn agent_chat_delete_session(
     db: State<'_, DatabaseStore>,
     thread_id: String,
 ) -> Result<(), String> {
+    // Best-effort: drop the thread's on-disk image directory alongside the
+    // DB rows. The messages cascade via FK, but the image files live
+    // outside SQLite, so nothing else would ever reclaim them. A failure
+    // here (missing dir is the common case) must not fail the delete.
+    if let Some(dir) = chat_images_dir(&thread_id) {
+        let _ = std::fs::remove_dir_all(&dir);
+    }
     db.delete_agent_chat_session(&thread_id)
 }
 
@@ -1607,12 +1774,36 @@ pub fn forward_event<R: Runtime>(app: &AppHandle<R>, event: ProviderRuntimeEvent
     // in provider memory, so this event is the one moment the command
     // layer can record the turn.
     if let ProviderRuntimeEvent::QueuedTurnDispatched {
-        thread_id, text, ..
+        thread_id,
+        queued_id,
+        text,
+        ..
     } = &event
     {
         if !thread_id.0.is_empty() {
             let db: State<'_, DatabaseStore> = app.state();
-            persist_user_message(&db, &thread_id.0, text);
+            // Reclaim any image records stashed at enqueue time (see
+            // `pending_queued_images`) so the deferred envelope carries the
+            // same attachments an immediate send would have. Absent entry →
+            // a text-only queued turn, persisted with no images.
+            let images = pending_queued_images()
+                .lock()
+                .unwrap()
+                .remove(queued_id)
+                .unwrap_or_default();
+            persist_user_message(&db, &thread_id.0, text, &images);
+        }
+    }
+    // A queued turn was cancelled before it dispatched, so its envelope
+    // will never be written. Drop the stashed image records and best-effort
+    // delete the orphaned on-disk copies so a cancelled attachment does not
+    // leak a file forever.
+    if let ProviderRuntimeEvent::QueuedTurnCancelled { queued_id, .. } = &event {
+        let orphaned = pending_queued_images().lock().unwrap().remove(queued_id);
+        if let Some(images) = orphaned {
+            for image in images {
+                let _ = std::fs::remove_file(&image.path);
+            }
         }
     }
     // Best-effort transcript persistence so the SessionSelector resume
@@ -2071,6 +2262,78 @@ mod tests {
         let multi: String = std::iter::repeat('漢').take(100).collect();
         let title = first_line_title(&multi).unwrap();
         assert_eq!(title.chars().count(), 58);
+    }
+
+    // ── chat image persistence ──
+
+    #[test]
+    fn chat_image_extension_maps_known_types_and_falls_back() {
+        assert_eq!(chat_image_extension("image/png"), "png");
+        assert_eq!(chat_image_extension("image/jpeg"), "jpg");
+        assert_eq!(chat_image_extension("image/jpg"), "jpg");
+        assert_eq!(chat_image_extension("image/gif"), "gif");
+        assert_eq!(chat_image_extension("image/webp"), "webp");
+        // Case-insensitive.
+        assert_eq!(chat_image_extension("IMAGE/PNG"), "png");
+        // Unknown / non-image types fall back to `bin` rather than drop.
+        assert_eq!(chat_image_extension("image/heic"), "bin");
+        assert_eq!(chat_image_extension("application/pdf"), "bin");
+    }
+
+    /// Build the user_message envelope the same way `persist_user_message`
+    /// does, so the shape assertions below don't need a DB.
+    fn user_message_envelope(
+        thread_id: &str,
+        text: &str,
+        images: &[PersistedChatImage],
+    ) -> serde_json::Value {
+        let mut user_msg = json!({
+            "type": "user_message",
+            "thread_id": thread_id,
+            "text": text,
+        });
+        if !images.is_empty() {
+            let images_json: Vec<serde_json::Value> = images
+                .iter()
+                .map(|image| json!({"path": image.path, "media_type": image.media_type}))
+                .collect();
+            user_msg["images"] = serde_json::Value::Array(images_json);
+        }
+        user_msg
+    }
+
+    #[test]
+    fn user_message_envelope_omits_images_when_none() {
+        let envelope = user_message_envelope("t1", "hello", &[]);
+        assert_eq!(
+            envelope,
+            json!({"type": "user_message", "thread_id": "t1", "text": "hello"})
+        );
+        // The field is ABSENT, not `null` — backward compatible with the
+        // pre-images transcript shape.
+        assert!(envelope.get("images").is_none());
+    }
+
+    #[test]
+    fn user_message_envelope_includes_images_when_present() {
+        let images = vec![
+            PersistedChatImage {
+                path: "/tmp/a.png".into(),
+                media_type: "image/png".into(),
+            },
+            PersistedChatImage {
+                path: "/tmp/b.jpg".into(),
+                media_type: "image/jpeg".into(),
+            },
+        ];
+        let envelope = user_message_envelope("t1", "look", &images);
+        assert_eq!(
+            envelope["images"],
+            json!([
+                {"path": "/tmp/a.png", "media_type": "image/png"},
+                {"path": "/tmp/b.jpg", "media_type": "image/jpeg"},
+            ])
+        );
     }
 
     #[test]

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -1357,6 +1357,8 @@ describe("AgentChatPane Thread Scope — deferred worktree first send", () => {
     expect(appendUserMessageMock).toHaveBeenCalledWith(
       startInput.thread_id,
       "fix the login bug",
+      undefined,
+      [],
     );
     // 4. Draft cleared so the new pane mounts solo.
     expect(setActiveDraftMock).toHaveBeenCalledWith(null);

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -13,6 +13,7 @@ import {
   buildAttachmentBlock,
   buildFileResolvedContent,
   buildFolderResolvedContent,
+  buildImageDisplaySources,
   buildImagePayloads,
   buildIssueResolvedContent,
   buildPrResolvedContent,
@@ -1112,6 +1113,10 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       // translate to provider-specific shapes (Claude `image/base64`,
       // Codex `image_url` data URI).
       const imagePayloads = buildImagePayloads(liveAttachments);
+      // The same images as `data:` URLs, attached to the
+      // optimistic bubble so the sent turn shows its thumbnails (the
+      // bytes only live in memory until the backend persists them).
+      const imageDisplaySources = buildImageDisplaySources(liveAttachments);
       const sdkText = applyAllPrefixes(
         rawText,
         mode,
@@ -1127,7 +1132,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         typeof crypto !== "undefined" && "randomUUID" in crypto
           ? crypto.randomUUID()
           : `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      appendUserMessage(threadId, plan.text, clientNonce);
+      appendUserMessage(threadId, plan.text, clientNonce, imageDisplaySources);
       // Clear chips per-turn (matches the inputDraft = "" reset that
       // appendUserMessage already does for the textarea).
       clearStagedAttachments(threadId);
@@ -2421,6 +2426,9 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
           activeAttachments(rawText, liveAttachments),
         );
         const imagePayloads = buildImagePayloads(liveAttachments);
+        // Display shape (`data:` URLs) for the optimistic
+        // bubble's thumbnails in the freshly-prestarted thread.
+        const imageDisplaySources = buildImageDisplaySources(liveAttachments);
         const sdkText = applyAllPrefixes(
           rawText,
           mode,
@@ -2432,7 +2440,12 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         // mounts on activation renders the user bubble immediately.
         useAgentChatStore
           .getState()
-          .appendUserMessage(prestarted.threadId, plan.text);
+          .appendUserMessage(
+            prestarted.threadId,
+            plan.text,
+            undefined,
+            imageDisplaySources,
+          );
         await agentChatSendTurn(provider, {
           thread_id: prestarted.threadId,
           text: sdkText,

--- a/src/components/chat/DraftChatSurface.test.tsx
+++ b/src/components/chat/DraftChatSurface.test.tsx
@@ -842,8 +842,8 @@ describe("DraftChatSurface", () => {
       });
       const call = vi.mocked(materializeAndSend).mock.calls[0];
       // (draft, text, cwd, actions, skillBodies, attachmentBlock,
-      //  imagePayloads, worktreeProjectPath)
-      expect(call[7]).toBe("/projects/foo");
+      //  imagePayloads, imageDisplaySources, worktreeProjectPath)
+      expect(call[8]).toBe("/projects/foo");
     });
 
     it("checkoutMode 'current' (the default) passes null as the worktree project path", async () => {
@@ -865,7 +865,7 @@ describe("DraftChatSurface", () => {
         expect(materializeAndSend).toHaveBeenCalled();
       });
       const call = vi.mocked(materializeAndSend).mock.calls[0];
-      expect(call[7]).toBeNull();
+      expect(call[8]).toBeNull();
     });
   });
 });

--- a/src/components/chat/DraftChatSurface.tsx
+++ b/src/components/chat/DraftChatSurface.tsx
@@ -4,6 +4,7 @@ import {
   buildAttachmentBlock,
   buildFileResolvedContent,
   buildFolderResolvedContent,
+  buildImageDisplaySources,
   buildImagePayloads,
   buildIssueResolvedContent,
   buildPrResolvedContent,
@@ -310,6 +311,9 @@ function DraftChatSurfaceInner({ draft }: { draft: ChatDraft }) {
     // Stage 6 — extract resolved image bytes for the multimodal SDK
     // path. Empty array when no images staged.
     const imagePayloads = buildImagePayloads(liveAttachments);
+    // The same images as `data:` URLs so the optimistic
+    // user bubble in the new pane renders their thumbnails immediately.
+    const imageDisplaySources = buildImageDisplaySources(liveAttachments);
 
     // Thread Scope redesign — when the checkout popover is set to
     // "worktree", pass along the project root to fork from so
@@ -348,6 +352,7 @@ function DraftChatSurfaceInner({ draft }: { draft: ChatDraft }) {
       skillBodies,
       attachmentBlock,
       imagePayloads,
+      imageDisplaySources,
       worktreeProjectPath,
     )
       .then((result) => {

--- a/src/components/chat/UserMessage.tsx
+++ b/src/components/chat/UserMessage.tsx
@@ -1,7 +1,13 @@
-import { memo } from "react";
-import { X } from "lucide-react";
+import { memo, useState } from "react";
+import { ImageOff, X } from "lucide-react";
 
-import type { UserMessageItem } from "@/lib/agent-chat/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { resolveAssetSrc } from "@/lib/asset-url";
+import type { UserMessageImage, UserMessageItem } from "@/lib/agent-chat/types";
 import { cn } from "@/lib/utils";
 
 /**
@@ -10,6 +16,13 @@ import { cn } from "@/lib/utils";
  * corner toward the composer, and pre-wrapped text so pasted snippets
  * keep their line breaks. Width is capped so long turns don't span the
  * whole 760px column.
+ *
+ * Attached images (paste / drop / picker) render as a wrapping
+ * thumbnail row above the text; clicking one opens it near-fullscreen
+ * in a lightbox. Sources are either `data:` URLs (fresh optimistic
+ * send) or absolute filesystem paths (hydrated) — `resolveAssetSrc`
+ * normalises both into a webview-loadable URL, so the bubble never has
+ * to know which form it got.
  *
  * Follow-up queueing: while `item.queued` is set the bubble renders
  * greyed-out (reduced opacity + muted foreground) with a small "Queued"
@@ -24,19 +37,39 @@ export const UserMessage = memo(function UserMessage({
   onCancelQueued?: (queuedId: string, text: string) => void;
 }) {
   const queued = item.queued;
+  const images = item.images ?? [];
+  // Index of the image currently shown in the lightbox, or `null` when
+  // it's closed. Tracked here (not per-thumbnail) so the same dialog
+  // instance serves every image in the turn.
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const lightboxImage =
+    lightboxIndex !== null ? images[lightboxIndex] : undefined;
 
   return (
     <div className="group flex justify-end">
       <div className="flex max-w-[82%] flex-col items-end gap-1">
         <div
           className={cn(
-            "whitespace-pre-wrap break-words rounded-[14px_14px_5px_14px] border px-[15px] py-[11px] text-[13.5px] leading-[1.55]",
+            "flex flex-col gap-2 rounded-[14px_14px_5px_14px] border px-[15px] py-[11px] text-[13.5px] leading-[1.55]",
             queued
               ? "border-dashed border-border/50 bg-muted/40 text-muted-foreground opacity-70"
               : "border-border/60 bg-card text-foreground",
           )}
         >
-          {item.text}
+          {images.length > 0 ? (
+            <div className="flex flex-wrap justify-end gap-2">
+              {images.map((image, i) => (
+                <ImageThumbnail
+                  key={`${image.src}-${i}`}
+                  image={image}
+                  onOpen={() => setLightboxIndex(i)}
+                />
+              ))}
+            </div>
+          ) : null}
+          {item.text ? (
+            <div className="whitespace-pre-wrap break-words">{item.text}</div>
+          ) : null}
         </div>
         {queued ? (
           <div className="flex items-center gap-1.5 pr-0.5">
@@ -57,6 +90,90 @@ export const UserMessage = memo(function UserMessage({
           </div>
         ) : null}
       </div>
+
+      {/* Lightbox — reuses the shared Dialog so Esc / click-outside close
+          for free (matches project-image-dialog). Near-fullscreen,
+          object-contain so no image is cropped. */}
+      <Dialog
+        open={lightboxImage !== undefined}
+        onOpenChange={(open) => {
+          if (!open) setLightboxIndex(null);
+        }}
+      >
+        <DialogContent className="max-w-[92vw] border-none bg-transparent p-0 shadow-none sm:max-w-[92vw]">
+          <DialogTitle className="sr-only">Attached image</DialogTitle>
+          {lightboxImage ? (
+            <LightboxImage image={lightboxImage} />
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 });
+
+/** A single clickable thumbnail. Owns its own broken-image state so one
+ *  unreadable path can't blank the others; the fallback keeps the same
+ *  footprint so the row layout doesn't jump. */
+function ImageThumbnail({
+  image,
+  onOpen,
+}: {
+  image: UserMessageImage;
+  onOpen: () => void;
+}) {
+  const [errored, setErrored] = useState(false);
+  const src = resolveAssetSrc(image.src, null);
+
+  if (errored || !src) {
+    return (
+      <div
+        className="flex h-20 w-28 items-center justify-center rounded-lg border border-border/60 bg-muted/40 text-muted-foreground"
+        aria-label="Image failed to load"
+      >
+        <ImageOff className="h-5 w-5 opacity-40" aria-hidden />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      aria-label="Open attached image"
+      className="cursor-pointer overflow-hidden rounded-lg border border-border/60 transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <img
+        src={src}
+        alt={image.mediaType ?? "attached image"}
+        className="max-h-40 max-w-[200px] object-contain"
+        onError={() => setErrored(true)}
+      />
+    </button>
+  );
+}
+
+/** The blown-up image inside the lightbox. Keeps its own error state so
+ *  a path that reads at thumbnail size but fails at full size still
+ *  degrades to a placeholder rather than a browser broken-image icon. */
+function LightboxImage({ image }: { image: UserMessageImage }) {
+  const [errored, setErrored] = useState(false);
+  const src = resolveAssetSrc(image.src, null);
+
+  if (errored || !src) {
+    return (
+      <div className="flex h-[60vh] w-full flex-col items-center justify-center gap-2 rounded-lg bg-muted/40 text-muted-foreground">
+        <ImageOff className="h-8 w-8 opacity-40" aria-hidden />
+        <span className="text-xs">Failed to load image</span>
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={image.mediaType ?? "attached image"}
+      className="mx-auto max-h-[88vh] w-auto max-w-full rounded-lg object-contain"
+      onError={() => setErrored(true)}
+    />
+  );
+}

--- a/src/dev/mock-fixtures.ts
+++ b/src/dev/mock-fixtures.ts
@@ -119,6 +119,18 @@ function terminalSurface(label: string, cwd: string): PaneRefs {
  *  browser (issue #77). */
 export const MOCK_CHAT_THREAD_ID = "thread-mock-chat";
 
+/** Inline data-URL PNG (200×120, teal field + magenta band + border)
+ *  used to seed a user turn's attached image in the dev mock. A
+ *  self-contained data URL is what an optimistic send produces at
+ *  runtime, and — crucially — it passes straight through
+ *  `resolveAssetSrc` (bypassing `convertFileSrc`), so the thumbnail +
+ *  lightbox render in a plain browser where Tauri's asset protocol is
+ *  unavailable. Persisted turns use `{ path, media_type }`; the mock
+ *  smuggles the data URL in via `path` so the same hydrate mapping
+ *  (`path` → `src`) exercises the render path. */
+export const MOCK_USER_IMAGE_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMgAAAB4CAIAAAA48Cq8AAADNUlEQVR4nO3cu7HVUBAF0RcENjYOaRAiQTybSIgIm6K4+tw5mj57umoHoOlapqSPL1+/OVe+j/YncJETllsyYbkl+wvW7x8/y/f91yd83lt176OwhrdmbtG9T8Manhu78nt7YM1sDV/tvW2wZuZuP+exe5thjWo96t5+WHNaj7oXAWtO7jn3gmDFtx51LwtWfO459xJhpbYedS8UVmTrUfdyYUXmnnMvHVZS61H3bgArKfece7eBFdB61L07wdq99ah7N4O1e+459/4XVnkdW4+69xWsFYGG555z7zEsbWnrxr2nYMF5tafU1r/3XoBFtrVL7jn3XoOlLW2tgiUveS2EpS1trYIF59Wedritd2GRbQFzz+FVAEtb2loFS17yWghLW9paBQvOq53OHFtLYJFtyWtvWNpC1YuCJS9avShY2kLVi4IF59VOJ9LWc7DItuS1NyxtoepFwZIXrV4ULG2h6kXB0haqXhQsedHqRcHSFqpeFCx50epFwdIWql4ULDivdjob2SLCItuS196wtIWqFwVLXrR6UbC0haoXBQvOq70M09Y2sMi25LU3LG2h6kXBkhetXhQsbaHqXYM1MJC2Cu99BWtgIHlV3XsAa2AdbZXcewxrZiB5vXnvWVgD62jrnV2ANTOQth6CNS2QvJ6DNaeOtp6GNSeQvBpgxdfRVhus+EDa6oQVHEhe9+qVwYqso63b9SphRQaS17169bCS6mjrdr0lsJICaeteuoWwMgLJ6169tbB2r9O+9ji36y2HtXsgwtrj3Kj36p1363DWHudqveOPKYYH4qy9zKV0x7C0hVp7nJP1TsHSFmrtcc7UOwtLXrS1x3m9a7C0hVp7nEpY2kKtPU4lLHnR1h6nEpa2UGuPUwlLXrS1x6mEpS3U2uNUwtIWau1x6v+PlRdIXghY2kItCpa8aIuCpS3UomDJC7U0WNpCLQqWtlCLgiUv2qJgaQu1KFjyQi0NlrZQi4KlLdSiYMmLtihY2kItCpa8UEuDpS3UomBpC7UoWPKiLQqWtlCLgiUv1NJgaQu1KFjaQi0Klrxoi4KlLdSiYMkLtTuwnKuasNySCcstmbDckv0BOQvYwYr8AtoAAAAASUVORK5CYII=";
+
 /** Build an agent-chat surface (+ tab) for a workspace. Mirrors the
  *  backend's `create_agent_chat_pane`: the surface root is an
  *  `agent_chat` pane and the tab keeps `kind: "terminal"` (TabKind has

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -36,6 +36,7 @@ import {
   MOCK_CHAT_THREAD_ID,
   MOCK_HOME_DIR,
   MOCK_USER,
+  MOCK_USER_IMAGE_DATA_URL,
   MOCK_WORKFLOW_APPROVAL_THREAD_ID,
   MOCK_WORKFLOW_COMPLETE_THREAD_ID,
   MOCK_WORKFLOW_RUNNING_THREAD_ID,
@@ -424,6 +425,12 @@ function mockChatTranscript(): string[] {
     type: "user_message",
     thread_id: T,
     text: "Implement clipboard-paste fallback",
+    // Seed an attached image on this tail turn so the
+    // thumbnail + lightbox render the moment the default seeded thread
+    // opens. The persisted envelope shape is `{ path, media_type }`;
+    // the mock uses a data URL as the `path` so it renders in a plain
+    // browser (no `convertFileSrc`).
+    images: [{ path: MOCK_USER_IMAGE_DATA_URL, media_type: "image/png" }],
   });
   for (const envelope of subagentTurnEnvelopes(T, subTurnId)) push(envelope);
   push({

--- a/src/lib/agent-chat/attachment-block.test.ts
+++ b/src/lib/agent-chat/attachment-block.test.ts
@@ -4,6 +4,7 @@ import {
   buildAttachmentBlock,
   buildFileResolvedContent,
   buildFolderResolvedContent,
+  buildImageDisplaySources,
   buildImagePayloads,
   buildIssueResolvedContent,
   buildPrResolvedContent,
@@ -589,5 +590,85 @@ describe("buildImagePayloads (Step 8 Stage 6)", () => {
     const out = buildImagePayloads([file, folder, img]);
     expect(out).toHaveLength(1);
     expect(out[0]?.media_type).toBe("image/png");
+  });
+});
+
+describe("buildImageDisplaySources", () => {
+  // The display shape the user-message bubble renders:
+  // `{ src: data-URL, mediaType }`. Same resolved-image filter as
+  // `buildImagePayloads`, but base64-encodes into a self-contained
+  // `data:` URL so the optimistic bubble shows thumbnails immediately.
+  function makeImageAttachment(
+    overrides: Partial<Attachment> = {},
+  ): Attachment {
+    return {
+      id: "img-1",
+      kind: "image",
+      ref: "image:img-1",
+      metadata: { label: "screenshot.png" },
+      resolvedImage: {
+        mime: "image/png",
+        bytes: new Uint8Array([1, 2, 3, 4]),
+      },
+      ...overrides,
+    };
+  }
+
+  it("builds a base64 data URL from the resolved bytes", () => {
+    const out = buildImageDisplaySources([makeImageAttachment()]);
+    // btoa of bytes [1,2,3,4] is "AQIDBA==".
+    expect(out).toEqual([
+      { src: "data:image/png;base64,AQIDBA==", mediaType: "image/png" },
+    ]);
+  });
+
+  it("skips loading images and non-image attachments", () => {
+    const loading: Attachment = {
+      id: "loading",
+      kind: "image",
+      ref: "image:loading",
+      metadata: { label: "pasting…", isLoading: true },
+    };
+    const file: Attachment = {
+      id: "f",
+      kind: "file",
+      ref: "x.ts",
+      metadata: { label: "x.ts" },
+      resolvedContent: "alpha",
+    };
+    expect(buildImageDisplaySources([loading, file])).toEqual([]);
+  });
+
+  it("preserves order and per-image mime across multiple images", () => {
+    const a = makeImageAttachment({
+      id: "a",
+      resolvedImage: { mime: "image/png", bytes: new Uint8Array([0]) },
+    });
+    const b = makeImageAttachment({
+      id: "b",
+      resolvedImage: { mime: "image/jpeg", bytes: new Uint8Array([255]) },
+    });
+    const out = buildImageDisplaySources([a, b]);
+    expect(out.map((s) => s.mediaType)).toEqual(["image/png", "image/jpeg"]);
+    expect(out[0]?.src.startsWith("data:image/png;base64,")).toBe(true);
+    expect(out[1]?.src.startsWith("data:image/jpeg;base64,")).toBe(true);
+  });
+
+  it("encodes a large image without a call-stack overflow", () => {
+    // 256 KB — well past the ~64K single-call argument ceiling that a
+    // naive `String.fromCharCode(...bytes)` spread would blow. The
+    // chunked encoder must handle it.
+    const big = new Uint8Array(256 * 1024);
+    for (let i = 0; i < big.length; i++) big[i] = i % 256;
+    const out = buildImageDisplaySources([
+      makeImageAttachment({ resolvedImage: { mime: "image/png", bytes: big } }),
+    ]);
+    expect(out).toHaveLength(1);
+    // Round-trip a prefix to confirm the base64 is valid, not garbage.
+    const b64 = out[0]!.src.split(",")[1]!;
+    const decoded = atob(b64);
+    expect(decoded.charCodeAt(0)).toBe(0);
+    expect(decoded.charCodeAt(1)).toBe(1);
+    expect(decoded.length).toBe(big.length);
   });
 });

--- a/src/lib/agent-chat/attachment-block.ts
+++ b/src/lib/agent-chat/attachment-block.ts
@@ -312,3 +312,50 @@ export function buildImagePayloads(
       media_type: a.resolvedImage.mime,
     }));
 }
+
+/**
+ * Base64-encode raw bytes for use in a `data:` URL.
+ *
+ * `btoa` needs a binary string, and the obvious
+ * `String.fromCharCode(...bytes)` spread passes every byte as its own
+ * argument — which overflows the call stack for anything but a tiny
+ * image (JS engines cap argument counts in the tens of thousands). We
+ * encode in fixed 32 KB windows so the per-call argument count stays
+ * bounded regardless of image size.
+ */
+function bytesToBase64(bytes: Uint8Array): string {
+  const CHUNK = 0x8000; // 32 KB — comfortably under engine arg limits.
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const window = bytes.subarray(i, i + CHUNK);
+    binary += String.fromCharCode(...window);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Sibling to `buildImagePayloads`: instead of the wire shape for the
+ * SDK, produce the display shape the user-message bubble renders
+ * (`{ src, mediaType }`). Each staged image becomes a self-contained
+ * `data:` URL so the optimistically-appended bubble can show the
+ * thumbnail immediately — before the turn round-trips and the backend
+ * persists the bytes to disk.
+ *
+ * Filters to resolved images exactly like `buildImagePayloads` so a
+ * still-loading chip never renders as a broken thumbnail, and returns
+ * `[]` when nothing is staged so callers can pass it straight into the
+ * optimistic append.
+ */
+export function buildImageDisplaySources(
+  attachments: Attachment[],
+): Array<{ src: string; mediaType: string }> {
+  return attachments
+    .filter(
+      (a): a is Attachment & { resolvedImage: { mime: string; bytes: Uint8Array } } =>
+        a.kind === "image" && !!a.resolvedImage,
+    )
+    .map((a) => ({
+      src: `data:${a.resolvedImage.mime};base64,${bytesToBase64(a.resolvedImage.bytes)}`,
+      mediaType: a.resolvedImage.mime,
+    }));
+}

--- a/src/lib/agent-chat/hydrate.test.ts
+++ b/src/lib/agent-chat/hydrate.test.ts
@@ -36,6 +36,56 @@ describe("replayPayloads", () => {
     });
   });
 
+  it("maps a user_message envelope's images onto the item", () => {
+    const state = replayPayloads([
+      JSON.stringify({
+        type: "user_message",
+        thread_id: "t",
+        text: "see attached",
+        images: [
+          { path: "/tmp/codemux/a.png", media_type: "image/png" },
+          { path: "/tmp/codemux/b.jpg" },
+        ],
+      }),
+    ]);
+    expect(state.messages).toHaveLength(1);
+    const item = state.messages[0];
+    expect(item.kind).toBe("user_message");
+    if (item.kind === "user_message") {
+      // `path` → `src`; `media_type` → `mediaType` (undefined when the
+      // backend omitted it).
+      expect(item.images).toEqual([
+        { src: "/tmp/codemux/a.png", mediaType: "image/png" },
+        { src: "/tmp/codemux/b.jpg", mediaType: undefined },
+      ]);
+    }
+  });
+
+  it("drops malformed image entries and keeps text-only when images is absent", () => {
+    const state = replayPayloads([
+      JSON.stringify({
+        type: "user_message",
+        thread_id: "t",
+        text: "mixed",
+        images: [
+          { path: "/ok.png", media_type: "image/png" },
+          { media_type: "image/png" }, // no path → dropped
+          "not-an-object", // → dropped
+          null, // → dropped
+        ],
+      }),
+      user("plain"),
+    ]);
+    const [withImages, plain] = state.messages;
+    if (withImages.kind === "user_message") {
+      expect(withImages.images).toEqual([
+        { src: "/ok.png", mediaType: "image/png" },
+      ]);
+    }
+    // A turn with no `images` field never gains one.
+    expect("images" in plain).toBe(false);
+  });
+
   it("rebuilds an assistant message from a completed item", () => {
     const state = replayPayloads([
       user("hi"),

--- a/src/lib/agent-chat/hydrate.ts
+++ b/src/lib/agent-chat/hydrate.ts
@@ -5,7 +5,7 @@ import {
   appendUserMessage,
   createEmptyThreadState,
 } from "./reducer";
-import type { ChatThreadState } from "./types";
+import type { ChatThreadState, UserMessageImage } from "./types";
 
 /**
  * Synthetic envelope written by the backend in `agent_chat_send_turn`
@@ -19,6 +19,12 @@ export interface UserMessageEnvelope {
   type: "user_message";
   thread_id: string;
   text: string;
+  /** Images attached to this turn, written by the backend when the
+   *  turn carried paste/drop/picker images. Each `path` is an absolute
+   *  filesystem location the webview loads via Tauri's asset protocol
+   *  (mapped onto the bubble item's `images[].src`). Absent for
+   *  text-only turns and for turns persisted before the field existed. */
+  images?: Array<{ path: string; media_type?: string }>;
 }
 
 type ReplayPayload = UserMessageEnvelope | ProviderRuntimeEvent;
@@ -43,7 +49,13 @@ export function replayPayloads(payloads: string[]): ChatThreadState {
     const parsed = parsePayload(raw);
     if (!parsed) continue;
     if (parsed.type === "user_message") {
-      state = appendUserMessage(state, parsed.text);
+      // Map the persisted `images` (absolute paths) onto the bubble's
+      // display shape; `src` is the path, which `resolveAssetSrc`
+      // routes through Tauri's asset protocol at render time.
+      const images: UserMessageImage[] | undefined = parsed.images?.map(
+        (img) => ({ src: img.path, mediaType: img.media_type }),
+      );
+      state = appendUserMessage(state, parsed.text, undefined, undefined, images);
     } else {
       state = applyEvent(state, parsed);
     }
@@ -91,7 +103,26 @@ function parsePayload(raw: string): ReplayPayload | null {
   if (type === "user_message") {
     const text = (value as { text?: unknown }).text;
     if (typeof text !== "string") return null;
-    return value as UserMessageEnvelope;
+    // Sanitize the optional `images` array: keep only well-formed
+    // entries with a string `path`, so a malformed row can never feed
+    // a non-string `src` into the render layer. A missing / non-array
+    // `images` field yields `undefined` (text-only turn).
+    const rawImages = (value as { images?: unknown }).images;
+    const images = Array.isArray(rawImages)
+      ? rawImages.flatMap((entry) => {
+          if (!entry || typeof entry !== "object") return [];
+          const path = (entry as { path?: unknown }).path;
+          if (typeof path !== "string") return [];
+          const mediaType = (entry as { media_type?: unknown }).media_type;
+          return [
+            {
+              path,
+              media_type: typeof mediaType === "string" ? mediaType : undefined,
+            },
+          ];
+        })
+      : undefined;
+    return { type: "user_message", thread_id: (value as { thread_id?: string }).thread_id ?? "", text, images };
   }
   // Provider events — trust the discriminated union shape. Unknown
   // discriminators fall through to the reducer's `warnOnce` path.

--- a/src/lib/agent-chat/materialize.test.ts
+++ b/src/lib/agent-chat/materialize.test.ts
@@ -356,6 +356,8 @@ describe("materializeAndSend", () => {
       expect(actions.appendUserMessage).toHaveBeenCalledWith(
         "tid-7",
         "first turn text",
+        undefined,
+        [],
       );
     });
 
@@ -607,6 +609,7 @@ describe("materializeAndSend", () => {
         null,
         null,
         [],
+        [],
         "/projects/foo",
       );
 
@@ -659,6 +662,7 @@ describe("materializeAndSend", () => {
         null,
         null,
         [],
+        [],
         "/projects/foo",
       );
 
@@ -694,6 +698,7 @@ describe("materializeAndSend", () => {
         null,
         null,
         [],
+        [],
         "/projects/foo",
       );
 
@@ -727,6 +732,7 @@ describe("materializeAndSend", () => {
         null,
         null,
         [],
+        [],
         "/projects/foo",
       );
 
@@ -758,6 +764,7 @@ describe("materializeAndSend", () => {
         null,
         null,
         [],
+        [],
         "/projects/foo",
       );
 
@@ -783,6 +790,7 @@ describe("materializeAndSend", () => {
         actions,
         null,
         null,
+        [],
         [],
         null,
       );
@@ -812,6 +820,7 @@ describe("materializeAndSend", () => {
         actions,
         null,
         null,
+        [],
         [],
         "/projects/foo",
       );
@@ -1263,6 +1272,8 @@ describe("materializeWithPreset", () => {
       expect(actions.appendUserMessage).toHaveBeenCalledWith(
         draft.threadId,
         userText,
+        undefined,
+        [],
       );
 
       // SDK send: wrapper applied.

--- a/src/lib/agent-chat/materialize.ts
+++ b/src/lib/agent-chat/materialize.ts
@@ -21,6 +21,7 @@ import type { TerminalPreset } from "@/tauri/types";
 
 import { deriveTitleFromFirstMessage } from "./derive-title";
 import { applyAllPrefixes } from "./mode-prefix";
+import type { UserMessageImage } from "./types";
 
 /**
  * Mutations performed as `materializeAndSend` progresses. Kept as a bag
@@ -50,8 +51,17 @@ export interface MaterializeActions {
    *  home before the live pane mounts. */
   ensureThread: (threadId: string) => void;
   /** Writes the optimistic user message into the agent-chat slice so
-   *  the live pane renders it as soon as it takes over. */
-  appendUserMessage: (threadId: string, text: string) => void;
+   *  the live pane renders it as soon as it takes over. `images` (when
+   *  present) carries the turn's staged images as `data:` URLs so the
+   *  bubble shows their thumbnails without waiting for a round-trip.
+   *  Signature matches the store action so `chat.appendUserMessage`
+   *  can be passed straight through. */
+  appendUserMessage: (
+    threadId: string,
+    text: string,
+    clientNonce?: string,
+    images?: UserMessageImage[],
+  ) => void;
   // ── Stage C Effort-lock fix: mirror the draft's session config
   //    onto the agent-chat slice so the ReasoningPicker (which gates
   //    on `slice.model`) renders correctly when `AgentChatPane`
@@ -123,6 +133,13 @@ export async function materializeAndSend(
    *  `buildImagePayloads` so this lib stays free of store imports.
    *  Defaults to empty so existing call sites keep compiling. */
   images: Array<{ data: number[]; media_type: string }> = [],
+  /** Display shape of the same staged images (`data:` URLs), for the
+   *  optimistic user bubble's thumbnails. Distinct from `images` above,
+   *  which is the raw-bytes wire shape the SDK needs. Caller
+   *  pre-extracts via `buildImageDisplaySources` so this lib stays free
+   *  of store imports. Defaults to empty so existing call sites keep
+   *  compiling. */
+  imageDisplaySources: UserMessageImage[] = [],
   /** Thread Scope redesign — project root to fork a deferred worktree
    *  from, when `draft.checkoutMode === "worktree"`. `null` (the
    *  default) keeps the pre-existing target-resolution behavior
@@ -213,7 +230,7 @@ export async function materializeAndSend(
   //    slice's `model` stays null and the pickers silently vanish.
   actions.ensureThread(draft.threadId);
   seedSliceFromDraft(draft, actions);
-  actions.appendUserMessage(draft.threadId, text);
+  actions.appendUserMessage(draft.threadId, text, undefined, imageDisplaySources);
 
   // 4. Start the provider session with the draft's pre-minted thread
   //    id. The backend accepts the caller's id verbatim (verified on

--- a/src/lib/agent-chat/reducer.test.ts
+++ b/src/lib/agent-chat/reducer.test.ts
@@ -361,6 +361,38 @@ describe("agent-chat reducer", () => {
     expect(state.messages[0].kind).toBe("user_message");
   });
 
+  it("appendUserMessage attaches images when provided", () => {
+    const state = appendUserMessage(
+      createEmptyThreadState(),
+      "look at this",
+      undefined,
+      undefined,
+      [{ src: "data:image/png;base64,AAAA", mediaType: "image/png" }],
+    );
+    const item = state.messages[0];
+    expect(item.kind).toBe("user_message");
+    if (item.kind === "user_message") {
+      expect(item.images).toEqual([
+        { src: "data:image/png;base64,AAAA", mediaType: "image/png" },
+      ]);
+    }
+  });
+
+  it("appendUserMessage omits `images` entirely for a text-only turn", () => {
+    // Empty / undefined image lists must not stamp an `images` key, so
+    // a text-only bubble stays byte-identical to the pre-images shape.
+    const withUndefined = appendUserMessage(createEmptyThreadState(), "hi");
+    const withEmpty = appendUserMessage(
+      createEmptyThreadState(),
+      "hi",
+      undefined,
+      undefined,
+      [],
+    );
+    expect("images" in withUndefined.messages[0]).toBe(false);
+    expect("images" in withEmpty.messages[0]).toBe(false);
+  });
+
   it("resume_cursor_updated is a transcript-level no-op (cursor stored in store, not ChatThreadState)", () => {
     const base = createEmptyThreadState();
     const after = applyEvent(base, {

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -18,6 +18,7 @@ import {
   type SubagentRunItem,
   type SubagentView,
   type ToolCallItem,
+  type UserMessageImage,
   type UserMessageItem,
   type WorkflowRunItem,
 } from "./types";
@@ -829,6 +830,7 @@ function appendUserMessageLocal(
   text: string,
   now: Clock,
   clientNonce?: string,
+  images?: UserMessageImage[],
 ): ChatThreadState {
   const sealed = sealTrailingReasoning(state, now);
   const { seq, next } = takeSeq(sealed);
@@ -838,6 +840,10 @@ function appendUserMessageLocal(
     seq,
     text,
     ...(clientNonce ? { clientNonce } : {}),
+    // Only stamp `images` when there actually are some, so a text-only
+    // turn's item stays byte-identical to the pre-images shape (keeps
+    // existing snapshot-style assertions honest).
+    ...(images && images.length > 0 ? { images } : {}),
   };
   return { ...next, messages: [...next.messages, item] };
 }
@@ -849,14 +855,21 @@ function appendUserMessageLocal(
  * later `turn_queued` event reconcile this exact bubble instead of
  * duplicating it, and lets an error path roll it back
  * (`removeUserMessageByNonce`).
+ *
+ * `images` (when present) attaches the turn's paste/drop/picker images
+ * to the bubble so they render alongside the text — `data:` URLs on an
+ * optimistic send, absolute filesystem paths on a hydrate replay.
  */
 export function appendUserMessage(
   state: ChatThreadState,
   text: string,
   now: Clock = defaultClock,
   clientNonce?: string,
+  images?: UserMessageImage[],
 ): ChatThreadState {
-  return maybeCapMessages(appendUserMessageLocal(state, text, now, clientNonce));
+  return maybeCapMessages(
+    appendUserMessageLocal(state, text, now, clientNonce, images),
+  );
 }
 
 /**

--- a/src/lib/agent-chat/types.ts
+++ b/src/lib/agent-chat/types.ts
@@ -10,6 +10,33 @@ export type { SubagentStatus };
 export type ChatItemId = string;
 
 /**
+ * One image attached to a user turn, in the shape the right-aligned
+ * bubble renders as a thumbnail (and opens in a lightbox).
+ *
+ * `src` is one of two forms, distinguished only by how the item was
+ * created — the renderer never has to know which:
+ *   - A `data:` URL, built optimistically at send time from the staged
+ *     image bytes (`resolvedImage.bytes` + `.mime`). At that point the
+ *     image lives only in memory, so a self-contained data URL is the
+ *     only thing that can render before any round-trip.
+ *   - An absolute filesystem path, read back at hydrate from the
+ *     persisted `user_message` envelope's `images[].path` (the backend
+ *     wrote the bytes to disk when the turn was sent).
+ *
+ * The renderer routes `src` through `resolveAssetSrc` (src/lib/
+ * asset-url.ts): data URLs pass through untouched, absolute paths go
+ * through Tauri's asset protocol (`convertFileSrc`). That keeps the
+ * bubble oblivious to the fresh-vs-hydrated distinction.
+ */
+export interface UserMessageImage {
+  src: string;
+  /** MIME type (`image/png`, …) when known. Purely informational
+   *  today (alt text / future download); the `<img>` src carries its
+   *  own type for data URLs. */
+  mediaType?: string;
+}
+
+/**
  * Every ChatViewItem carries a monotonic `seq`. The render layer sorts
  * by `seq` so message order is a property of the data, not of React
  * reconciliation or store-update timing. Mirrors a reference
@@ -35,6 +62,12 @@ export interface UserMessageItem {
    *  event reconcile against this exact item instead of appending a
    *  duplicate. Absent for hydrated / backend-reconstructed items. */
   clientNonce?: string;
+  /** Images attached to this turn (paste / drop / picker). Optimistic
+   *  appends carry `data:` URLs built from the staged bytes at send
+   *  time; hydrated items carry absolute filesystem paths mapped from
+   *  the persisted envelope's `images[].path`. Absent for text-only
+   *  turns and for messages persisted before this field existed. */
+  images?: UserMessageImage[];
 }
 
 export interface AssistantMessageItem {

--- a/src/stores/agent-chat-store.ts
+++ b/src/stores/agent-chat-store.ts
@@ -9,7 +9,11 @@ import {
   markRequestResponding,
   removeUserMessageByNonce,
 } from "@/lib/agent-chat/reducer";
-import type { ChatThreadState, ChatViewItem } from "@/lib/agent-chat/types";
+import type {
+  ChatThreadState,
+  ChatViewItem,
+  UserMessageImage,
+} from "@/lib/agent-chat/types";
 import type { AgentChatCheckpointRecord } from "@/tauri/commands";
 import type {
   ApprovalDecision,
@@ -158,11 +162,14 @@ interface AgentChatStore {
   ensureThread: (threadId: string) => void;
   /** Apply a canonical provider event to the matching slice. */
   applyEvent: (threadId: string, event: ProviderRuntimeEvent) => void;
-  /** Append a user message optimistically (no provider echo). */
+  /** Append a user message optimistically (no provider echo).
+   *  `images` (when present) carries the turn's staged images as
+   *  `data:` URLs so the bubble renders their thumbnails immediately. */
   appendUserMessage: (
     threadId: string,
     text: string,
     clientNonce?: string,
+    images?: UserMessageImage[],
   ) => void;
   /** Roll back an optimistic user bubble by its client nonce (send RPC
    *  failed). No-op when not found. */
@@ -313,11 +320,11 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
       }),
     ),
 
-  appendUserMessage: (threadId, text, clientNonce) =>
+  appendUserMessage: (threadId, text, clientNonce, images) =>
     set((state) =>
       updateSlice(state, threadId, (slice) => ({
         ...slice,
-        ...appendUserMessage(slice, text, undefined, clientNonce),
+        ...appendUserMessage(slice, text, undefined, clientNonce, images),
         inputDraft: "",
       })),
     ),


### PR DESCRIPTION
## Problem

Images attached to an Agent Chat message (paste / drop / picker) were sent to the provider but silently vanished from the conversation: the optimistic append stored only text, the persisted `user_message` envelope had no image field, and `UserMessage` rendered nothing but `item.text`. Image rendering in sent bubbles never existed — the pipeline was send-only.

## Fix

**Backend (`agent_chat.rs`)**
- Image bytes are written to disk at send time under `<config>/codemux/agent-chat/images/<thread_id>/<uuid>.<ext>` (best-effort, never blocks the turn)
- The persisted `user_message` envelope gains an optional `images: [{path, media_type}]` — omitted when empty, so old transcripts are untouched
- Queued follow-ups stash their image records by `queued_id` and attach them at dispatch-time persistence; `QueuedTurnCancelled` deletes the orphaned files
- Deleting a chat session removes its image directory

**Frontend**
- `UserMessageItem.images[]`, stamped at all three send sites as `data:` URLs (chunked base64) so thumbnails appear instantly on send
- Hydrate maps persisted paths back through the asset protocol, so images survive app restart
- `UserMessage` renders a wrapping thumbnail row (rounded, bordered, ≤160px, broken-image fallback — design tokens only) with a near-fullscreen `Dialog` lightbox on click (Esc / click-outside to close)
- Dev mock seeds an image turn on the default chat thread, so the render path is verifiable under `npm run dev` in a plain browser

## Verification

- `npm run check` + full frontend suite (2366 tests) green; `cargo check` + backend tests green (3 new envelope/extension tests, 125 tests across the touched frontend modules)
- Driven end-to-end in the real UI via the dev mock: thumbnail renders in the sent bubble, click opens the lightbox, Esc closes it
- `docs/features/agent-chat.md` updated