### PR TITLE
fix(agent-chat): stop labeling a live run as interrupted after a workspace switch

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -814,6 +814,32 @@ A new `interrupted` flag on `ChatThreadState`
   `user_message` envelope has no later `turn_completed`; `replayPayloads`
   ORs that with the replay-observed `child_exited` completion so both the
   "app died mid-turn" and "watchdog settled the turn" cases surface.
+- **Live-run guard on hydrate** — `lastTurnUnsettled` cannot distinguish
+  "run died mid-turn" from "run is healthy but the pane wasn't watching":
+  only the active workspace renders, so switching workspaces unmounts the
+  inactive pane while its run keeps going and keeps persisting rows
+  (subagent `item_completed`s in particular grow the disk transcript past
+  the frozen in-memory slice, which is exactly what lets the remount
+  hydrate guard pass). Before this guard, switching back to a workspace
+  mid-run reliably showed a false "Run interrupted" divider + Continue
+  chip until the next live event cleared it. The remount hydrate effect
+  (`AgentChatPane.tsx`) now probes the backend **after** fetching the
+  payloads (ordering matters: if the turn settles between the two calls,
+  the settling `turn_completed` row is already in the fetched payloads,
+  so a stale "alive" answer can't mislabel a finished run) via the new
+  `agent_chat_turn_active` command — true iff a live (non-dead) session
+  is bound to the thread and its `active_turn` is set. The result is
+  threaded as `hydrateThread(threadId, payloads, { runLive })` →
+  `replayPayloads(payloads, { runLive })`: `runLive: true` forces
+  `interrupted: false` (suppressing both the unsettled-tail heuristic and
+  a replay-observed `child_exited` — an in-flight turn means the run is
+  alive/recovered) and sets `streaming: true` so the streaming marker
+  shows instead of the divider. A probe error degrades to `false`
+  (previous behavior). Backend: default trait method
+  `AgentProvider::turn_active` (false), implemented for Claude and Codex
+  as a cheap in-memory `sessions` map check (`!is_dead()` +
+  `active_turn.is_some()`) and for OpenCode via the session's SSE
+  event-context `turn_active` flag behind the same absent/dead guards.
 - **Live detection** — the reducer sets `interrupted` on a
   `turn_completed` with `subtype === "child_exited"` and (belt-and-braces)
   on a `session_state_changed{error}` while streaming. It clears on the
@@ -1516,6 +1542,7 @@ surfacing a `feature_disabled` string.
 | `agent_chat_start_session` | Start a provider session, writing the returned thread id back onto the pane. |
 | `agent_chat_send_turn` | Queue a user turn on a thread. Auto-resumes a dead session (rebuilt from its persisted row) before the turn, so a pane reopened after an app restart never sees `session_not_found`. |
 | `agent_chat_interrupt_turn` | Halt the currently-running turn. On a live session the turn ends as `TurnCompleted(interrupted)` and the session stays `Ready` (the sidecar keeps the thread alive and the next `send_turn` rebuilds a resumed query). A `SessionNotFound` (nothing to interrupt on an already-dead session) is swallowed into `Ok`; unlike `send_turn` it does NOT auto-resume a dead session just to interrupt it. |
+| `agent_chat_turn_active` | Cheap in-memory liveness probe: `true` iff a live (non-dead) session is bound to the thread and its `active_turn` is set (Running or WaitingApproval). Never touches the subprocess and never auto-resumes. Used by the remount hydrate path to suppress the false "Run interrupted" divider on a healthy mid-flight run (see "Live-run guard on hydrate"). |
 | `agent_chat_respond_to_request` | Resolve a pending approval / input request. Auto-resumes a dead session first (same choke point as `send_turn`). |
 | `agent_chat_set_model` | Swap a thread's model. Persist-always, apply-if-live: writes the model to the session row unconditionally, then applies to the live session if one exists; a `SessionNotFound` from the apply is swallowed into `Ok` (the value takes effect on the next auto-resume). |
 | `agent_chat_set_permission_mode` | Swap a thread's permission mode. Same persist-always, apply-if-live contract as `agent_chat_set_model`. |

--- a/src-tauri/src/agent_provider/claude/mod.rs
+++ b/src-tauri/src/agent_provider/claude/mod.rs
@@ -355,6 +355,25 @@ impl AgentProvider for ClaudeAgentProvider {
             .is_some_and(|session| !session.is_dead())
     }
 
+    async fn turn_active(&self, thread_id: &ThreadId) -> bool {
+        // Cheap in-memory check for the frontend hydrate path: a live
+        // (non-dead) session bound to the thread with `active_turn` set. Does
+        // not touch the sidecar. A dead session (watchdog fired) reports false
+        // even if a turn was mid-flight when the child exited.
+        let session = {
+            let sessions = self.sessions.read().await;
+            sessions.get(thread_id).cloned()
+        };
+        let Some(session) = session else {
+            return false;
+        };
+        if session.is_dead() {
+            return false;
+        }
+        let state = session.state.lock().await;
+        state.active_turn.is_some()
+    }
+
     async fn list_sessions(&self) -> Result<Vec<ProviderSession>, ProviderError> {
         let sessions = self.collect_sessions().await;
         let mut out = Vec::with_capacity(sessions.len());

--- a/src-tauri/src/agent_provider/codex/mod.rs
+++ b/src-tauri/src/agent_provider/codex/mod.rs
@@ -353,6 +353,25 @@ impl AgentProvider for CodexAgentProvider {
             .is_some_and(|session| !session.is_dead())
     }
 
+    async fn turn_active(&self, thread_id: &ThreadId) -> bool {
+        // Cheap in-memory check for the frontend hydrate path: a live
+        // (non-dead) session bound to the thread with `active_turn` set. Does
+        // not touch the `codex app-server`. A dead session (watchdog fired)
+        // reports false even if a turn was mid-flight when the child exited.
+        let session = {
+            let sessions = self.sessions.read().await;
+            sessions.get(thread_id).cloned()
+        };
+        let Some(session) = session else {
+            return false;
+        };
+        if session.is_dead() {
+            return false;
+        }
+        let state = session.state.lock().await;
+        state.active_turn.is_some()
+    }
+
     async fn list_sessions(&self) -> Result<Vec<ProviderSession>, ProviderError> {
         let sessions = self.collect_sessions().await;
         let mut out = Vec::with_capacity(sessions.len());

--- a/src-tauri/src/agent_provider/opencode/agent.rs
+++ b/src-tauri/src/agent_provider/opencode/agent.rs
@@ -304,6 +304,24 @@ impl AgentProvider for OpenCodeAgentProvider {
             .is_some_and(|session| !session.is_dead())
     }
 
+    async fn turn_active(&self, thread_id: &ThreadId) -> bool {
+        // Cheap in-memory check for the frontend hydrate path: a live
+        // (non-dead) session bound to the thread whose SSE routing context has
+        // `turn_active` armed. Does not touch the server. A dead session
+        // (SSE listener gave up) reports false.
+        let session = {
+            let sessions = self.sessions.read().await;
+            sessions.get(thread_id).cloned()
+        };
+        let Some(session) = session else {
+            return false;
+        };
+        if session.is_dead() {
+            return false;
+        }
+        session.turn_active().await
+    }
+
     async fn list_sessions(&self) -> Result<Vec<ProviderSession>, ProviderError> {
         let sessions = self.sessions.read().await;
         let mut out = Vec::with_capacity(sessions.len());

--- a/src-tauri/src/agent_provider/opencode/session.rs
+++ b/src-tauri/src/agent_provider/opencode/session.rs
@@ -228,6 +228,13 @@ impl OpenCodeSession {
         self.dead.load(Ordering::Relaxed)
     }
 
+    /// Whether a turn is currently in flight on this session. Reads the
+    /// SSE routing context's `turn_active` flag (armed on send, cleared when
+    /// the turn settles). Cheap in-memory check — does not touch the server.
+    pub async fn turn_active(&self) -> bool {
+        self.event_ctx.lock().await.turn_active
+    }
+
     /// Send a user turn. Mints a new Codemux turn id, threads it into
     /// the SSE routing context, then `POST`s `prompt_async`.
     pub async fn send_turn(

--- a/src-tauri/src/agent_provider/provider.rs
+++ b/src-tauri/src/agent_provider/provider.rs
@@ -125,6 +125,19 @@ pub trait AgentProvider: Send + Sync {
     /// operation can proceed.
     async fn has_session(&self, thread_id: &ThreadId) -> bool;
 
+    /// Whether a live turn is currently in flight on `thread_id`.
+    ///
+    /// Cheap in-memory check: true iff a live (non-dead) session is bound to
+    /// the thread AND its `active_turn` is set (i.e. a turn is Running or
+    /// WaitingApproval). Must not touch the subprocess. The frontend hydrate
+    /// path uses this to distinguish "run still in flight" from "run died
+    /// mid-turn", so a healthy run is not falsely labeled "Run interrupted"
+    /// after a workspace switch remount. Defaults to `false` so providers
+    /// without support are safe.
+    async fn turn_active(&self, _thread_id: &ThreadId) -> bool {
+        false
+    }
+
     /// Subscribe to the canonical runtime event stream.
     ///
     /// Each call typically returns a fresh subscription; implementations are

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -1364,6 +1364,28 @@ pub async fn agent_chat_interrupt_turn(
     }
 }
 
+/// Whether a live turn is currently in flight on a thread.
+///
+/// Cheap in-memory probe used by the frontend hydrate-on-remount path to
+/// tell "run still in flight" apart from "run died mid-turn": a healthy
+/// mid-flight run must not be labeled "Run interrupted" after a workspace
+/// switch remount. Deliberately does NOT auto-resume — this is a read-only
+/// check against the provider's live session registry, and a thread with no
+/// live session (e.g. after a restart) is correctly `false`. The frontend
+/// treats any error as `false`, so gating/lookup failures degrade safely.
+#[tauri::command]
+pub async fn agent_chat_turn_active(
+    app: AppHandle,
+    provider: ProviderKind,
+    thread_id: ThreadId,
+) -> Result<bool, String> {
+    let observability: State<'_, ObservabilityStore> = app.state();
+    feature_flag_on(&observability)?;
+    let registry: State<'_, ProviderRegistry> = app.state();
+    let impl_ = lookup_provider(&registry, provider).await?;
+    Ok(impl_.turn_active(&thread_id).await)
+}
+
 /// Respond to a pending approval / tool / input request.
 #[tauri::command]
 pub async fn agent_chat_respond_to_request(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1598,6 +1598,7 @@ pub fn run() {
             commands::agent_chat_cancel_queued_turn,
             commands::agent_chat_send_queued_turn_now,
             commands::agent_chat_interrupt_turn,
+            commands::agent_chat_turn_active,
             commands::agent_chat_respond_to_request,
             commands::agent_chat_set_model,
             commands::agent_chat_set_permission_mode,

--- a/src-tauri/tests/claude_adapter.rs
+++ b/src-tauri/tests/claude_adapter.rs
@@ -1373,6 +1373,119 @@ async fn dead_sidecar_is_evicted_and_start_session_rebuilds() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_active_false_for_unknown_thread() {
+    // The frontend hydrate path treats an unbound thread as "not in flight".
+    let provider = provider_with_fake().await;
+    assert!(
+        !provider.turn_active(&ThreadId("t-unknown".into())).await,
+        "no session bound => turn_active must be false"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_active_true_in_flight_then_false_after_settle() {
+    // A `result` at the turn boundary clears `active_turn` while the
+    // streaming-queue session stays alive, so turn_active flips true->false
+    // without the session disappearing.
+    let script = write_script(json!([
+        {
+            "after": "send-turn", "delay_ms": 300, "emit": "notification",
+            "method": "sdk-message",
+            "params": {
+                "threadId": "t-ta",
+                "message": {
+                    "type": "result", "subtype": "success",
+                    "turn_id": "sdk-turn-1", "duration_ms": 10, "num_turns": 1
+                }
+            }
+        }
+    ]));
+    let wrapper = wrapper_with_env(&[(
+        "FAKE_CLAUDE_SIDECAR_SCRIPT",
+        &script.path.to_string_lossy(),
+    )]);
+    let provider = provider_with_custom_sidecar(wrapper.path.clone()).await;
+    provider.start_session(start_input("t-ta")).await.unwrap();
+    assert!(
+        !provider.turn_active(&ThreadId("t-ta".into())).await,
+        "no turn yet => false"
+    );
+    provider
+        .send_turn(SendTurnInput {
+            thread_id: ThreadId("t-ta".into()),
+            text: "hi".into(),
+            images: vec![],
+            model_override: None,
+            effort_override: None,
+            permission_mode_override: None,
+            client_nonce: None,
+        })
+        .await
+        .unwrap();
+    // `active_turn` is armed synchronously before send_turn returns.
+    assert!(
+        provider.turn_active(&ThreadId("t-ta".into())).await,
+        "turn in flight => true"
+    );
+    // The scripted result settles the turn ~300ms later.
+    let settled = timeout(Duration::from_secs(3), async {
+        loop {
+            if !provider.turn_active(&ThreadId("t-ta".into())).await {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(settled.is_ok(), "turn_active must return to false after settle");
+    assert!(
+        provider.has_session(&ThreadId("t-ta".into())).await,
+        "session stays live across the turn boundary"
+    );
+    provider.stop_session(ThreadId("t-ta".into())).await.ok();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_active_false_when_session_dead() {
+    // Mid-turn child death: the watchdog flips `dead`, and turn_active's
+    // is_dead() short-circuit reports false for the corpse even though a turn
+    // was in flight when the child exited — so hydrate treats a died-mid-turn
+    // run as "not in flight" (it gets the interrupted marker via other means).
+    let wrapper = wrapper_with_env(&[("FAKE_CLAUDE_SIDECAR_EXIT_AFTER", "send-turn")]);
+    let provider = provider_with_custom_sidecar(wrapper.path.clone()).await;
+    let thread = ThreadId("t-ta-dead".into());
+    provider.start_session(start_input("t-ta-dead")).await.unwrap();
+    provider
+        .send_turn(SendTurnInput {
+            thread_id: thread.clone(),
+            text: "x".into(),
+            images: vec![],
+            model_override: None,
+            effort_override: None,
+            permission_mode_override: None,
+            client_nonce: None,
+        })
+        .await
+        .expect("send_turn must succeed: the response is written before the exit");
+    // Wait for the watchdog (100ms poll) to observe the dead child.
+    let went_absent = timeout(Duration::from_secs(4), async {
+        loop {
+            if !provider.has_session(&thread).await {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+    assert!(went_absent.is_ok(), "watchdog must mark the session dead");
+    assert!(
+        !provider.turn_active(&thread).await,
+        "a dead session must report turn_active false"
+    );
+    provider.stop_session(thread).await.ok();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn session_ended_with_iteration_complete_emits_turn_completed_success() {
     let script = write_script(json!([
         {

--- a/src-tauri/tests/codex_adapter.rs
+++ b/src-tauri/tests/codex_adapter.rs
@@ -540,6 +540,71 @@ async fn interrupt_turn_with_wrong_turn_id_fails_validation() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_active_false_for_unknown_thread() {
+    // The frontend hydrate path treats an unbound thread as "not in flight".
+    let provider = provider_with_fixture();
+    assert!(
+        !provider.turn_active(&ThreadId("t-unknown".into())).await,
+        "no session bound => turn_active must be false"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_active_true_in_flight_then_false_after_settle() {
+    // `turn/started` arms `active_turn`; `turn/completed` clears it. The
+    // frontend hydrate path reads turn_active to tell "run still in flight"
+    // apart from "run died mid-turn".
+    let script = write_script(json!([
+        {"after":"turn/start","delay_ms":5,"emit":"notification","method":"turn/started",
+         "params":{"threadId":"c-1","turnId":"t-ta-1"}},
+        {"after":"turn/start","delay_ms":250,"emit":"notification","method":"turn/completed",
+         "params":{"threadId":"c-1","turnId":"t-ta-1","status":"succeeded"}}
+    ]));
+    let wrapper = wrapper_with_env(&[("FAKE_CODEX_SCRIPT", &script.to_string_lossy())]);
+    let provider = provider_with_fixture_and_binary(wrapper.to_path_buf());
+    start_session_resilient(&provider, start_input("t-ta")).await.unwrap();
+    assert!(
+        !provider.turn_active(&ThreadId("t-ta".into())).await,
+        "no turn yet => false"
+    );
+    provider
+        .send_turn(SendTurnInput {
+            thread_id: ThreadId("t-ta".into()),
+            text: "hi".into(),
+            images: vec![],
+            model_override: None,
+            effort_override: None,
+            permission_mode_override: None,
+            client_nonce: None,
+        })
+        .await
+        .unwrap();
+    // `active_turn` is armed asynchronously by the scripted turn/started.
+    let armed = timeout(Duration::from_secs(3), async {
+        loop {
+            if provider.turn_active(&ThreadId("t-ta".into())).await {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    assert!(armed.is_ok(), "turn/started must arm turn_active");
+    // turn/completed settles the turn ~250ms later.
+    let settled = timeout(Duration::from_secs(3), async {
+        loop {
+            if !provider.turn_active(&ThreadId("t-ta".into())).await {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+    assert!(settled.is_ok(), "turn_active must return to false after settle");
+    provider.stop_session(ThreadId("t-ta".into())).await.ok();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn set_permission_mode_returns_validation_error() {
     let provider = provider_with_fixture();
     start_session_resilient(&provider, start_input("t-perm")).await.unwrap();

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -293,6 +293,10 @@ vi.mock("@/tauri/commands", () => ({
   // with a truthy threadId — return an empty transcript so the effect
   // short-circuits without exercising the resume path in unit tests.
   agentChatListMessages: vi.fn().mockResolvedValue([]),
+  // Liveness probe fired right after `agentChatListMessages` on the
+  // hydrate path. Default to `false` (no live turn) so hydrate keeps its
+  // resume-path behavior unless a test opts into the live-run case.
+  agentChatTurnActive: vi.fn().mockResolvedValue(false),
   // The D2 session-start marker effect looks the active thread up in the
   // persisted sessions list; default to empty so it clears to the plain
   // divider unless a test seeds a record.
@@ -491,6 +495,7 @@ import { AgentChatPane } from "./AgentChatPane";
 import {
   agentChatGetSession,
   agentChatListMessages,
+  agentChatTurnActive,
   agentChatListSessions,
   agentChatSendTurn,
   agentChatSetPermissionMode,
@@ -676,6 +681,8 @@ describe("AgentChatPane hydrate-on-mount (workspace swap recovery)", () => {
     workspaceIdForPaneOverride = "ws-home";
     vi.mocked(agentChatListMessages).mockReset();
     vi.mocked(agentChatListMessages).mockResolvedValue([]);
+    vi.mocked(agentChatTurnActive).mockReset();
+    vi.mocked(agentChatTurnActive).mockResolvedValue(false);
     hydrateThreadMock.mockClear();
   });
 
@@ -713,10 +720,76 @@ describe("AgentChatPane hydrate-on-mount (workspace swap recovery)", () => {
     ]);
     render(<AgentChatPane pane={pane} />);
     await waitFor(() => {
-      expect(hydrateThreadMock).toHaveBeenCalledWith("thread-x", [
-        userPayload,
-        assistantPayload,
-      ]);
+      expect(hydrateThreadMock).toHaveBeenCalledWith(
+        "thread-x",
+        [userPayload, assistantPayload],
+        { runLive: false },
+      );
+    });
+  });
+
+  it("hydrates with runLive:true — and no interrupted state — when the backend reports the turn is still active", async () => {
+    // The workspace-switch false-positive: a healthy live run whose
+    // pane remounted. The persisted tail has no terminal event after the
+    // last user turn, but the backend confirms the turn is in flight, so
+    // hydrate must pass runLive so the streaming marker shows instead of
+    // the Run-interrupted divider.
+    currentMessages = [{ kind: "user_message", id: "m1" }];
+    const userPayload = JSON.stringify({
+      type: "user_message",
+      thread_id: "thread-x",
+      text: "hello",
+    });
+    const assistantPayload = JSON.stringify({
+      type: "item_completed",
+      thread_id: "thread-x",
+      turn_id: "turn-1",
+      item: { kind: "assistant_text", text: "hi back" },
+    });
+    vi.mocked(agentChatListMessages).mockResolvedValue([
+      userPayload,
+      assistantPayload,
+    ]);
+    vi.mocked(agentChatTurnActive).mockResolvedValue(true);
+    render(<AgentChatPane pane={pane} />);
+    await waitFor(() => {
+      expect(hydrateThreadMock).toHaveBeenCalledWith(
+        "thread-x",
+        [userPayload, assistantPayload],
+        { runLive: true },
+      );
+    });
+  });
+
+  it("falls back to interrupted (runLive:false) when the liveness probe rejects", async () => {
+    // A backend without the command, or a transient failure, must degrade
+    // to today's heuristic behavior rather than blocking hydrate.
+    currentMessages = [{ kind: "user_message", id: "m1" }];
+    const userPayload = JSON.stringify({
+      type: "user_message",
+      thread_id: "thread-x",
+      text: "hello",
+    });
+    const assistantPayload = JSON.stringify({
+      type: "item_completed",
+      thread_id: "thread-x",
+      turn_id: "turn-1",
+      item: { kind: "assistant_text", text: "hi back" },
+    });
+    vi.mocked(agentChatListMessages).mockResolvedValue([
+      userPayload,
+      assistantPayload,
+    ]);
+    vi.mocked(agentChatTurnActive).mockRejectedValue(
+      new Error("command unavailable"),
+    );
+    render(<AgentChatPane pane={pane} />);
+    await waitFor(() => {
+      expect(hydrateThreadMock).toHaveBeenCalledWith(
+        "thread-x",
+        [userPayload, assistantPayload],
+        { runLive: false },
+      );
     });
   });
 

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -61,6 +61,7 @@ import {
   agentChatGetSession,
   agentChatInterruptTurn,
   agentChatListMessages,
+  agentChatTurnActive,
   agentChatListSessions,
   agentChatRespondToRequest,
   agentChatSendTurn,
@@ -860,7 +861,22 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         // has strictly more rendered messages than memory. Equal /
         // shorter means the live stream kept up.
         if (replayed.messages.length <= localCount) return;
-        useAgentChatStore.getState().hydrateThread(threadId, payloads);
+        // Ask the backend whether this thread's turn is still in flight.
+        // Ordering matters: messages are fetched FIRST, liveness SECOND —
+        // if the turn settles between the two calls the `turn_completed`
+        // row is already in `payloads`, so `runLive` can only ever be a
+        // conservative false, never a stale "alive". Any invoke error
+        // (missing command, transient failure) degrades to `false`, i.e.
+        // today's heuristic behavior. A live turn means the persisted
+        // tail's missing terminal event is expected, not an interrupt —
+        // `runLive` suppresses the false Run-interrupted divider.
+        const runLive = await agentChatTurnActive(provider, threadId).catch(
+          () => false,
+        );
+        if (cancelled) return;
+        useAgentChatStore
+          .getState()
+          .hydrateThread(threadId, payloads, { runLive });
       } catch (err) {
         // Soft-fail: if hydrate fails, the user still sees whatever
         // the live stream brings in. Log so it's debuggable.

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -1564,6 +1564,14 @@ const handlers: Record<string, Handler> = {
     return undefined;
   },
   agent_chat_interrupt_turn: () => undefined,
+  // Liveness probe used by the remount-hydrate path to tell a live run
+  // (whose terminal event simply hasn't persisted yet) apart from a
+  // genuinely-interrupted one. The mock tracks in-flight turns in
+  // `chatActiveTurns`, so mirror that directly.
+  agent_chat_turn_active: (a) => {
+    const { threadId } = a as { threadId: string };
+    return chatActiveTurns.has(threadId);
+  },
   agent_chat_respond_to_request: () => undefined,
   agent_chat_set_model: () => undefined,
   agent_chat_set_permission_mode: () => undefined,

--- a/src/lib/agent-chat/hydrate.test.ts
+++ b/src/lib/agent-chat/hydrate.test.ts
@@ -604,3 +604,58 @@ describe("replayPayloads interrupted/stalled (issue #154)", () => {
     expect(state.stalled).toBeNull();
   });
 });
+
+describe("replayPayloads runLive (workspace-switch remount of a live run)", () => {
+  it("suppresses interrupted and streams for an unsettled tail when runLive is true", () => {
+    const payloads = [
+      user("first"),
+      event({
+        type: "turn_completed",
+        thread_id: "t",
+        turn_id: "turn-1",
+        status: { kind: "success" },
+        usage: null,
+      }),
+      // Unsettled tail — a live run whose terminal event isn't persisted
+      // yet. Without runLive this would flag interrupted.
+      user("second — still in flight"),
+    ];
+    expect(replayPayloads(payloads).interrupted).toBe(true);
+    const live = replayPayloads(payloads, { runLive: true });
+    expect(live.interrupted).toBe(false);
+    expect(live.streaming).toBe(true);
+  });
+
+  it("keeps current behavior when runLive is false or the opts are absent", () => {
+    const payloads = [user("only — never finished")];
+    const absent = replayPayloads(payloads);
+    const explicit = replayPayloads(payloads, { runLive: false });
+    for (const state of [absent, explicit]) {
+      expect(state.interrupted).toBe(true);
+      expect(state.streaming).toBe(false);
+    }
+  });
+
+  it("overrides a replay-observed child_exited when runLive is true", () => {
+    const payloads = [
+      user("go"),
+      event({
+        type: "turn_completed",
+        thread_id: "t",
+        turn_id: "turn-1",
+        status: {
+          kind: "error",
+          subtype: "child_exited",
+          message: "sidecar exited unexpectedly",
+        },
+        usage: null,
+      }),
+    ];
+    // Default: the child_exited terminal turn flags interrupted.
+    expect(replayPayloads(payloads).interrupted).toBe(true);
+    // runLive means the run recovered / is alive — suppress it.
+    const live = replayPayloads(payloads, { runLive: true });
+    expect(live.interrupted).toBe(false);
+    expect(live.streaming).toBe(true);
+  });
+});

--- a/src/lib/agent-chat/hydrate.ts
+++ b/src/lib/agent-chat/hydrate.ts
@@ -43,8 +43,29 @@ type ReplayPayload = UserMessageEnvelope | ProviderRuntimeEvent;
  * the original session ended cleanly. The caller is on the resume
  * path; a fresh provider session will flip streaming back on once
  * the user sends the next turn.
+ *
+ * `opts.runLive` overrides that resting default for one specific
+ * false-positive: a live run whose pane was unmounted and remounted
+ * (switching away from and back to a workspace tears the whole inactive
+ * workspace's pane tree down, so the live event listener detaches while
+ * the backend keeps streaming and persisting rows). On remount the
+ * persisted tail has no terminal event after the last user turn, so the
+ * `lastTurnUnsettled` heuristic would flag the transcript as
+ * "interrupted" and render a Run-interrupted divider over a perfectly
+ * healthy run. When the caller has authoritatively confirmed a turn is
+ * in flight (`runLive: true`), we force `interrupted: false` — suppressing
+ * BOTH the `lastTurnUnsettled` heuristic AND any replay-observed
+ * `child_exited` flag, since an in-flight turn means the run recovered /
+ * is alive — and set `streaming: true` so the streaming marker shows
+ * instead of the divider. The next live event keeps or clears that flag
+ * through the reducer as usual. With `opts` absent (or `runLive` falsy)
+ * behavior is identical to the resume path.
  */
-export function replayPayloads(payloads: string[]): ChatThreadState {
+export function replayPayloads(
+  payloads: string[],
+  opts?: { runLive?: boolean },
+): ChatThreadState {
+  const runLive = opts?.runLive ?? false;
   let state = createEmptyThreadState();
   for (const raw of payloads) {
     const parsed = parsePayload(raw);
@@ -104,7 +125,10 @@ export function replayPayloads(payloads: string[]): ChatThreadState {
   return {
     ...state,
     messages,
-    streaming: false,
+    // Normally a resting resume state, but when the backend confirms a
+    // turn is in flight we mark the thread streaming so the streaming
+    // marker shows instead of the Run-interrupted divider.
+    streaming: runLive,
     pendingRequestIds: [],
     // Interrupted when EITHER the replay itself observed a `child_exited`
     // terminal turn (the watchdog persisted a `turn_completed` error) OR
@@ -112,7 +136,13 @@ export function replayPayloads(payloads: string[]): ChatThreadState {
     // any terminal event was written — laptop sleep, hard crash). Both mean
     // "the last run never cleanly finished", so the tail shows the "Run
     // interrupted" divider and the composer offers a Continue chip.
-    interrupted: state.interrupted || lastTurnUnsettled(payloads),
+    //
+    // `runLive` overrides both signals: a confirmed in-flight turn means
+    // the run is alive, so neither the unsettled-tail heuristic nor a
+    // stale replay-observed `child_exited` should surface the divider.
+    interrupted: runLive
+      ? false
+      : state.interrupted || lastTurnUnsettled(payloads),
     // Transient — never persisted, so a hydrated thread always starts clear.
     stalled: null,
   };

--- a/src/stores/agent-chat-store.ts
+++ b/src/stores/agent-chat-store.ts
@@ -215,8 +215,17 @@ interface AgentChatStore {
    *  conversation before a fresh provider session boots. UI-only
    *  fields (model, permissionMode, mode, …) on the slice are
    *  preserved so resume keeps the user's current picker choices.
-   *  Calling on an unknown thread creates the slice. */
-  hydrateThread: (threadId: string, payloads: string[]) => void;
+   *  Calling on an unknown thread creates the slice.
+   *
+   *  `opts.runLive` is forwarded to `replayPayloads`: when the caller
+   *  has confirmed the thread's turn is in flight (remount of a live
+   *  run) it suppresses the Run-interrupted heuristic and marks the
+   *  slice streaming. Omit for the plain resume path. */
+  hydrateThread: (
+    threadId: string,
+    payloads: string[],
+    opts?: { runLive?: boolean },
+  ) => void;
   /** Clear a thread entirely (e.g. on session stop). */
   resetThread: (threadId: string) => void;
   /** Seed / update the thread's resume cursor. Normally set by the
@@ -423,9 +432,9 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
       return { threads: nextThreads };
     }),
 
-  hydrateThread: (threadId, payloads) =>
+  hydrateThread: (threadId, payloads, opts) =>
     set((state) => {
-      const replayed = replayPayloads(payloads);
+      const replayed = replayPayloads(payloads, opts);
       const existing = state.threads[threadId] ?? emptySlice();
       // Spread `replayed` last so its `messages`, `nextSeq`,
       // `streaming`, `pendingRequestIds` overwrite the empty slice's

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1276,6 +1276,23 @@ export const agentChatInterruptTurn = (
     turnId,
   });
 
+/** True iff the thread has a live (non-dead) session whose turn is
+ *  currently in flight. Used by the remount-hydrate path to tell a
+ *  genuinely-finished run apart from a still-running one whose terminal
+ *  event simply hasn't been persisted yet (a workspace-switch unmount
+ *  drops the live event listener while the backend keeps streaming).
+ *  Callers must treat any invoke error as `false` so a backend that
+ *  lacks the command, or a transient failure, falls back to today's
+ *  heuristic behavior. */
+export const agentChatTurnActive = (
+  provider: AgentChatProviderKind,
+  threadId: string,
+) =>
+  invoke<boolean>("agent_chat_turn_active", {
+    provider,
+    threadId,
+  });
+
 /** Cancel a queued (not-yet-dispatched) follow-up turn. On success the
  *  provider emits a `queued_turn_cancelled` event so the UI removes the
  *  greyed bubble. */


### PR DESCRIPTION
## Problem

Switching workspaces unmounts the inactive workspace's chat pane while its run keeps going in the backend. On switch-back, the remount hydrate recomputes the `interrupted` flag purely from the persisted transcript: a healthy mid-flight run has no `turn_completed` after its last user turn yet, so `lastTurnUnsettled` flags it and the pane shows a false **"Run interrupted"** divider + **Continue run** chip over a run that is actually alive (it then "continues by itself" once the next live event clears the flag).

Subagent-heavy runs hit this reliably: their `item_completed` rows grow the disk transcript past the frozen in-memory slice, which is exactly the condition that lets the remount hydrate guard pass.

## Fix

Give hydrate an authoritative liveness signal instead of the heuristic alone:

- **`AgentProvider::turn_active`** — new default trait method: `true` iff a live (non-dead) session is bound to the thread and its `active_turn` is set. Cheap in-memory check, never touches the subprocess. Implemented for Claude and Codex via the sessions map, and for OpenCode via the SSE event-context flag behind the same absent/dead guards.
- **`agent_chat_turn_active`** — new read-only command exposing it (no auto-resume).
- The remount hydrate effect probes it **after** fetching payloads (if the turn settles between the two calls, the settling `turn_completed` row is already in the payloads — a stale "alive" answer can't mislabel a finished run) and threads `{ runLive }` through `hydrateThread` → `replayPayloads`. `runLive: true` forces `interrupted: false` and sets `streaming: true` so the streaming marker shows instead of the divider. A probe error degrades to `false` (previous behavior).
- Dev mock implements the command from its in-flight turn set; `docs/features/agent-chat.md` documents the new guard and command.

The genuine cases keep working: dead-run detection (child-exit watchdog, app-died-mid-turn hydrate) still surfaces the divider and Continue chip.

## Verification

- `npm run verify` green: cargo check + cargo test, tsc, vitest (171 files / 2522 tests).
- New tests: Rust adapter coverage for unknown-thread / in-flight / settled / dead-session on Claude and Codex; hydrate unit tests for the `runLive` override (incl. overriding a replay-observed `child_exited`); pane tests for probe-true, probe-rejected fallback, and arg routing.
- Exercised end to end in the browser against the dev mock: the probe flips `false → true → false` across a streamed turn; switching away and back mid-run no longer surfaces the divider; a genuine `child_exited` interrupt still renders the divider + Continue chip.