### PR TITLE
fix: keep the working indicator alive through the empty-first-delta gap

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -271,6 +271,26 @@ Contract preserved from the pre-redesign renderer:
   the thread `streaming` flag into `buildTranscriptSlots`, and the
   marker only renders when the tail slot is not a working Activity block
   (it still fills the gap right after send, before any step arrives).
+  The marker carries a **live elapsed-time suffix** ("Writing… · 40s"):
+  `StreamingMarker` derives the active turn's start with
+  `deriveTurnStartedAt` (the earliest reducer-stamped `started_at` of the
+  reasoning / tool steps after the last non-queued user turn) and ticks a
+  text node via `setInterval` writing `textContent` directly — no
+  per-second React re-render of the transcript. No start is derivable in
+  the gap right after send or on a hydrated transcript whose rows predate
+  the timestamp fields; the suffix is then omitted rather than faked.
+- **Empty deltas never materialize a message.** The partial-message
+  stream often opens a new text content block with an empty (or
+  whitespace-only) first delta. `appendTextDelta` (`reducer.ts`) drops it
+  instead of creating an empty `assistant_message`: an empty row would
+  render near-blank AND, as a non-step item, flush the live Activity run
+  as settled mid-turn — so the transcript would read finished-but-empty
+  while the turn is still working. The drop is deterministic, so a
+  hydrate/replay of the same events (`hydrate.ts`) keeps the identical
+  item count as live streaming. `shouldShowThinkingIndicator`
+  (`thinking.ts`) also keeps the tail marker up for a
+  streaming-but-empty `assistant_message` as defense in depth for a
+  provider that lands one anyway.
 
 ### Activity block (Activity Stream)
 
@@ -289,7 +309,10 @@ derivations (unit-tested in `activity-steps.test.ts`).
   rolls up to a green circled check + a derived summary sentence
   (`deriveActivitySummary`: read-heavy → "Explored the codebase",
   command-heavy → "Ran commands", edit-heavy → "Edited files", mixed →
-  sensible) + a mono `N steps · 1m 12s` meta (duration from step
+  sensible; its "Worked through N steps" fallback counts **all**
+  non-reasoning steps including `other`-family tools — Task/agent spawns,
+  MCP tools — so it never claims fewer steps than the header meta) + a
+  mono `N steps · 1m 12s` meta (duration from step
   `started_at`/`completed_at`, omitted when < 1s / not derivable, e.g.
   hydrated transcripts) + a Details/Hide toggle. On settle the block
   re-renders collapsed (any mid-stream expansion resets).

--- a/docs/features/dev-mock-runtime.md
+++ b/docs/features/dev-mock-runtime.md
@@ -60,7 +60,10 @@ Command handling:
     `MOCK_CHAT_THREAD_ID`; `agent_chat_list_messages` hydrates a long
     generated transcript so the virtualized MessageList is exercisable,
     and `window.__codemuxChatMock.streamReply()` triggers a live
-    streamed reply on demand.
+    streamed reply on demand (`{ emptyGapTicks: N }` reproduces the
+    issue #155 stream shape — an empty first text delta then N silent
+    ticks before prose — for verifying the working indicator never
+    drops out mid-turn).
   - `chat-streaming` — its pane has no thread bound, walking the
     fresh-session flow: `agent_chat_start_session`, then the
     per-thread channel pair

--- a/src/components/chat/StreamingMarker.test.tsx
+++ b/src/components/chat/StreamingMarker.test.tsx
@@ -1,0 +1,72 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import type { ChatViewItem } from "@/lib/agent-chat/types";
+
+import { StreamingMarker, deriveTurnStartedAt } from "./StreamingMarker";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+function userMsg(seq: number, overrides: Partial<ChatViewItem> = {}): ChatViewItem {
+  return { kind: "user_message", id: `u${seq}`, seq, text: "go", ...overrides } as ChatViewItem;
+}
+
+function toolCall(seq: number, startedAt?: number): ChatViewItem {
+  return {
+    kind: "tool_call",
+    id: `tc${seq}`,
+    seq,
+    tool_use_id: `tu${seq}`,
+    tool_name: "Read",
+    input: {},
+    status: "running",
+    result_content: null,
+    approval_request_id: null,
+    started_at: startedAt,
+  };
+}
+
+describe("deriveTurnStartedAt", () => {
+  it("takes the earliest step start after the last non-queued user message", () => {
+    expect(
+      deriveTurnStartedAt([userMsg(0), toolCall(1, 5_000), toolCall(2, 3_000)]),
+    ).toBe(3_000);
+  });
+
+  it("ignores queued follow-up prompts when locating the active turn", () => {
+    const msgs = [
+      userMsg(0),
+      toolCall(1, 7_000),
+      userMsg(1_000_000_050, { queued: { queuedId: "q1" } }),
+    ];
+    expect(deriveTurnStartedAt(msgs)).toBe(7_000);
+  });
+
+  it("returns null when no step after the prompt carries a start", () => {
+    expect(deriveTurnStartedAt([userMsg(0)])).toBeNull();
+    expect(deriveTurnStartedAt([userMsg(0), toolCall(1, undefined)])).toBeNull();
+  });
+});
+
+describe("StreamingMarker elapsed time", () => {
+  it("renders a live elapsed suffix that ticks each second without re-rendering", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    render(<StreamingMarker messages={[userMsg(0), toolCall(1, 4_000)]} />);
+    // 10_000 − 4_000 = 6_000ms → "· 6s".
+    expect(screen.getByText("· 6s")).toBeInTheDocument();
+    vi.advanceTimersByTime(2_000);
+    // The interval writes textContent directly (no React re-render).
+    expect(screen.getByText("· 8s")).toBeInTheDocument();
+  });
+
+  it("renders no elapsed suffix when no turn start is derivable", () => {
+    render(<StreamingMarker messages={[userMsg(0)]} />);
+    expect(screen.getByText("Working…")).toBeInTheDocument();
+    expect(screen.queryByText(/·\s*\d+s/)).toBeNull();
+  });
+});

--- a/src/components/chat/StreamingMarker.tsx
+++ b/src/components/chat/StreamingMarker.tsx
@@ -1,16 +1,38 @@
 import { LoaderCircle } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
 
 import type { ChatViewItem } from "@/lib/agent-chat/types";
+
+import { formatActivityDuration } from "./activity-steps";
 
 /**
  * Tail "working" marker (design D9) — the last row inside the scroller
  * while a turn is in flight and no approval is pending. An ember spinner
  * sits in the 29px turn gutter (aligned under the assistant avatar) next
- * to a shimmering status line. Gating lives in
- * `shouldShowThinkingIndicator`; this component only derives the label.
+ * to a shimmering status line, followed by a live elapsed-time suffix
+ * (e.g. "Writing… · 40s"). Gating lives in `shouldShowThinkingIndicator`;
+ * this component derives the label + turn start.
  */
 export function StreamingMarker({ messages }: { messages: ChatViewItem[] }) {
   const label = deriveStreamingLabel(messages);
+  const startedAt = useMemo(() => deriveTurnStartedAt(messages), [messages]);
+  const elapsedRef = useRef<HTMLSpanElement>(null);
+
+  // Tick the elapsed suffix once a second WITHOUT re-rendering the
+  // transcript: write `textContent` straight to the text node. React never
+  // sees the per-second change, so the memoized rows above stay untouched.
+  useEffect(() => {
+    if (startedAt == null) return;
+    const node = elapsedRef.current;
+    if (!node) return;
+    const render = () => {
+      node.textContent = `· ${formatActivityDuration(Date.now() - startedAt)}`;
+    };
+    render();
+    const id = setInterval(render, 1000);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
   return (
     <div
       className="flex items-center gap-[13px] pt-0.5"
@@ -24,7 +46,19 @@ export function StreamingMarker({ messages }: { messages: ChatViewItem[] }) {
           aria-hidden
         />
       </span>
-      <span className="shimmer text-[12.5px] font-semibold">{label}</span>
+      <span className="flex min-w-0 items-baseline gap-1.5">
+        <span className="shimmer text-[12.5px] font-semibold">{label}</span>
+        {startedAt != null && (
+          // Populated imperatively by the effect; render nothing when no
+          // turn start is derivable (e.g. hydrated old transcripts) so the
+          // marker never shows a bogus number.
+          <span
+            ref={elapsedRef}
+            className="font-mono text-[11px] tabular-nums text-muted-foreground"
+            aria-hidden
+          />
+        )}
+      </span>
     </div>
   );
 }
@@ -45,4 +79,39 @@ export function deriveStreamingLabel(messages: ChatViewItem[]): string {
     default:
       return "Working…";
   }
+}
+
+/**
+ * Best-effort wall-clock start of the active turn, for the elapsed-time
+ * suffix. Derived purely from timestamps the reducer already stamps (via
+ * its injectable `Clock`) — no new reducer state:
+ *
+ *  1. Find the active turn's prompt: the last NON-queued `user_message`
+ *     (queued follow-ups sit at the very bottom by seq but belong to a
+ *     later turn).
+ *  2. Return the earliest `started_at` among the reasoning / tool_call
+ *     steps of that turn (items at or after the prompt's seq).
+ *
+ * Returns `null` when nothing after the prompt carries a `started_at`
+ * (e.g. the gap right after send before the first step, or a hydrated
+ * transcript whose rows predate the timestamp fields) — the caller then
+ * renders no suffix rather than a fabricated duration.
+ */
+export function deriveTurnStartedAt(messages: ChatViewItem[]): number | null {
+  let promptSeq = -Infinity;
+  for (const m of messages) {
+    if (m.kind === "user_message" && !m.queued && m.seq >= promptSeq) {
+      promptSeq = m.seq;
+    }
+  }
+  let earliest: number | null = null;
+  for (const m of messages) {
+    if (m.seq < promptSeq) continue;
+    const startedAt =
+      m.kind === "reasoning" || m.kind === "tool_call" ? m.started_at : undefined;
+    if (startedAt != null && (earliest == null || startedAt < earliest)) {
+      earliest = startedAt;
+    }
+  }
+  return earliest;
 }

--- a/src/components/chat/activity-steps.test.ts
+++ b/src/components/chat/activity-steps.test.ts
@@ -56,6 +56,24 @@ describe("deriveActivitySummary", () => {
       "Explored and edited files",
     );
   });
+  it("all other-family tools (Task / MCP) hit the fallback with the correct count", () => {
+    // `other`-family tools used to be dropped from the fallback tally, so a
+    // run of only Task / MCP tools claimed "Worked through 0 steps" while
+    // the header meta said "3 steps". They now count.
+    expect(
+      deriveActivitySummary([
+        tool("Task"),
+        tool("mcp__codemux__browser_click"),
+        tool("Task"),
+      ]),
+    ).toBe("Worked through 3 steps");
+  });
+  it("counts other-family tools alongside a reasoning step (reasoning excluded from the tool tally)", () => {
+    // A lone Task with a thought falls to the fallback; the tool tally is 1.
+    expect(deriveActivitySummary([tool("Task"), think()])).toBe(
+      "Worked through 1 step",
+    );
+  });
 });
 
 describe("deriveWorkingCounter", () => {

--- a/src/components/chat/activity-steps.ts
+++ b/src/components/chat/activity-steps.ts
@@ -157,6 +157,7 @@ export function deriveActivitySummary(steps: ActivityStep[]): string {
   let edits = 0;
   let commands = 0;
   let webCount = 0;
+  let other = 0;
   for (const s of steps) {
     if (isReasoning(s)) continue;
     switch (FAMILY_BY_TOOL[s.tool_name] ?? "other") {
@@ -172,6 +173,11 @@ export function deriveActivitySummary(steps: ActivityStep[]): string {
       case "web":
         webCount += 1;
         break;
+      default:
+        // `other`-family tools (Task/agent spawns, MCP tools, …) still
+        // count toward the fallback tally, so an all-`other` run reports
+        // its real step count instead of "Worked through 0 steps".
+        other += 1;
     }
   }
   const reading = reads + webCount;
@@ -183,7 +189,7 @@ export function deriveActivitySummary(steps: ActivityStep[]): string {
   if (onlyCommands) return "Ran commands";
   if (edits > 0 && reading > 0 && commands === 0) return "Explored and edited files";
   if (commands > 0) return "Ran commands and inspected the code";
-  const toolCount = reads + edits + commands + webCount;
+  const toolCount = reads + edits + commands + webCount + other;
   return `Worked through ${toolCount} step${toolCount === 1 ? "" : "s"}`;
 }
 

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -559,11 +559,18 @@ function drainChatQueue(threadId: string): void {
  *  backend's `forward_event` routing. */
 function streamMockChatReply(
   threadId: string,
-  opts: { tokens?: number; intervalMs?: number } = {},
+  opts: { tokens?: number; intervalMs?: number; emptyGapTicks?: number } = {},
 ): string {
   const turnId = `live-turn-${++mockChatTurnSeq}`;
   const tokens = Math.max(1, opts.tokens ?? 120);
   const intervalMs = Math.max(5, opts.intervalMs ?? 40);
+  // `emptyGapTicks` reproduces the real partial-message stream shape from
+  // issue #155: after the tool run, the provider opens the text content
+  // block with an EMPTY first delta, then goes silent for a while before
+  // prose streams. Used to visually verify the transcript never reads
+  // finished-and-empty during that gap. 0 (default) keeps the old shape.
+  let gapTicksLeft = Math.max(0, opts.emptyGapTicks ?? 0);
+  let emptyDeltaSent = false;
   const send = (event: unknown) => emitChatEvent(threadId, event);
 
   chatActiveTurns.add(threadId);
@@ -688,6 +695,20 @@ function streamMockChatReply(
       toolIdx += 1;
       toolSubphase = "use";
       if (toolIdx >= TOOL_STEPS.length) phase = "text";
+      return;
+    }
+    if (!emptyDeltaSent && gapTicksLeft > 0) {
+      emptyDeltaSent = true;
+      send({
+        type: "content_delta",
+        thread_id: threadId,
+        turn_id: turnId,
+        delta: { kind: "text", text: "" },
+      });
+      return;
+    }
+    if (gapTicksLeft > 0) {
+      gapTicksLeft -= 1;
       return;
     }
     emitted += 1;

--- a/src/lib/agent-chat/reducer.test.ts
+++ b/src/lib/agent-chat/reducer.test.ts
@@ -70,6 +70,130 @@ describe("agent-chat reducer", () => {
     expect(state.streaming).toBe(true);
   });
 
+  describe("empty text deltas never materialize an assistant message", () => {
+    const textDelta = (text: string): ProviderRuntimeEvent => ({
+      type: "content_delta",
+      thread_id: "t1",
+      turn_id: "turn-1",
+      delta: { kind: "text", text },
+    });
+    const assistants = (s: ChatThreadState): AssistantMessageItem[] =>
+      s.messages.filter(
+        (m): m is AssistantMessageItem => m.kind === "assistant_message",
+      );
+
+    it("an empty first delta creates no assistant item", () => {
+      const state = runEvents([textDelta("")]);
+      expect(assistants(state)).toHaveLength(0);
+      // Nothing appended → nextSeq untouched.
+      expect(state.nextSeq).toBe(0);
+      // The delta still marks the turn streaming (session-owned flag path).
+      expect(state.streaming).toBe(true);
+    });
+
+    it("a whitespace-only first delta creates no assistant item", () => {
+      const state = runEvents([textDelta("   \n\t")]);
+      expect(assistants(state)).toHaveLength(0);
+      expect(state.nextSeq).toBe(0);
+    });
+
+    it("an empty delta then a non-empty delta yields exactly one item with the right text", () => {
+      const state = runEvents([textDelta(""), textDelta("Hello")]);
+      const list = assistants(state);
+      expect(list).toHaveLength(1);
+      expect(list[0].text).toBe("Hello");
+      expect(list[0].streaming).toBe(true);
+    });
+
+    it("an empty delta merging into an existing streaming tail is a no-op (same reference, same text)", () => {
+      const first = runEvents([textDelta("Hi")]);
+      const before = first.messages[first.messages.length - 1];
+      const after = applyEvent(first, textDelta(""));
+      const list = assistants(after);
+      expect(list).toHaveLength(1);
+      expect(list[0].text).toBe("Hi");
+      // Reference-stable: the empty merge cloned nothing.
+      expect(after.messages[after.messages.length - 1]).toBe(before);
+    });
+
+    it("an empty delta between tool steps keeps the run contiguous (no phantom item to break it)", () => {
+      // Reproduces the settle-mid-run bug: a Read runs, then Claude opens a
+      // new text block with an empty delta, then another Read runs. The
+      // empty delta must NOT land an assistant_message between the two
+      // tools (which would flush the live Activity run as settled).
+      const state = runEvents([
+        {
+          type: "item_completed",
+          thread_id: "t1",
+          turn_id: "turn-1",
+          item: {
+            kind: "tool_use",
+            tool_use_id: "tu-1",
+            tool_name: "Read",
+            input: { file_path: "/a" },
+          },
+        },
+        textDelta(""),
+        {
+          type: "item_completed",
+          thread_id: "t1",
+          turn_id: "turn-1",
+          item: {
+            kind: "tool_use",
+            tool_use_id: "tu-2",
+            tool_name: "Read",
+            input: { file_path: "/b" },
+          },
+        },
+      ]);
+      expect(assistants(state)).toHaveLength(0);
+      expect(state.messages.map((m) => m.kind)).toEqual([
+        "tool_call",
+        "tool_call",
+      ]);
+    });
+
+    it("an assistant_text completion after only-empty deltas settles without a blank row", () => {
+      const state = runEvents([
+        {
+          type: "session_state_changed",
+          thread_id: "t1",
+          status: { status: "running", active_turn: "turn-1" },
+        },
+        textDelta(""),
+        {
+          type: "item_completed",
+          thread_id: "t1",
+          turn_id: "turn-1",
+          item: { kind: "assistant_text", text: "" },
+        },
+        {
+          type: "turn_completed",
+          thread_id: "t1",
+          turn_id: "turn-1",
+          status: { kind: "success" },
+          usage: null,
+        },
+      ]);
+      // No orphaned/blank assistant row, no crash, turn settled.
+      expect(assistants(state)).toHaveLength(0);
+      expect(state.streaming).toBe(false);
+    });
+
+    it("hydrate/replay of the same deltas produces an identical item count", () => {
+      const events: ProviderRuntimeEvent[] = [
+        textDelta(""),
+        textDelta("real text"),
+        textDelta(""),
+      ];
+      const live = runEvents(events);
+      __resetReducerIdCounterForTests();
+      const replayed = runEvents(events);
+      expect(assistants(replayed).length).toBe(assistants(live).length);
+      expect(assistants(replayed)[0].text).toBe("real text");
+    });
+  });
+
   it("item_completed(assistant_text) after deltas seals with the full final text (no duplication, no truncation)", () => {
     // The Rust producer emits content_delta chunks during streaming,
     // then a single item_completed(assistant_text) carrying the FULL

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -288,6 +288,10 @@ function appendTextDelta(
     tail.streaming &&
     (!tail.turn_id || tail.turn_id === turnId)
   ) {
+    // Merging an empty delta into the existing streaming tail changes
+    // nothing — keep the ctx reference-stable rather than cloning the row
+    // (tail is the assistant, so no reasoning was sealed above).
+    if (text.length === 0) return ctx;
     const next: AssistantMessageItem = {
       ...tail,
       turn_id: turnId,
@@ -299,6 +303,16 @@ function appendTextDelta(
       nextSeq: ctx.nextSeq,
     };
   }
+  // No streaming assistant tail to merge into. Providers (notably the
+  // partial-message stream) routinely open a fresh text content block with
+  // an empty first delta. Materializing an assistant_message for it would
+  // render a near-blank row AND, being a non-step item, settle the live
+  // Activity run mid-turn — so the transcript reads finished-but-empty while
+  // the turn is still working. Drop the empty / whitespace-only delta; a
+  // later non-empty delta creates the row. The guard is deterministic, so a
+  // hydrate/replay of the same event sequence produces the identical item
+  // count as live streaming.
+  if (text.trim().length === 0) return ctx;
   const { seq, ctx: c2 } = takeSeqList({ messages, nextSeq: ctx.nextSeq });
   const newAssistant: AssistantMessageItem = {
     kind: "assistant_message",
@@ -353,6 +367,14 @@ function applyCompletedItemToList(
           messages: replaceItem(messages, existing.index, next),
           nextSeq: ctx.nextSeq,
         };
+      }
+      // No streaming assistant to seal. A completion whose text is empty
+      // (a turn whose only text block was empty — Layer 1 dropped its
+      // deltas) must not materialize a blank settled row: there is nothing
+      // to render and nothing to seal. Return the (reasoning-sealed)
+      // messages so the turn still settles cleanly.
+      if (item.text.length === 0) {
+        return { messages, nextSeq: ctx.nextSeq };
       }
       const { seq, ctx: c2 } = takeSeqList({ messages, nextSeq: ctx.nextSeq });
       const newAssistant: AssistantMessageItem = {

--- a/src/lib/agent-chat/thinking.test.ts
+++ b/src/lib/agent-chat/thinking.test.ts
@@ -101,6 +101,14 @@ describe("shouldShowThinkingIndicator", () => {
     expect(shouldShowThinkingIndicator(msgs, true)).toBe(false);
   });
 
+  it("shows while a streaming-but-empty assistant tail renders nothing yet", () => {
+    // Defense in depth for a provider that lands an empty streaming
+    // assistant message despite the reducer's drop-empty-delta guard: the
+    // row shows no caret, so the tail marker must keep the turn alive.
+    const msgs: ChatViewItem[] = [userMsg(0), assistantMsg(1, true, "")];
+    expect(shouldShowThinkingIndicator(msgs, true)).toBe(true);
+  });
+
   it("shows when the trailing assistant message has sealed", () => {
     const msgs: ChatViewItem[] = [userMsg(0), assistantMsg(1, false, "done")];
     expect(shouldShowThinkingIndicator(msgs, true)).toBe(true);

--- a/src/lib/agent-chat/thinking.ts
+++ b/src/lib/agent-chat/thinking.ts
@@ -23,6 +23,12 @@ export function shouldShowThinkingIndicator(
   const last = messages[messages.length - 1];
   switch (last.kind) {
     case "assistant_message":
+      // A streaming assistant tail normally renders its own caret, so the
+      // pulse steps back (`!streaming` → false). But a streaming-but-EMPTY
+      // tail renders nothing yet — keep the marker up so the turn never
+      // looks finished. Layer 1 drops empty deltas before they become an
+      // item; this is defense in depth for providers that still land one.
+      if (last.streaming && last.text.length === 0) return true;
       return !last.streaming;
     case "reasoning":
       // A streaming reasoning block renders its own "Thinking…" header, so


### PR DESCRIPTION
Fixes #155

## Problem

While an agent run is still in progress, the transcript could read **finished and empty**: the amber "Working" activity card settled to the green summary, followed by a blank assistant block, with no working indicator anywhere — until prose finally streamed in seconds later. Trigger: the partial-message stream opens a new text content block with an **empty first text delta**, which materialized a blank `assistant_message` that (a) settled the live activity run, (b) rendered as nothing, and (c) suppressed the tail marker.

## Fix — 4 layers (1 and 2 each independently kill the main symptom)

1. **Reducer** (`src/lib/agent-chat/reducer.ts`): `appendTextDelta` drops an empty/whitespace-only delta instead of creating an empty `assistant_message`; an empty delta merging into an existing streaming tail is reference-stable. An empty `assistant_text` completion with nothing to seal no longer lands a blank settled row. The guard is deterministic, so hydrate/replay keeps identical item counts vs live streaming.
2. **Marker gate** (`src/lib/agent-chat/thinking.ts`): a streaming-but-**empty** assistant tail now keeps the tail marker up (defense in depth for providers that still land one).
3. **StreamingMarker** (`src/components/chat/StreamingMarker.tsx`): live elapsed-time suffix ("Working… · 40s"). `deriveTurnStartedAt` anchors to the earliest reducer-stamped `started_at` after the last non-queued user prompt; the 1s tick writes `textContent` directly so per-second updates never re-render the transcript. Suffix omitted when no start is derivable (post-send gap, old hydrated transcripts).
4. **"Worked through 0 steps"** (`src/components/chat/activity-steps.ts`): the settled-summary fallback now counts `other`-family tools (Task/agent spawns, MCP tools), so it never claims fewer steps than the header meta.

Invariants preserved: no double indication (marker still suppressed while the tail is a live working Activity block), `buildTranscriptSlots` untouched and slot keys stable, reducer stays pure with injectable Clock, fix is provider-agnostic at reducer/slot level.

## Verification

- `tsc --noEmit` clean; **2396/2396 tests pass** (new coverage in `reducer.test.ts`, `thinking.test.ts`, `activity-steps.test.ts`, new `StreamingMarker.test.tsx`); `cargo check` clean (no Rust changes).
- Visual (dev mock, headless browser): `streamReply` gained `{ emptyGapTicks }` to reproduce the exact stream shape (empty first delta + silence before prose). During the gap the tail stays the amber **"Working · 6 done · 0 running"** card — never a settled header + blank block — then settles normally once prose lands. The tail marker renders as spinner + shimmer label + mono elapsed suffix.

## Docs

- `docs/features/agent-chat.md`: empty-delta drop, marker elapsed suffix, other-family counting.
- `docs/features/dev-mock-runtime.md`: `emptyGapTicks` knob.

## Screenshots

Captured against the dev mock (`streamReply({ intervalMs: 400, emptyGapTicks: 22 })`) in a headless browser.

**Mid-gap — all 5 tools done, empty first delta already received.** The tail stays the amber "Working · 6 done · 0 running" card. Before this fix it settled to the green summary followed by a blank assistant block:

![Working card stays amber through the empty-delta gap](https://raw.githubusercontent.com/Zeus-Deus/codemux/a18bd72662f76beb820650da52406241c85f22fe/gap-still-working.png)

**After prose lands** the run settles normally ("Ran commands and inspected the code · 6 steps · 5s") with the streamed text below:

![Settled card with streamed prose](https://raw.githubusercontent.com/Zeus-Deus/codemux/a18bd72662f76beb820650da52406241c85f22fe/settled-after-prose.png)

**The upgraded tail marker** — spinner + shimmer label + mono elapsed suffix ("Working… · 1m 49s"; the large value is a mock artifact — on-demand mock streams have no fresh user prompt, so the anchor is the hydrated transcript's timestamps):

![Streaming marker with elapsed time](https://raw.githubusercontent.com/Zeus-Deus/codemux/a18bd72662f76beb820650da52406241c85f22fe/marker-elapsed-time.png)
