### PR TITLE
Add "Send now" steering for queued follow-up messages

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -879,7 +879,7 @@ Two side-channel notifications are emitted in addition to the raw
 |---|---|
 | `start-session` | Spawn a new ClaudeSession. |
 | `send-turn` | Queue a user message onto the session. |
-| `interrupt` | Halt the current turn (`query.interrupt`). |
+| `interrupt` | Halt the current turn (`query.interrupt`), await the SDK query iterator's exit, and emit `turn-interrupted` instead of `session-ended` — the session survives with the same thread id and the next `send-turn` rebuilds a resumed query. Also auto-aborts any outstanding tool approval via `request-resolved` (deny). |
 | `set-model` | Swap the session's default model. |
 | `set-permission-mode` | Change the session's permission mode. |
 | `update-mcp-tools` | Push an updated MCP tool list into the live session (`query.setMcpServers`); lets servers that come up after `start-session` surface without a chat restart. Empty list removes the codemux MCP. Idempotent. |
@@ -959,7 +959,11 @@ surface tiny and lets the Rust side evolve independently. Two paths:
 
 - Sidecar-specific notifications (`session-configured`,
   `request-opened`, `plan-proposed`, `user-input-requested`,
-  `session-ended`, `session-error`) map directly to trait events.
+  `session-ended`, `session-error`, `turn-interrupted`) map directly to
+  trait events. `turn-interrupted` (emitted only by the explicit interrupt
+  RPC) maps to `TurnCompleted(interrupted)` + `SessionStateChanged(Ready)`,
+  keeping the session alive; a spontaneous `session-ended
+  {reason:"interrupted"}` still maps to `Closed`.
 - SDK messages are structurally classified by `type` (and `subtype`
   for `system:*`). 15+ known shapes; unknown variants always surface
   as `RuntimeWarning` with the raw payload preserved. The
@@ -1327,7 +1331,7 @@ surfacing a `feature_disabled` string.
 | `dev_agent_chat_spawn_test_pane` | Debug-only. Spawns a chat pane in the active workspace for manual QA from the browser devtools. |
 | `agent_chat_start_session` | Start a provider session, writing the returned thread id back onto the pane. |
 | `agent_chat_send_turn` | Queue a user turn on a thread. Auto-resumes a dead session (rebuilt from its persisted row) before the turn, so a pane reopened after an app restart never sees `session_not_found`. |
-| `agent_chat_interrupt_turn` | Halt the currently-running turn. A `SessionNotFound` (nothing to interrupt on a dead session) is swallowed into `Ok`; does NOT auto-resume. |
+| `agent_chat_interrupt_turn` | Halt the currently-running turn. On a live session the turn ends as `TurnCompleted(interrupted)` and the session stays `Ready` (the sidecar keeps the thread alive and the next `send_turn` rebuilds a resumed query). A `SessionNotFound` (nothing to interrupt on an already-dead session) is swallowed into `Ok`; unlike `send_turn` it does NOT auto-resume a dead session just to interrupt it. |
 | `agent_chat_respond_to_request` | Resolve a pending approval / input request. Auto-resumes a dead session first (same choke point as `send_turn`). |
 | `agent_chat_set_model` | Swap a thread's model. Persist-always, apply-if-live: writes the model to the session row unconditionally, then applies to the live session if one exists; a `SessionNotFound` from the apply is swallowed into `Ok` (the value takes effect on the next auto-resume). |
 | `agent_chat_set_permission_mode` | Swap a thread's permission mode. Same persist-always, apply-if-live contract as `agent_chat_set_model`. |
@@ -1509,15 +1513,21 @@ queued (its `turn_id` is then an empty placeholder). OpenCode has no busy
 guard and no queue; `cancel_queued_turn` is a trait-default no-op there.
 
 **Draining.** On the turn-completion transition (Claude: the SDK `result`
-message → Ready; Codex: `turn/completed` → Ready), and after
-interrupt/abort, the session pops the next queued turn (FIFO) and
+message → Ready; Codex: `turn/completed` → Ready), and after an explicit
+interrupt (Claude: `turn-interrupted` → Ready; Codex: the `turn/completed`
+an interrupt produces), the session pops the next queued turn (FIFO) and
 dispatches it through the same internal send path
 (`drain_queue`). Dispatch happens **after** the completion handler
 releases the session lock, so `do_send` can re-acquire it without
 deadlocking. Draining only fires when the session is truly idle (Ready,
-no active turn, no pending approval). On session error/close the whole
-queue is cancelled (`cancel_all_queued`). A failed dispatch cancels that
-item and continues — the queue never wedges.
+no active turn, no pending approval) — an interrupt clears the active turn
+and auto-aborts any pending approval, so both preconditions hold. On
+session error/close the whole queue is cancelled (`cancel_all_queued`); an
+**explicit interrupt no longer counts as a close**, so the queue is
+preserved and drained rather than cancelled. A spontaneous abort that ends
+the session (Claude `session-ended {reason:"interrupted"}` not driven by
+the interrupt RPC) still translates to a close and cancels the queue. A
+failed dispatch cancels that item and continues — the queue never wedges.
 
 **Events** (`ProviderRuntimeEvent`, forwarded through `forward_event`):
 
@@ -1557,10 +1567,24 @@ method `send_queued_turn_now` (default no-op for OpenCode) to the session's
    `cancel_queued`, covering the race where the item dispatched between the
    UI click and this call.
 2. **Interrupt + drain.** If a turn is active it calls the existing
-   interrupt path — a **soft** stop: the SDK/Codex session, the full
-   transcript, and all on-disk work are preserved; **nothing** is discarded.
-   - *Claude:* `interrupt(None)` flips the session to `Ready` and ends with
-     `drain_queue()`, so the promoted item dispatches inline.
+   interrupt path. The active turn ends, but the session, the full
+   transcript, and all on-disk work survive — **nothing** is discarded.
+   - *Claude:* `interrupt(None)` drives the sidecar's explicit interrupt
+     RPC, which awaits the SDK query iterator's exit and emits a
+     `turn-interrupted` notification (suppressing the old
+     `session-ended {reason:"interrupted"}` the SDK query would otherwise
+     have thrown). Rust translates that to
+     `TurnCompleted { status: Error { subtype: "interrupted" } }` plus
+     `SessionStateChanged(Ready)` — the interrupted turn closes out, but the
+     sidecar session object survives with the same thread id (**Ready**, not
+     **Closed**). The **next** `send-turn` transparently rebuilds a resumed
+     SDK query (fresh prompt queue, `resume` set to the last observed
+     sdk-session-id, which is re-observed and re-emitted so the host's resume
+     cursor stays current), so the promoted item dispatches onto that rebuilt
+     query. Rust ends `interrupt()` with `drain_queue()` and the
+     notifications task also drains when the `turn-interrupted` → `Ready`
+     transition lands; a `dispatching` guard lets those two drains race
+     without double-dispatch.
    - *Codex:* `interrupt_turn(None)` does not drain inline — the abort lands
      as a `turn/completed` notification that returns the session to `Ready`
      and the event loop drains there. If `interrupt_turn` returns the "no
@@ -1568,6 +1592,9 @@ method `send_queued_turn_now` (default no-op for OpenCode) to the session's
      race) it falls back to `drain_queue()` directly.
    - If the session is already idle (the turn finished before the call) it
      just `drain_queue()`s.
+   - If the interrupt RPC itself fails, `send_queued_now` restores the
+     promoted item to its original queue position rather than leaving the
+     queue silently reordered (both the Claude and Codex paths do this).
 
 The promoted message then dispatches through the identical
 `QueuedTurnDispatched` path as a normal drain, so the reducer promotes the
@@ -1575,14 +1602,18 @@ greyed bubble and `forward_event` writes the deferred user-message envelope
 (with any `pending_queued_images`) exactly as before — no persistence
 changes were needed.
 
-**Pending-approval behaviour (verified).** `drain_queue` refuses to
-dispatch while `pending_approvals` is non-empty, and neither Claude's
-`interrupt` nor Codex's `interrupt_turn` clears pending approvals (only
-session `Closed`/`Error` does, in `shutdown`/teardown). So send-now behaves
-**identically to a manual stop-button interrupt**: if a tool approval is
-still outstanding, the promoted message stays queued until the user
-resolves that approval, then drains. Send-now deliberately does not invent
-new approval-clearing behaviour.
+**Pending-approval behaviour.** `drain_queue` refuses to dispatch while
+`pending_approvals` is non-empty, so an outstanding tool approval would
+otherwise wedge a promoted send-now message behind a tool call that the
+interrupt already killed. To avoid that, an interrupt now **auto-aborts**
+any outstanding approval: the sidecar emits `request-resolved` (deny, with
+message `"Tool request was aborted."`) for the dead tool call, and the Rust
+side clears its `pending_approvals` entry on that notification. Because the
+notifications task drains the queue after **every** notification, resolving
+the approval immediately triggers dispatch — so the promoted message drains
+right away instead of waiting for the user to resolve an approval whose tool
+call no longer exists. (The approval card resolves as denied/aborted in the
+UI.)
 
 **Frontend.** `handleSendQueuedNow` in `AgentChatPane` calls the command
 with no optimistic state change — the `queued_turn_dispatched` event
@@ -1614,7 +1645,7 @@ follow-up.
 - **True inject-into-live-turn steering** (feeding the message into the
   *running* turn via the SDK's `streamInput` without interrupting).
   Remains out of scope pending SDK support. The interrupt-based **"Send
-  now"** above (soft-stop + promote-to-front + drain) is **done** and
+  now"** above (interrupt + promote-to-front + drain) is **done** and
   covers the steering use-case for now.
 - **Editing a queued message in place** (cancel-restores-to-composer
   covers the common case).

--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -1538,6 +1538,59 @@ item and continues — the queue never wedges.
 queued_id)` cancels a queued turn (idempotent). Wrapper:
 `agentChatCancelQueuedTurn` in `src/tauri/commands.ts`.
 
+### Send now (steer)
+
+The greyed queued bubble also exposes a hover-reveal **"Send now"** action
+(a `CornerDownLeft` icon in the same pill row as Cancel) that dispatches
+the queued message *immediately* instead of waiting for the active turn to
+finish. This mirrors Claude Code's interrupt-and-resubmit steering path.
+
+The command `agent_chat_send_queued_turn_now(provider, thread_id,
+queued_id)` (wrapper `agentChatSendQueuedTurnNow`) routes through the trait
+method `send_queued_turn_now` (default no-op for OpenCode) to the session's
+`send_queued_now`. That method, under the state lock:
+
+1. **Promote to front.** Locate `queued_id` in `queued_turns` and move it
+   to the front (`promote_queued_to_front`) so it is the next item the
+   drain dispatches. An unknown / already-dispatched / already-cancelled id
+   is a silent no-op `Ok(())` — the same idempotency philosophy as
+   `cancel_queued`, covering the race where the item dispatched between the
+   UI click and this call.
+2. **Interrupt + drain.** If a turn is active it calls the existing
+   interrupt path — a **soft** stop: the SDK/Codex session, the full
+   transcript, and all on-disk work are preserved; **nothing** is discarded.
+   - *Claude:* `interrupt(None)` flips the session to `Ready` and ends with
+     `drain_queue()`, so the promoted item dispatches inline.
+   - *Codex:* `interrupt_turn(None)` does not drain inline — the abort lands
+     as a `turn/completed` notification that returns the session to `Ready`
+     and the event loop drains there. If `interrupt_turn` returns the "no
+     active turn" `ValidationError` (turn finished during the click→call
+     race) it falls back to `drain_queue()` directly.
+   - If the session is already idle (the turn finished before the call) it
+     just `drain_queue()`s.
+
+The promoted message then dispatches through the identical
+`QueuedTurnDispatched` path as a normal drain, so the reducer promotes the
+greyed bubble and `forward_event` writes the deferred user-message envelope
+(with any `pending_queued_images`) exactly as before — no persistence
+changes were needed.
+
+**Pending-approval behaviour (verified).** `drain_queue` refuses to
+dispatch while `pending_approvals` is non-empty, and neither Claude's
+`interrupt` nor Codex's `interrupt_turn` clears pending approvals (only
+session `Closed`/`Error` does, in `shutdown`/teardown). So send-now behaves
+**identically to a manual stop-button interrupt**: if a tool approval is
+still outstanding, the promoted message stays queued until the user
+resolves that approval, then drains. Send-now deliberately does not invent
+new approval-clearing behaviour.
+
+**Frontend.** `handleSendQueuedNow` in `AgentChatPane` calls the command
+with no optimistic state change — the `queued_turn_dispatched` event
+promotes the bubble and the interrupt's `ready`/`running` state events
+settle the composer. Errors surface via a toast, like `handleCancelQueued`.
+The `onSendQueuedNow` prop threads through
+`ChatTranscript → MessageList → ItemRow → UserMessage`.
+
 **Frontend.** `UserMessageItem` gained `queued?: { queuedId }` (greyed
 render + "Queued" pill + hover-X) and `clientNonce?` (reconciliation +
 error rollback). Queued items sort to the very bottom via a `QUEUED_SEQ_BASE`
@@ -1558,8 +1611,11 @@ follow-up.
 
 **Out of scope (TODO):**
 
-- **Steering / inject-into-live-turn** (Cmd+Enter "send now" that injects
-  into the running turn rather than queuing behind it).
+- **True inject-into-live-turn steering** (feeding the message into the
+  *running* turn via the SDK's `streamInput` without interrupting).
+  Remains out of scope pending SDK support. The interrupt-based **"Send
+  now"** above (soft-stop + promote-to-front + drain) is **done** and
+  covers the steering use-case for now.
 - **Editing a queued message in place** (cancel-restores-to-composer
   covers the common case).
 - **Persisting the queue across app restart.**

--- a/sidecar/claude-agent/src/permissions.ts
+++ b/sidecar/claude-agent/src/permissions.ts
@@ -161,7 +161,18 @@ export function makeCanUseTool(
       decision = await decisionPromise;
     } catch {
       // Signal aborted before user responded — the SDK treats this as
-      // a deny. Abort handler already removed the pending entry.
+      // a deny. Abort handler already removed the local pending entry;
+      // mirror a `request-resolved` back so the host clears its own
+      // pending-approvals map too. Without it the host keeps a stale
+      // entry after an interrupt and its dispatch queue wedges forever.
+      emit.notification("request-resolved", {
+        threadId,
+        requestId,
+        decision: {
+          behavior: "deny",
+          message: "Tool request was aborted.",
+        },
+      });
       return {
         behavior: "deny",
         message: "Tool request was aborted.",

--- a/sidecar/claude-agent/src/session.ts
+++ b/sidecar/claude-agent/src/session.ts
@@ -122,6 +122,23 @@ export function resetQueryFactoryForTests(): void {
   queryFactory = defaultQuery;
 }
 
+/** How long `interrupt()` waits for the SDK query's iterator to exit
+ *  before assuming the interrupt was treated as soft. Real SDK aborts
+ *  land in single-digit milliseconds; the ceiling only guards against
+ *  a hung subprocess. */
+let interruptExitTimeoutMs = 2000;
+
+/** Lower the interrupt-exit timeout so tests don't wait on the real
+ *  ceiling. Mirrors the `setQueryFactoryForTests` DI seam. */
+export function setInterruptExitTimeoutForTests(ms: number): void {
+  interruptExitTimeoutMs = ms;
+}
+
+/** Restore the default interrupt-exit timeout. Call from test teardown. */
+export function resetInterruptExitTimeoutForTests(): void {
+  interruptExitTimeoutMs = 2000;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -232,12 +249,29 @@ function buildQueryOptions(
 /** A single live SDK session bound to one runtime thread. */
 export class ClaudeSession {
   readonly threadId: string;
-  private readonly promptQueue: AsyncPromptQueue<SDKUserMessage>;
-  private readonly query: Query;
+  /** Rebuilt by `ensureLiveQuery` after an interrupt, so mutable. */
+  private promptQueue: AsyncPromptQueue<SDKUserMessage>;
+  /** Rebuilt by `ensureLiveQuery` after an interrupt, so mutable. */
+  private query: Query;
   private readonly emitter: EventEmitter;
   private readonly pendingApprovals: PendingApprovals;
   private closed = false;
   private iterationTask: Promise<void>;
+  /** Full start input, retained so `ensureLiveQuery` can rebuild a
+   *  resumed query after an interrupt kills the original. Mutable
+   *  session settings (`model`, `permissionMode`, `mcpTools`) are
+   *  recorded here as they change so a rebuild keeps fidelity. */
+  private readonly startInput: SessionStartInput;
+  /** The `canUseTool` bridge, retained so a rebuilt query reuses the
+   *  same closure over `pendingApprovals` and the emitter. */
+  private readonly canUseTool: CanUseTool;
+  /** True while `interrupt()` is in flight, so `consumeMessages` knows
+   *  an iterator exit is expected and stays silent instead of firing
+   *  `session-ended`. */
+  private interrupting = false;
+  /** True once an interrupt has killed the SDK query. The next
+   *  `sendTurn` rebuilds a resumed query via `ensureLiveQuery`. */
+  private queryDead = false;
   /** SDK-assigned session id, observed from the first incoming SDK
    *  message that carries `session_id`. Forwarded to the Rust side
    *  as a `sdk-session-id` notification so restarts can resume from
@@ -255,15 +289,22 @@ export class ClaudeSession {
     this.threadId = input.threadId;
     this.emitter = emit;
     this.effort = input.effort;
+    // Shallow copy so later `setModel`/`setPermissionMode`/`updateMcpTools`
+    // recordings don't mutate the caller's object; copy `mcpTools` too
+    // since it's the one array field a rebuild reads back.
+    this.startInput = { ...input };
+    if (input.mcpTools) {
+      this.startInput.mcpTools = [...input.mcpTools];
+    }
     this.promptQueue = new AsyncPromptQueue<SDKUserMessage>();
     this.pendingApprovals = new Map();
 
-    const canUseTool = makeCanUseTool(
+    this.canUseTool = makeCanUseTool(
       input.threadId,
       emit,
       this.pendingApprovals,
     );
-    const options = buildQueryOptions(input, canUseTool);
+    const options = buildQueryOptions(input, this.canUseTool);
 
     this.query = queryFactory({
       prompt: this.promptQueue,
@@ -294,6 +335,14 @@ export class ClaudeSession {
         });
         this.emitSpecialCases(message);
       }
+      // An interrupt makes the SDK iterator exit — sometimes cleanly
+      // like this, sometimes via an abort-like throw below. Mark the
+      // query dead so the next `sendTurn` rebuilds a resumed query, and
+      // stay silent: `interrupt()` fires the `turn-interrupted` event.
+      if (this.interrupting && !this.closed) {
+        this.queryDead = true;
+        return;
+      }
       if (!this.closed) {
         this.emitter.notification("session-ended", {
           threadId: this.threadId,
@@ -301,6 +350,12 @@ export class ClaudeSession {
         });
       }
     } catch (err) {
+      // Interrupt-driven abort: same silent, mark-dead handling as the
+      // clean-exit path above.
+      if (this.interrupting && !this.closed && isAbortLikeError(err)) {
+        this.queryDead = true;
+        return;
+      }
       if (isAbortLikeError(err)) {
         this.emitter.notification("session-ended", {
           threadId: this.threadId,
@@ -378,6 +433,9 @@ export class ClaudeSession {
     if (this.closed) {
       throw new Error("session is closed");
     }
+    // If a prior interrupt killed the query, transparently rebuild a
+    // resumed one before enqueuing this turn.
+    this.ensureLiveQuery();
     // If a per-turn model override was supplied, apply it before the
     // turn is dispatched. The SDK applies `setModel` to subsequent
     // messages, not retroactively, which matches what we want.
@@ -423,12 +481,77 @@ export class ClaudeSession {
     this.promptQueue.push(msg);
   }
 
-  /** Halt the current turn. The SDK emits no final `result` for an
-   *  interrupted turn; our message-iteration loop surfaces a
-   *  `session-ended` notification with `reason: "interrupted"`. */
+  /** Halt the current turn. `query.interrupt()` makes the SDK query's
+   *  iterator exit, so the query is marked dead and the next
+   *  `sendTurn` rebuilds a resumed query. A `turn-interrupted`
+   *  notification (not `session-ended`) tells the host the turn is
+   *  over but the session lives. */
   async interrupt(): Promise<void> {
-    if (this.closed) return;
-    await this.query.interrupt();
+    if (this.closed || this.queryDead) return;
+    this.interrupting = true;
+    try {
+      await this.query.interrupt();
+      // Wait for `consumeMessages` to observe the iterator exit (which
+      // flips `queryDead`), bounded by a timeout in case the SDK
+      // treated the interrupt as soft and kept iterating.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        this.iterationTask,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, interruptExitTimeoutMs);
+        }),
+      ]);
+      if (timer !== undefined) clearTimeout(timer);
+      if (this.queryDead && !this.closed) {
+        this.emitter.notification("turn-interrupted", {
+          threadId: this.threadId,
+        });
+      }
+      // If the timeout won (iterator still alive), do nothing extra:
+      // the `finally` reset restores old behavior for a later exit.
+    } finally {
+      this.interrupting = false;
+    }
+  }
+
+  /** Rebuild the SDK query after an interrupt marked it dead. No-op
+   *  while the query is live or the session is closed. The rebuilt
+   *  query resumes the SDK session so history is preserved; the SDK
+   *  issues a fresh session id which `observeSdkSessionId` re-emits so
+   *  the host updates its resume cursor. Mirrors the reference impl's
+   *  `ensureSessionForThread`. */
+  private ensureLiveQuery(): void {
+    if (!this.queryDead || this.closed) return;
+
+    const resume = this.sdkSessionId ?? this.startInput.resume;
+    // A resumed session is issued a NEW session id by the SDK; clear
+    // the observed id so `observeSdkSessionId` re-emits it.
+    this.sdkSessionId = null;
+
+    // Best-effort reap of the dead subprocess.
+    try {
+      this.query.close();
+    } catch (err) {
+      logger.warn("query.close during rebuild threw", {
+        threadId: this.threadId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    this.queryDead = false;
+    this.promptQueue = new AsyncPromptQueue<SDKUserMessage>();
+    // Drop the explicit `sessionId` — that uuid named the ORIGINAL
+    // fresh session; the rebuild resumes instead.
+    const rebuildInput: SessionStartInput = { ...this.startInput };
+    delete rebuildInput.sessionId;
+    if (resume === undefined) {
+      delete rebuildInput.resume;
+    } else {
+      rebuildInput.resume = resume;
+    }
+    const options = buildQueryOptions(rebuildInput, this.canUseTool);
+    this.query = queryFactory({ prompt: this.promptQueue, options });
+    this.iterationTask = this.consumeMessages();
   }
 
   /** Stage 4 — push an updated MCP tool list to the live SDK
@@ -441,6 +564,10 @@ export class ClaudeSession {
    *  is the right shape for "user disabled all MCPs". Idempotent. */
   async updateMcpTools(tools: RegisteredMcpTool[]): Promise<void> {
     if (this.closed) return;
+    // Record first so a rebuild after an interrupt keeps the latest
+    // tool list even if the live query call below throws / is skipped.
+    this.startInput.mcpTools = tools;
+    if (this.queryDead) return;
     const servers: Record<string, ReturnType<typeof buildCodemuxMcpServer>> =
       tools.length > 0 ? { codemux: buildCodemuxMcpServer(tools) } : {};
     try {
@@ -462,6 +589,15 @@ export class ClaudeSession {
     if (this.closed) {
       throw new Error("session is closed");
     }
+    // Record first so a rebuild after an interrupt keeps the latest
+    // model even if the live query call below throws / is skipped.
+    // `undefined` reverts to the SDK default, so drop the recorded key.
+    if (model === undefined) {
+      delete this.startInput.model;
+    } else {
+      this.startInput.model = model;
+    }
+    if (this.queryDead) return;
     await this.query.setModel(model);
   }
 
@@ -470,6 +606,8 @@ export class ClaudeSession {
     if (this.closed) {
       throw new Error("session is closed");
     }
+    this.startInput.permissionMode = mode;
+    if (this.queryDead) return;
     await this.query.setPermissionMode(mode);
   }
 

--- a/sidecar/claude-agent/test/fake-query.ts
+++ b/sidecar/claude-agent/test/fake-query.ts
@@ -28,6 +28,10 @@ export class FakeQuery implements AsyncIterable<SDKMessage> {
   public setPermissionModeCalls: PermissionMode[] = [];
   public interruptCalls = 0;
   public closed = false;
+  /** When set, `interrupt()` throws this from the iterator, emulating
+   *  the real SDK aborting the query when interrupted. Leave null to
+   *  emulate a soft interrupt where the iterator keeps running. */
+  public interruptError: Error | null = null;
 
   public initResult: unknown = {
     commands: [],
@@ -137,6 +141,9 @@ export class FakeQuery implements AsyncIterable<SDKMessage> {
 
   async interrupt(): Promise<void> {
     this.interruptCalls += 1;
+    if (this.interruptError) {
+      this.errorStream(this.interruptError);
+    }
   }
 
   async setModel(model?: string): Promise<void> {

--- a/sidecar/claude-agent/test/permissions.test.ts
+++ b/sidecar/claude-agent/test/permissions.test.ts
@@ -162,8 +162,8 @@ test("ExitPlanMode emits plan-proposed and returns deny with interrupt=true", as
   expect((plan?.params as { plan: string }).plan).toBe("first do X");
 });
 
-test("abort on signal rejects the pending decision and translates to deny", async () => {
-  const { emit } = recorder();
+test("abort on signal rejects the pending decision, emits request-resolved deny, and clears pending", async () => {
+  const { emit, events } = recorder();
   const pending: PendingApprovals = new Map();
   const cb = makeCanUseTool("thr", emit, pending);
   const controller = new AbortController();
@@ -173,10 +173,27 @@ test("abort on signal rejects the pending decision and translates to deny", asyn
     { signal: controller.signal, toolUseID: "tu" },
   );
   await new Promise((r) => setTimeout(r, 0));
+  const requestId = [...pending.keys()][0] as string;
   controller.abort();
   const result = await promise;
   expect(result.behavior).toBe("deny");
+  if (result.behavior === "deny") {
+    expect(result.message).toBe("Tool request was aborted.");
+  }
   expect(pending.size).toBe(0);
+  // The host mirrors this to clear its own pending-approvals map;
+  // without it the dispatch queue wedges after an interrupt.
+  const resolved = events.find((e) => e.method === "request-resolved");
+  expect(resolved).toBeDefined();
+  const params = resolved?.params as {
+    requestId: string;
+    decision: ApprovalDecision;
+  };
+  expect(params.requestId).toBe(requestId);
+  expect(params.decision.behavior).toBe("deny");
+  if (params.decision.behavior === "deny") {
+    expect(params.decision.message).toBe("Tool request was aborted.");
+  }
 });
 
 // ────────────────────────────────────────────────────────────────────

--- a/sidecar/claude-agent/test/session.test.ts
+++ b/sidecar/claude-agent/test/session.test.ts
@@ -7,7 +7,9 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import type { EventEmitter } from "../src/session.ts";
 import {
   ClaudeSession,
+  resetInterruptExitTimeoutForTests,
   resetQueryFactoryForTests,
+  setInterruptExitTimeoutForTests,
   setQueryFactoryForTests,
   type SessionStartInput,
 } from "../src/session.ts";
@@ -40,6 +42,34 @@ function minimalInput(overrides: Partial<SessionStartInput> = {}): SessionStartI
   };
 }
 
+/** Minimal assistant SDK message carrying a `session_id`, shared by
+ *  the interrupt/rebuild tests. */
+function mkAssistant(sessionId: string): SDKMessage {
+  return {
+    type: "assistant",
+    message: {
+      id: "m1",
+      type: "message",
+      role: "assistant",
+      content: [],
+      model: "claude-opus",
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+    parent_tool_use_id: null,
+    uuid: "u-1" as `${string}-${string}-${string}-${string}-${string}`,
+    session_id: sessionId,
+  } as unknown as SDKMessage;
+}
+
+/** An abort-like error matching the SDK's interrupt-abort shape. */
+function abortLikeError(): Error {
+  const err = new Error("request was aborted");
+  err.name = "AbortError";
+  return err;
+}
+
 let fake: FakeQuery;
 
 beforeEach(() => {
@@ -47,10 +77,14 @@ beforeEach(() => {
     fake = new FakeQuery(args);
     return asQuery(fake);
   });
+  // Keep the interrupt-exit race short so the soft-interrupt (timeout)
+  // path doesn't stall the suite.
+  setInterruptExitTimeoutForTests(50);
 });
 
 afterEach(() => {
   resetQueryFactoryForTests();
+  resetInterruptExitTimeoutForTests();
 });
 
 test("session starts with minimal options and emits session-configured", () => {
@@ -360,6 +394,113 @@ test("session-ended with reason=interrupted when query throws AbortError-like", 
       (e.params as { reason: string }).reason === "interrupted",
   );
   expect(ended).toBeDefined();
+  await session.close();
+});
+
+test("interrupt on an abort-like exit emits turn-interrupted, not session-ended", async () => {
+  const { emit, events } = recordingEmitter();
+  const session = new ClaudeSession(minimalInput(), emit);
+  // The SDK aborts the query when interrupted; model that on the fake.
+  fake.interruptError = abortLikeError();
+  await session.interrupt();
+  expect(events.filter((e) => e.method === "session-ended")).toHaveLength(0);
+  const interrupted = events.filter((e) => e.method === "turn-interrupted");
+  expect(interrupted).toHaveLength(1);
+  expect((interrupted[0]?.params as { threadId: string }).threadId).toBe("t-1");
+  await session.close();
+});
+
+test("sendTurn after an interrupt rebuilds a resumed query that consumes the turn", async () => {
+  const fakes: FakeQuery[] = [];
+  setQueryFactoryForTests((args) => {
+    const f = new FakeQuery(args);
+    fakes.push(f);
+    return asQuery(f);
+  });
+  const { emit } = recordingEmitter();
+  const session = new ClaudeSession(minimalInput(), emit);
+  // Observe an sdk session id on the original query.
+  fakes[0]?.emit(mkAssistant("sdk-sess-1"));
+  await new Promise((r) => setTimeout(r, 10));
+  // Interrupt kills the original query.
+  const first = fakes[0] as FakeQuery;
+  first.interruptError = abortLikeError();
+  await session.interrupt();
+  // The next turn transparently rebuilds a resumed query.
+  await session.sendTurn({ text: "resumed turn" });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(fakes.length).toBe(2);
+  // The rebuild resumes from the previously observed sdk session id and
+  // drops the explicit fresh-session uuid.
+  expect(fakes[1]?.capturedOptions?.resume).toBe("sdk-sess-1");
+  expect(fakes[1]?.capturedOptions?.sessionId).toBeUndefined();
+  // The message lands on the NEW query, not the dead one.
+  expect(fakes[1]?.capturedPrompts.length).toBe(1);
+  expect(fakes[0]?.capturedPrompts.length).toBe(0);
+  await session.close();
+});
+
+test("rebuilt query re-emits sdk-session-id when its first message carries a new id", async () => {
+  const fakes: FakeQuery[] = [];
+  setQueryFactoryForTests((args) => {
+    const f = new FakeQuery(args);
+    fakes.push(f);
+    return asQuery(f);
+  });
+  const { emit, events } = recordingEmitter();
+  const session = new ClaudeSession(minimalInput(), emit);
+  fakes[0]?.emit(mkAssistant("sdk-sess-1"));
+  await new Promise((r) => setTimeout(r, 10));
+  const first = fakes[0] as FakeQuery;
+  first.interruptError = abortLikeError();
+  await session.interrupt();
+  await session.sendTurn({ text: "again" });
+  // The resumed session is issued a fresh id.
+  fakes[1]?.emit(mkAssistant("sdk-sess-2"));
+  await new Promise((r) => setTimeout(r, 10));
+  const ids = events
+    .filter((e) => e.method === "sdk-session-id")
+    .map((e) => (e.params as { sessionId: string }).sessionId);
+  expect(ids).toEqual(["sdk-sess-1", "sdk-sess-2"]);
+  await session.close();
+});
+
+test("setModel/setPermissionMode while the query is dead don't throw and are reflected on rebuild", async () => {
+  const fakes: FakeQuery[] = [];
+  setQueryFactoryForTests((args) => {
+    const f = new FakeQuery(args);
+    fakes.push(f);
+    return asQuery(f);
+  });
+  const { emit } = recordingEmitter();
+  const session = new ClaudeSession(minimalInput(), emit);
+  const first = fakes[0] as FakeQuery;
+  first.interruptError = abortLikeError();
+  await session.interrupt();
+  // Query is dead — these record without touching the dead query.
+  await session.setModel("claude-opus-4-8");
+  await session.setPermissionMode("plan");
+  expect(fakes[0]?.setModelCalls).toEqual([]);
+  expect(fakes[0]?.setPermissionModeCalls).toEqual([]);
+  await session.sendTurn({ text: "go" });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(fakes[1]?.capturedOptions?.model).toBe("claude-opus-4-8");
+  expect(fakes[1]?.capturedOptions?.permissionMode).toBe("plan");
+  await session.close();
+});
+
+test("interrupt with a soft (non-exiting) iterator resolves without turn-interrupted and stays usable", async () => {
+  const { emit, events } = recordingEmitter();
+  const session = new ClaudeSession(minimalInput(), emit);
+  // interruptError stays null — the fake's iterator keeps running, so
+  // the interrupt-exit race resolves via the (lowered) timeout.
+  await session.interrupt();
+  expect(fake.interruptCalls).toBe(1);
+  expect(events.some((e) => e.method === "turn-interrupted")).toBe(false);
+  // Session is still usable and did NOT rebuild (query still live).
+  await session.sendTurn({ text: "still here" });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(fake.capturedPrompts.length).toBe(1);
   await session.close();
 });
 

--- a/src-tauri/src/agent_provider/claude/mod.rs
+++ b/src-tauri/src/agent_provider/claude/mod.rs
@@ -261,6 +261,22 @@ impl AgentProvider for ClaudeAgentProvider {
         session.cancel_queued(&queued_id).await
     }
 
+    async fn send_queued_turn_now(
+        &self,
+        thread_id: ThreadId,
+        queued_id: String,
+    ) -> Result<(), ProviderError> {
+        let session = {
+            let sessions = self.sessions.read().await;
+            sessions.get(&thread_id).cloned()
+        };
+        // A missing session means nothing is queued — treat as a no-op.
+        let Some(session) = session else {
+            return Ok(());
+        };
+        session.send_queued_now(&queued_id).await
+    }
+
     async fn respond_to_request(
         &self,
         thread_id: ThreadId,

--- a/src-tauri/src/agent_provider/claude/protocol.rs
+++ b/src-tauri/src/agent_provider/claude/protocol.rs
@@ -351,6 +351,14 @@ pub enum SidecarNotification {
         thread_id: String,
         reason: String,
     },
+    /// The sidecar ended the SDK query's active turn in response to an
+    /// explicit `interrupt` RPC. Unlike `session-ended {reason:
+    /// "interrupted"}` (a spontaneous abort that tears the session down),
+    /// this notification means the session survives — the next send-turn
+    /// transparently rebuilds a resumed query.
+    TurnInterrupted {
+        thread_id: String,
+    },
     SessionError {
         thread_id: String,
         error: SidecarError,
@@ -427,6 +435,9 @@ impl SidecarNotification {
             "session-ended" => Self::SessionEnded {
                 thread_id: field_string(&params, "threadId"),
                 reason: field_string(&params, "reason"),
+            },
+            "turn-interrupted" => Self::TurnInterrupted {
+                thread_id: field_string(&params, "threadId"),
             },
             "session-error" => Self::SessionError {
                 thread_id: field_string(&params, "threadId"),

--- a/src-tauri/src/agent_provider/claude/session.rs
+++ b/src-tauri/src/agent_provider/claude/session.rs
@@ -87,6 +87,11 @@ pub(crate) struct ClaudeSessionState {
     /// dispatch order. Drained one-at-a-time as the session returns to
     /// idle (see [`ClaudeSession::drain_queue`]).
     pub queued_turns: VecDeque<QueuedTurn>,
+    /// Set while a `drain_queue` has popped an item and is mid-flight in
+    /// `do_send`, before `active_turn` is populated. Guards against two
+    /// concurrent drains (notifications task + inline interrupt fallback)
+    /// each popping and dispatching an item in the same idle window.
+    pub dispatching: bool,
 }
 
 /// A user turn parked in the follow-up queue behind the active turn.
@@ -107,19 +112,41 @@ fn mint_queued_id() -> String {
 
 /// Move the queued turn with `queued_id` to the front of `queue` so it
 /// is the next item [`ClaudeSession::drain_queue`] dispatches. Returns
-/// `true` when the item was found (and is now at the front), `false`
-/// when no such id is queued (already dispatched / cancelled / unknown).
-/// A no-op when the item is already at the front.
-fn promote_queued_to_front(queue: &mut VecDeque<QueuedTurn>, queued_id: &str) -> bool {
+/// `Some(original_index)` when the item was found (and is now at the
+/// front), `None` when no such id is queued (already dispatched /
+/// cancelled / unknown). A no-op when the item is already at the front.
+/// The returned index lets a caller undo the reorder via
+/// [`restore_queued_position`] when a follow-up step (e.g. `interrupt`)
+/// fails.
+fn promote_queued_to_front(queue: &mut VecDeque<QueuedTurn>, queued_id: &str) -> Option<usize> {
     match queue.iter().position(|q| q.queued_id == queued_id) {
-        Some(0) => true,
+        Some(0) => Some(0),
         Some(pos) => {
             if let Some(item) = queue.remove(pos) {
                 queue.push_front(item);
             }
-            true
+            Some(pos)
         }
-        None => false,
+        None => None,
+    }
+}
+
+/// Undo a [`promote_queued_to_front`] by moving `queued_id` back to
+/// `original_index`. Finds the item's CURRENT position first — it may
+/// have been dispatched or cancelled in the meantime, in which case this
+/// is a no-op. Otherwise it is removed and re-inserted at
+/// `min(original_index, queue.len())` so the queue order is restored.
+fn restore_queued_position(
+    queue: &mut VecDeque<QueuedTurn>,
+    queued_id: &str,
+    original_index: usize,
+) {
+    let Some(pos) = queue.iter().position(|q| q.queued_id == queued_id) else {
+        return;
+    };
+    if let Some(item) = queue.remove(pos) {
+        let insert_at = original_index.min(queue.len());
+        queue.insert(insert_at, item);
     }
 }
 
@@ -282,6 +309,7 @@ impl ClaudeSession {
             permission_mode: input.permission_mode.clone(),
             sdk_session_id: None,
             queued_turns: VecDeque::new(),
+            dispatching: false,
         });
         let session = Arc::new(Self {
             thread_id: thread_id.clone(),
@@ -397,16 +425,27 @@ impl ClaudeSession {
     pub async fn drain_queue(self: &Arc<Self>) {
         loop {
             // Pop the next item only if the session is truly idle: no
-            // active turn, Ready status, and nothing parked on approval.
+            // active turn, Ready status, nothing parked on approval, and
+            // no concurrent drain already mid-dispatch. The `dispatching`
+            // flag closes the gap between popping here and `do_send`
+            // setting `active_turn` — without it a second drain sees the
+            // session idle and pops the NEXT item, double-dispatching.
             let next = {
                 let mut state = self.state.lock().await;
                 let idle = state.active_turn.is_none()
                     && matches!(state.status, SessionStatus::Ready)
-                    && state.pending_approvals.is_empty();
+                    && state.pending_approvals.is_empty()
+                    && !state.dispatching;
                 if !idle {
                     return;
                 }
-                state.queued_turns.pop_front()
+                match state.queued_turns.pop_front() {
+                    Some(queued) => {
+                        state.dispatching = true;
+                        Some(queued)
+                    }
+                    None => None,
+                }
             };
             let Some(queued) = next else { return };
             let text = queued.input.text.clone();
@@ -419,6 +458,10 @@ impl ClaudeSession {
                 .await
             {
                 Ok(turn_id) => {
+                    {
+                        let mut state = self.state.lock().await;
+                        state.dispatching = false;
+                    }
                     let _ = self.event_tx.send(ProviderRuntimeEvent::QueuedTurnDispatched {
                         thread_id: self.thread_id.clone(),
                         queued_id: queued.queued_id,
@@ -428,6 +471,10 @@ impl ClaudeSession {
                     return;
                 }
                 Err(err) => {
+                    {
+                        let mut state = self.state.lock().await;
+                        state.dispatching = false;
+                    }
                     // Don't wedge the queue: surface the failure, cancel
                     // this item, and try the next one.
                     let _ = self.event_tx.send(ProviderRuntimeEvent::RuntimeWarning {
@@ -488,31 +535,56 @@ impl ClaudeSession {
     /// dispatched between the UI click and this call).
     ///
     /// When a turn is active we call [`interrupt`](Self::interrupt), which
-    /// flips the session to `Ready` and ends with `drain_queue()` — so the
-    /// item we just moved to the front goes out next. When the session is
-    /// already idle (the turn finished during the click→call race) we just
-    /// `drain_queue()` directly.
+    /// ends the SDK query's current turn. The sidecar emits
+    /// `turn-interrupted` (the session stays alive and rebuilds a resumed
+    /// query on the next send-turn; the queue is preserved) rather than
+    /// tearing the session down. The promoted item then dispatches via the
+    /// notifications-task drain that fires on `turn-interrupted`, or via
+    /// `interrupt`'s own inline fallback drain — whichever runs first; the
+    /// `dispatching` guard in [`drain_queue`](Self::drain_queue) makes that
+    /// race safe. When the session is already idle (the turn finished
+    /// during the click→call race) we just `drain_queue()` directly.
     ///
-    /// **Pending approvals:** `drain_queue` refuses to dispatch while
-    /// `pending_approvals` is non-empty, and `interrupt` does not clear
-    /// them (only session close/error does). So — exactly like a manual
-    /// stop-button interrupt — if a tool approval is outstanding the
-    /// promoted message stays queued until that approval resolves, then
-    /// drains. Send-now deliberately does not invent new approval-clearing
-    /// behaviour.
+    /// If the promotion succeeds but the interrupt RPC then fails, we undo
+    /// the reorder (via [`restore_queued_position`]) before propagating the
+    /// error, so a failed steer does not silently leave the queue
+    /// reordered.
+    ///
+    /// **Pending approvals:** an interrupt now aborts any outstanding
+    /// approval sidecar-side and emits `request-resolved` for it, which
+    /// clears the stale `pending_approvals` entry (see
+    /// [`mutate_state_from_notification`]). So the promoted message no
+    /// longer waits on a zombie approval — the following drain dispatches
+    /// it as soon as the turn ends.
     pub async fn send_queued_now(self: &Arc<Self>, queued_id: &str) -> Result<(), ProviderError> {
-        let has_active_turn = {
+        let (has_active_turn, original_index) = {
             let mut state = self.state.lock().await;
-            if !promote_queued_to_front(&mut state.queued_turns, queued_id) {
+            match promote_queued_to_front(&mut state.queued_turns, queued_id) {
+                Some(idx) => (state.active_turn.is_some(), idx),
                 // Unknown / already-dispatched / cancelled — no-op.
-                return Ok(());
+                None => return Ok(()),
             }
-            state.active_turn.is_some()
         };
         if has_active_turn {
-            // Soft-stop the running turn; `interrupt` flips to Ready and
-            // drains, dispatching the item we just promoted to the front.
-            self.interrupt(None).await
+            // Soft-stop the running turn; the sidecar's `turn-interrupted`
+            // notification (or `interrupt`'s inline fallback drain)
+            // dispatches the item we just promoted to the front.
+            match self.interrupt(None).await {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    // Undo the reorder so a failed steer doesn't leave the
+                    // queue silently rearranged.
+                    {
+                        let mut state = self.state.lock().await;
+                        restore_queued_position(
+                            &mut state.queued_turns,
+                            queued_id,
+                            original_index,
+                        );
+                    }
+                    Err(err)
+                }
+            }
         } else {
             // Race: the turn finished between the UI click and this call.
             // The session is idle, so just drain the promoted item out.
@@ -619,22 +691,32 @@ impl ClaudeSession {
             .map_err(|e| ProviderError::RpcError {
                 message: format!("interrupt RPC failed: {e}"),
             })?;
-        // Announce Ready before mutating local state so subscribers
-        // never observe `Ready` in the struct with no corresponding
-        // event in flight. The SessionEnded notification that the
-        // sidecar will emit next translates to `Closed`, so this is
-        // the only place Ready is surfaced after an interrupt.
-        let _ = self.event_tx.send(ProviderRuntimeEvent::SessionStateChanged {
-            thread_id: self.thread_id.clone(),
-            status: SessionStatus::Ready,
-        });
+        // By the time the RPC returns, the sidecar's `turn-interrupted`
+        // notification may ALREADY have been processed by the
+        // notifications task, which may already have flipped the session
+        // to Ready and drained the queue — dispatching the next turn and
+        // setting `active_turn` to a NEW turn. Only surface Ready + clear
+        // state when the turn we interrupted is still the active one (the
+        // notification hasn't landed yet); otherwise we would clobber the
+        // freshly-dispatched turn and could double-dispatch.
         {
             let mut state = self.state.lock().await;
-            state.active_turn = None;
-            state.status = SessionStatus::Ready;
+            if state.active_turn == active && active.is_some() {
+                state.active_turn = None;
+                state.status = SessionStatus::Ready;
+                // Announce Ready while holding the lock so subscribers
+                // never observe `Ready` in the struct with no
+                // corresponding event in flight.
+                let _ = self.event_tx.send(ProviderRuntimeEvent::SessionStateChanged {
+                    thread_id: self.thread_id.clone(),
+                    status: SessionStatus::Ready,
+                });
+            }
         }
-        // The user probably interrupted to make the next (queued) message
-        // go sooner — drain now that the session is idle again.
+        // Fallback drain: if the notification hasn't run yet, this
+        // dispatches the next (queued) turn now that the session is idle.
+        // The `dispatching` guard makes a concurrent drain (from the
+        // notifications task) safe.
         self.drain_queue().await;
         Ok(())
     }
@@ -675,7 +757,7 @@ impl ClaudeSession {
     }
 
     pub async fn respond_to_request(
-        &self,
+        self: &Arc<Self>,
         request_id: RequestId,
         decision: crate::agent_provider::ApprovalDecision,
     ) -> Result<(), ProviderError> {
@@ -699,7 +781,15 @@ impl ClaudeSession {
             )
             .await;
         match res {
-            Ok(_) => Ok(()),
+            Ok(_) => {
+                // The approval cleared, so the session may now be idle
+                // with a queued follow-up waiting. The notification path
+                // usually covers this, but draining here closes the
+                // ordering gap between the local removal above and the
+                // sidecar's `request-resolved` notification arriving.
+                self.drain_queue().await;
+                Ok(())
+            }
             Err(crate::json_rpc_child::RpcChildError::RpcError(err))
                 if err.code == -32602 =>
             {
@@ -1310,6 +1400,29 @@ async fn mutate_state_from_notification(
                 SessionStatus::Closed
             };
         }
+        SidecarNotification::TurnInterrupted { .. } => {
+            // An explicit interrupt RPC ended the turn but the session
+            // survives. Clear the active turn and return to Ready — but
+            // only from Running, so we never resurrect a session that has
+            // since gone Closed / Error.
+            let mut state = session.state.lock().await;
+            state.active_turn = None;
+            if matches!(state.status, SessionStatus::Running { .. }) {
+                state.status = SessionStatus::Ready;
+            }
+        }
+        SidecarNotification::RequestResolved { request_id, .. } => {
+            // The sidecar resolved a pending approval on its own — e.g.
+            // an interrupt that aborted a turn with an outstanding tool
+            // approval emits `request-resolved` with a deny decision.
+            // Nothing else removes entries on the notification path (only
+            // the local `respond_to_request` / `shutdown` do), so without
+            // this the stale entry would block `drain_queue` forever.
+            let mut state = session.state.lock().await;
+            state
+                .pending_approvals
+                .remove(&RequestId(request_id.clone()));
+        }
         SidecarNotification::SessionError { error, .. } => {
             let mut state = session.state.lock().await;
             state.status = SessionStatus::Error {
@@ -1354,7 +1467,7 @@ mod tests {
     #[test]
     fn promote_queued_to_front_unknown_id_is_noop() {
         let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
-        assert!(!promote_queued_to_front(&mut q, "missing"));
+        assert_eq!(promote_queued_to_front(&mut q, "missing"), None);
         // Order unchanged.
         let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
         assert_eq!(ids, ["a", "b"]);
@@ -1363,7 +1476,8 @@ mod tests {
     #[test]
     fn promote_queued_to_front_moves_mid_queue_item() {
         let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b"), queued("c")].into();
-        assert!(promote_queued_to_front(&mut q, "c"));
+        // Returns the item's original index so the reorder can be undone.
+        assert_eq!(promote_queued_to_front(&mut q, "c"), Some(2));
         let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
         assert_eq!(ids, ["c", "a", "b"]);
     }
@@ -1371,8 +1485,38 @@ mod tests {
     #[test]
     fn promote_queued_to_front_head_item_stays_put() {
         let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
-        assert!(promote_queued_to_front(&mut q, "a"));
+        assert_eq!(promote_queued_to_front(&mut q, "a"), Some(0));
         let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
         assert_eq!(ids, ["a", "b"]);
+    }
+
+    #[test]
+    fn restore_queued_position_undoes_a_promotion() {
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b"), queued("c")].into();
+        let idx = promote_queued_to_front(&mut q, "c").unwrap();
+        assert_eq!(idx, 2);
+        restore_queued_position(&mut q, "c", idx);
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn restore_queued_position_already_dispatched_is_noop() {
+        // The item was promoted then removed (dispatched/cancelled)
+        // before restore ran — restoring is a harmless no-op.
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
+        restore_queued_position(&mut q, "gone", 1);
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b"]);
+    }
+
+    #[test]
+    fn restore_queued_position_clamps_out_of_range_index() {
+        // A stale original index past the current end clamps to the tail
+        // rather than panicking.
+        let mut q: VecDeque<QueuedTurn> = [queued("c"), queued("a")].into();
+        restore_queued_position(&mut q, "c", 9);
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "c"]);
     }
 }

--- a/src-tauri/src/agent_provider/claude/session.rs
+++ b/src-tauri/src/agent_provider/claude/session.rs
@@ -105,6 +105,24 @@ fn mint_queued_id() -> String {
     format!("claude-queued-{}", uuid::Uuid::new_v4())
 }
 
+/// Move the queued turn with `queued_id` to the front of `queue` so it
+/// is the next item [`ClaudeSession::drain_queue`] dispatches. Returns
+/// `true` when the item was found (and is now at the front), `false`
+/// when no such id is queued (already dispatched / cancelled / unknown).
+/// A no-op when the item is already at the front.
+fn promote_queued_to_front(queue: &mut VecDeque<QueuedTurn>, queued_id: &str) -> bool {
+    match queue.iter().position(|q| q.queued_id == queued_id) {
+        Some(0) => true,
+        Some(pos) => {
+            if let Some(item) = queue.remove(pos) {
+                queue.push_front(item);
+            }
+            true
+        }
+        None => false,
+    }
+}
+
 /// A live Claude session handle.
 pub(crate) struct ClaudeSession {
     pub thread_id: ThreadId,
@@ -455,6 +473,52 @@ impl ClaudeSession {
             });
         }
         Ok(())
+    }
+
+    /// **Send now (steer):** promote a queued follow-up to the front of
+    /// the queue and dispatch it immediately, interrupting the active
+    /// turn if one is running. This is a *soft* stop — the SDK session,
+    /// the full transcript, and all on-disk work are preserved; nothing
+    /// is discarded. The promoted message then dispatches as a normal
+    /// follow-up turn, so the agent re-plans with the user's steer.
+    ///
+    /// Idempotent: an unknown / already-dispatched / already-cancelled id
+    /// is a silent no-op `Ok(())` (the same philosophy as
+    /// [`cancel_queued`](Self::cancel_queued) — the item may have just
+    /// dispatched between the UI click and this call).
+    ///
+    /// When a turn is active we call [`interrupt`](Self::interrupt), which
+    /// flips the session to `Ready` and ends with `drain_queue()` — so the
+    /// item we just moved to the front goes out next. When the session is
+    /// already idle (the turn finished during the click→call race) we just
+    /// `drain_queue()` directly.
+    ///
+    /// **Pending approvals:** `drain_queue` refuses to dispatch while
+    /// `pending_approvals` is non-empty, and `interrupt` does not clear
+    /// them (only session close/error does). So — exactly like a manual
+    /// stop-button interrupt — if a tool approval is outstanding the
+    /// promoted message stays queued until that approval resolves, then
+    /// drains. Send-now deliberately does not invent new approval-clearing
+    /// behaviour.
+    pub async fn send_queued_now(self: &Arc<Self>, queued_id: &str) -> Result<(), ProviderError> {
+        let has_active_turn = {
+            let mut state = self.state.lock().await;
+            if !promote_queued_to_front(&mut state.queued_turns, queued_id) {
+                // Unknown / already-dispatched / cancelled — no-op.
+                return Ok(());
+            }
+            state.active_turn.is_some()
+        };
+        if has_active_turn {
+            // Soft-stop the running turn; `interrupt` flips to Ready and
+            // drains, dispatching the item we just promoted to the front.
+            self.interrupt(None).await
+        } else {
+            // Race: the turn finished between the UI click and this call.
+            // The session is idle, so just drain the promoted item out.
+            self.drain_queue().await;
+            Ok(())
+        }
     }
 
     /// Cancel every queued turn, emitting a
@@ -1267,5 +1331,48 @@ mod tests {
             "alreadyClosed": true
         })));
         assert!(!stop_response_indicates_already_closed(&json!({})));
+    }
+
+    /// Build a bare `QueuedTurn` with a given id for reorder tests. The
+    /// `input` payload is irrelevant to `promote_queued_to_front`, which
+    /// only inspects `queued_id`.
+    fn queued(id: &str) -> QueuedTurn {
+        QueuedTurn {
+            queued_id: id.to_string(),
+            input: SendTurnInput {
+                thread_id: ThreadId("t".into()),
+                text: String::new(),
+                images: vec![],
+                model_override: None,
+                effort_override: None,
+                permission_mode_override: None,
+                client_nonce: None,
+            },
+        }
+    }
+
+    #[test]
+    fn promote_queued_to_front_unknown_id_is_noop() {
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
+        assert!(!promote_queued_to_front(&mut q, "missing"));
+        // Order unchanged.
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b"]);
+    }
+
+    #[test]
+    fn promote_queued_to_front_moves_mid_queue_item() {
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b"), queued("c")].into();
+        assert!(promote_queued_to_front(&mut q, "c"));
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["c", "a", "b"]);
+    }
+
+    #[test]
+    fn promote_queued_to_front_head_item_stays_put() {
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
+        assert!(promote_queued_to_front(&mut q, "a"));
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b"]);
     }
 }

--- a/src-tauri/src/agent_provider/claude/translate.rs
+++ b/src-tauri/src/agent_provider/claude/translate.rs
@@ -286,6 +286,28 @@ pub fn translate_notification_with(
                 },
             ]
         }
+        SidecarNotification::TurnInterrupted { .. } => {
+            // An explicit interrupt RPC ended the active turn but the
+            // session survives (the sidecar rebuilds a resumed query on
+            // the next send-turn). Mirror the `session-ended` shape —
+            // a `TurnCompleted(Error)` closes out the interrupted turn —
+            // but keep the session `Ready`, NOT `Closed`.
+            vec![
+                ProviderRuntimeEvent::TurnCompleted {
+                    thread_id: thread_id.clone(),
+                    turn_id: TurnId(String::new()),
+                    status: TurnStatus::Error {
+                        subtype: "interrupted".into(),
+                        message: "turn interrupted".into(),
+                    },
+                    usage: None,
+                },
+                ProviderRuntimeEvent::SessionStateChanged {
+                    thread_id: thread_id.clone(),
+                    status: SessionStatus::Ready,
+                },
+            ]
+        }
         SidecarNotification::SessionError {
             thread_id: _,
             error: SidecarError { message, .. },
@@ -1984,6 +2006,35 @@ mod tests {
             &events[1],
             ProviderRuntimeEvent::SessionStateChanged {
                 status: SessionStatus::Closed,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn notification_turn_interrupted_emits_error_and_ready() {
+        // An explicit interrupt RPC keeps the session alive: the turn
+        // closes out as an interrupted error but the session returns to
+        // Ready (NOT Closed like a spontaneous `session-ended`).
+        let n = SidecarNotification::TurnInterrupted {
+            thread_id: "t".into(),
+        };
+        let events = translate_notification(&tid(), n);
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            ProviderRuntimeEvent::TurnCompleted { status, .. } => match status {
+                TurnStatus::Error { subtype, message } => {
+                    assert_eq!(subtype, "interrupted");
+                    assert_eq!(message, "turn interrupted");
+                }
+                _ => panic!("expected Error"),
+            },
+            _ => panic!("expected TurnCompleted"),
+        }
+        assert!(matches!(
+            &events[1],
+            ProviderRuntimeEvent::SessionStateChanged {
+                status: SessionStatus::Ready,
                 ..
             }
         ));

--- a/src-tauri/src/agent_provider/codex/mod.rs
+++ b/src-tauri/src/agent_provider/codex/mod.rs
@@ -261,6 +261,21 @@ impl AgentProvider for CodexAgentProvider {
         session.cancel_queued(&queued_id).await
     }
 
+    async fn send_queued_turn_now(
+        &self,
+        thread_id: ThreadId,
+        queued_id: String,
+    ) -> Result<(), ProviderError> {
+        let session = {
+            let sessions = self.sessions.read().await;
+            sessions.get(&thread_id).cloned()
+        };
+        let Some(session) = session else {
+            return Ok(());
+        };
+        session.send_queued_now(&queued_id).await
+    }
+
     async fn respond_to_request(
         &self,
         thread_id: ThreadId,

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -102,6 +102,23 @@ fn mint_queued_id() -> String {
     )
 }
 
+/// Move the queued turn with `queued_id` to the front of `queue` so it
+/// is the next item [`CodexSession::drain_queue`] dispatches. Returns
+/// `true` when the item was found (and is now at the front), `false`
+/// when no such id is queued. A no-op when it is already at the front.
+fn promote_queued_to_front(queue: &mut VecDeque<QueuedTurn>, queued_id: &str) -> bool {
+    match queue.iter().position(|q| q.queued_id == queued_id) {
+        Some(0) => true,
+        Some(pos) => {
+            if let Some(item) = queue.remove(pos) {
+                queue.push_front(item);
+            }
+            true
+        }
+        None => false,
+    }
+}
+
 /// Handle for a live Codex session.
 pub(crate) struct CodexSession {
     /// Runtime-owned thread identifier.
@@ -501,6 +518,56 @@ impl CodexSession {
             });
         }
         Ok(())
+    }
+
+    /// **Send now (steer):** promote a queued follow-up to the front of
+    /// the queue and dispatch it immediately, interrupting the active
+    /// turn if one is running. Soft stop — the Codex thread, transcript,
+    /// and on-disk work are preserved; nothing is discarded.
+    ///
+    /// Idempotent: an unknown / already-dispatched id is a silent no-op.
+    ///
+    /// When a turn is active we call
+    /// [`interrupt_turn`](Self::interrupt_turn). Unlike Claude's
+    /// `interrupt`, it does NOT drain inline — the abort lands as a
+    /// `turn/completed` (or aborted) notification that returns the session
+    /// to `Ready`, and the event loop drains there, dispatching the item
+    /// we just promoted to the front. If `interrupt_turn` returns the
+    /// "no active turn" `ValidationError` because the turn finished during
+    /// the click→call race, we fall back to draining directly. When the
+    /// session is already idle we drain directly.
+    ///
+    /// **Pending approvals:** like a manual interrupt, an outstanding
+    /// approval keeps `drain_queue` from dispatching until it resolves, so
+    /// the promoted message stays queued until then.
+    pub async fn send_queued_now(self: &Arc<Self>, queued_id: &str) -> Result<(), ProviderError> {
+        let has_active_turn = {
+            let mut state = self.state.lock().await;
+            if !promote_queued_to_front(&mut state.queued_turns, queued_id) {
+                // Unknown / already-dispatched / cancelled — no-op.
+                return Ok(());
+            }
+            state.active_turn.is_some()
+        };
+        if has_active_turn {
+            // Soft-stop the running turn. The event-loop drain (on the
+            // resulting turn/completed → Ready) dispatches the promoted
+            // item — `interrupt_turn` does not drain inline.
+            match self.interrupt_turn(None).await {
+                Ok(()) => Ok(()),
+                // Race: the turn finished between our busy check and the
+                // interrupt RPC. The session is idle, so drain directly.
+                Err(ProviderError::ValidationError { .. }) => {
+                    self.drain_queue().await;
+                    Ok(())
+                }
+                Err(err) => Err(err),
+            }
+        } else {
+            // Already idle — drain the promoted item out.
+            self.drain_queue().await;
+            Ok(())
+        }
     }
 
     /// Cancel every queued turn, emitting a cancellation for each. Used
@@ -991,5 +1058,46 @@ mod tests {
         let a = mint_request_id();
         let b = mint_request_id();
         assert_ne!(a.0, b.0);
+    }
+
+    /// Build a bare `QueuedTurn` with a given id for reorder tests. Only
+    /// `queued_id` is inspected by `promote_queued_to_front`.
+    fn queued(id: &str) -> QueuedTurn {
+        QueuedTurn {
+            queued_id: id.to_string(),
+            input: SendTurnInput {
+                thread_id: ThreadId("t".into()),
+                text: String::new(),
+                images: vec![],
+                model_override: None,
+                effort_override: None,
+                permission_mode_override: None,
+                client_nonce: None,
+            },
+        }
+    }
+
+    #[test]
+    fn promote_queued_to_front_unknown_id_is_noop() {
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
+        assert!(!promote_queued_to_front(&mut q, "missing"));
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b"]);
+    }
+
+    #[test]
+    fn promote_queued_to_front_moves_mid_queue_item() {
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b"), queued("c")].into();
+        assert!(promote_queued_to_front(&mut q, "c"));
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["c", "a", "b"]);
+    }
+
+    #[test]
+    fn promote_queued_to_front_head_item_stays_put() {
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
+        assert!(promote_queued_to_front(&mut q, "a"));
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b"]);
     }
 }

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -104,18 +104,40 @@ fn mint_queued_id() -> String {
 
 /// Move the queued turn with `queued_id` to the front of `queue` so it
 /// is the next item [`CodexSession::drain_queue`] dispatches. Returns
-/// `true` when the item was found (and is now at the front), `false`
-/// when no such id is queued. A no-op when it is already at the front.
-fn promote_queued_to_front(queue: &mut VecDeque<QueuedTurn>, queued_id: &str) -> bool {
+/// `Some(original_index)` when the item was found (and is now at the
+/// front), `None` when no such id is queued. A no-op when it is already
+/// at the front. The returned index lets a caller undo the reorder via
+/// [`restore_queued_position`] when a follow-up step (e.g.
+/// `interrupt_turn`) fails.
+fn promote_queued_to_front(queue: &mut VecDeque<QueuedTurn>, queued_id: &str) -> Option<usize> {
     match queue.iter().position(|q| q.queued_id == queued_id) {
-        Some(0) => true,
+        Some(0) => Some(0),
         Some(pos) => {
             if let Some(item) = queue.remove(pos) {
                 queue.push_front(item);
             }
-            true
+            Some(pos)
         }
-        None => false,
+        None => None,
+    }
+}
+
+/// Undo a [`promote_queued_to_front`] by moving `queued_id` back to
+/// `original_index`. Finds the item's CURRENT position first — it may
+/// have been dispatched or cancelled in the meantime, in which case this
+/// is a no-op. Otherwise it is removed and re-inserted at
+/// `min(original_index, queue.len())` so the queue order is restored.
+fn restore_queued_position(
+    queue: &mut VecDeque<QueuedTurn>,
+    queued_id: &str,
+    original_index: usize,
+) {
+    let Some(pos) = queue.iter().position(|q| q.queued_id == queued_id) else {
+        return;
+    };
+    if let Some(item) = queue.remove(pos) {
+        let insert_at = original_index.min(queue.len());
+        queue.insert(insert_at, item);
     }
 }
 
@@ -541,13 +563,13 @@ impl CodexSession {
     /// approval keeps `drain_queue` from dispatching until it resolves, so
     /// the promoted message stays queued until then.
     pub async fn send_queued_now(self: &Arc<Self>, queued_id: &str) -> Result<(), ProviderError> {
-        let has_active_turn = {
+        let (has_active_turn, original_index) = {
             let mut state = self.state.lock().await;
-            if !promote_queued_to_front(&mut state.queued_turns, queued_id) {
+            match promote_queued_to_front(&mut state.queued_turns, queued_id) {
+                Some(idx) => (state.active_turn.is_some(), idx),
                 // Unknown / already-dispatched / cancelled — no-op.
-                return Ok(());
+                None => return Ok(()),
             }
-            state.active_turn.is_some()
         };
         if has_active_turn {
             // Soft-stop the running turn. The event-loop drain (on the
@@ -561,7 +583,20 @@ impl CodexSession {
                     self.drain_queue().await;
                     Ok(())
                 }
-                Err(err) => Err(err),
+                Err(err) => {
+                    // A real interrupt failure: undo the reorder so a
+                    // failed steer doesn't leave the queue silently
+                    // rearranged.
+                    {
+                        let mut state = self.state.lock().await;
+                        restore_queued_position(
+                            &mut state.queued_turns,
+                            queued_id,
+                            original_index,
+                        );
+                    }
+                    Err(err)
+                }
             }
         } else {
             // Already idle — drain the promoted item out.
@@ -1080,7 +1115,7 @@ mod tests {
     #[test]
     fn promote_queued_to_front_unknown_id_is_noop() {
         let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
-        assert!(!promote_queued_to_front(&mut q, "missing"));
+        assert_eq!(promote_queued_to_front(&mut q, "missing"), None);
         let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
         assert_eq!(ids, ["a", "b"]);
     }
@@ -1088,7 +1123,8 @@ mod tests {
     #[test]
     fn promote_queued_to_front_moves_mid_queue_item() {
         let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b"), queued("c")].into();
-        assert!(promote_queued_to_front(&mut q, "c"));
+        // Returns the item's original index so the reorder can be undone.
+        assert_eq!(promote_queued_to_front(&mut q, "c"), Some(2));
         let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
         assert_eq!(ids, ["c", "a", "b"]);
     }
@@ -1096,8 +1132,38 @@ mod tests {
     #[test]
     fn promote_queued_to_front_head_item_stays_put() {
         let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
-        assert!(promote_queued_to_front(&mut q, "a"));
+        assert_eq!(promote_queued_to_front(&mut q, "a"), Some(0));
         let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
         assert_eq!(ids, ["a", "b"]);
+    }
+
+    #[test]
+    fn restore_queued_position_undoes_a_promotion() {
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b"), queued("c")].into();
+        let idx = promote_queued_to_front(&mut q, "c").unwrap();
+        assert_eq!(idx, 2);
+        restore_queued_position(&mut q, "c", idx);
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn restore_queued_position_already_dispatched_is_noop() {
+        // The item was promoted then removed (dispatched/cancelled)
+        // before restore ran — restoring is a harmless no-op.
+        let mut q: VecDeque<QueuedTurn> = [queued("a"), queued("b")].into();
+        restore_queued_position(&mut q, "gone", 1);
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "b"]);
+    }
+
+    #[test]
+    fn restore_queued_position_clamps_out_of_range_index() {
+        // A stale original index past the current end clamps to the tail
+        // rather than panicking.
+        let mut q: VecDeque<QueuedTurn> = [queued("c"), queued("a")].into();
+        restore_queued_position(&mut q, "c", 9);
+        let ids: Vec<_> = q.iter().map(|t| t.queued_id.as_str()).collect();
+        assert_eq!(ids, ["a", "c"]);
     }
 }

--- a/src-tauri/src/agent_provider/provider.rs
+++ b/src-tauri/src/agent_provider/provider.rs
@@ -70,6 +70,23 @@ pub trait AgentProvider: Send + Sync {
         Ok(())
     }
 
+    /// **Send now (steer):** promote a queued follow-up to the front of
+    /// the queue and dispatch it immediately, soft-interrupting the active
+    /// turn if one is running. The interrupt preserves the session,
+    /// transcript, and on-disk work — nothing is discarded — and the
+    /// promoted message then runs as a normal follow-up turn so the agent
+    /// re-plans with the steer. Idempotent — an unknown or
+    /// already-dispatched id is a silent success. The default
+    /// implementation is a no-op for providers without a follow-up queue
+    /// (e.g. OpenCode).
+    async fn send_queued_turn_now(
+        &self,
+        _thread_id: ThreadId,
+        _queued_id: String,
+    ) -> Result<(), ProviderError> {
+        Ok(())
+    }
+
     /// Respond to a pending approval request with the user's decision.
     async fn respond_to_request(
         &self,

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -1118,6 +1118,33 @@ pub async fn agent_chat_cancel_queued_turn(
         .map_err(provider_err)
 }
 
+/// Send a queued (not-yet-dispatched) follow-up turn **now**: promote it
+/// to the front of the queue and dispatch it immediately, soft-interrupting
+/// the active turn if one is running. The interrupt preserves the session,
+/// the full transcript, and all on-disk work — nothing is discarded — and
+/// the message then runs as a normal follow-up turn so the agent re-plans
+/// with the steer. Idempotent — an unknown or already-dispatched id is a
+/// silent success. No persistence work here: the interrupt's `Ready` state
+/// events settle the composer and the provider's `QueuedTurnDispatched`
+/// event (handled in [`forward_event`]) promotes the bubble and writes the
+/// deferred user-message envelope, attaching any `pending_queued_images`.
+#[tauri::command]
+pub async fn agent_chat_send_queued_turn_now(
+    app: AppHandle,
+    provider: ProviderKind,
+    thread_id: ThreadId,
+    queued_id: String,
+) -> Result<(), String> {
+    let observability: State<'_, ObservabilityStore> = app.state();
+    feature_flag_on(&observability)?;
+    let registry: State<'_, ProviderRegistry> = app.state();
+    let impl_ = lookup_provider(&registry, provider).await?;
+    impl_
+        .send_queued_turn_now(thread_id, queued_id)
+        .await
+        .map_err(provider_err)
+}
+
 /// A chat image attachment that has been written to disk for the
 /// transcript. User messages (and their images) never come back through
 /// the provider event stream, so the only record of an attachment is the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1587,6 +1587,7 @@ pub fn run() {
             commands::agent_chat_start_session,
             commands::agent_chat_send_turn,
             commands::agent_chat_cancel_queued_turn,
+            commands::agent_chat_send_queued_turn_now,
             commands::agent_chat_interrupt_turn,
             commands::agent_chat_respond_to_request,
             commands::agent_chat_set_model,

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -57,6 +57,7 @@ import {
 import {
   activateWorkspace,
   agentChatCancelQueuedTurn,
+  agentChatSendQueuedTurnNow,
   agentChatGetSession,
   agentChatInterruptTurn,
   agentChatListMessages,
@@ -1698,6 +1699,22 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     [threadId, provider, setInputDraft],
   );
 
+  // Follow-up queueing: send a queued turn NOW (steer). The backend
+  // promotes it to the front of the queue and soft-interrupts the active
+  // turn — the session, transcript, and on-disk work are all preserved —
+  // then dispatches it as a normal follow-up. No optimistic state change:
+  // the `queued_turn_dispatched` event promotes the greyed bubble and the
+  // interrupt's `ready`/`running` state events settle the composer.
+  const handleSendQueuedNow = useCallback(
+    (queuedId: string) => {
+      if (!threadId) return;
+      agentChatSendQueuedTurnNow(provider, threadId, queuedId).catch((err) => {
+        toast.error(`Failed to send queued message: ${err}`);
+      });
+    },
+    [threadId, provider],
+  );
+
   const handleRespond = useCallback(
     (requestId: string, decision: ApprovalDecision) => {
       if (!threadId) return;
@@ -2644,6 +2661,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
               onAcceptPlan={handleAcceptPlan}
               onRejectPlan={handleRejectPlan}
               onCancelQueued={handleCancelQueued}
+              onSendQueuedNow={handleSendQueuedNow}
               onEnterSubagent={handleEnterSubagent}
               workspaceId={workspaceIdForPane}
             />

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -1605,15 +1605,16 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   }, [isSending, streaming, activeTurnId]);
 
   // Interrupt mechanic: the SDK's `query.interrupt()` causes its
-  // async iterator to exit. The session is functionally dead after
-  // that (ClaudeAdapter.ts:2363 calls `stopSessionInternal`
-  // unconditionally). The reference impl's next `sendTurn` creates
-  // a brand-new SDK query transparently via
-  // `ensureSessionForThread`. Our Rust adapter has no equivalent
-  // auto-recreate, so we do it proactively:
-  // interrupt for the immediate turn abort, then stop + start the
-  // session so subsequent turns land on a live SDK query. Transcript
-  // and picker state persist via `migrateThreadId`.
+  // async iterator to exit, so the underlying SDK query is dead after
+  // an interrupt. The sidecar now recovers from that transparently —
+  // like the reference multi-provider client, its next `send-turn`
+  // rebuilds a resumed SDK query for the (surviving) session, so a bare
+  // interrupt already lets subsequent turns land on a live query.
+  // The Stop button still performs a deliberate hard reset: interrupt
+  // for the immediate turn abort, then stop + start the session (fresh
+  // thread id, resume cursor) so subsequent turns land on a known-good
+  // SDK query and any wedged sidecar state is cleared. Transcript and
+  // picker state persist via `migrateThreadId`.
   const handleStop = useCallback(() => {
     if (!threadId) return;
     if (restarting) return;

--- a/src/components/chat/ChatTranscript.tsx
+++ b/src/components/chat/ChatTranscript.tsx
@@ -23,6 +23,9 @@ interface Props {
   /** Follow-up queueing: cancel a queued turn (X on the greyed bubble).
    *  `text` is passed back so the caller can restore it to the composer. */
   onCancelQueued?: (queuedId: string, text: string) => void;
+  /** Follow-up queueing: send a queued turn now (steer) — soft-interrupts
+   *  the active turn and dispatches this message immediately. */
+  onSendQueuedNow?: (queuedId: string) => void;
   /** Enter a subagent's read-only drill-in (design "Enter subagent"). */
   onEnterSubagent?: (subagentId: string) => void;
   /** Forwarded to MessageList for the WorkflowRunCard "Open panel"
@@ -46,6 +49,7 @@ export function ChatTranscript({
   onAcceptPlan,
   onRejectPlan,
   onCancelQueued,
+  onSendQueuedNow,
   onEnterSubagent,
   workspaceId,
 }: Props) {
@@ -63,6 +67,7 @@ export function ChatTranscript({
         onAcceptPlan={onAcceptPlan}
         onRejectPlan={onRejectPlan}
         onCancelQueued={onCancelQueued}
+        onSendQueuedNow={onSendQueuedNow}
         onEnterSubagent={onEnterSubagent}
         workspaceId={workspaceId}
       />

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -73,6 +73,9 @@ interface Props {
   /** Follow-up queueing: cancel a queued user turn. `text` is passed
    *  back so the caller can restore it into the composer. */
   onCancelQueued?: (queuedId: string, text: string) => void;
+  /** Follow-up queueing: send a queued user turn now (steer) —
+   *  soft-interrupts the active turn and dispatches it immediately. */
+  onSendQueuedNow?: (queuedId: string) => void;
   /** Enter a subagent's read-only drill-in (design "Enter subagent").
    *  Wired by AgentChatPane's viewMode state; absent → the card's Enter
    *  affordance is inert. */
@@ -136,6 +139,7 @@ export function MessageList({
   onAcceptPlan,
   onRejectPlan,
   onCancelQueued,
+  onSendQueuedNow,
   onEnterSubagent,
   workspaceId,
 }: Props) {
@@ -260,6 +264,7 @@ export function MessageList({
                 onAcceptPlan={onAcceptPlan}
                 onRejectPlan={onRejectPlan}
                 onCancelQueued={onCancelQueued}
+                onSendQueuedNow={onSendQueuedNow}
                 onEnterSubagent={onEnterSubagent}
               />
             ))}
@@ -432,6 +437,7 @@ function ItemRow({
   onAcceptPlan,
   onRejectPlan,
   onCancelQueued,
+  onSendQueuedNow,
   onEnterSubagent,
   workspaceId,
 }: {
@@ -444,6 +450,7 @@ function ItemRow({
   onAcceptPlan: (requestId: string) => void | Promise<void>;
   onRejectPlan: (requestId: string) => void | Promise<void>;
   onCancelQueued?: (queuedId: string, text: string) => void;
+  onSendQueuedNow?: (queuedId: string) => void;
   onEnterSubagent?: (subagentId: string) => void;
   workspaceId?: string | null;
 }) {
@@ -473,7 +480,13 @@ function ItemRow({
   }, [item, onRejectPlan]);
 
   if (item.kind === "user_message") {
-    return <UserMessage item={item} onCancelQueued={onCancelQueued} />;
+    return (
+      <UserMessage
+        item={item}
+        onCancelQueued={onCancelQueued}
+        onSendQueuedNow={onSendQueuedNow}
+      />
+    );
   }
 
   // The orchestration card is a full-width standalone surface (no avatar
@@ -643,6 +656,7 @@ function SlotRow({
   onAcceptPlan,
   onRejectPlan,
   onCancelQueued,
+  onSendQueuedNow,
   onEnterSubagent,
 }: {
   slot: TranscriptSlot;
@@ -654,6 +668,7 @@ function SlotRow({
   onAcceptPlan: (requestId: string) => void | Promise<void>;
   onRejectPlan: (requestId: string) => void | Promise<void>;
   onCancelQueued?: (queuedId: string, text: string) => void;
+  onSendQueuedNow?: (queuedId: string) => void;
   onEnterSubagent?: (subagentId: string) => void;
 }) {
   return (
@@ -689,6 +704,7 @@ function SlotRow({
           onAcceptPlan={onAcceptPlan}
           onRejectPlan={onRejectPlan}
           onCancelQueued={onCancelQueued}
+          onSendQueuedNow={onSendQueuedNow}
           onEnterSubagent={onEnterSubagent}
           workspaceId={workspaceId}
         />

--- a/src/components/chat/UserMessage.tsx
+++ b/src/components/chat/UserMessage.tsx
@@ -1,5 +1,5 @@
 import { memo, useState } from "react";
-import { ImageOff, X } from "lucide-react";
+import { CornerDownLeft, ImageOff, X } from "lucide-react";
 
 import {
   Dialog,
@@ -26,15 +26,19 @@ import { cn } from "@/lib/utils";
  *
  * Follow-up queueing: while `item.queued` is set the bubble renders
  * greyed-out (reduced opacity + muted foreground) with a small "Queued"
- * pill and, on hover, an X to cancel — cancelling restores the text into
- * the composer (handled by the parent). All colors are theme tokens.
+ * pill and, on hover, two actions — "Send now" (steer: soft-interrupt the
+ * active turn and dispatch this message immediately, keeping all progress)
+ * and an X to cancel (restores the text into the composer). Both are
+ * handled by the parent. All colors are theme tokens.
  */
 export const UserMessage = memo(function UserMessage({
   item,
   onCancelQueued,
+  onSendQueuedNow,
 }: {
   item: UserMessageItem;
   onCancelQueued?: (queuedId: string, text: string) => void;
+  onSendQueuedNow?: (queuedId: string) => void;
 }) {
   const queued = item.queued;
   const images = item.images ?? [];
@@ -76,6 +80,18 @@ export const UserMessage = memo(function UserMessage({
             <span className="rounded-full bg-muted px-2 py-[1px] text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
               Queued
             </span>
+            {onSendQueuedNow ? (
+              <button
+                type="button"
+                aria-label="Send now"
+                title="Interrupt current work and send this message now — progress so far is kept"
+                onClick={() => onSendQueuedNow(queued.queuedId)}
+                className="flex items-center gap-0.5 rounded text-[10px] text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+              >
+                <CornerDownLeft className="h-3 w-3" aria-hidden />
+                Send now
+              </button>
+            ) : null}
             {onCancelQueued ? (
               <button
                 type="button"

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -722,6 +722,10 @@ interface MockQueuedTurn {
   clientNonce: string | null;
 }
 const chatQueues = new Map<string, MockQueuedTurn[]>();
+// The active streaming turn's interval id per thread, so a soft interrupt
+// (stop button / "Send now" steer) can end the turn early — mirroring the
+// real backend's `interrupt`, which preserves the session and transcript.
+const chatTurnTimers = new Map<string, number>();
 
 /** Pop the next queued follow-up (if any) and dispatch it, mirroring the
  *  provider's drain-on-completion. */
@@ -737,6 +741,27 @@ function drainChatQueue(threadId: string): void {
     turn_id: turnId,
     text: next.text,
   });
+}
+
+/** Soft-interrupt the active streaming turn, mirroring the real Claude
+ *  `interrupt`: stop the stream and flip the session back to `ready`
+ *  WITHOUT discarding anything already emitted. Returns `true` when a turn
+ *  was actually running. Does NOT drain — the caller decides what to
+ *  dispatch next. */
+function interruptMockChatTurn(threadId: string): boolean {
+  if (!chatActiveTurns.has(threadId)) return false;
+  const timer = chatTurnTimers.get(threadId);
+  if (timer !== undefined) {
+    window.clearInterval(timer);
+    chatTurnTimers.delete(threadId);
+  }
+  chatActiveTurns.delete(threadId);
+  emitChatEvent(threadId, {
+    type: "session_state_changed",
+    thread_id: threadId,
+    status: { status: "ready" },
+  });
+  return true;
 }
 
 /** Simulate a streaming assistant reply on the real event channel.
@@ -935,9 +960,11 @@ function streamMockChatReply(
       });
       // Turn done — drain the next queued follow-up (FIFO).
       chatActiveTurns.delete(threadId);
+      chatTurnTimers.delete(threadId);
       drainChatQueue(threadId);
     }
   }, intervalMs);
+  chatTurnTimers.set(threadId, timer);
   return turnId;
 }
 
@@ -1465,6 +1492,28 @@ const handlers: Record<string, Handler> = {
         });
       }
     }
+    return undefined;
+  },
+  agent_chat_send_queued_turn_now: (a) => {
+    const { threadId, queuedId } = a as {
+      threadId: string;
+      queuedId: string;
+    };
+    const q = chatQueues.get(threadId);
+    const idx = q ? q.findIndex((e) => e.queuedId === queuedId) : -1;
+    // Unknown / already-dispatched id — idempotent no-op, matching the
+    // real backend.
+    if (!q || idx < 0) return undefined;
+    // Promote the item to the front of the queue so the drain dispatches
+    // it next (mirrors `promote_queued_to_front`).
+    if (idx > 0) {
+      const [item] = q.splice(idx, 1);
+      q.unshift(item);
+    }
+    // Soft-interrupt the active turn (if any); either way, drain the
+    // now-front item out immediately.
+    interruptMockChatTurn(threadId);
+    drainChatQueue(threadId);
     return undefined;
   },
   agent_chat_interrupt_turn: () => undefined,

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1280,6 +1280,22 @@ export const agentChatCancelQueuedTurn = (
     queuedId,
   });
 
+/** Send a queued (not-yet-dispatched) follow-up turn **now**: the backend
+ *  promotes it to the front of the queue and soft-interrupts the active
+ *  turn (session, transcript, and on-disk work are preserved), then
+ *  dispatches it as a normal follow-up. The `queued_turn_dispatched` event
+ *  promotes the greyed bubble — no optimistic state change needed here. */
+export const agentChatSendQueuedTurnNow = (
+  provider: AgentChatProviderKind,
+  threadId: string,
+  queuedId: string,
+) =>
+  invoke<void>("agent_chat_send_queued_turn_now", {
+    provider,
+    threadId,
+    queuedId,
+  });
+
 export const agentChatRespondToRequest = (
   provider: AgentChatProviderKind,
   threadId: string,


### PR DESCRIPTION
## Summary

Adds a **"Send now"** action to queued follow-up messages, so a user can steer a running agent without waiting for the whole turn to finish — and without losing anything.

Previously, a message sent while a turn was in flight queued behind it and only dispatched when the turn fully completed. That wastes tokens on a stale plan when the user's follow-up was meant to redirect the work. This mirrors Claude Code's documented interrupt-and-resubmit steering path (true inject-into-live-turn steering isn't exposed by the Agent SDK yet — see docs update).

**Nothing is discarded:** the interrupt is a soft stop — same SDK session, full transcript preserved, all on-disk work from the turn (including subagents) kept. The queued message simply dispatches immediately as a normal follow-up turn, in real turn order.

## How it works

- `send_queued_now()` on the Claude and Codex sessions promotes the queued item to the front of the follow-up queue, then reuses the existing interrupt + `drain_queue` machinery:
  - **Claude:** `interrupt` already flips the session to `Ready` and drains inline — the promoted item goes out next.
  - **Codex:** `turn/interrupt` aborts; the event loop drains when the session returns to `Ready`. A "no active turn" race falls back to draining directly.
- Idempotent semantics matching `cancel_queued`: an unknown / already-dispatched id is a silent no-op.
- Pending approvals behave exactly like a manual stop-button interrupt: an outstanding approval holds the dispatch until resolved (no new approval-clearing behavior invented).
- New `agent_chat_send_queued_turn_now` command mirrors `agent_chat_cancel_queued_turn`; the provider trait default is a no-op for queue-less providers (OpenCode).
- No reducer or persistence changes needed — the existing `QueuedTurnDispatched` event promotes the greyed bubble and writes the deferred user-message envelope (with any stashed images) in real turn order.
- UI: hover-reveal "Send now" (↵) button beside Cancel on the queued bubble, theme tokens only.
- Dev mock: soft-interrupt support so the whole flow is demoable in `npm run dev`.

## Verification

- `cargo check` / `cargo test` — pass (6 new unit tests for the queue-promotion helper)
- `npm run check` / `npm run test` — pass (one pre-existing flaky teardown failure in `new-workspace-dialog.test.tsx`, passes in isolation)
- Verified end-to-end in the browser against the dev mock: queued a steer message mid-turn, clicked "Send now" — queued pill cleared, the steer dispatched as its own follow-up turn, and the interrupted turn's partial output remained in the transcript.

## Docs

`docs/features/agent-chat.md` § Follow-up queueing gains a "Send now (steer)" subsection; the steering TODO is updated: interrupt-based send-now is done, inject-into-live-turn (`streamInput`) remains out of scope pending Agent SDK support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
