### PR TITLE
fix(agent-chat): stale "subagents running" indicators — settle non-terminal subagents in the transcript layer

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -535,9 +535,55 @@ idle — no resting state.
   top-edge sweep animation (`cm-sweep` in `globals.css`) and `.cm-blink`
   (still used by the breadcrumb's status dot) honor reduced-motion.
 
+### Run-state settlement (issue #153)
+
+The transcript layer's only "running → terminal" transition used to be a
+terminal `subagent_updated` snapshot. When the Claude adapter's demux
+loses track (sidecar restart/resume) the spawning `Task` tool's raw
+parent-scoped `tool_result` flows through and no terminal snapshot ever
+arrives, so a subagent could show "N running" forever — persisted that
+way, and resurrected on hydrate. The frontend now settles run state from
+several additional signals (the transcript-layer counterpart of the
+backend `SubagentTracker`; pure helpers in `subagents.ts`, unit-tested):
+
+- **`tool_result` derivation.** A parent-scoped `tool_result` (no
+  `subagent_id`) whose `tool_use_id` matches a still-running subagent's
+  demux id **or** its `parentItemId` (the spawning tool_use/call id,
+  merged from `SubagentSnapshot.parent_item_id`) settles that subagent
+  (`completed`, or `failed` on error). A subagent-**tagged** `tool_result`
+  routes into the sub-transcript and never settles the row. The matching
+  Workflow tool's own `tool_result` likewise settles the run and its
+  in-flight phase agents.
+- **Forced settle.** `session_state_changed{closed|error}` and a new user
+  turn (mirroring `SubagentTracker::clear_thread` on send) interrupt every
+  running/pending subagent and stop running workflows; a queued follow-up
+  (sent while streaming) leaves the active turn's subagents alone.
+- **Interrupted-on-hydrate.** The hydrate reconciliation force-settles any
+  subagent still running at end-of-replay to a **view-only `interrupted`**
+  status (`SubagentViewStatus = SubagentStatus | "interrupted"`, never on
+  the wire; muted-amber tone, a non-spinning glyph) and stops a still-
+  `running` workflow — a resumed transcript never renders a live spinner.
+  A `pending_approval` workflow is preserved (a resting state awaiting the
+  user, not a runaway spinner).
+- **`statusAssumed` + revive-on-running-snapshot.** Every inferred
+  settlement stamps `statusAssumed`, so a later **real** `running`
+  snapshot (e.g. a Claude background task re-emitting `running` via
+  `task_progress`) revives the row back to `running`, and a later real
+  terminal snapshot wins by rank and clears the flag. This makes the
+  inference self-healing on live streams and on replay.
+- **`runtime_warning` notices.** A small classifier (`runtime-notice.ts`)
+  promotes the user-facing runtime warnings — a provider rate-limit
+  rejection (`rate_limit_info.status === "rejected"`), the SDK's
+  enumerated `assistant error: …` — into a compact muted-amber inline
+  `runtime_notice` transcript row; all other `runtime_warning`s stay
+  console-only debug noise.
+
 The dev mock seeds one subagent turn in the demo transcript and exposes
 `window.__codemuxChatMock.streamSubagents()` for a live two-subagent
-lifecycle over the real per-thread Channel.
+lifecycle over the real per-thread Channel. Because the seeded transcript
+is served through the hydrate path, its still-running subagent (and the
+mid-run `/workflow` demo) correctly settle to `interrupted`/`stopped` on
+load; the live running bar remains demoable via `streamSubagents()`.
 
 **Workflow runs are a Claude-only relative of this system.** When a
 Claude session runs a top-level `Workflow` tool_use (a script that

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -370,6 +370,8 @@ function intrinsicSizeClass(slot: TranscriptSlot): string {
     case "tool_call":
     case "reasoning":
       return "[contain-intrinsic-size:auto_5rem]";
+    case "runtime_notice":
+      return "[contain-intrinsic-size:auto_2.5rem]";
     case "subagent_run":
     case "workflow_run":
       return "[contain-intrinsic-size:auto_14rem]";
@@ -555,6 +557,15 @@ function renderAssistantBody(
         <div className="py-0.5 text-xs text-muted-foreground">
           Turn ended: {item.status.subtype}
           {item.status.message ? ` — ${item.status.message}` : ""}
+        </div>
+      );
+    case "runtime_notice":
+      // Compact muted-amber inline notice (provider rate-limit rejection,
+      // enumerated assistant error) — a left-bordered line in the
+      // assistant gutter. Tokens only (design-system no-hardcoded-color).
+      return (
+        <div className="border-l-2 border-status-working/40 bg-status-working/10 px-3 py-1.5 text-[12px] text-status-working">
+          {item.message}
         </div>
       );
     case "subagent_run":

--- a/src/components/chat/SubagentsCard.tsx
+++ b/src/components/chat/SubagentsCard.tsx
@@ -1,4 +1,5 @@
 import {
+  Ban,
   Check,
   ChevronDown,
   ChevronRight,
@@ -50,7 +51,11 @@ export const SubagentsCard = memo(function SubagentsCard({
   const [openId, setOpenId] = useState<string | null>(null);
 
   const doneCount = subs.filter(
-    (s) => s.status === "completed" || s.status === "failed" || s.status === "stopped",
+    (s) =>
+      s.status === "completed" ||
+      s.status === "failed" ||
+      s.status === "stopped" ||
+      s.status === "interrupted",
   ).length;
   const activeCount = subs.filter((s) => isRunning(s)).length;
 
@@ -167,6 +172,10 @@ function SubagentRow({
             />
           ) : sub.status === "failed" ? (
             <X className={cn("h-[18px] w-[18px]", tone.text)} strokeWidth={1.8} aria-hidden />
+          ) : sub.status === "interrupted" ? (
+            // Muted-amber non-spinning glyph — settled-but-unresolved, not
+            // a green success check and not a red failure ✕.
+            <Ban className={cn("h-[17px] w-[17px]", tone.text)} strokeWidth={1.8} aria-hidden />
           ) : (
             <Check
               className={cn("h-[18px] w-[18px]", tone.text)}

--- a/src/components/workflow/workflow-tone.ts
+++ b/src/components/workflow/workflow-tone.ts
@@ -1,5 +1,5 @@
 import { statusTone, type SubagentToneClasses } from "@/lib/agent-chat/subagents";
-import type { SubagentStatus, WorkflowRunStatus } from "@/lib/agent-chat/types";
+import type { SubagentViewStatus, WorkflowRunStatus } from "@/lib/agent-chat/types";
 
 export type { SubagentToneClasses };
 
@@ -50,7 +50,7 @@ export function workflowPhaseTone(
  *  started — the design's "queued" hollow-dot row) reads as muted rather
  *  than amber-running, so it doesn't visually compete with agents
  *  actually in flight. */
-export function workflowAgentTone(status: SubagentStatus): SubagentToneClasses {
+export function workflowAgentTone(status: SubagentViewStatus): SubagentToneClasses {
   if (status === "pending") return statusTone("stopped");
   return statusTone(status);
 }

--- a/src/dev/subagent-fixture.test.ts
+++ b/src/dev/subagent-fixture.test.ts
@@ -13,7 +13,14 @@ import { subagentTurnEnvelopes } from "./mock-fixtures";
  * Guards the seeded dev fixture against reducer drift: the same
  * hydrate path the mock uses (`agent_chat_list_messages` → JSON strings
  * → `replayPayloads`) must rebuild the design-fixture card (Implement
- * completed, Verify running) from the persisted envelopes.
+ * completed, Verify interrupted).
+ *
+ * The transcript ends with Verify still emitting `running` snapshots and
+ * no terminal signal, so the hydrate reconciliation (issue #153) settles
+ * it to the view-only `interrupted` state — a persisted transcript never
+ * resurrects a perpetual spinner. The LIVE running bar stays demoable via
+ * the mock's `streamSubagents()` command (real events, no hydrate
+ * reconciliation).
  */
 describe("subagentTurnEnvelopes seed", () => {
   it("replays into the two-subagent design card", () => {
@@ -38,14 +45,19 @@ describe("subagentTurnEnvelopes seed", () => {
     expect(impl.items.some((i) => i.kind === "tool_call")).toBe(true);
 
     const verify = findSubagentView(state.messages, "verify")!;
-    expect(verify.status).toBe("running");
-    // Its `npm run verify` call has no result → still running in the peek.
+    // Ends mid-run with no terminal snapshot → force-settled on hydrate.
+    expect(verify.status).toBe("interrupted");
+    expect(verify.statusAssumed).toBe(true);
+    // The subagent VIEW is interrupted, but its child tool call was never
+    // given a result, so the sub-transcript row itself stays "running"
+    // (the settlement is on the subagent, not its inner steps).
     expect(
       verify.items.some(
         (i) => i.kind === "tool_call" && i.status === "running",
       ),
     ).toBe(true);
 
-    expect(countRunningSubagents(state.messages)).toBe(1);
+    // No spinner survives hydrate — the docked bar's count is 0.
+    expect(countRunningSubagents(state.messages)).toBe(0);
   });
 });

--- a/src/dev/workflow-fixture.test.ts
+++ b/src/dev/workflow-fixture.test.ts
@@ -57,11 +57,16 @@ describe("workflow demo fixtures", () => {
     }
   });
 
-  it("running thread: phase 1 done, phase 2 mixed states with a findings badge, phase 3 pending", () => {
+  it("running thread: phase 1 done, phase 2 in-flight agents interrupted on hydrate", () => {
     const state = replay(workflowRunningEnvelopes("t-running"));
     const wf = soleWorkflow(state);
 
-    expect(wf.status).toBe("running");
+    // The persisted stream ends mid-run (no terminal workflow snapshot),
+    // so the hydrate reconciliation (issue #153) stops the workflow and
+    // interrupts its still-in-flight agents — a resumed transcript never
+    // resurrects a live spinner. (A genuinely live run is demoed via the
+    // real event stream, not this persisted-replay path.)
+    expect(wf.status).toBe("stopped");
     // Stays linked after resolution so transcript-slots keeps suppressing
     // the standalone resolved permission block (no stray "Allowed" row).
     expect(wf.approvalRequestId).toBe("req-workflow-running");
@@ -72,13 +77,15 @@ describe("workflow demo fixtures", () => {
 
     const audit = phase(wf, "Audit each file for missing auth");
     const byId = Object.fromEntries(audit.agents.map((a) => [a.id, a]));
+    // Already-terminal agents are left untouched…
     expect(byId["audit-auth"].status).toBe("completed");
     expect(byId["audit-billing"].status).toBe("completed");
     expect(byId["audit-webhooks"].status).toBe("completed");
-    expect(byId["audit-orders"].status).toBe("running");
-    expect(byId["audit-reports"].status).toBe("running");
-    expect(byId["audit-admin"].status).toBe("pending");
-    expect(byId["audit-search"].status).toBe("pending");
+    // …and the running / pending ones are force-settled to interrupted.
+    expect(byId["audit-orders"].status).toBe("interrupted");
+    expect(byId["audit-reports"].status).toBe("interrupted");
+    expect(byId["audit-admin"].status).toBe("interrupted");
+    expect(byId["audit-search"].status).toBe("interrupted");
 
     expect(subagentFindingBadge(byId["audit-auth"])).toEqual({ label: "clean", tone: "green" });
     expect(subagentFindingBadge(byId["audit-billing"])).toEqual({

--- a/src/lib/agent-chat/hydrate.test.ts
+++ b/src/lib/agent-chat/hydrate.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import type { ProviderRuntimeEvent } from "@/tauri/events";
 
 import { replayPayloads } from "./hydrate";
+import { findSubagentView, runningSubagentEntries } from "./subagents";
+import type { WorkflowRunItem } from "./types";
 
 function user(text: string): string {
   return JSON.stringify({ type: "user_message", thread_id: "t", text });
@@ -408,5 +410,107 @@ describe("replayPayloads", () => {
     if (ended?.kind === "turn_ended") {
       expect(ended.status.kind).toBe("error");
     }
+  });
+
+  // ── Run-state reconciliation (issue #153) ──
+
+  it("interrupts a subagent left running by a transcript that ends mid-run", () => {
+    const state = replayPayloads([
+      user("delegate"),
+      event({
+        type: "subagent_updated",
+        thread_id: "t",
+        subagent: {
+          subagent_id: "s1",
+          status: "running",
+          name: "Explore",
+          parent_item_id: "tool-1",
+        },
+      } as ProviderRuntimeEvent),
+      // No terminal snapshot, no tool_result — the stuck-forever shape.
+    ]);
+    const sub = findSubagentView(state.messages, "s1");
+    expect(sub?.status).toBe("interrupted");
+    expect(sub?.statusAssumed).toBe(true);
+    // Never resurrects a live spinner in the docked bar.
+    expect(runningSubagentEntries(state.messages)).toHaveLength(0);
+  });
+
+  it("self-heals: a running snapshot then a parent tool_result hydrates as completed (not interrupted)", () => {
+    const state = replayPayloads([
+      user("delegate"),
+      event({
+        type: "subagent_updated",
+        thread_id: "t",
+        subagent: {
+          subagent_id: "s1",
+          status: "running",
+          name: "Explore",
+          parent_item_id: "tool-1",
+        },
+      } as ProviderRuntimeEvent),
+      // The raw parent-scoped tool_result for the spawning tool leaks
+      // through (demux lost track) — the reducer derives the settlement,
+      // which the hydrate reconciliation then leaves untouched.
+      event({
+        type: "item_completed",
+        thread_id: "t",
+        turn_id: "turn-1",
+        item: { kind: "tool_result", tool_use_id: "tool-1", content: "ok", is_error: false },
+      }),
+    ]);
+    const sub = findSubagentView(state.messages, "s1");
+    expect(sub?.status).toBe("completed");
+    expect(sub?.statusAssumed).toBe(true);
+    expect(runningSubagentEntries(state.messages)).toHaveLength(0);
+  });
+
+  it("stops a workflow left running by a truncated transcript", () => {
+    const state = replayPayloads([
+      user("/workflow audit"),
+      event({
+        type: "workflow_updated",
+        thread_id: "t",
+        workflow: {
+          workflow_id: "wf",
+          status: "running",
+          name: "Audit",
+          phases: [{ title: "Run", detail: null }],
+        },
+      } as ProviderRuntimeEvent),
+    ]);
+    const wf = state.messages.find(
+      (m): m is WorkflowRunItem => m.kind === "workflow_run",
+    );
+    expect(wf?.status).toBe("stopped");
+  });
+
+  it("preserves a pending_approval workflow on hydrate (a resting state, not a spinner)", () => {
+    const state = replayPayloads([
+      user("/workflow audit"),
+      event({
+        type: "workflow_updated",
+        thread_id: "t",
+        workflow: {
+          workflow_id: "wf",
+          status: "pending_approval",
+          name: "Audit",
+          phases: [{ title: "Run", detail: null }],
+        },
+      } as ProviderRuntimeEvent),
+      event({
+        type: "request_opened",
+        thread_id: "t",
+        turn_id: "turn-1",
+        request_id: "req-1",
+        request_kind: "other",
+        payload: {},
+        tool_use_id: "wf",
+      }),
+    ]);
+    const wf = state.messages.find(
+      (m): m is WorkflowRunItem => m.kind === "workflow_run",
+    );
+    expect(wf?.status).toBe("pending_approval");
   });
 });

--- a/src/lib/agent-chat/hydrate.ts
+++ b/src/lib/agent-chat/hydrate.ts
@@ -5,7 +5,8 @@ import {
   appendUserMessage,
   createEmptyThreadState,
 } from "./reducer";
-import type { ChatThreadState, UserMessageImage } from "./types";
+import { interruptRunningSubagents } from "./subagents";
+import type { ChatThreadState, ChatViewItem, UserMessageImage } from "./types";
 
 /**
  * Synthetic envelope written by the backend in `agent_chat_send_turn`
@@ -72,11 +73,34 @@ export function replayPayloads(payloads: string[]): ChatThreadState {
   const hasStreamingReasoning = state.messages.some(
     (m) => m.kind === "reasoning" && m.streaming,
   );
-  const messages = hasStreamingReasoning
+  let messages: ChatViewItem[] = hasStreamingReasoning
     ? state.messages.map((m) =>
         m.kind === "reasoning" && m.streaming ? { ...m, streaming: false } : m,
       )
     : state.messages;
+
+  // Belt-and-braces run-state reconciliation (issue #153): a transcript
+  // that ends mid-run — the last persisted event was a `running` snapshot
+  // with no terminal snapshot after it — must NEVER hydrate with a live
+  // spinner. Interrupt every still-running subagent (in cards and
+  // workflow phases) and stop any still-`running` workflow. This mirrors
+  // the reducer's own settle paths and self-heals: if the persisted
+  // stream actually did settle a subagent (e.g. a parent `tool_result`
+  // the reducer derived from), that terminal state already won during
+  // replay and is left untouched here.
+  //
+  // A `pending_approval` workflow is deliberately PRESERVED — it is a
+  // legitimate persisted resting state awaiting the user's decision (the
+  // "Run as a workflow?" card), not a runaway spinner, and the backend
+  // auto-resume re-establishes the session so the approval can still be
+  // answered after a restart.
+  messages = interruptRunningSubagents(messages);
+  messages = messages.map((m) =>
+    m.kind === "workflow_run" && m.status === "running"
+      ? { ...m, status: "stopped" as const }
+      : m,
+  );
+
   return {
     ...state,
     messages,

--- a/src/lib/agent-chat/reducer.test.ts
+++ b/src/lib/agent-chat/reducer.test.ts
@@ -789,6 +789,36 @@ describe("agent-chat reducer", () => {
     warn.mockRestore();
   });
 
+  it("runtime_warning promotes a rejected rate-limit event to an inline runtime_notice", () => {
+    const state = applyEvent(createEmptyThreadState(), {
+      type: "runtime_warning",
+      thread_id: "t1",
+      message: "rate limit event",
+      original_payload: { rate_limit_info: { status: "rejected" } },
+    });
+    expect(state.messages).toHaveLength(1);
+    const notice = state.messages[0];
+    expect(notice.kind).toBe("runtime_notice");
+    if (notice.kind === "runtime_notice") {
+      expect(notice.message).toBe(
+        "Usage limit reached — the provider stopped the run.",
+      );
+    }
+  });
+
+  it("runtime_warning debug noise still appends nothing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const base = createEmptyThreadState();
+    const after = applyEvent(base, {
+      type: "runtime_warning",
+      thread_id: "t1",
+      message: "rate limit event",
+      original_payload: { rate_limit_info: { status: "allowed" } },
+    });
+    expect(after).toBe(base);
+    warn.mockRestore();
+  });
+
   it("content_delta that follows a sealed assistant + tool_call starts a NEW assistant block at a fresh seq (AskUserQuestion position bug)", () => {
     // Reproduces the AskUserQuestion "Answered above older tool calls"
     // bug. Timeline: assistant emits a preamble, a tool runs, the user
@@ -1543,6 +1573,100 @@ describe("agent-chat reducer — subagents", () => {
       cards(once)[0].subagents[0].items.length,
     );
   });
+
+  // ── Run-state settlement (issue #153) ──
+
+  it("a parent-scoped tool_result settles a stuck running subagent (the issue shape)", () => {
+    const state = runEvents([
+      subagentUpdated({
+        subagent_id: "s1",
+        status: "running",
+        name: "Explore",
+        parent_item_id: "spawn-1",
+      }),
+      // The raw spawning tool_result flows through the PARENT flow (no
+      // subagent_id) because the adapter's demux lost track — and no
+      // terminal snapshot ever follows.
+      {
+        type: "item_completed",
+        thread_id: "t1",
+        turn_id: "turn-1",
+        item: { kind: "tool_result", tool_use_id: "spawn-1", content: "ok", is_error: false },
+      },
+    ]);
+    const sub = cards(state)[0].subagents[0];
+    expect(sub.status).toBe("completed");
+    expect(sub.statusAssumed).toBe(true);
+  });
+
+  it("a parent-scoped error tool_result settles the subagent as failed", () => {
+    const state = runEvents([
+      subagentUpdated({ subagent_id: "s1", status: "running", parent_item_id: "spawn-1" }),
+      {
+        type: "item_completed",
+        thread_id: "t1",
+        turn_id: "turn-1",
+        item: { kind: "tool_result", tool_use_id: "spawn-1", content: "boom", is_error: true },
+      },
+    ]);
+    expect(cards(state)[0].subagents[0].status).toBe("failed");
+  });
+
+  it("a subagent-TAGGED tool_result does NOT settle the subagent view", () => {
+    const state = runEvents([
+      subagentUpdated({ subagent_id: "s1", status: "running", parent_item_id: "spawn-1" }),
+      subItem("s1", { kind: "tool_use", tool_name: "Bash", tool_use_id: "child-1", input: {} }),
+      // Tagged with subagent_id → routes into the sub-transcript, never
+      // the parent settle path.
+      subItem("s1", { kind: "tool_result", tool_use_id: "child-1", content: "ok", is_error: false }),
+    ]);
+    const sub = cards(state)[0].subagents[0];
+    expect(sub.status).toBe("running");
+    expect(sub.statusAssumed).toBeUndefined();
+  });
+
+  it("session_state_changed closed interrupts running subagents even when not streaming", () => {
+    const running = runEvents([
+      subagentUpdated({ subagent_id: "s1", status: "running", name: "A" }),
+    ]);
+    expect(running.streaming).toBe(false);
+    const closed = applyEvent(running, {
+      type: "session_state_changed",
+      thread_id: "t1",
+      status: { status: "closed" },
+    });
+    expect(cards(closed)[0].subagents[0].status).toBe("interrupted");
+    expect(cards(closed)[0].subagents[0].statusAssumed).toBe(true);
+  });
+
+  it("session_state_changed error interrupts running subagents", () => {
+    const running = runEvents([
+      subagentUpdated({ subagent_id: "s1", status: "running", name: "A" }),
+    ]);
+    const errored = applyEvent(running, {
+      type: "session_state_changed",
+      thread_id: "t1",
+      status: { status: "error", message: "boom" },
+    });
+    expect(cards(errored)[0].subagents[0].status).toBe("interrupted");
+  });
+
+  it("a new user turn (not streaming) interrupts leftover running subagents", () => {
+    const running = runEvents([
+      subagentUpdated({ subagent_id: "s1", status: "running", name: "A" }),
+    ]);
+    const next = appendUserMessage(running, "another question");
+    expect(cards(next)[0].subagents[0].status).toBe("interrupted");
+  });
+
+  it("a queued follow-up (streaming) leaves running subagents alone", () => {
+    const running = runEvents([
+      subagentUpdated({ subagent_id: "s1", status: "running", name: "A" }),
+    ]);
+    const streaming = { ...running, streaming: true };
+    const next = appendUserMessage(streaming, "queued behind the active turn");
+    expect(cards(next)[0].subagents[0].status).toBe("running");
+  });
 });
 
 describe("agent-chat reducer — workflows", () => {
@@ -1795,5 +1919,52 @@ describe("agent-chat reducer — workflows", () => {
     });
     const wf = workflows(state)[0];
     expect(wf.status).toBe("completed");
+  });
+
+  it("a parent-scoped tool_result for the Workflow tool settles the run + its agents (issue #153)", () => {
+    const state = runEvents([
+      workflowUpdated({ workflow_id: "wf1", status: "running", phases: samplePhases }),
+      workflowSubagentUpdated({
+        subagent_id: "sub-a",
+        status: "running",
+        workflow_id: "wf1",
+        phase: "Explore",
+      }),
+      // The Workflow tool's own tool_result (tool_use_id == workflow_id)
+      // leaks through the parent flow with no terminal workflow snapshot.
+      {
+        type: "item_completed",
+        thread_id: "t1",
+        turn_id: "turn-1",
+        item: { kind: "tool_result", tool_use_id: "wf1", content: "done", is_error: false },
+      },
+    ]);
+    const wf = workflows(state)[0];
+    expect(wf.status).toBe("completed");
+    const agent = wf.phases.find((p) => p.title === "Explore")!.agents[0];
+    expect(agent.status).toBe("completed");
+    expect(agent.statusAssumed).toBe(true);
+  });
+
+  it("an error tool_result for the Workflow tool fails the run and interrupts its agents", () => {
+    const state = runEvents([
+      workflowUpdated({ workflow_id: "wf1", status: "running", phases: samplePhases }),
+      workflowSubagentUpdated({
+        subagent_id: "sub-a",
+        status: "running",
+        workflow_id: "wf1",
+        phase: "Explore",
+      }),
+      {
+        type: "item_completed",
+        thread_id: "t1",
+        turn_id: "turn-1",
+        item: { kind: "tool_result", tool_use_id: "wf1", content: "boom", is_error: true },
+      },
+    ]);
+    const wf = workflows(state)[0];
+    expect(wf.status).toBe("failed");
+    const agent = wf.phases.find((p) => p.title === "Explore")!.agents[0];
+    expect(agent.status).toBe("interrupted");
   });
 });

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -7,7 +7,13 @@ import type {
   WorkflowSnapshot,
 } from "@/tauri/events";
 
-import { mergeSnapshot, newSubagentView } from "./subagents";
+import { runtimeNoticeFromWarning } from "./runtime-notice";
+import {
+  interruptRunningSubagents,
+  mergeSnapshot,
+  newSubagentView,
+  settleSubagentsForToolResult,
+} from "./subagents";
 import {
   emptyThreadState,
   type AssistantMessageItem,
@@ -15,11 +21,13 @@ import {
   type ChatViewItem,
   type PermissionRequestItem,
   type ReasoningItem,
+  type RuntimeNoticeItem,
   type SubagentRunItem,
   type SubagentView,
   type ToolCallItem,
   type UserMessageImage,
   type UserMessageItem,
+  type WorkflowPhaseView,
   type WorkflowRunItem,
 } from "./types";
 import { mergeWorkflowSnapshot, newWorkflowRunItem } from "./workflows";
@@ -701,13 +709,61 @@ function applyWorkflowSubagentUpdated(
 }
 
 /** Stop every workflow still `running`/`pending_approval` — used when
- *  the thread's turn dies with no other terminal signal coming for it. */
+ *  the thread's turn dies with no other terminal signal coming for it.
+ *  Returns the SAME array reference when no workflow changed, so callers
+ *  can cheaply detect a no-op (issue #153: the session-close settle path
+ *  keys off reference identity to avoid a needless state churn). */
 function stopRunningWorkflows(messages: ChatViewItem[]): ChatViewItem[] {
-  return messages.map((m) => {
+  let changed = false;
+  const next: ChatViewItem[] = messages.map((m) => {
     if (m.kind !== "workflow_run") return m;
     if (m.status !== "running" && m.status !== "pending_approval") return m;
+    changed = true;
     return { ...m, status: "stopped" };
   });
+  return changed ? next : messages;
+}
+
+/** Settle a workflow whose spawning `Workflow` tool_use just produced a
+ *  parent-scoped `tool_result` (the raw spawn result leaked through
+ *  because the adapter's demux lost track — issue #153): flip the run to
+ *  `completed`/`failed` and settle its still-running phase agents
+ *  (`completed` on success; view-only `interrupted` on error) with
+ *  `statusAssumed` so a later real snapshot can revive/confirm them.
+ *  Same-ref when there is no matching in-flight workflow. */
+function settleWorkflowForToolResult(
+  messages: ChatViewItem[],
+  toolUseId: string,
+  isError: boolean,
+): ChatViewItem[] {
+  const found = findWorkflow(messages, toolUseId);
+  if (!found) return messages;
+  if (
+    found.item.status !== "running" &&
+    found.item.status !== "pending_approval"
+  ) {
+    return messages;
+  }
+  const agentTarget: SubagentView["status"] = isError
+    ? "interrupted"
+    : "completed";
+  const phases: WorkflowPhaseView[] = found.item.phases.map((p) => {
+    let phaseChanged = false;
+    const agents: SubagentView[] = p.agents.map((a) => {
+      if (a.status === "running" || a.status === "pending") {
+        phaseChanged = true;
+        return { ...a, status: agentTarget, statusAssumed: true };
+      }
+      return a;
+    });
+    return phaseChanged ? { ...p, agents } : p;
+  });
+  const nextItem: WorkflowRunItem = {
+    ...found.item,
+    status: isError ? "failed" : "completed",
+    phases,
+  };
+  return replaceItem(messages, found.index, nextItem);
 }
 
 /** Merge a `workflow_updated` snapshot into its item (non-null fields
@@ -832,7 +888,22 @@ function appendUserMessageLocal(
   clientNonce?: string,
   images?: UserMessageImage[],
 ): ChatThreadState {
-  const sealed = sealTrailingReasoning(state, now);
+  let sealed = sealTrailingReasoning(state, now);
+  // A new user turn while nothing is streaming is a fresh boundary —
+  // mirror the backend `SubagentTracker::clear_thread` on send (issue
+  // #153): interrupt any leftover running subagents and stop any leftover
+  // running workflow from a PRIOR turn so they don't spin under the new
+  // turn. When STREAMING (this is a queued follow-up parked behind an
+  // active turn) leave them alone — that turn is still live. On hydrate
+  // replay this also runs for each persisted user_message and self-
+  // corrects: a later replayed `running` snapshot revives, a later
+  // terminal snapshot wins by rank.
+  if (!state.streaming) {
+    const settled = interruptRunningSubagents(
+      stopRunningWorkflows(sealed.messages),
+    );
+    if (settled !== sealed.messages) sealed = { ...sealed, messages: settled };
+  }
   const { seq, next } = takeSeq(sealed);
   const item: UserMessageItem = {
     kind: "user_message",
@@ -969,13 +1040,22 @@ function applyEventInner(
         if (state.streaming) return state;
         return { ...state, streaming: true };
       }
-      if (
-        status.status === "ready" ||
-        status.status === "closed" ||
-        status.status === "error"
-      ) {
+      if (status.status === "ready") {
         if (!state.streaming) return state;
         return { ...state, streaming: false };
+      }
+      if (status.status === "closed" || status.status === "error") {
+        // Session teardown is a hard boundary with no further terminal
+        // signal coming for anything still in flight (issue #153): stop
+        // running workflows and interrupt running/pending subagents so a
+        // persisted transcript never resurrects a perpetual spinner.
+        // Settle even when `streaming` is already false (the running flag
+        // is cleared independently of subagent lifetimes).
+        const settled = interruptRunningSubagents(
+          stopRunningWorkflows(state.messages),
+        );
+        if (settled === state.messages && !state.streaming) return state;
+        return { ...state, streaming: false, messages: settled };
       }
       return state;
     }
@@ -1036,10 +1116,31 @@ function applyEventInner(
         event.turn_id,
         now,
       );
-      if (ctx.messages === state.messages && ctx.nextSeq === state.nextSeq) {
+      let messages = ctx.messages;
+      // A parent-scoped `tool_result` for a spawning tool settles any
+      // subagent the adapter's demux lost track of (issue #153): normally
+      // the Claude adapter suppresses the spawn tool_result and emits a
+      // terminal snapshot, but on a sidecar restart/resume the raw
+      // parent-scoped result leaks through and no terminal snapshot ever
+      // arrives — leaving the row stuck "running" forever. Derive the
+      // settlement here (revivable by a later real `running` snapshot for
+      // Claude background tasks).
+      if (item.kind === "tool_result") {
+        messages = settleSubagentsForToolResult(
+          messages,
+          item.tool_use_id,
+          item.is_error,
+        );
+        messages = settleWorkflowForToolResult(
+          messages,
+          item.tool_use_id,
+          item.is_error,
+        );
+      }
+      if (messages === state.messages && ctx.nextSeq === state.nextSeq) {
         return state;
       }
-      return { ...state, messages: ctx.messages, nextSeq: ctx.nextSeq };
+      return { ...state, messages, nextSeq: ctx.nextSeq };
     }
 
     case "subagent_updated": {
@@ -1194,10 +1295,33 @@ function applyEventInner(
     }
 
     case "runtime_warning": {
-      // Runtime warnings carry SDK-lifecycle debug strings meant for
-      // devtools, not the transcript. Surface to console only.
-      console.warn("[agent-chat]", event.message, event.original_payload ?? event);
-      return state;
+      // Most runtime warnings carry SDK-lifecycle debug strings meant for
+      // devtools, not the transcript. The classifier promotes only the
+      // user-facing ones (provider rate-limit rejection, enumerated
+      // assistant errors) to an inline notice; the rest stay console-only.
+      const notice = runtimeNoticeFromWarning(
+        event.message,
+        event.original_payload,
+      );
+      if (notice == null) {
+        console.warn(
+          "[agent-chat]",
+          event.message,
+          event.original_payload ?? event,
+        );
+        return state;
+      }
+      // A notice is a non-thinking boundary — seal any trailing reasoning
+      // before it lands.
+      const sealed = sealTrailingReasoning(state, now);
+      const { seq, next } = takeSeq(sealed);
+      const item: RuntimeNoticeItem = {
+        kind: "runtime_notice",
+        id: nextId("notice"),
+        seq,
+        message: notice,
+      };
+      return { ...next, messages: [...next.messages, item] };
     }
 
     case "resume_cursor_updated": {

--- a/src/lib/agent-chat/runtime-notice.test.ts
+++ b/src/lib/agent-chat/runtime-notice.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { runtimeNoticeFromWarning } from "./runtime-notice";
+
+describe("runtimeNoticeFromWarning", () => {
+  it("promotes a rejected rate-limit event to a usage-limit notice", () => {
+    expect(
+      runtimeNoticeFromWarning("rate limit event", {
+        rate_limit_info: { status: "rejected" },
+      }),
+    ).toBe("Usage limit reached — the provider stopped the run.");
+  });
+
+  it("ignores an informational (non-rejected) rate-limit event", () => {
+    expect(
+      runtimeNoticeFromWarning("rate limit event", {
+        rate_limit_info: { status: "allowed" },
+      }),
+    ).toBeNull();
+    // Missing / malformed payload also stays console-only.
+    expect(runtimeNoticeFromWarning("rate limit event", null)).toBeNull();
+    expect(runtimeNoticeFromWarning("rate limit event", {})).toBeNull();
+    expect(
+      runtimeNoticeFromWarning("rate limit event", { rate_limit_info: 42 }),
+    ).toBeNull();
+  });
+
+  it("maps an enumerated assistant error to a provider-error notice", () => {
+    expect(
+      runtimeNoticeFromWarning("assistant error: rate_limit", null),
+    ).toBe("Provider error: rate_limit");
+    expect(
+      runtimeNoticeFromWarning("assistant error: overloaded_error", {}),
+    ).toBe("Provider error: overloaded_error");
+  });
+
+  it("keeps SDK debug chatter console-only", () => {
+    expect(
+      runtimeNoticeFromWarning("stream_event message_start", {
+        type: "stream_event",
+      }),
+    ).toBeNull();
+    expect(runtimeNoticeFromWarning("unknown sdk variant", {})).toBeNull();
+  });
+});

--- a/src/lib/agent-chat/runtime-notice.ts
+++ b/src/lib/agent-chat/runtime-notice.ts
@@ -1,0 +1,51 @@
+/**
+ * Classifier that decides which `runtime_warning` events deserve a
+ * user-facing inline transcript notice (a `RuntimeNoticeItem`) versus
+ * staying console-only SDK debug noise.
+ *
+ * Kept pure + separately unit-tested: the reducer's `runtime_warning`
+ * case calls this and only appends a row when it returns a non-null
+ * message. Deliberately conservative — the vast majority of
+ * `runtime_warning`s are SDK lifecycle chatter (`stream_event …`) that
+ * must never spam the transcript.
+ */
+
+/** Prefix the SDK uses for its enumerated assistant errors (rate_limit,
+ *  overloaded, …). The remainder is a short human-readable reason. */
+const ASSISTANT_ERROR_PREFIX = "assistant error: ";
+
+/** Defensive nested access: `originalPayload.rate_limit_info.status`. */
+function readRateLimitStatus(originalPayload: unknown): string | null {
+  if (!originalPayload || typeof originalPayload !== "object") return null;
+  const info = (originalPayload as { rate_limit_info?: unknown })
+    .rate_limit_info;
+  if (!info || typeof info !== "object") return null;
+  const status = (info as { status?: unknown }).status;
+  return typeof status === "string" ? status : null;
+}
+
+/**
+ * Map a `runtime_warning` to a user-facing notice string, or `null` when
+ * it should stay console-only.
+ *
+ * - `"rate limit event"` → a notice only when
+ *   `rate_limit_info.status === "rejected"` (the provider actually
+ *   stopped the run); an informational rate-limit tick is null.
+ * - `"assistant error: <reason>"` → `"Provider error: <reason>"` (the
+ *   SDK's enumerated assistant errors, e.g. rate_limit / overloaded).
+ * - anything else → null (SDK debug noise).
+ */
+export function runtimeNoticeFromWarning(
+  message: string,
+  originalPayload: unknown,
+): string | null {
+  if (message === "rate limit event") {
+    return readRateLimitStatus(originalPayload) === "rejected"
+      ? "Usage limit reached — the provider stopped the run."
+      : null;
+  }
+  if (message.startsWith(ASSISTANT_ERROR_PREFIX)) {
+    return "Provider error: " + message.slice(ASSISTANT_ERROR_PREFIX.length);
+  }
+  return null;
+}

--- a/src/lib/agent-chat/subagents.test.ts
+++ b/src/lib/agent-chat/subagents.test.ts
@@ -7,15 +7,19 @@ import {
   describeToolCall,
   findSubagentView,
   formatElapsed,
+  interruptRunningSubagents,
+  isDone,
   mergeSnapshot,
   mergeStatus,
   newSubagentView,
   recentToolCalls,
   runningSubagentEntries,
+  settleSubagentsForToolResult,
   subagentActivityLine,
   subagentElapsedMs,
   subagentMetaLine,
   subagentOrdinal,
+  subagentStatusLabel,
   subagentToolCount,
   toneIndexForId,
 } from "./subagents";
@@ -23,6 +27,7 @@ import type {
   ChatViewItem,
   SubagentRunItem,
   SubagentView,
+  WorkflowRunItem,
   ToolCallItem,
 } from "./types";
 
@@ -65,6 +70,171 @@ describe("mergeStatus", () => {
 
   it("does not downgrade a terminal state to running", () => {
     expect(mergeStatus("completed", "running")).toBe("completed");
+  });
+
+  it("does not let a stray running snapshot regress interrupted (revive is mergeSnapshot's job)", () => {
+    expect(mergeStatus("interrupted", "running")).toBe("interrupted");
+    expect(mergeStatus("interrupted", "completed")).toBe("completed");
+  });
+
+  it("treats a missing/unknown incoming status as pending (no-op) instead of leaking it into the view", () => {
+    // The wire type says `status` is required, but replayed dev fixtures /
+    // hand-built payloads can omit it (Rust serde-defaults to `pending`).
+    // An `undefined` leaking through used to crash `statusTone` at render.
+    expect(
+      mergeStatus("running", undefined as unknown as SubagentSnapshot["status"]),
+    ).toBe("running");
+    expect(
+      mergeStatus("completed", "bogus" as SubagentSnapshot["status"]),
+    ).toBe("completed");
+  });
+});
+
+describe("mergeSnapshot revive / statusAssumed (issue #153)", () => {
+  const snap = (status: SubagentSnapshot["status"]): SubagentSnapshot =>
+    ({ subagent_id: "s1", status }) as SubagentSnapshot;
+
+  it("a real running snapshot revives an interrupted row and clears assumed", () => {
+    const v = view({ status: "interrupted", statusAssumed: true });
+    const next = mergeSnapshot(v, snap("running"));
+    expect(next.status).toBe("running");
+    expect(next.statusAssumed).toBe(false);
+  });
+
+  it("a real running snapshot revives an ASSUMED-completed row (Claude background task tick)", () => {
+    const v = view({ status: "completed", statusAssumed: true });
+    const next = mergeSnapshot(v, snap("running"));
+    expect(next.status).toBe("running");
+    expect(next.statusAssumed).toBe(false);
+  });
+
+  it("a real terminal snapshot wins over an assumed one and clears assumed", () => {
+    const v = view({ status: "completed", statusAssumed: true });
+    const next = mergeSnapshot(v, snap("failed"));
+    expect(next.status).toBe("failed");
+    expect(next.statusAssumed).toBe(false);
+  });
+
+  it("a real completed snapshot settles an interrupted row (not revived by a terminal)", () => {
+    const v = view({ status: "interrupted", statusAssumed: true });
+    const next = mergeSnapshot(v, snap("completed"));
+    expect(next.status).toBe("completed");
+    expect(next.statusAssumed).toBe(false);
+  });
+
+  it("a status-less snapshot (activity-only tick) leaves the status untouched", () => {
+    const v = view({ status: "running" });
+    const next = mergeSnapshot(v, {
+      subagent_id: "s1",
+      activity: "mapping the call graph…",
+    } as unknown as SubagentSnapshot);
+    expect(next.status).toBe("running");
+    expect(next.activity).toBe("mapping the call graph…");
+  });
+
+  it("maps parent_item_id → parentItemId", () => {
+    const v = newSubagentView("s1", 0);
+    const next = mergeSnapshot(v, {
+      subagent_id: "s1",
+      status: "running",
+      parent_item_id: "tool-use-9",
+    } as SubagentSnapshot);
+    expect(next.parentItemId).toBe("tool-use-9");
+  });
+});
+
+describe("settleSubagentsForToolResult / interruptRunningSubagents", () => {
+  function card(subs: SubagentView[]): SubagentRunItem {
+    return { kind: "subagent_run", id: "run-1", seq: 0, turn_id: "t", subagents: subs };
+  }
+  function workflowWith(agents: SubagentView[]): WorkflowRunItem {
+    return {
+      kind: "workflow_run",
+      id: "wf-1",
+      seq: 1,
+      workflowId: "wf",
+      status: "running",
+      name: null,
+      description: null,
+      script: null,
+      plannedPhases: [{ title: "P", detail: null }],
+      phases: [{ title: "P", detail: null, agents }],
+      resultText: null,
+      totalTokens: null,
+      agentCount: null,
+      startedAt: 0,
+      durationMs: null,
+      approvalRequestId: null,
+    };
+  }
+
+  it("settles a running subagent matched by id, and by parentItemId", () => {
+    const messages: ChatViewItem[] = [
+      card([
+        view({ id: "tool-a", status: "running" }),
+        view({ id: "child", status: "running", parentItemId: "tool-b" }),
+        view({ id: "other", status: "running" }),
+      ]),
+    ];
+    const byId = settleSubagentsForToolResult(messages, "tool-a", false);
+    const c1 = byId[0] as SubagentRunItem;
+    expect(c1.subagents[0].status).toBe("completed");
+    expect(c1.subagents[0].statusAssumed).toBe(true);
+    expect(c1.subagents[2].status).toBe("running"); // untouched
+
+    const byParent = settleSubagentsForToolResult(messages, "tool-b", false);
+    expect((byParent[0] as SubagentRunItem).subagents[1].status).toBe("completed");
+  });
+
+  it("uses failed when the tool_result is an error", () => {
+    const messages: ChatViewItem[] = [card([view({ id: "tool-a", status: "running" })])];
+    const out = settleSubagentsForToolResult(messages, "tool-a", true);
+    expect((out[0] as SubagentRunItem).subagents[0].status).toBe("failed");
+  });
+
+  it("returns the SAME array reference when nothing matched or is already terminal", () => {
+    const done = view({ id: "tool-a", status: "completed" });
+    const messages: ChatViewItem[] = [card([done])];
+    // Already terminal → untouched, same ref.
+    expect(settleSubagentsForToolResult(messages, "tool-a", false)).toBe(messages);
+    // No id/parent match → same ref.
+    expect(settleSubagentsForToolResult(messages, "nope", false)).toBe(messages);
+  });
+
+  it("settles running agents inside workflow phases too", () => {
+    const messages: ChatViewItem[] = [
+      workflowWith([view({ id: "wa", status: "running", parentItemId: "wf" })]),
+    ];
+    const out = settleSubagentsForToolResult(messages, "wf", false);
+    const wf = out[0] as WorkflowRunItem;
+    expect(wf.phases[0].agents[0].status).toBe("completed");
+    expect(wf.phases[0].agents[0].statusAssumed).toBe(true);
+  });
+
+  it("interruptRunningSubagents flips running/pending to interrupted across cards and phases", () => {
+    const messages: ChatViewItem[] = [
+      card([view({ id: "a", status: "running" }), view({ id: "b", status: "completed" })]),
+      workflowWith([view({ id: "c", status: "pending" })]),
+    ];
+    const out = interruptRunningSubagents(messages);
+    expect((out[0] as SubagentRunItem).subagents[0].status).toBe("interrupted");
+    expect((out[0] as SubagentRunItem).subagents[0].statusAssumed).toBe(true);
+    expect((out[0] as SubagentRunItem).subagents[1].status).toBe("completed"); // untouched
+    expect((out[1] as WorkflowRunItem).phases[0].agents[0].status).toBe("interrupted");
+  });
+
+  it("interruptRunningSubagents returns the SAME ref when nothing is running", () => {
+    const messages: ChatViewItem[] = [card([view({ id: "a", status: "completed" })])];
+    expect(interruptRunningSubagents(messages)).toBe(messages);
+  });
+});
+
+describe("interrupted view status", () => {
+  it("is done, not running, and labelled/activity-lined", () => {
+    const v = view({ status: "interrupted" });
+    expect(isDone(v)).toBe(true);
+    expect(subagentStatusLabel(v)).toBe("Interrupted");
+    expect(subagentActivityLine(v)).toBe("Interrupted");
   });
 });
 

--- a/src/lib/agent-chat/subagents.ts
+++ b/src/lib/agent-chat/subagents.ts
@@ -4,6 +4,7 @@ import type {
   ChatViewItem,
   SubagentRunItem,
   SubagentView,
+  SubagentViewStatus,
   ToolCallItem,
 } from "./types";
 
@@ -17,22 +18,33 @@ import type {
 /** Rank used to keep `status` monotonic across dribbled snapshots: a
  *  provider that re-emits the default `pending` must never regress a row
  *  that is already running or finished. */
-const STATUS_RANK: Record<SubagentStatus, number> = {
+const STATUS_RANK: Record<SubagentViewStatus, number> = {
   pending: 0,
   running: 1,
   completed: 2,
   failed: 2,
   stopped: 2,
+  // View-only forced-settle state — terminal rank so a stray `running`
+  // snapshot can't quietly regress it via `mergeStatus`; the revive rule
+  // in `mergeSnapshot` is the ONLY path back to `running`.
+  interrupted: 2,
 };
 
 /** Merge an incoming wire `status` without regressing. A `pending`
  *  update (the serde default) never overwrites a more-advanced state;
- *  anything else (running / terminal) wins. */
+ *  anything else (running / terminal) wins. `current` may be the
+ *  view-only `interrupted`; the incoming wire status is never that.
+ *
+ *  Defensive: a missing/unknown incoming status (the wire type says
+ *  `status` is required, but replayed dev fixtures and hand-built
+ *  payloads can omit it — Rust serde-defaults it to `pending`) is
+ *  treated as `pending`, i.e. a no-op. Without this, an `undefined`
+ *  status would leak into the view and crash `statusTone` at render. */
 export function mergeStatus(
-  current: SubagentStatus,
+  current: SubagentViewStatus,
   incoming: SubagentStatus,
-): SubagentStatus {
-  if (incoming === "pending") return current;
+): SubagentViewStatus {
+  if (incoming === "pending" || STATUS_RANK[incoming] == null) return current;
   if (STATUS_RANK[incoming] < STATUS_RANK[current]) return current;
   return incoming;
 }
@@ -64,7 +76,31 @@ export function mergeSnapshot(
   snap: SubagentSnapshot,
 ): SubagentView {
   const next: SubagentView = { ...view };
-  next.status = mergeStatus(view.status, snap.status);
+  // Revive rule: a real `running` snapshot un-settles a row that was
+  // inferred to have finished (interrupted, or any assumed status —
+  // e.g. a Claude background task re-emitting `running` via task_progress
+  // after its spawn tool_result was derived as settled).
+  if (
+    snap.status === "running" &&
+    (view.status === "interrupted" || view.statusAssumed)
+  ) {
+    next.status = "running";
+    next.statusAssumed = false;
+  } else {
+    next.status = mergeStatus(view.status, snap.status);
+    // A REAL terminal snapshot (completed/failed/stopped) that wins by
+    // rank clears a previously-assumed flag — the settlement is now
+    // authoritative. Guarded on `view.statusAssumed` so a normal (never
+    // assumed) view's shape stays byte-identical (no stray `false` key).
+    if (
+      view.statusAssumed &&
+      next.status === snap.status &&
+      snap.status !== "pending"
+    ) {
+      next.statusAssumed = false;
+    }
+  }
+  if (snap.parent_item_id != null) next.parentItemId = snap.parent_item_id;
   if (snap.name != null) next.name = snap.name;
   if (snap.agent_type != null) next.agentType = snap.agent_type;
   if (snap.model != null) next.model = snap.model;
@@ -84,7 +120,8 @@ export function isDone(view: SubagentView): boolean {
   return (
     view.status === "completed" ||
     view.status === "failed" ||
-    view.status === "stopped"
+    view.status === "stopped" ||
+    view.status === "interrupted"
   );
 }
 
@@ -227,6 +264,8 @@ export function subagentActivityLine(view: SubagentView): string {
       return "Failed";
     case "stopped":
       return "Stopped";
+    case "interrupted":
+      return "Interrupted";
     default:
       return "Pending";
   }
@@ -245,6 +284,8 @@ export function subagentStatusLabel(view: SubagentView): string {
       return "Failed";
     case "stopped":
       return "Stopped";
+    case "interrupted":
+      return "Interrupted";
   }
 }
 
@@ -258,7 +299,7 @@ export interface SubagentToneClasses {
   border: string;
 }
 
-export function statusTone(status: SubagentStatus): SubagentToneClasses {
+export function statusTone(status: SubagentViewStatus): SubagentToneClasses {
   switch (status) {
     case "running":
     case "pending":
@@ -267,6 +308,16 @@ export function statusTone(status: SubagentStatus): SubagentToneClasses {
         chipBg: "bg-status-working/15 text-status-working",
         softBg: "bg-status-working/[0.08]",
         border: "border-status-working/25",
+      };
+    case "interrupted":
+      // Muted amber — settled-but-unresolved (forced stop / left mid-run).
+      // Same hue as running (status-working) but dimmed, so it reads as
+      // "was working, now halted" rather than success/failure.
+      return {
+        text: "text-status-working/80",
+        chipBg: "bg-status-working/10 text-status-working/80",
+        softBg: "bg-status-working/[0.05]",
+        border: "border-status-working/20",
       };
     case "completed":
       return {
@@ -374,4 +425,102 @@ export function runningSubagentEntries(
     }
   });
   return entries;
+}
+
+// ── Run-state settlement (issue #153) ──
+//
+// Force a stuck-running subagent to a terminal VIEW state when the only
+// real terminal signal (a terminal `subagent_updated` snapshot) never
+// arrives — a parent-scoped `tool_result` for the spawning tool, a
+// session close/error, a new user turn, or a hydrate that ends mid-run.
+// Every settlement stamps `statusAssumed` so a later real `running`
+// snapshot can revive it (see `mergeSnapshot`) and a later real terminal
+// snapshot wins by rank and clears the flag.
+
+/** Map every `SubagentView` inside a card / workflow-phase container
+ *  through `fn`, preserving reference identity for any item (and any
+ *  phase) whose agents didn't change — so the transcript array stays
+ *  reference-stable where nothing settled. Non-container items pass
+ *  through untouched. */
+function mapItemSubagents(
+  item: ChatViewItem,
+  fn: (sub: SubagentView) => SubagentView,
+): ChatViewItem {
+  if (item.kind === "subagent_run") {
+    let changed = false;
+    const subs = item.subagents.map((s) => {
+      const n = fn(s);
+      if (n !== s) changed = true;
+      return n;
+    });
+    return changed ? { ...item, subagents: subs } : item;
+  }
+  if (item.kind === "workflow_run") {
+    let changed = false;
+    const phases = item.phases.map((p) => {
+      let phaseChanged = false;
+      const agents = p.agents.map((s) => {
+        const n = fn(s);
+        if (n !== s) phaseChanged = true;
+        return n;
+      });
+      if (!phaseChanged) return p;
+      changed = true;
+      return { ...p, agents };
+    });
+    return changed ? { ...item, phases } : item;
+  }
+  return item;
+}
+
+function mapAllSubagents(
+  messages: ChatViewItem[],
+  fn: (sub: SubagentView) => SubagentView,
+): ChatViewItem[] {
+  let changed = false;
+  const next = messages.map((m) => {
+    const nm = mapItemSubagents(m, fn);
+    if (nm !== m) changed = true;
+    return nm;
+  });
+  return changed ? next : messages;
+}
+
+/**
+ * Settle every running subagent (in `subagent_run` cards AND
+ * `workflow_run` phases) whose demux key or spawning tool matches a
+ * parent-scoped `tool_result`: `sub.id === toolUseId` (Claude keys on
+ * the spawning tool_use_id) or `sub.parentItemId === toolUseId`. Sets
+ * `completed` (or `failed` when `isError`) + `statusAssumed`. Returns the
+ * SAME array reference when nothing matched.
+ */
+export function settleSubagentsForToolResult(
+  messages: ChatViewItem[],
+  toolUseId: string,
+  isError: boolean,
+): ChatViewItem[] {
+  const target: SubagentViewStatus = isError ? "failed" : "completed";
+  return mapAllSubagents(messages, (sub) => {
+    if (!isRunning(sub)) return sub;
+    if (sub.id !== toolUseId && sub.parentItemId !== toolUseId) return sub;
+    return { ...sub, status: target, statusAssumed: true };
+  });
+}
+
+/**
+ * Force every running/pending subagent (in `subagent_run` cards AND
+ * `workflow_run` phases) to the view-only `interrupted` state +
+ * `statusAssumed`. Used on session close/error, a new user turn, and the
+ * hydrate reconciliation, so a transcript that ends mid-run never renders
+ * a perpetual spinner. Returns the SAME array reference when none were
+ * running.
+ */
+export function interruptRunningSubagents(
+  messages: ChatViewItem[],
+): ChatViewItem[] {
+  return mapAllSubagents(messages, (sub) =>
+    isRunning(sub)
+      ? { ...sub, status: "interrupted", statusAssumed: true }
+      : sub,
+  );
 }

--- a/src/lib/agent-chat/thinking.ts
+++ b/src/lib/agent-chat/thinking.ts
@@ -49,6 +49,9 @@ export function shouldShowThinkingIndicator(
       );
     case "user_message":
     case "turn_ended":
+    case "runtime_notice":
+      // Settled inline rows — back to dead time waiting on the agent, so
+      // the tail pulse fills the gap (still gated by `streaming` above).
       return true;
   }
 }

--- a/src/lib/agent-chat/types.ts
+++ b/src/lib/agent-chat/types.ts
@@ -7,6 +7,15 @@ import type {
 
 export type { SubagentStatus };
 
+/**
+ * View-only subagent status. `interrupted` never appears on the wire —
+ * it is derived in the frontend when a run is force-settled (a new turn,
+ * a session close/error, or a hydrate that ends mid-run) so a persisted
+ * transcript never resurrects a perpetual "running" spinner. A later real
+ * `running` snapshot revives an interrupted row (see `mergeSnapshot`).
+ */
+export type SubagentViewStatus = SubagentStatus | "interrupted";
+
 export type ChatItemId = string;
 
 /**
@@ -179,7 +188,18 @@ export interface SubagentView {
   name?: string;
   agentType?: string;
   model?: string;
-  status: SubagentStatus;
+  status: SubagentViewStatus;
+  /** The spawning tool_use / call id (`SubagentSnapshot.parent_item_id`)
+   *  for all three providers. Lets a parent-scoped `tool_result` settle
+   *  this row when the adapter's demux lost track and let the raw
+   *  spawning `tool_result` through (the issue-#153 stuck-thread shape). */
+  parentItemId?: string;
+  /** True when `status` was settled by INFERENCE (a parent-scoped
+   *  `tool_result` derivation, a forced settle on close/new-turn, or a
+   *  hydrate reconciliation) rather than a real terminal snapshot. A real
+   *  terminal snapshot clears it; a real `running` snapshot revives an
+   *  assumed/interrupted row back to `running` and clears it. */
+  statusAssumed?: boolean;
   /** Provider-pushed "currently doing X" line, when supplied. */
   activity?: string;
   /** Final report first surfaced on completion. */
@@ -280,6 +300,20 @@ export interface WorkflowRunItem {
   approvalRequestId: string | null;
 }
 
+/**
+ * A compact inline notice surfaced from a `runtime_warning` the reducer
+ * decides is user-facing (a provider rate-limit rejection, an enumerated
+ * SDK assistant error). Most `runtime_warning`s stay console-only debug
+ * noise; the classifier (`runtime-notice.ts`) decides which ones become
+ * one of these rows. Rendered as a muted-amber left-bordered line.
+ */
+export interface RuntimeNoticeItem {
+  kind: "runtime_notice";
+  id: ChatItemId;
+  seq: number;
+  message: string;
+}
+
 export type ChatViewItem =
   | UserMessageItem
   | AssistantMessageItem
@@ -288,7 +322,8 @@ export type ChatViewItem =
   | PermissionRequestItem
   | TurnEndedItem
   | SubagentRunItem
-  | WorkflowRunItem;
+  | WorkflowRunItem
+  | RuntimeNoticeItem;
 
 export interface ChatThreadState {
   messages: ChatViewItem[];

--- a/src/lib/agent-chat/workflows.ts
+++ b/src/lib/agent-chat/workflows.ts
@@ -180,7 +180,12 @@ export function workflowPhaseStats(
   for (const agent of phase.agents) {
     if (agent.status === "running" || agent.status === "pending") running += 1;
     else if (agent.status === "completed") done += 1;
-    else if (agent.status === "failed" || agent.status === "stopped") failed += 1;
+    else if (
+      agent.status === "failed" ||
+      agent.status === "stopped" ||
+      agent.status === "interrupted"
+    )
+      failed += 1;
     if (agent.totalTokens != null) tokens += agent.totalTokens;
     if (agent.startedAt != null) {
       minStart = minStart == null ? agent.startedAt : Math.min(minStart, agent.startedAt);
@@ -208,9 +213,15 @@ export function workflowPhaseStatus(
   if (hasRunning) return "running";
   if (phase.agents.length > 0) {
     const allTerminal = phase.agents.every(
-      (a) => a.status === "completed" || a.status === "failed" || a.status === "stopped",
+      (a) =>
+        a.status === "completed" ||
+        a.status === "failed" ||
+        a.status === "stopped" ||
+        a.status === "interrupted",
     );
     if (allTerminal) {
+      // `interrupted` behaves like `stopped` here — only a real `failed`
+      // marks the phase failed.
       const hasFailed = phase.agents.some((a) => a.status === "failed");
       return hasFailed ? "failed" : "done";
     }


### PR DESCRIPTION
Fixes #153

## Problem

The frontend transcript layer had no settlement path for non-terminal subagents: the only running→terminal transition was a terminal `subagent_updated` snapshot. When the Claude adapter's demux loses track (sidecar restart/resume), the spawning tool's raw parent-scoped `tool_result` flows through and no terminal snapshot ever arrives — so the `SubagentActivityBar` / `SubagentsCard` showed "N subagents running" forever, the thread persisted that way, and reopening the workspace resurrected running spinners on a dead session. Provider rate-limit stops were invisible (`runtime_warning` → `console.warn` only).

## Fix (frontend-only — the backend `SubagentTracker` already handles the sidebar dot)

1. **`tool_result` derivation** — a parent-scoped `tool_result` whose `tool_use_id` matches a running subagent's demux id or its `parentItemId` (spawning call id, now merged from `SubagentSnapshot.parent_item_id`) settles it (`completed`/`failed`). The `Workflow` tool's own `tool_result` likewise settles the run + its in-flight phase agents. Because `tool_result`s are persisted, **existing stuck threads self-heal on hydrate replay — no migration**.
2. **Forced settle** — `session_state_changed{closed|error}` and a new user turn (mirror of `SubagentTracker::clear_thread`; queued follow-ups behind an active turn are left alone) interrupt running subagents and stop running workflows, even when `streaming` was already false.
3. **Interrupted-on-hydrate** — new view-only `interrupted` status (`SubagentViewStatus`, never on the wire): muted-amber non-spinning glyph, excluded from `runningSubagentEntries`. Post-replay reconciliation force-settles anything still running — a dead session never hydrates a spinner. A `pending_approval` workflow is preserved (a legitimate resting state, not a spinner).
4. **Revivable `assumed` settles** — every inferred settlement stamps `statusAssumed`; a later real `running` snapshot (Claude background `task_progress` ticks) revives the row, a later real terminal snapshot confirms and clears the flag. Self-healing on live streams and on replay.
5. **`runtime_warning` visibility** — a conservative classifier (`runtime-notice.ts`) promotes user-facing warnings (rate-limit `status: "rejected"`, enumerated `assistant error: …`) to an inline amber `runtime_notice` transcript row; SDK debug noise stays console-only.
6. **Hardening found in review** — a status-less snapshot (Rust serde-defaults `status` to `pending`; hand-built payloads can omit it) leaked `undefined` into the view and crashed `SubagentRow` at render. `mergeStatus` now treats missing/unknown incoming status as `pending`.

## Verification

- `npm run check` clean, `npm run test` **2415/2415** (new: settlement/revive/classifier/hydrate-reconciliation coverage; dev-fixture tests deliberately updated — the hydrated seed's still-running subagent now correctly settles to `interrupted`).
- Visually verified in the dev mock (browser pane): the hydrated seed shows the muted-amber ⊘ interrupted row with **no stale docked bar**; a live `streamSubagents()` run still shows the running bar, then settles green end-to-end.
- Rust untouched (`should_persist_event` already persists everything needed).