### PR TITLE
fix: prevent ssh bootstrap from installing a 0-byte/truncated codemux-remote

### DIFF
--- a/docs/features/remote-hosts.md
+++ b/docs/features/remote-hosts.md
@@ -352,15 +352,19 @@ Three modules under `src-tauri/src/ssh/` (Unix-only — Windows gracefully skips
 ```sh
 printf 'UNAME: ' ; uname -sm
 if command -v codemux-remote >/dev/null 2>&1 ; then
-  printf 'CMR: ' ; codemux-remote version
+  printf 'CMR: ' ; codemux-remote version 2>/dev/null || printf 'BROKEN\n'
+elif [ -x "$HOME/.local/bin/codemux-remote" ] ; then
+  printf 'CMR: ' ; "$HOME/.local/bin/codemux-remote" version 2>/dev/null || printf 'BROKEN\n'
 else
   printf 'CMR: NOT_INSTALLED\n'
 fi
 ```
 
+The `2>/dev/null || printf 'BROKEN\n'` on both version invocations matters (issue #133): a truncated ELF exec-fails with exit 126, and since the invocation is the last statement of its branch, that would become ssh's exit status — the probe would report `Unreachable` with raw exec noise instead of a classifiable result. The fallback converts exec failure into a `CMR: BROKEN` line (exit 0), which — like the bare `CMR: ` line a 0-byte binary produces — is unparseable as version JSON and gets classified as present-but-broken.
+
 Parses the output into one of three outcomes:
-- `Reachable { codemux_remote_version: Some(...), uname: Some(...) }` — green light.
-- `Reachable { codemux_remote_version: None, uname: Some(...) }` — host is up, binary missing → triggers the bootstrap-install consent modal.
+- `Reachable { codemux_remote_version: Some(...), uname: Some(...), .. }` — green light.
+- `Reachable { codemux_remote_version: None, uname: Some(...), binary_present_but_broken }` — host is up but the binary isn't usable. `binary_present_but_broken: false` → genuinely absent → the bootstrap-install consent modal ("isn't installed yet"); `true` → something is at the install path but doesn't produce valid version output (0-byte or truncated binary — issue #133) → "present and not working … Install to repair".
 - `Unreachable { reason }` — SSH itself failed (DNS, refused, auth, timeout). `reason` is the SSH stderr so the user can debug.
 
 Critical SSH flags (locked in via unit tests):
@@ -378,6 +382,11 @@ Runs after the user clicks "Install" in the consent modal. Four steps:
 4. Re-probe via `ssh ... codemux-remote version` to verify the install worked. Parse out the reported version.
 
 Returns `BootstrapResult::Installed { reported_version }` on success; one of three failure variants otherwise, each with a specific error message the UI surfaces verbatim.
+
+**Integrity guards (issue #133).** A field host once ended up with a 0-byte, mode-0700 `~/.local/bin/codemux-remote` — the atomic install had shipped an empty file over a working binary, and both devices then reported "Reachable, but codemux-remote isn't installed yet". Two guards close the holes:
+
+- **Local ≥1 MB plausibility gate.** `bundled_binary_path` no longer accepts any candidate that merely `.exists()`. Every lookup tier (Tauri resource dir, source-tree relative paths, dev sibling-exe fallback) is filtered through `plausible_remote_binary`, which requires a regular file of at least `MIN_PLAUSIBLE_REMOTE_BINARY_BYTES` (1 MB; the real binary is ~16 MB). The 0-byte placeholder sidecars checked into `src-tauri/binaries/` for dev builds no longer qualify — an empty candidate is treated as *not bundled* → `BinaryNotBundled { wanted_target }`, so a dev build fails loudly instead of silently uploading a placeholder over a host's good binary.
+- **Remote `wc -c` byte-count verification.** `ssh_upload_executable` streams into a `.tmp` and the remote reads it back with `wc -c`, comparing against the exact source length *before* the `mv`. The pipeline is `umask 077 && mkdir -p … && cat > tmp && [ wc -c == len ] && chmod +x tmp && mv -f tmp p || { warn; rm -f tmp; exit 1; }`: any failure in the `&&` chain (including a size mismatch from a partially-streamed upload) funnels into the `|| { … }` cleanup — the tmp file is removed, a clear reason goes to stderr (surfacing in `BootstrapResult::UploadFailed`), and the prior binary at the destination is left untouched (atomic ≠ verified). The function also rejects a 0-byte source outright before spawning ssh (an empty file would trivially pass a `-eq 0` check), and kills the ssh child if the local `write_all` fails partway rather than letting `cat` see a clean EOF.
 
 ### `tunnel.rs` — SSH-tunneled daemon
 
@@ -428,8 +437,8 @@ The pane built in 2a now uses the real probe + bootstrap:
 
 - **DevicePicker** (`src/components/hosts/device-picker.test.tsx`): 7 tests — local label, custom local label, remote selection, fallback when configured hostId is missing, dropdown open with Local Device entry, Other Hosts submenu, graceful failure when `hostsList` rejects.
 - **codemux-remote binary** (`src-tauri/tests/codemux_remote_binary.rs`): 3 tests — `version` subcommand prints valid JSON, no-subcommand defaults to version, end-to-end spawn-and-reap via `PtyDaemonClient` against the real binary.
-- **SSH probe** (`src-tauri/src/ssh/probe.rs::tests`): 5 tests — argv construction (BatchMode + ConnectTimeout + StrictHostKeyChecking + target + command position), parsing reachable+installed, reachable+missing, unparseable version, empty payload.
-- **SSH bootstrap** (`src-tauri/src/ssh/bootstrap.rs::tests`): 3 tests — `target_for_uname` covers all four release targets including aliases (`amd64`, `arm64`), returns None for unsupported (FreeBSD/Windows/garbage), trims whitespace.
+- **SSH probe** (`src-tauri/src/ssh/probe.rs::tests`): 8 tests — argv construction (BatchMode + ConnectTimeout + StrictHostKeyChecking + target + command position), the `~/.local/bin` PATH fallback + the `|| printf 'BROKEN'` exec-failure fallback on both version invocations, parsing reachable+installed (broken=false), reachable+missing/`NOT_INSTALLED` (broken=false), unparseable version → version None + `binary_present_but_broken: true`, the bare-`CMR:` line from a 0-byte binary → broken=true, the `CMR: BROKEN` marker from a truncated-ELF exec failure → broken=true (issue #133), empty payload. The unparseable-version case is no longer treated as "not installed" — it's classified as present-but-broken so the UI can offer "Install to repair".
+- **SSH bootstrap** (`src-tauri/src/ssh/bootstrap.rs::tests`): 5 tests — `target_for_uname` covers all four release targets including aliases (`amd64`, `arm64`), returns None for unsupported (FreeBSD/Windows/garbage), trims whitespace; `plausible_remote_binary` gates on size + file type (missing / 0-byte / 4 KB / directory → false, ≥1 MB file → true — issue #133); `upload_script` locks in the `wc -c` byte-count check, the exact expected length, `rm -f` + `exit 1` cleanup, the `umask 077`/`chmod +x`/`mv -f` chain, and tilde-aware escaping. The localhost E2E `ssh_upload_executable` test also now asserts an empty source is rejected with Err and never creates/replaces the destination.
 - **SSH tunnel** (`src-tauri/src/ssh/tunnel.rs::tests`): 4 tests — required ssh flags locked in, `-L` forwarding spec contains both paths, remote command is the last arg, target comes before remote command.
 - **SSH round-trip** (`src-tauri/tests/codemux_ssh_roundtrip.rs`, post-`v0.7.6`): an env-gated (`CODEMUX_E2E_SSH_HOST`) real-host harness that drives a push / `--delete`-mirror / pull-back / `RemoteNotFound` / `.mcp.json`-absolute / tilde round-trip against an SSH target, encoding the `RemoteNotFound`, `.mcp.json`-absolute, and tilde-expansion regressions. Skips with a `SKIP:` message when the env var is unset, so CI stays green without a live host.
 
@@ -472,6 +481,10 @@ Landed since the original 2b–2d cut: **"Push workspace to host" action** (`8c7
 
 **"Reachable, but codemux-remote isn't installed yet" but the Install button does nothing:**
 - Check the laptop's `src-tauri/binaries/` directory has `codemux-remote-<target>` for the host's uname. In dev builds, cross-compiles aren't usually run; the bootstrap returns `BinaryNotBundled` with the target triple it was looking for.
+
+**"Reachable, but codemux-remote is present and not working (binary may be corrupted or truncated)" — or, on pre-fix builds, "isn't installed yet" with a 0-byte `~/.local/bin/codemux-remote` while an old daemon keeps running:**
+- **Cause (issue #133).** Pre-fix Codemux builds could atomically install an empty or truncated binary — a dev 0-byte placeholder that passed the old `.exists()` check, or an upload whose stream failed partway but whose `cat` still saw a clean EOF. The file at the install path exists (mode 0700) but is not a runnable binary; a `serve`/`pty-daemon` started earlier keeps running from the now-deleted inode, so the host still *works* until that daemon exits — which is why both devices reported the binary "missing". The probe now classifies this as present-but-broken (`binary_present_but_broken: true`) so the UI says "Install to repair" instead of "isn't installed yet".
+- **Repair.** Click plain **Install** on Settings → Hosts. It re-uploads (now with the local ≥1 MB gate + remote `wc -c` verification) over the broken file WITHOUT restarting the running daemon — the swap is atomic and old fd-holders keep running until they idle out. The daemon picks up the new binary on its next idle auto-upgrade or on reboot. Do **not** use "Reinstall agent" while live host sessions matter — it `pkill`s the pty-daemon and drops those sessions.
 
 **Probe says "Permission denied (publickey)":**
 - Your key isn't authorized on the host. Add the laptop's public key to the host's `~/.ssh/authorized_keys`. Codemux deliberately doesn't paper over this — it would mean storing your private key in our process, which is a security regression.

--- a/src-tauri/src/commands/hosts.rs
+++ b/src-tauri/src/commands/hosts.rs
@@ -200,6 +200,7 @@ pub async fn hosts_test_connection(
             ProbeOutcome::Reachable {
                 codemux_remote_version: Some(version),
                 uname,
+                ..
             } => {
                 // Automations preflight — flag a host that can't reach
                 // GitHub before an automation silently fails at run time.
@@ -240,18 +241,37 @@ pub async fn hosts_test_connection(
             ProbeOutcome::Reachable {
                 codemux_remote_version: None,
                 uname,
-            } => HostTestResult {
-                ok: false,
-                message: format!(
-                    "Reachable, but codemux-remote isn't installed yet{}",
-                    uname
-                        .as_ref()
-                        .map(|u| format!(" ({u})"))
-                        .unwrap_or_default()
-                ),
-                needs_install: true,
-                uname,
-            },
+                binary_present_but_broken,
+            } => {
+                let uname_suffix = uname
+                    .as_ref()
+                    .map(|u| format!(" ({u})"))
+                    .unwrap_or_default();
+                // `needs_install: true` drives the same Install button
+                // in either case — the button re-uploads over whatever
+                // is there. But the message distinguishes a genuinely
+                // absent binary from a present-but-corrupted one (issue
+                // #133) so the user understands they're repairing, not
+                // installing fresh — and that repair is safe for a
+                // running daemon (the new file is swapped in without a
+                // restart).
+                let message = if binary_present_but_broken {
+                    format!(
+                        "Reachable, but codemux-remote is present and not working \
+                         (binary may be corrupted or truncated){uname_suffix}. \
+                         Install to repair — this replaces the file without touching \
+                         a running daemon."
+                    )
+                } else {
+                    format!("Reachable, but codemux-remote isn't installed yet{uname_suffix}")
+                };
+                HostTestResult {
+                    ok: false,
+                    message,
+                    needs_install: true,
+                    uname,
+                }
+            }
             ProbeOutcome::Unreachable { reason } => HostTestResult {
                 ok: false,
                 message: reason,

--- a/src-tauri/src/hosts_upgrade.rs
+++ b/src-tauri/src/hosts_upgrade.rs
@@ -120,19 +120,29 @@ async fn check_and_upgrade(
         ProbeOutcome::Reachable {
             codemux_remote_version: Some(v),
             uname,
+            ..
         } => (v, uname),
         ProbeOutcome::Reachable {
             codemux_remote_version: None,
+            binary_present_but_broken,
             ..
         } => {
-            // Host reachable but codemux-remote not installed. Don't
-            // install it as part of the background poll — that
+            // Host reachable but codemux-remote not usable. Don't
+            // install/repair it as part of the background poll — that
             // requires the user's consent (handled by the Install
             // button on Settings → Hosts). The background poll only
-            // *upgrades* existing installations.
-            return Ok(UpgradeOutcome::Skipped {
-                reason: "codemux-remote not installed (background poll won't auto-install — use Settings → Hosts)".into(),
-            });
+            // *upgrades* existing, working installations.
+            //
+            // Distinguish "present but broken" (0-byte / truncated
+            // binary — issue #133) from "genuinely absent" so the
+            // Skipped reason tells the operator which it is. Either way
+            // we stay Skipped: no consent for a background repair.
+            let reason = if binary_present_but_broken {
+                "codemux-remote present but not working — background poll won't auto-repair; use Settings → Hosts → Install".to_string()
+            } else {
+                "codemux-remote not installed (background poll won't auto-install — use Settings → Hosts)".to_string()
+            };
+            return Ok(UpgradeOutcome::Skipped { reason });
         }
         ProbeOutcome::Unreachable { reason } => {
             return Ok(UpgradeOutcome::Skipped {

--- a/src-tauri/src/ssh/bootstrap.rs
+++ b/src-tauri/src/ssh/bootstrap.rs
@@ -21,6 +21,19 @@ use std::time::Duration;
 use tokio::process::Command;
 use tokio::time::timeout;
 
+/// Minimum size (in bytes) a candidate `codemux-remote` binary must be
+/// before we'll treat it as a real, uploadable binary. The production
+/// binary is ~16 MB; the dev-build placeholder sidecars checked into
+/// `src-tauri/binaries/` are 0 bytes. 1 MB is comfortably above any
+/// plausible placeholder yet far below the real binary, so it cleanly
+/// separates "actual binary" from "empty/truncated placeholder".
+///
+/// Issue #133: without this gate, a 0-byte placeholder passed the old
+/// `.exists()` check and the background upgrade poller atomically
+/// installed the empty file over a working production binary on the
+/// host — silent corruption. See `plausible_remote_binary`.
+pub(crate) const MIN_PLAUSIBLE_REMOTE_BINARY_BYTES: u64 = 1024 * 1024;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum BootstrapResult {
@@ -81,6 +94,17 @@ pub fn target_for_uname(uname: &str) -> Option<&'static str> {
 /// and push-to-host dies on first attempt. The dev fallbacks are
 /// what let `cargo build && npm run tauri:dev` work for push to a
 /// SAME-ARCH remote without running the full release pipeline.
+///
+/// **Size gate (issue #133):** every candidate is validated by
+/// `plausible_remote_binary` — it must exist, be a regular file, AND
+/// be at least `MIN_PLAUSIBLE_REMOTE_BINARY_BYTES`. A bare
+/// `.exists()` check let a 0-byte dev placeholder (the empty sidecar
+/// files checked into `src-tauri/binaries/`) qualify as "bundled";
+/// the background upgrade poller then atomically installed that empty
+/// file over a working host binary, bricking it. Gating on size means
+/// an empty/tiny candidate is treated as *not bundled* → the caller
+/// returns `BinaryNotBundled { wanted_target }` and a dev build fails
+/// loudly instead of silently shipping a placeholder to a host.
 pub fn bundled_binary_path(
     app: Option<&tauri::AppHandle>,
     target: &str,
@@ -93,7 +117,7 @@ pub fn bundled_binary_path(
             let candidate = resource_dir
                 .join("binaries")
                 .join(format!("codemux-remote-{target}"));
-            if candidate.exists() {
+            if plausible_remote_binary(&candidate) {
                 return Some(candidate);
             }
         }
@@ -106,7 +130,7 @@ pub fn bundled_binary_path(
         PathBuf::from(format!("../binaries/codemux-remote-{target}")),
     ];
     for c in candidates {
-        if c.exists() {
+        if plausible_remote_binary(&c) {
             return Some(c);
         }
     }
@@ -126,7 +150,7 @@ pub fn bundled_binary_path(
                     "codemux-remote"
                 };
                 let candidate = parent.join(sibling_name);
-                if candidate.exists() {
+                if plausible_remote_binary(&candidate) {
                     return Some(candidate);
                 }
             }
@@ -134,6 +158,23 @@ pub fn bundled_binary_path(
     }
 
     None
+}
+
+/// True only when `path` points at a regular file that is at least
+/// `MIN_PLAUSIBLE_REMOTE_BINARY_BYTES` in size — i.e. a candidate that
+/// could actually be a real `codemux-remote`.
+///
+/// Returns false for a missing path, a directory, or an empty/truncated
+/// file. This is the guard that stops a 0-byte dev placeholder (or a
+/// half-written file) from ever being uploaded over a working host
+/// binary (issue #133). A `metadata` error (permission denied, broken
+/// symlink) also yields false — if we can't confirm the size, we don't
+/// trust the candidate.
+fn plausible_remote_binary(path: &std::path::Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(meta) => meta.is_file() && meta.len() >= MIN_PLAUSIBLE_REMOTE_BINARY_BYTES,
+        Err(_) => false,
+    }
 }
 
 /// True when `target` equals the rust target triple this codemux
@@ -560,21 +601,73 @@ pub async fn provision_workspace_mcp_config(
         .map_err(|e| format!("writing .mcp.json: {e}"))
 }
 
-/// Upload a binary to the remote host, atomically replacing whatever
-/// is currently at `remote_path` and marking it `chmod +x`.
+/// Build the remote shell one-liner that receives the streamed binary
+/// on stdin, verifies its byte count, and atomically swaps it into
+/// place. Extracted so tests can assert the exact pipeline without an
+/// SSH round-trip.
 ///
-/// Uses `ssh … 'cat > <path>.tmp && chmod +x <path>.tmp && mv <path>.tmp <path>'`
-/// with the binary streamed via stdin, all in **one** SSH session:
+/// `remote_path` may contain `~/` — the tilde-aware `shell_escape`
+/// keeps the leading `~/` unquoted (so the remote shell expands it to
+/// $HOME) while single-quoting the rest, neutralising any shell
+/// metacharacters in a future caller's path (today's callers pass a
+/// hardcoded path, so this is defense-in-depth).
+///
+/// `expected_len` is the exact source byte count. The remote reads back
+/// `wc -c < {p}.tmp` and refuses to `mv` unless it matches — the fix
+/// for issue #133, where a partially-streamed binary (e.g. a local
+/// `write_all` that failed mid-flight) sent EOF to `cat`, which exited
+/// 0, letting the old code `chmod`+`mv` a truncated file over a working
+/// binary. Atomic ≠ verified.
+///
+/// Pipeline shape:
+/// `umask 077 && mkdir -p … && cat > tmp && [ wc -c == len ] && chmod +x tmp && mv -f tmp p || { warn; rm -f tmp; exit 1; }`
+///
+/// In POSIX sh, `a && b && … && e || f` runs `f` when the `&&` chain
+/// fails at ANY step. So a failure of mkdir, cat, the size check,
+/// chmod, or mv all funnel into the `|| { … }` block: it removes the
+/// tmp file, prints a clear stderr reason (which surfaces in
+/// `BootstrapResult::UploadFailed`), and exits non-zero. Crucially the
+/// previously-working binary at `{p}` is never touched, because it's
+/// only replaced by the final `mv` which only runs on full success.
+fn upload_script(remote_path: &str, expected_len: u64) -> String {
+    // `umask 077` lands the tmpfile 0600 the moment it's created;
+    // `chmod +x` then bumps it to 0700 before the rename. `mv -f`
+    // overwrites whatever was at the destination — important when a
+    // stale older binary from a previous Codemux install is there.
+    // Note the `{{`/`}}` escaping: they emit literal `{`/`}` for the
+    // shell's `|| { … }` group command.
+    let p = crate::ssh::push::shell_escape(remote_path);
+    format!(
+        "umask 077 && mkdir -p \"$(dirname {p})\" && \
+         cat > {p}.tmp && \
+         [ \"$(wc -c < {p}.tmp)\" -eq {expected_len} ] && \
+         chmod +x {p}.tmp && \
+         mv -f {p}.tmp {p} || \
+         {{ echo \"upload integrity check failed: expected {expected_len} bytes\" >&2; rm -f {p}.tmp; exit 1; }}"
+    )
+}
+
+/// Upload a binary to the remote host, verifying its byte count before
+/// atomically replacing whatever is currently at `remote_path` and
+/// marking it `chmod +x`.
+///
+/// Streams the binary via stdin into a remote shell one-liner (see
+/// `upload_script`), all in **one** SSH session:
 ///
 /// 1. The remote login shell expands `~/`, sidestepping the OpenSSH
 ///    9.0+ SFTP-default scp bug where `~` is taken literally and the
 ///    upload fails with `dest open ".local/bin/foo": Failure`.
-/// 2. Writing to a sibling `.tmp` path and then `mv`-ing into place
-///    makes the swap atomic — if anything is currently exec'ing the
-///    old binary, the new one becomes visible at the path the moment
-///    rename completes. Old fd-holders keep running on the old inode
-///    until they exit.
-/// 3. Single SSH round-trip (was three: mkdir, scp, chmod). Cheaper
+/// 2. The remote reads back `wc -c` on the received tmpfile and refuses
+///    to promote it unless the byte count matches the source exactly
+///    (issue #133). A stream that failed partway — or any other reason
+///    the tmpfile ends up short — is rejected, the tmpfile removed, and
+///    the previously-working binary at the destination left untouched.
+///    Atomicity alone doesn't help here: a truncated file `mv`'d into
+///    place is atomically wrong.
+/// 3. Only after the size check pass does `mv -f` swap the new binary
+///    into place — atomic, so anything exec'ing the old binary keeps
+///    running on the old inode until it exits.
+/// 4. Single SSH round-trip (was three: mkdir, scp, chmod). Cheaper
 ///    on flaky networks.
 ///
 /// `remote_path` may contain `~/` — the remote shell expands it.
@@ -593,23 +686,18 @@ async fn ssh_upload_executable(
         .await
         .map_err(|e| format!("read {}: {e}", local_binary.display()))?;
 
-    // One-liner the remote shell runs. Use `umask 077` so the tmpfile
-    // is 0600 from the moment it lands; `chmod +x` then bumps it to
-    // 0700 before the rename. `mv -f` overwrites whatever was at the
-    // destination — important when a stale older binary from a
-    // previous Codemux install is sitting there.
-    // Tilde-aware shell quoting: preserves a leading `~/` (so the
-    // remote shell still expands it to $HOME) while single-quoting the
-    // rest, closing any shell-injection surface if a future caller ever
-    // passes a path with metacharacters. Today's callers pass a
-    // hardcoded path, so this is defense-in-depth.
-    let p = crate::ssh::push::shell_escape(remote_path);
-    let script = format!(
-        "umask 077 && mkdir -p \"$(dirname {p})\" && \
-         cat > {p}.tmp && \
-         chmod +x {p}.tmp && \
-         mv -f {p}.tmp {p}"
-    );
+    // Refuse an empty source outright. An empty file would trivially
+    // satisfy the remote `[ … -eq 0 ]` size check, defeating the whole
+    // guard — never even attempt the upload. Belt-and-braces on top of
+    // the ≥1 MB plausibility gate in `bundled_binary_path` (issue #133).
+    if bytes.is_empty() {
+        return Err(format!(
+            "refusing to upload empty binary {} (0 bytes)",
+            local_binary.display()
+        ));
+    }
+
+    let script = upload_script(remote_path, bytes.len() as u64);
 
     let mut child = Command::new("ssh")
         .arg("-o")
@@ -625,12 +713,16 @@ async fn ssh_upload_executable(
         .map_err(|e| format!("ssh spawn failed: {e}"))?;
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(&bytes)
-            .await
-            .map_err(|e| format!("failed to stream binary: {e}"))?;
+        if let Err(e) = stdin.write_all(&bytes).await {
+            // The stream failed partway. The remote `wc -c` check is
+            // the real backstop against a truncated install, but don't
+            // leave the ssh child (and its remote shell) running —
+            // kill it so we don't dangle a half-written tmpfile.
+            let _ = child.kill().await;
+            return Err(format!("failed to stream binary: {e}"));
+        }
         // `stdin` drops here, closing the pipe so `cat` sees EOF and
-        // exits 0, letting the chained `chmod` + `mv` run.
+        // exits 0, letting the chained size check + `chmod` + `mv` run.
     }
 
     let out = timeout(deadline, child.wait_with_output())
@@ -881,6 +973,110 @@ mod tests {
         assert!(result.is_ok(), "second upload failed: {:?}", result);
         let on_disk2 = std::fs::read(&dst).unwrap();
         assert_eq!(on_disk2, payload2, "second upload didn't replace");
+
+        // Issue #133: an empty source must be rejected locally with Err
+        // and must NOT create or replace the destination. The dest here
+        // already holds `payload2`; after a rejected empty upload it must
+        // still hold `payload2` untouched.
+        let empty_src = tmp.path().join("empty-payload.bin");
+        std::fs::write(&empty_src, b"").unwrap();
+        let empty_result = ssh_upload_executable(
+            "localhost",
+            &dst_str,
+            &empty_src,
+            Duration::from_secs(15),
+        )
+        .await;
+        assert!(
+            empty_result.is_err(),
+            "empty source must be rejected, got: {empty_result:?}"
+        );
+        let on_disk3 = std::fs::read(&dst).unwrap();
+        assert_eq!(
+            on_disk3, payload2,
+            "rejected empty upload must not touch the destination"
+        );
+
+        // And a brand-new destination path must never be created by an
+        // empty upload either.
+        let fresh_dst = dst_dir.join("never-created");
+        let fresh_result = ssh_upload_executable(
+            "localhost",
+            &fresh_dst.to_string_lossy(),
+            &empty_src,
+            Duration::from_secs(15),
+        )
+        .await;
+        assert!(fresh_result.is_err(), "empty source must be rejected");
+        assert!(
+            !fresh_dst.exists(),
+            "rejected empty upload must not create the destination"
+        );
+    }
+
+    #[test]
+    fn plausible_remote_binary_gates_on_size_and_file_type() {
+        // Issue #133: only a real, sufficiently-large regular file may
+        // ever be uploaded. Exercise every reject reason plus the pass.
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Missing path → false (nothing to upload).
+        assert!(!plausible_remote_binary(&tmp.path().join("does-not-exist")));
+
+        // 0-byte file → false. This is the exact dev-placeholder shape
+        // that bricked hosts before the fix.
+        let empty = tmp.path().join("empty");
+        std::fs::write(&empty, b"").unwrap();
+        assert!(!plausible_remote_binary(&empty));
+
+        // Small (4 KB) file → false. A truncated / half-written binary
+        // is still far below the 1 MB floor.
+        let small = tmp.path().join("small");
+        std::fs::write(&small, vec![0u8; 4 * 1024]).unwrap();
+        assert!(!plausible_remote_binary(&small));
+
+        // A directory → false (must be a regular file).
+        let dir = tmp.path().join("a-dir");
+        std::fs::create_dir(&dir).unwrap();
+        assert!(!plausible_remote_binary(&dir));
+
+        // File at exactly the 1 MB floor → true (real binary is ~16 MB,
+        // this stands in for it without writing 16 MB to disk).
+        let big = tmp.path().join("big");
+        std::fs::write(&big, vec![0u8; MIN_PLAUSIBLE_REMOTE_BINARY_BYTES as usize]).unwrap();
+        assert!(plausible_remote_binary(&big));
+    }
+
+    #[test]
+    fn upload_script_verifies_byte_count_and_cleans_up() {
+        // Lock in the integrity-check pipeline shape (issue #133).
+        let script = upload_script("~/.local/bin/codemux-remote", 16_777_216);
+
+        // The size check reads the received tmpfile back with `wc -c`
+        // and compares against the exact expected byte count.
+        assert!(script.contains("wc -c"), "must read back byte count");
+        assert!(
+            script.contains("-eq 16777216"),
+            "must compare against the exact expected length: {script}"
+        );
+
+        // On any failure the tmpfile is removed and we exit non-zero so
+        // the prior binary is left untouched and the error propagates.
+        assert!(script.contains("rm -f"), "must clean up the tmpfile on failure");
+        assert!(script.contains("exit 1"), "must exit non-zero on failure");
+
+        // The core atomic-install chain is preserved.
+        assert!(script.contains("umask 077"), "tmpfile must land 0600");
+        assert!(script.contains("chmod +x"), "must mark executable");
+        assert!(script.contains("mv -f"), "must atomically replace");
+
+        // Tilde-aware escaping: a `~/`-prefixed path keeps the leading
+        // `~/` unquoted (so the remote shell expands it) with the body
+        // single-quoted — exactly what `shell_escape` produces.
+        assert!(
+            script.contains("~/'.local/bin/codemux-remote'"),
+            "must preserve tilde-aware escaping: {script}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/ssh/probe.rs
+++ b/src-tauri/src/ssh/probe.rs
@@ -33,6 +33,29 @@ pub enum ProbeOutcome {
         /// by the bootstrap step to pick the right binary to scp.
         /// Example: `"Linux x86_64"`, `"Darwin arm64"`.
         uname: Option<String>,
+        /// True when the remote emitted a `CMR:` line that is neither
+        /// `NOT_INSTALLED` nor a parseable `version` JSON payload —
+        /// i.e. *something* is present at the install path / on PATH
+        /// but it doesn't produce valid version output. Two corruption
+        /// modes from issue #133, two mechanisms:
+        ///
+        /// - A 0-byte file executes as an empty shell script: exit 0,
+        ///   no output → the probe emits a bare `CMR: ` line.
+        /// - A truncated ELF fails to exec (exit 126, "Exec format
+        ///   error"); the probe command's `2>/dev/null || printf
+        ///   'BROKEN\n'` fallback swallows the noise and emits
+        ///   `CMR: BROKEN` (keeping ssh's exit status 0 so we still
+        ///   parse stdout instead of reporting Unreachable).
+        ///
+        /// Both are unparseable as version JSON → classified broken,
+        /// not merely missing — the UI can then say "installed but
+        /// corrupted — Install to repair" instead of "isn't installed
+        /// yet".
+        ///
+        /// `#[serde(default)]` so payloads serialized before this field
+        /// existed still deserialize (to `false`).
+        #[serde(default)]
+        binary_present_but_broken: bool,
     },
     /// SSH did not connect (DNS failure, refused, timeout, key not
     /// authorized). The user-visible message comes from `reason`.
@@ -89,11 +112,26 @@ pub fn build_probe_argv(ssh_target: &str, timeout_secs: u64) -> Vec<String> {
         // every subsequent "Test connection" press. Mirrors the same
         // fix applied in `commands::hosts::ensure_remote_binary_current`
         // and the supervisor's tunnel-spawn command.
+        //
+        // Both version invocations carry `2>/dev/null || printf 'BROKEN\n'`
+        // (issue #133): a truncated ELF fails to exec with exit 126
+        // ("cannot execute binary file: Exec format error"), and because
+        // the version invocation is the LAST statement of its `if`
+        // branch, that 126 would become the whole remote command's exit
+        // status — ssh exits 126 and `probe_host` takes the
+        // `!status.success()` path, reporting `Unreachable` with raw
+        // exec noise instead of ever reaching `parse_probe_stdout`. The
+        // `|| printf` fallback turns exec failure into a `CMR: BROKEN`
+        // line and printf's exit 0, so the probe stays Reachable and
+        // the parser classifies present-but-broken (→ "Install to
+        // repair"). `2>/dev/null` keeps the shell's exec-error noise
+        // out of the stream. The genuinely-absent branch
+        // (`NOT_INSTALLED`) is untouched.
         "printf 'UNAME: ' ; uname -sm ; \
          if command -v codemux-remote >/dev/null 2>&1 ; then \
-           printf 'CMR: ' ; codemux-remote version ; \
+           printf 'CMR: ' ; codemux-remote version 2>/dev/null || printf 'BROKEN\\n' ; \
          elif [ -x \"$HOME/.local/bin/codemux-remote\" ] ; then \
-           printf 'CMR: ' ; \"$HOME/.local/bin/codemux-remote\" version ; \
+           printf 'CMR: ' ; \"$HOME/.local/bin/codemux-remote\" version 2>/dev/null || printf 'BROKEN\\n' ; \
          else \
            printf 'CMR: NOT_INSTALLED\\n' ; \
          fi"
@@ -161,21 +199,32 @@ pub fn parse_probe_stdout(stdout: &str) -> ProbeOutcome {
             cmr_line = Some(rest.trim().to_string());
         }
     }
+    let mut binary_present_but_broken = false;
     let codemux_remote_version = match cmr_line.as_deref() {
+        // No `CMR:` line at all, or an explicit `NOT_INSTALLED`: the
+        // binary is genuinely absent. Not broken.
         None | Some("NOT_INSTALLED") => None,
         Some(json_line) => {
             // The `version` subcommand emits {"name":"codemux-remote","version":"x.y.z",...}
-            // Parse it; on any error treat as "not installed" so the
-            // UI offers the bootstrap path (better than claiming an
-            // unparseable version is fine).
-            serde_json::from_str::<serde_json::Value>(json_line)
+            let parsed = serde_json::from_str::<serde_json::Value>(json_line)
                 .ok()
-                .and_then(|v| v["version"].as_str().map(|s| s.to_string()))
+                .and_then(|v| v["version"].as_str().map(|s| s.to_string()));
+            if parsed.is_none() {
+                // Something answered on the `CMR:` line but it's not a
+                // parseable version (incl. an empty string from a 0-byte
+                // binary running as an empty script, or exec-format noise
+                // from a truncated ELF). The binary is present but broken
+                // — classify it so the UI offers "Install to repair"
+                // rather than "isn't installed yet" (issue #133).
+                binary_present_but_broken = true;
+            }
+            parsed
         }
     };
     ProbeOutcome::Reachable {
         codemux_remote_version,
         uname,
+        binary_present_but_broken,
     }
 }
 
@@ -227,6 +276,24 @@ mod tests {
             cmd.contains("\"$HOME/.local/bin/codemux-remote\" version"),
             "fallback must invoke the binary's version subcommand"
         );
+        // BOTH version invocations must carry the `|| printf 'BROKEN`
+        // failure fallback (issue #133). Without it, a truncated ELF
+        // exec-fails with exit 126 as the LAST statement of its branch,
+        // that 126 becomes the whole remote command's (and ssh's) exit
+        // status, and probe_host reports `Unreachable` with raw exec
+        // noise — parse_probe_stdout is never reached, so the
+        // present-but-broken classification (and the Install-to-repair
+        // path) can never fire.
+        assert!(
+            cmd.contains("codemux-remote version 2>/dev/null || printf 'BROKEN"),
+            "PATH-lookup branch must tolerate exec failure: {cmd}"
+        );
+        assert!(
+            cmd.contains(
+                "\"$HOME/.local/bin/codemux-remote\" version 2>/dev/null || printf 'BROKEN"
+            ),
+            "absolute-path fallback branch must tolerate exec failure: {cmd}"
+        );
     }
 
     #[test]
@@ -238,9 +305,12 @@ CMR: {"name":"codemux-remote","version":"0.3.1","protocol_version":1}
             ProbeOutcome::Reachable {
                 codemux_remote_version,
                 uname,
+                binary_present_but_broken,
             } => {
                 assert_eq!(codemux_remote_version.as_deref(), Some("0.3.1"));
                 assert_eq!(uname.as_deref(), Some("Linux x86_64"));
+                // A cleanly-installed binary is not "broken".
+                assert!(!binary_present_but_broken);
             }
             other => panic!("expected Reachable, got {other:?}"),
         }
@@ -253,9 +323,13 @@ CMR: {"name":"codemux-remote","version":"0.3.1","protocol_version":1}
             ProbeOutcome::Reachable {
                 codemux_remote_version,
                 uname,
+                binary_present_but_broken,
             } => {
                 assert!(codemux_remote_version.is_none());
                 assert_eq!(uname.as_deref(), Some("Darwin arm64"));
+                // Explicit NOT_INSTALLED means genuinely absent, not
+                // broken — the UI says "install", not "repair".
+                assert!(!binary_present_but_broken);
             }
             other => panic!("expected Reachable, got {other:?}"),
         }
@@ -263,17 +337,64 @@ CMR: {"name":"codemux-remote","version":"0.3.1","protocol_version":1}
 
     #[test]
     fn parse_probe_stdout_unparseable_version_treats_as_missing() {
-        // If a malformed remote emits garbage where we expect JSON,
-        // we degrade gracefully — pretend the binary isn't installed
-        // so the user gets offered the bootstrap path. This is safer
-        // than reporting a phantom version.
+        // If a malformed remote emits garbage where we expect JSON, we
+        // no longer pretend the binary isn't installed. Version is still
+        // None (we have nothing usable), but we now classify it as
+        // present-but-broken so the UI can offer "Install to repair"
+        // instead of "isn't installed yet" (issue #133).
         let payload = "UNAME: Linux x86_64\nCMR: not-json-at-all\n";
         match parse_probe_stdout(payload) {
             ProbeOutcome::Reachable {
                 codemux_remote_version,
+                binary_present_but_broken,
                 ..
             } => {
                 assert!(codemux_remote_version.is_none());
+                assert!(binary_present_but_broken);
+            }
+            other => panic!("expected Reachable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_probe_stdout_bare_cmr_from_zero_byte_binary_is_broken() {
+        // A 0-byte codemux-remote executes as an empty shell script:
+        // exits 0, prints nothing, so the probe's `printf 'CMR: '`
+        // yields a bare `CMR: ` line with no version JSON (and here no
+        // trailing newline). This is the exact field-observed corruption
+        // from issue #133 — must be classified broken, not missing.
+        let payload = "UNAME: Linux x86_64\nCMR: ";
+        match parse_probe_stdout(payload) {
+            ProbeOutcome::Reachable {
+                codemux_remote_version,
+                uname,
+                binary_present_but_broken,
+            } => {
+                assert!(codemux_remote_version.is_none());
+                assert_eq!(uname.as_deref(), Some("Linux x86_64"));
+                assert!(binary_present_but_broken);
+            }
+            other => panic!("expected Reachable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_probe_stdout_broken_marker_from_exec_failure_is_broken() {
+        // A truncated ELF can't exec: the remote command's `2>/dev/null
+        // || printf 'BROKEN\n'` fallback emits this exact marker (and
+        // keeps ssh's exit status 0 so we parse stdout at all instead
+        // of reporting Unreachable). `BROKEN` is not parseable version
+        // JSON → classified present-but-broken (issue #133).
+        let payload = "UNAME: Linux x86_64\nCMR: BROKEN\n";
+        match parse_probe_stdout(payload) {
+            ProbeOutcome::Reachable {
+                codemux_remote_version,
+                uname,
+                binary_present_but_broken,
+            } => {
+                assert!(codemux_remote_version.is_none());
+                assert_eq!(uname.as_deref(), Some("Linux x86_64"));
+                assert!(binary_present_but_broken);
             }
             other => panic!("expected Reachable, got {other:?}"),
         }
@@ -283,15 +404,18 @@ CMR: {"name":"codemux-remote","version":"0.3.1","protocol_version":1}
     fn parse_probe_stdout_handles_missing_lines() {
         // Empty payload means nothing got back. Still parse as
         // Reachable (the ssh process succeeded) with both fields
-        // None — the UI will treat this as "weird, retry."
+        // None — the UI will treat this as "weird, retry." No `CMR:`
+        // line at all means not-broken (nothing claimed to be present).
         let outcome = parse_probe_stdout("");
         match outcome {
             ProbeOutcome::Reachable {
                 codemux_remote_version,
                 uname,
+                binary_present_but_broken,
             } => {
                 assert!(codemux_remote_version.is_none());
                 assert!(uname.is_none());
+                assert!(!binary_present_but_broken);
             }
             other => panic!("expected Reachable, got {other:?}"),
         }


### PR DESCRIPTION
Closes #133.

## Symptom

A field host ended up with a 0-byte, mode-0700 `~/.local/bin/codemux-remote` while the old `serve` daemon kept running from the deleted inode — every probe failed and all devices reported "Reachable, but codemux-remote isn't installed yet", even though the correct repair (plain Install) was never offered.

## Root causes & fixes

**1. `bundled_binary_path()` accepted 0-byte placeholder binaries** (`src-tauri/src/ssh/bootstrap.rs`)
All three lookup tiers (Tauri resource dir, source-tree paths, dev sibling-exe) gated only on `.exists()`. A 0-byte dev placeholder sidecar passed, and the background upgrade poller (`hosts_upgrade.rs`, best-effort by design) then atomically installed the empty file over a working production binary — silent corruption.
→ Every tier now goes through `plausible_remote_binary`: regular file, ≥ `MIN_PLAUSIBLE_REMOTE_BINARY_BYTES` (1 MB; the real binary is ~16 MB). Empty/tiny candidates are treated as *not bundled* → `BinaryNotBundled`, so dev builds fail loudly instead of shipping placeholders to hosts.

**2. `ssh_upload_executable()` completed the remote chain on a dead local stream**
If `stdin.write_all` failed partway, the ssh child wasn't killed — remote `cat` saw EOF, exited 0, and `chmod && mv -f` atomically installed a truncated binary. Atomic ≠ verified.
→ The remote script now verifies the received byte count before the swap:
```sh
umask 077 && mkdir -p "$(dirname <p>)" && cat > <p>.tmp \
  && [ "$(wc -c < <p>.tmp)" -eq <NNN> ] \
  && chmod +x <p>.tmp && mv -f <p>.tmp <p> \
  || { echo "upload integrity check failed: expected <NNN> bytes" >&2; rm -f <p>.tmp; exit 1; }
```
On any failure the tmp file is removed, the error surfaces as `UploadFailed`, and the previously-working binary is left untouched — closing the hole for *any* stream-failure mode. The uploader also rejects an empty source outright (it would trivially pass an `-eq 0` check) and kills the ssh child on `write_all` failure.

**3. Probe classification (issue's fix 3)** (`src-tauri/src/ssh/probe.rs`)
A present-but-broken binary was reported identically to "not installed". `ProbeOutcome::Reachable` gains `#[serde(default)] binary_present_but_broken`:
- 0-byte file → executes as an empty script, exit 0, no output → bare `CMR: ` line → broken.
- Truncated ELF → exec fails (exit 126); both probe version invocations now carry `2>/dev/null || printf 'BROKEN\n'` so the failure yields a `CMR: BROKEN` line instead of making the whole probe report `Unreachable` with raw exec noise (which previously bypassed classification entirely and hid the Install button).

`hosts_test_connection` now says *"Reachable, but codemux-remote is present and not working (binary may be corrupted or truncated). Install to repair — this replaces the file without touching a running daemon."* — same `needs_install: true`, so the existing Install button repairs in place (no frontend changes). The background poller still never auto-repairs (consent), but its skip reason now distinguishes broken from absent.

## Verification

- `cargo check` clean; full lib suite **1974 passed / 0 failed** (61 in `ssh::`).
- New/updated tests: `plausible_remote_binary` size+type gating, `upload_script` pipeline shape (byte-count check, cleanup, tilde-aware escaping), empty-source rejection assertions in the localhost E2E upload test, probe argv `BROKEN`-fallback assertions, and parse classification tests for bare-`CMR:` / garbage / `BROKEN` / `NOT_INSTALLED` payloads.
- Pipeline semantics additionally validated against real `sh`: truncated stream → exit 1, tmp removed, old binary untouched; exact stream → installed with exec bit; mkdir failure → clean non-zero exit.

## Docs

`docs/features/remote-hosts.md`: integrity guards in § bootstrap.rs, updated probe command + classification in § probe.rs, test-coverage counts, and a new Troubleshooting entry for the corrupted-binary case (plain **Install** repairs without restarting the live daemon; **Reinstall agent** kills live sessions — matching the issue's repair note).