### PR TITLE
feat(remote): GitHub OAuth sign-in for the hosted web client

### DIFF
--- a/docs/plans/app-codemux-org-hosting.md
+++ b/docs/plans/app-codemux-org-hosting.md
@@ -134,6 +134,60 @@ The hosted client is inert until the control plane is ready. Two API-side change
 
 ---
 
+## 5b. Security headers (REQUIRED)
+
+The static host **must** send a Content-Security-Policy and the standard
+security headers. Without a CSP, an XSS on `app.codemux.org` could read the
+in-memory account bearer and drive any of the account's desktops — a
+credential-theft path *around* the (otherwise end-to-end) encryption. The
+encryption itself is unaffected; this closes the operational gap.
+
+The deployed nginx config (`~/app-codemux/default.conf` on the host) is:
+
+```nginx
+server {
+    listen 80;
+    server_name app.codemux.org;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Security headers. nginx add_header does NOT merge across levels — a
+    # location with its own add_header drops these — so the cache locations
+    # below use `expires` (not add_header) to keep inheriting them.
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https: wss:; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'self' https://api.codemux.org; manifest-src 'self'" always;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+
+    gzip on;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_types application/javascript text/css application/json image/svg+xml application/wasm;
+
+    location ~ \.wasm$ { default_type application/wasm; expires 5m; try_files $uri =404; }
+    location /assets/   { expires 1y; try_files $uri =404; }
+    location /iroh-wasm/ { expires 5m; try_files $uri =404; }
+    location = /index.html { expires -1; }
+    location /          { try_files $uri $uri/ /index.html; }
+}
+```
+
+Notes:
+- `script-src 'self' 'wasm-unsafe-eval'` — the bundle ships no inline scripts,
+  so `'self'` is enough for JS; `'wasm-unsafe-eval'` is required for the iroh
+  WASM transport to instantiate.
+- `style-src 'unsafe-inline'` — the built `index.html` has one inline `<style>`
+  (splash/reset); style injection is far lower-risk than script injection.
+- `connect-src 'self' https: wss:` — permissive on the iroh relay side (the
+  relay host set is not fully enumerable and cannot be smoke-tested without a
+  live device); the real XSS defense is the tight `script-src`.
+- `Strict-Transport-Security` has **no** `includeSubDomains` on purpose, so it
+  never forces HSTS onto sibling `*.codemux.org` services.
+- After editing, `docker exec app-codemux nginx -t && docker exec app-codemux nginx -s reload`.
+
+---
+
 ## 6. Smoke test after deploy
 
 1. On a desktop: sign into the Codemux account, **Settings → Remote Access → enable**, then turn on **relay mode**. Confirm it shows a `node_id` and "device registered".

--- a/src/remote/device-registry.ts
+++ b/src/remote/device-registry.ts
@@ -92,6 +92,15 @@ export class DeviceRegistry {
   }
 
   /**
+   * Adopt a bearer obtained out-of-band — the GitHub OAuth code exchange
+   * (`/api/auth/web/exchange`) hands back the same account bearer the
+   * email/password `signIn` captures, so the rest of the flow is identical.
+   */
+  setToken(token: string): void {
+    this.token = token;
+  }
+
+  /**
    * Sign into the account with a pre-derived AuthSecret (the browser derives it
    * from the raw password via `deriveAuthSecret`). Captures the session on
    * success; throws a mapped {@link DeviceRegistryError} otherwise.

--- a/src/remote/hosted-bootstrap.tsx
+++ b/src/remote/hosted-bootstrap.tsx
@@ -36,6 +36,13 @@ import {
   type HostedFlowDeps,
   type HostedState,
 } from "./hosted";
+import {
+  clearOAuthParams,
+  exchangeAuthCode,
+  prepareGithubOAuth,
+  readOAuthReturn,
+  sessionOAuthStore,
+} from "./hosted-oauth";
 import { createIrohConnection } from "./iroh-connection";
 import { IrohWasmUnavailableError, loadIrohDialer } from "./iroh-wasm-loader";
 import { installShim } from "./shim";
@@ -75,6 +82,8 @@ export async function bootstrapHosted(): Promise<void> {
     }
   }
 
+  const oauthStore = sessionOAuthStore();
+
   const deps: HostedFlowDeps = {
     async signIn(email, password) {
       // Derive the AuthSecret locally — the raw password never leaves the page.
@@ -91,16 +100,48 @@ export async function bootstrapHosted(): Promise<void> {
         onUnauthorized: handleUnauthorized,
       });
     },
+    beginGithubSignIn() {
+      // Mint + store the state, then hand the browser to the API's OAuth
+      // interstitial. This unloads the page; the return leg is handled below.
+      const { url } = prepareGithubOAuth({
+        apiBase: base,
+        returnTo: window.location.origin,
+        store: oauthStore,
+      });
+      window.location.assign(url);
+    },
+    async completeGithubSignIn(code) {
+      const session = await exchangeAuthCode({ apiBase: base, code });
+      // Adopt the bearer exactly as the email/password path does, then list.
+      registry.setToken(session.token);
+      return registry.listDevices();
+    },
   };
 
   const flow = new HostedFlow(deps);
+
+  // Handle a GitHub OAuth return before the first paint: verify the echoed
+  // state, then trade the single-use code for a bearer. The code is stripped
+  // from the URL immediately so a refresh/screenshot can't leak it.
+  const ret = readOAuthReturn(window.location.search, oauthStore);
+  if (ret.kind !== "none") {
+    clearOAuthParams(window.location, window.history);
+  }
+
   const done = new Promise<void>((resolve) => {
     flow.subscribe((state) => {
       overlay.render(<HostedScreen state={state} flow={flow} apiHost={hostOf(base)} />);
       if (state.phase === "connected") resolve();
     });
   });
-  // Initial paint.
+
+  if (ret.kind === "code") {
+    void flow.resumeGithubSignIn(ret.code);
+  } else if (ret.kind === "error") {
+    flow.failSignIn(ret.message);
+  }
+
+  // Initial paint (covers the "none" case; resume/fail above already emitted).
   overlay.render(
     <HostedScreen state={flow.getState()} flow={flow} apiHost={hostOf(base)} />,
   );
@@ -234,43 +275,85 @@ function SignInForm(props: {
     void props.flow.submitSignIn(email, password);
   }
 
+  const canGithub = typeof props.flow.startGithubSignIn === "function";
+
   return (
-    <form style={cardStyle} onSubmit={submit}>
+    <div style={cardStyle}>
       <div style={titleStyle}>Sign in to connect</div>
       <div style={subtitleStyle}>
         Use your Codemux account to reach a desktop you have set up for remote
-        access. Your password is stretched on this device and never sent as-is.
+        access.
       </div>
-      <input
-        type="email"
-        value={email}
-        autoFocus
-        autoComplete="username"
-        disabled={busy}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="Email"
-        aria-label="Email"
-        style={inputStyle}
-      />
-      <input
-        type="password"
-        value={password}
-        autoComplete="current-password"
-        disabled={busy}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="Password"
-        aria-label="Password"
-        style={{ ...inputStyle, marginTop: 10 }}
-      />
-      {props.state.error && (
-        <div role="alert" style={errorStyle}>
-          {props.state.error}
-        </div>
+      {canGithub && (
+        <>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => props.flow.startGithubSignIn()}
+            style={githubButtonStyle(busy)}
+            aria-label="Sign in with GitHub"
+          >
+            <GithubMark />
+            <span>Sign in with GitHub</span>
+          </button>
+          <div style={dividerStyle} aria-hidden="true">
+            <span style={dividerLineStyle} />
+            <span style={dividerTextStyle}>or</span>
+            <span style={dividerLineStyle} />
+          </div>
+        </>
       )}
-      <button type="submit" disabled={busy} style={primaryButtonStyle(busy)}>
-        {busy ? "Signing in…" : "Sign in"}
-      </button>
-    </form>
+      <form onSubmit={submit}>
+        <input
+          type="email"
+          value={email}
+          autoComplete="username"
+          disabled={busy}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          aria-label="Email"
+          style={inputStyle}
+        />
+        <input
+          type="password"
+          value={password}
+          autoComplete="current-password"
+          disabled={busy}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          aria-label="Password"
+          style={{ ...inputStyle, marginTop: 10 }}
+        />
+        {props.state.error && (
+          <div role="alert" style={errorStyle}>
+            {props.state.error}
+          </div>
+        )}
+        <button type="submit" disabled={busy} style={primaryButtonStyle(busy)}>
+          {busy ? "Signing in…" : "Sign in with email"}
+        </button>
+      </form>
+      <div style={derivationNoteStyle}>
+        With email, your password is stretched on this device and never sent
+        as-is.
+      </div>
+    </div>
+  );
+}
+
+/** GitHub logo mark (inline SVG — the bundle ships no external assets). */
+function GithubMark(): React.ReactElement {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+      style={{ flexShrink: 0 }}
+    >
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+    </svg>
   );
 }
 
@@ -417,6 +500,48 @@ const subtitleStyle: React.CSSProperties = {
   lineHeight: 1.5,
   color: "var(--muted-foreground, #9a9a97)",
   marginBottom: 18,
+};
+
+const githubButtonStyle = (busy: boolean): React.CSSProperties => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 8,
+  width: "100%",
+  padding: "10px 14px",
+  fontSize: 13.5,
+  fontWeight: 600,
+  cursor: busy ? "default" : "pointer",
+  color: "var(--foreground, #e8e8e8)",
+  background: "var(--background, #0C0C0E)",
+  border: "1px solid var(--input, rgba(255,255,255,0.15))",
+  borderRadius: 9,
+  opacity: busy ? 0.7 : 1,
+});
+
+const dividerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 10,
+  margin: "14px 0",
+};
+
+const dividerLineStyle: React.CSSProperties = {
+  flex: 1,
+  height: 1,
+  background: "var(--border, rgba(255,255,255,0.1))",
+};
+
+const dividerTextStyle: React.CSSProperties = {
+  fontSize: 11,
+  color: "var(--muted-foreground, #9a9a97)",
+};
+
+const derivationNoteStyle: React.CSSProperties = {
+  marginTop: 14,
+  fontSize: 11,
+  lineHeight: 1.45,
+  color: "var(--muted-foreground, #9a9a97)",
 };
 
 const deviceRowStyle: React.CSSProperties = {

--- a/src/remote/hosted-oauth.test.ts
+++ b/src/remote/hosted-oauth.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  OAUTH_STATE_KEY,
+  clearOAuthParams,
+  exchangeAuthCode,
+  prepareGithubOAuth,
+  readOAuthReturn,
+  type OAuthReturnStore,
+} from "./hosted-oauth";
+
+/** In-memory store standing in for sessionStorage. */
+function memStore(seed: Record<string, string> = {}): OAuthReturnStore & {
+  data: Record<string, string>;
+} {
+  const data: Record<string, string> = { ...seed };
+  return {
+    data,
+    get: (k) => (k in data ? data[k] : null),
+    set: (k, v) => {
+      data[k] = v;
+    },
+    remove: (k) => {
+      delete data[k];
+    },
+  };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("prepareGithubOAuth", () => {
+  it("stores the state and builds the connect URL with all params", () => {
+    const store = memStore();
+    const { url, state } = prepareGithubOAuth({
+      apiBase: "https://api.codemux.org/",
+      returnTo: "https://app.codemux.org",
+      store,
+      randomState: () => "STATE123",
+    });
+    expect(state).toBe("STATE123");
+    expect(store.data[OAUTH_STATE_KEY]).toBe("STATE123");
+    const u = new URL(url);
+    expect(u.origin + u.pathname).toBe(
+      "https://api.codemux.org/api/auth/web/connect",
+    );
+    expect(u.searchParams.get("provider")).toBe("github");
+    expect(u.searchParams.get("state")).toBe("STATE123");
+    expect(u.searchParams.get("returnTo")).toBe("https://app.codemux.org");
+  });
+
+  it("generates an opaque state matching the API's charset when not injected", () => {
+    const store = memStore();
+    const { state } = prepareGithubOAuth({
+      apiBase: "https://api.codemux.org",
+      returnTo: "https://app.codemux.org",
+      store,
+    });
+    expect(state).toMatch(/^[A-Za-z0-9_-]{1,128}$/);
+  });
+});
+
+describe("readOAuthReturn — CSRF state machine", () => {
+  it("returns none when there are no callback params", () => {
+    const store = memStore({ [OAUTH_STATE_KEY]: "s1" });
+    expect(readOAuthReturn("", store)).toEqual({ kind: "none" });
+    // A no-op read must NOT spend the pending state.
+    expect(store.data[OAUTH_STATE_KEY]).toBe("s1");
+  });
+
+  it("yields the code when the returned state matches the stored one", () => {
+    const store = memStore({ [OAUTH_STATE_KEY]: "s1" });
+    const ret = readOAuthReturn("?authcode=abc&state=s1", store);
+    expect(ret).toEqual({ kind: "code", code: "abc" });
+    // State is consumed (one-shot).
+    expect(store.get(OAUTH_STATE_KEY)).toBeNull();
+  });
+
+  it("rejects a mismatched state (CSRF) and consumes the stored state", () => {
+    const store = memStore({ [OAUTH_STATE_KEY]: "s1" });
+    const ret = readOAuthReturn("?authcode=abc&state=EVIL", store);
+    expect(ret.kind).toBe("error");
+    expect(store.get(OAUTH_STATE_KEY)).toBeNull();
+  });
+
+  it("rejects when no state was stored (fresh session / forged link)", () => {
+    const store = memStore();
+    const ret = readOAuthReturn("?authcode=abc&state=s1", store);
+    expect(ret.kind).toBe("error");
+  });
+
+  it("rejects a return that carries a code but no state", () => {
+    const store = memStore({ [OAUTH_STATE_KEY]: "s1" });
+    const ret = readOAuthReturn("?authcode=abc", store);
+    expect(ret.kind).toBe("error");
+    expect(store.get(OAUTH_STATE_KEY)).toBeNull();
+  });
+
+  it("a replayed return can't be honored twice (state already spent)", () => {
+    const store = memStore({ [OAUTH_STATE_KEY]: "s1" });
+    const first = readOAuthReturn("?authcode=abc&state=s1", store);
+    expect(first.kind).toBe("code");
+    const second = readOAuthReturn("?authcode=abc&state=s1", store);
+    expect(second.kind).toBe("error");
+  });
+});
+
+describe("clearOAuthParams", () => {
+  it("removes authcode + state but keeps other query, path, and hash", () => {
+    const calls: string[] = [];
+    const hist = {
+      replaceState: (_d: unknown, _t: string, url: string) => calls.push(url),
+    };
+    clearOAuthParams(
+      {
+        href: "https://app.codemux.org/app?authcode=abc&state=s1&hosted=1#frag",
+        pathname: "/app",
+        hash: "#frag",
+      },
+      hist,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe("/app?hosted=1#frag");
+  });
+
+  it("collapses to the root path when only OAuth params were present", () => {
+    const calls: string[] = [];
+    const hist = {
+      replaceState: (_d: unknown, _t: string, url: string) => calls.push(url),
+    };
+    clearOAuthParams(
+      {
+        href: "https://app.codemux.org/?authcode=abc&state=s1",
+        pathname: "/",
+        hash: "",
+      },
+      hist,
+    );
+    expect(calls[0]).toBe("/");
+  });
+});
+
+describe("exchangeAuthCode", () => {
+  it("POSTs the code and returns the account session on success", async () => {
+    let captured: { url: string; init?: RequestInit } | null = null;
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      captured = { url: String(url), init };
+      return jsonResponse(200, {
+        token: "bearer-xyz",
+        expiresAt: "2026-08-01T00:00:00.000Z",
+        user: { id: "u1", name: "Me", email: "me@x.com", image: null },
+      });
+    }) as unknown as typeof fetch;
+
+    const session = await exchangeAuthCode({
+      apiBase: "https://api.codemux.org/",
+      code: "abc",
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(captured!.url).toBe("https://api.codemux.org/api/auth/web/exchange");
+    expect(captured!.init!.method).toBe("POST");
+    expect(captured!.init!.credentials).toBe("include");
+    expect(JSON.parse(captured!.init!.body as string)).toEqual({ code: "abc" });
+    expect(session.token).toBe("bearer-xyz");
+    expect(session.user.email).toBe("me@x.com");
+  });
+
+  it("throws a friendly error on a non-2xx (expired/used code)", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(400, { error: "invalid_or_expired_code" }),
+    ) as unknown as typeof fetch;
+    await expect(
+      exchangeAuthCode({ apiBase: "https://api.codemux.org", code: "x", fetchImpl }),
+    ).rejects.toThrow(/expired|try again/i);
+  });
+
+  it("throws a friendly error on a network failure", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    }) as unknown as typeof fetch;
+    await expect(
+      exchangeAuthCode({ apiBase: "https://api.codemux.org", code: "x", fetchImpl }),
+    ).rejects.toThrow(/connection|try again/i);
+  });
+
+  it("throws when the response body has no token", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, { user: { id: "u1" } }),
+    ) as unknown as typeof fetch;
+    await expect(
+      exchangeAuthCode({ apiBase: "https://api.codemux.org", code: "x", fetchImpl }),
+    ).rejects.toThrow(/incomplete|try again/i);
+  });
+});

--- a/src/remote/hosted-oauth.ts
+++ b/src/remote/hosted-oauth.ts
@@ -1,0 +1,204 @@
+/**
+ * GitHub OAuth sign-in for the hosted web client (framework-free, testable).
+ *
+ * The hosted client can't run the desktop deep-link callback, so it uses a
+ * browser-return OAuth flow served by the control plane (api.codemux.org):
+ *
+ *   1. {@link prepareGithubOAuth} mints an opaque `state`, stores it, and builds
+ *      the `GET /api/auth/web/connect` URL. The click handler navigates there.
+ *   2. The API runs the GitHub OAuth dance and 302s the browser back to the
+ *      hosted origin with `?authcode=<code>&state=<state>` — the long-lived
+ *      bearer is deliberately NOT in the URL, only a 60s single-use code.
+ *   3. On load, {@link readOAuthReturn} verifies the returned `state` matches the
+ *      stored one (CSRF guard) and yields the `code`.
+ *   4. {@link exchangeAuthCode} POSTs the code to `/api/auth/web/exchange` and
+ *      receives the account bearer in the response BODY.
+ *   5. {@link clearOAuthParams} strips `authcode`/`state` from the URL so a
+ *      refresh or screenshot can't leak the code.
+ *
+ * Every side effect (state storage, navigation, `fetch`, `history`) is injected
+ * so this module unit-tests with fakes and never touches the real network.
+ */
+
+/** sessionStorage key holding the pending OAuth `state` between redirect legs. */
+export const OAUTH_STATE_KEY = "codemux.hosted.oauth.state";
+
+const RETURN_ERROR =
+  "We couldn't verify that GitHub sign-in. Please try again.";
+
+/** Minimal storage seam (sessionStorage in the browser; a fake in tests). */
+export interface OAuthReturnStore {
+  get(key: string): string | null;
+  set(key: string, value: string): void;
+  remove(key: string): void;
+}
+
+/** The account bearer + identity returned by a successful code exchange. */
+export interface ExchangedSession {
+  token: string;
+  expiresAt: string;
+  user: { id: string; name: string; email: string; image: string | null };
+}
+
+/** Outcome of inspecting the return URL. */
+export type OAuthReturn =
+  | { kind: "none" }
+  | { kind: "code"; code: string }
+  | { kind: "error"; message: string };
+
+/** A browser-backed {@link OAuthReturnStore}. Degrades to a no-op if
+ *  sessionStorage is unavailable (private mode, sandboxed iframe). */
+export function sessionOAuthStore(): OAuthReturnStore {
+  return {
+    get(key) {
+      try {
+        return window.sessionStorage.getItem(key);
+      } catch {
+        return null;
+      }
+    },
+    set(key, value) {
+      try {
+        window.sessionStorage.setItem(key, value);
+      } catch {
+        /* ignore */
+      }
+    },
+    remove(key) {
+      try {
+        window.sessionStorage.removeItem(key);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/** Opaque `state` matching the API's `^[A-Za-z0-9_-]{1,128}$` contract. */
+function defaultRandomState(): string {
+  const bytes = new Uint8Array(16);
+  (globalThis.crypto ?? window.crypto).getRandomValues(bytes);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function trimBase(apiBase: string): string {
+  return apiBase.replace(/\/+$/, "");
+}
+
+/**
+ * Mint + persist a `state` and build the connect URL. The caller navigates the
+ * browser to `url` (a full-page redirect); the persisted state is consumed by
+ * {@link readOAuthReturn} on the way back.
+ */
+export function prepareGithubOAuth(opts: {
+  apiBase: string;
+  /** Where the API should return to — must be the hosted origin. */
+  returnTo: string;
+  store: OAuthReturnStore;
+  randomState?: () => string;
+}): { url: string; state: string } {
+  const state = (opts.randomState ?? defaultRandomState)();
+  opts.store.set(OAUTH_STATE_KEY, state);
+  const url = new URL(`${trimBase(opts.apiBase)}/api/auth/web/connect`);
+  url.searchParams.set("provider", "github");
+  url.searchParams.set("state", state);
+  url.searchParams.set("returnTo", opts.returnTo);
+  return { url: url.toString(), state };
+}
+
+/**
+ * Inspect the return URL's query for an OAuth callback. The stored `state` is
+ * consumed (removed) on every call that sees callback params, so a stale state
+ * can never satisfy a later attempt. A mismatched or missing state is an error,
+ * not a silent pass — that's the CSRF guard.
+ */
+export function readOAuthReturn(
+  search: string,
+  store: OAuthReturnStore,
+): OAuthReturn {
+  const params = new URLSearchParams(search);
+  const code = params.get("authcode");
+  const state = params.get("state");
+  if (code === null && state === null) return { kind: "none" };
+
+  // One-shot: whatever the outcome, the pending state is spent.
+  const expected = store.get(OAUTH_STATE_KEY);
+  store.remove(OAUTH_STATE_KEY);
+
+  if (code === null || state === null) {
+    return { kind: "error", message: RETURN_ERROR };
+  }
+  if (!expected || state !== expected) {
+    return { kind: "error", message: RETURN_ERROR };
+  }
+  return { kind: "code", code };
+}
+
+/**
+ * Trade a single-use `authcode` for the account bearer. Never leaks a raw
+ * network error — failures surface as friendly, retryable copy.
+ */
+export async function exchangeAuthCode(opts: {
+  apiBase: string;
+  code: string;
+  fetchImpl?: typeof fetch;
+}): Promise<ExchangedSession> {
+  const f = opts.fetchImpl ?? ((...a: Parameters<typeof fetch>) => fetch(...a));
+  let res: Response;
+  try {
+    res = await f(`${trimBase(opts.apiBase)}/api/auth/web/exchange`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ code: opts.code }),
+    });
+  } catch {
+    throw new Error(
+      "Couldn't reach the sign-in service. Check your connection and try again.",
+    );
+  }
+  if (!res.ok) {
+    throw new Error("That GitHub sign-in expired. Please sign in again.");
+  }
+  const body = (await res.json().catch(() => null)) as
+    | Partial<ExchangedSession>
+    | null;
+  if (!body || typeof body.token !== "string") {
+    throw new Error("The sign-in response was incomplete. Please try again.");
+  }
+  return {
+    token: body.token,
+    expiresAt: typeof body.expiresAt === "string" ? body.expiresAt : "",
+    user: {
+      id: String(body.user?.id ?? ""),
+      name: String(body.user?.name ?? ""),
+      email: String(body.user?.email ?? ""),
+      image:
+        typeof body.user?.image === "string" ? body.user.image : null,
+    },
+  };
+}
+
+/**
+ * Strip `authcode` + `state` from the current URL (keeping any other query, the
+ * path, and the hash) so the single-use code never survives in history.
+ */
+export function clearOAuthParams(
+  loc: { href: string; pathname: string; hash: string },
+  hist: { replaceState(data: unknown, unused: string, url: string): void },
+): void {
+  let url: URL;
+  try {
+    url = new URL(loc.href);
+  } catch {
+    hist.replaceState(null, "", loc.pathname || "/");
+    return;
+  }
+  url.searchParams.delete("authcode");
+  url.searchParams.delete("state");
+  const query = url.searchParams.toString();
+  const next = `${url.pathname}${query ? `?${query}` : ""}${url.hash}`;
+  hist.replaceState(null, "", next || "/");
+}

--- a/src/remote/hosted.test.ts
+++ b/src/remote/hosted.test.ts
@@ -152,6 +152,63 @@ describe("HostedFlow: select → connect", () => {
   });
 });
 
+describe("HostedFlow: GitHub OAuth", () => {
+  it("startGithubSignIn marks busy and triggers the redirect dep once", () => {
+    const beginGithubSignIn = vi.fn();
+    const flow = new HostedFlow({
+      signIn: async () => [],
+      connect: async () => {},
+      beginGithubSignIn,
+      completeGithubSignIn: async () => [],
+    });
+    flow.startGithubSignIn();
+    expect(beginGithubSignIn).toHaveBeenCalledTimes(1);
+    expect(flow.getState().busy).toBe(true);
+    // A second click while busy is ignored (no double redirect).
+    flow.startGithubSignIn();
+    expect(beginGithubSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumeGithubSignIn exchanges the code once and lands on the device list", async () => {
+    const completeGithubSignIn = vi.fn(async () => [device("a"), device("b")]);
+    const flow = new HostedFlow({
+      signIn: async () => [],
+      connect: async () => {},
+      beginGithubSignIn: () => {},
+      completeGithubSignIn,
+    });
+    const t = track(flow);
+    await flow.resumeGithubSignIn("code-123");
+    expect(completeGithubSignIn).toHaveBeenCalledTimes(1);
+    expect(completeGithubSignIn).toHaveBeenCalledWith("code-123");
+    expect(t.last().phase).toBe("devices");
+    expect(t.last().devices.map((d) => d.id)).toEqual(["a", "b"]);
+    expect(t.last().busy).toBe(false);
+  });
+
+  it("resumeGithubSignIn returns to sign-in with the error on exchange failure", async () => {
+    const flow = new HostedFlow({
+      signIn: async () => [],
+      connect: async () => {},
+      beginGithubSignIn: () => {},
+      completeGithubSignIn: async () => {
+        throw new Error("That GitHub sign-in expired. Please sign in again.");
+      },
+    });
+    await flow.resumeGithubSignIn("bad-code");
+    expect(flow.getState().phase).toBe("signin");
+    expect(flow.getState().error).toMatch(/expired/i);
+    expect(flow.getState().busy).toBe(false);
+  });
+
+  it("failSignIn surfaces an error on the sign-in screen", () => {
+    const flow = new HostedFlow({ signIn: async () => [], connect: async () => {} });
+    flow.failSignIn("could not verify");
+    expect(flow.getState().phase).toBe("signin");
+    expect(flow.getState().error).toBe("could not verify");
+  });
+});
+
 describe("isHostedOrigin", () => {
   it("is true on the canonical hosted hostname", () => {
     expect(isHostedOrigin({ hostname: "app.codemux.org", search: "" }, {})).toBe(true);

--- a/src/remote/hosted.ts
+++ b/src/remote/hosted.ts
@@ -71,6 +71,18 @@ export interface HostedFlowDeps {
     device: RegisteredDevice,
     handlers: HostedConnectHandlers,
   ): Promise<void>;
+  /**
+   * Kick off the GitHub OAuth redirect. Side-effecting (navigates the browser
+   * away); the flow just marks itself busy first. Optional so existing callers
+   * that only use email/password need not provide it.
+   */
+  beginGithubSignIn?(): void;
+  /**
+   * Finish a GitHub OAuth return: exchange the single-use `code` for the account
+   * bearer, adopt it, and return the account's devices. Throws with a
+   * user-facing message on failure. Optional (see {@link beginGithubSignIn}).
+   */
+  completeGithubSignIn?(code: string): Promise<RegisteredDevice[]>;
 }
 
 type Listener = (state: HostedState) => void;
@@ -119,6 +131,45 @@ export class HostedFlow {
       return;
     }
     this.set({ busy: false, phase: "devices", devices, error: null });
+  }
+
+  /**
+   * Begin GitHub OAuth. Marks the form busy (so it disables while the browser
+   * navigates away) and delegates the redirect to the injected dep.
+   */
+  startGithubSignIn(): void {
+    if (this.state.busy) return;
+    if (!this.deps.beginGithubSignIn) return;
+    this.set({ busy: true, error: null });
+    this.deps.beginGithubSignIn();
+  }
+
+  /**
+   * Resume after a GitHub OAuth return: exchange the code, then move to the
+   * device list on success or back to sign-in (with the reason) on failure.
+   * Mirrors {@link submitSignIn} so both auth paths converge on the same state.
+   */
+  async resumeGithubSignIn(code: string): Promise<void> {
+    if (this.state.busy) return;
+    if (!this.deps.completeGithubSignIn) return;
+    this.set({ busy: true, error: null, phase: "signin" });
+    let devices: RegisteredDevice[];
+    try {
+      devices = await this.deps.completeGithubSignIn(code);
+    } catch (err) {
+      this.set({
+        busy: false,
+        phase: "signin",
+        error: err instanceof Error ? err.message : "GitHub sign-in failed.",
+      });
+      return;
+    }
+    this.set({ busy: false, phase: "devices", devices, error: null });
+  }
+
+  /** Surface an error on the sign-in screen (e.g. a failed OAuth return). */
+  failSignIn(message: string): void {
+    this.set({ phase: "signin", busy: false, error: message });
   }
 
   /** Select a device and connect the app to it over iroh. */


### PR DESCRIPTION
## What
Adds **"Sign in with GitHub"** to the hosted web-remote client (app.codemux.org). It previously offered only email/password, so account holders who use GitHub (the primary OAuth method) could not sign in. This is the frontend half of the hosted GitHub OAuth flow; the matching API routes (`/api/auth/web/connect`, `/success`, `/exchange`) are deployed on api.codemux.org.

## Flow (security)
- Browser → `api.codemux.org/api/auth/web/connect?provider=github&state=<nonce>&returnTo=<origin>` (reuses the existing interstitial + signed state-cookie machinery).
- After GitHub, the server mints the account bearer server-side and returns a **short-lived (60s) single-use code** in the redirect — the long-lived bearer never rides a URL.
- Client verifies `state`, `POST /api/auth/web/exchange {code}` → bearer (response body), stores it (same storage the email/password path uses), clears the URL.
- `returnTo` is exact-match allowlisted (no open redirect); CSRF via `state`.

## Testing
- Frontend: `npm run check` clean, `npm run test` 2768 pass (incl. `hosted-oauth.test.ts` — state-mismatch rejected, code exchanged once, URL cleared, replay blocked).
- API side (separate, deployed): 33 web-oauth tests pass.
- Live: the button renders on app.codemux.org and the click redirects to `github.com/login/oauth/authorize` with correct PKCE/params; existing desktop GitHub OAuth verified unaffected.

Email/password sign-in is unchanged.