### PR TITLE
fix(agent-chat): stop auto-resumed sessions from prompting while the picker shows Full access

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -183,6 +183,21 @@ The chat pane stack:
   pickers + resume cursor from the row, falling back to the provider
   default model only when no row (or no persisted model) exists —
   fixing the post-restart "reset to Opus" regression.
+  - **NULL `permission_mode` heal**: rows created before the
+    `permission_mode` column existed read back NULL. The frontend seeds its
+    permission picker to the provider default ("Full access" =
+    `bypassPermissions` for Claude, `danger-full-access` for Codex) for such
+    rows, so `ensure_live_session` resolves a NULL to that same provider
+    default (`fallback_permission_mode`) before rebuilding — otherwise the
+    SDK launches in `default` mode and prompts for every Edit/Bash while the
+    UI still says Full access. When it substitutes a default it also
+    best-effort persists the resolved mode back to the row (never failing
+    the resume on a DB write) so future rebuilds and the frontend seed
+    agree. A one-time `database.rs` migration backfills the same defaults
+    onto existing NULL Claude/Codex rows (OpenCode has no permission modes,
+    so its rows stay NULL). This became user-visible in v0.13.2 once the
+    dead-run watchdog started rebuilding sessions mid-lifetime, not just
+    after an app restart.
 - **Reusable JSON-RPC-over-stdio child-process helper** with timeout,
   graceful shutdown, bidirectional notifications, server-initiated
   requests, and child-exit cleanup.

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -900,6 +900,35 @@ fn resume_lock_for(thread_id: &str) -> Arc<tokio::sync::Mutex<()>> {
         .clone()
 }
 
+/// The provider default permission mode used to heal a session row whose
+/// persisted `permission_mode` is NULL.
+///
+/// WHY: the `permission_mode` column was added to `agent_chat_sessions`
+/// after chat had already shipped (see the
+/// `ALTER TABLE agent_chat_sessions ADD COLUMN permission_mode` migration
+/// in `database.rs`), so rows created before it read back `None`. The
+/// frontend seeds its permission picker to the provider default ("Full
+/// access" for Claude) for such rows, so if [`ensure_live_session`]
+/// rebuilds the live session passing `None` the SDK launches in `default`
+/// mode and prompts for every tool — the UI says Full access while the
+/// live session desyncs and asks for approvals on every Edit/Bash.
+/// Substituting the provider default here keeps the rebuilt session in the
+/// same mode the UI already displays.
+///
+/// The returned strings MUST match the `default_permission_mode` each
+/// provider declares in its capabilities module
+/// (`agent_provider/{claude,codex,opencode}/capabilities.rs`); they are
+/// duplicated here as a cheap `&'static str` rather than building the full
+/// capabilities bundle (which allocates the model list) just to read one
+/// field. OpenCode has no permission modes, so it stays `None`.
+fn fallback_permission_mode(provider: ProviderKind) -> Option<&'static str> {
+    match provider {
+        ProviderKind::Claude => Some("bypassPermissions"),
+        ProviderKind::Codex => Some("danger-full-access"),
+        ProviderKind::OpenCode => None,
+    }
+}
+
 /// Ensure a live provider session is bound to `thread_id`, silently
 /// rebuilding it from the persisted `agent_chat_sessions` row when the
 /// provider's in-memory session map has no entry (the state after an app
@@ -999,12 +1028,44 @@ pub async fn ensure_live_session<R: Runtime>(
         .as_ref()
         .map(|id| serde_json::json!({ "resume": id }));
 
+    // Heal a NULL persisted permission_mode to the provider default the
+    // frontend already displays for such rows (see
+    // `fallback_permission_mode` for the WHY). `healed_permission_mode` is
+    // `Some` only when we actually substituted a default, so the
+    // best-effort persist below never rewrites a row that already carries a
+    // value.
+    let (permission_mode, healed_permission_mode) = match record.permission_mode.clone() {
+        Some(mode) => (Some(mode), None),
+        None => {
+            let fallback = fallback_permission_mode(provider_kind).map(str::to_string);
+            (fallback.clone(), fallback)
+        }
+    };
+
+    if let Some(mode) = healed_permission_mode {
+        // Best-effort heal the row so future rebuilds and the frontend's
+        // picker seed agree on the mode. Never fail the resume over a DB
+        // write — the in-memory session is already resolving to the right
+        // mode via `permission_mode` above.
+        let db: State<'_, DatabaseStore> = app.state();
+        let config = AgentChatSessionConfig {
+            permission_mode: AgentChatSessionConfig::set(mode),
+            ..AgentChatSessionConfig::default()
+        };
+        if let Err(error) = db.update_agent_chat_session_config(&thread_id.0, &config) {
+            eprintln!(
+                "[codemux::agent_chat] failed to heal NULL permission_mode for thread={}: {error}",
+                thread_id.0,
+            );
+        }
+    }
+
     let build_input = |resume_cursor: Option<serde_json::Value>| StartSessionInput {
         thread_id: thread_id.clone(),
         cwd: cwd.clone(),
         model: record.model.clone(),
         resume_cursor,
-        permission_mode: record.permission_mode.clone(),
+        permission_mode: permission_mode.clone(),
         effort: record.effort.clone(),
         context_window: record.context_window.clone(),
         additional_directories: vec![],

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -564,6 +564,24 @@ fn create_schema(conn: &Connection) -> Result<(), String> {
         // reads back as a paired device; account sessions set it to 'account'.
         "ALTER TABLE web_remote_sessions ADD COLUMN source TEXT NOT NULL DEFAULT 'pair'",
         "ALTER TABLE web_remote_sessions ADD COLUMN account_user_id TEXT",
+        // Backfill permission_mode for rows created before the column above
+        // existed. Those rows read back NULL, which makes backend
+        // auto-resume rebuild the live session with no permissionMode (SDK
+        // `default` mode → an approval prompt for every tool) even though
+        // the frontend has always displayed the provider default ("Full
+        // access") for them. Heal them to that same displayed default so the
+        // UI and the rebuilt session agree. `provider` is stored lowercase
+        // (see `upsert_agent_chat_session`); these strings mirror the
+        // per-provider fallback in `commands::agent_chat::fallback_permission_mode`
+        // and each provider's `default_permission_mode` in
+        // `agent_provider/*/capabilities.rs`. OpenCode has no permission
+        // modes, so its rows stay NULL. Ordered after the ALTER above so the
+        // column exists; idempotent because after the first run no NULL rows
+        // remain to update.
+        "UPDATE agent_chat_sessions SET permission_mode = 'bypassPermissions' \
+             WHERE permission_mode IS NULL AND provider = 'claude'",
+        "UPDATE agent_chat_sessions SET permission_mode = 'danger-full-access' \
+             WHERE permission_mode IS NULL AND provider = 'codex'",
     ] {
         if let Err(e) = conn.execute(stmt, []) {
             let msg = e.to_string();
@@ -3235,6 +3253,53 @@ mod tests {
         // Delete
         db.delete_setting("theme").unwrap();
         assert_eq!(db.get_setting("theme"), None);
+    }
+
+    #[test]
+    fn backfill_null_permission_mode_migration() {
+        let db = init_test_database();
+
+        // Legacy rows: `upsert_agent_chat_session` never writes
+        // permission_mode, so the column reads back NULL — exactly the
+        // pre-column shape the migration backfills.
+        db.upsert_agent_chat_session("t-claude", "ws", Some("/tmp"), "claude")
+            .unwrap();
+        db.upsert_agent_chat_session("t-codex", "ws", Some("/tmp"), "codex")
+            .unwrap();
+        db.upsert_agent_chat_session("t-opencode", "ws", Some("/tmp"), "opencode")
+            .unwrap();
+        // A claude row that already carries an explicit non-default mode
+        // must survive the backfill untouched.
+        db.upsert_agent_chat_session("t-claude-set", "ws", Some("/tmp"), "claude")
+            .unwrap();
+        db.update_agent_chat_session_config(
+            "t-claude-set",
+            &AgentChatSessionConfig {
+                permission_mode: AgentChatSessionConfig::set("plan"),
+                ..AgentChatSessionConfig::default()
+            },
+        )
+        .unwrap();
+
+        // Re-run the schema migrations (idempotent) to fire the backfill.
+        {
+            let conn = db.conn.lock().unwrap();
+            create_schema(&conn).unwrap();
+        }
+
+        let mode = |thread: &str| {
+            db.get_agent_chat_session(thread)
+                .unwrap()
+                .permission_mode
+        };
+        assert_eq!(mode("t-claude").as_deref(), Some("bypassPermissions"));
+        assert_eq!(mode("t-codex").as_deref(), Some("danger-full-access"));
+        assert_eq!(mode("t-opencode"), None, "opencode rows stay NULL");
+        assert_eq!(
+            mode("t-claude-set").as_deref(),
+            Some("plan"),
+            "rows with an explicit mode are untouched"
+        );
     }
 
     #[test]

--- a/src-tauri/tests/agent_chat_commands.rs
+++ b/src-tauri/tests/agent_chat_commands.rs
@@ -940,6 +940,77 @@ mod auto_resume {
             .expect("send_turn succeeds on the resumed session");
     }
 
+    // Regression: a row whose `permission_mode` is NULL (created before the
+    // column existed) must NOT rebuild the live session in `default` mode.
+    // The frontend shows "Full access" (bypassPermissions) for such rows, so
+    // `ensure_live_session` substitutes the Claude provider default —
+    // otherwise the SDK prompts for every Edit/Bash while the UI says Full
+    // access. It also heals the row so the value persists.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn null_permission_mode_rebuilds_with_provider_default_and_heals_row() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let capture = tmp.path().join("start-session-capture.jsonl");
+        let cwd = tmp.path().join("workdir");
+        std::fs::create_dir_all(&cwd).unwrap();
+        let wrapper = capture_wrapper(tmp.path(), &capture);
+
+        let app = tauri::test::mock_app();
+        app.manage(DatabaseStore::new_in_memory());
+        app.manage(AppStateStore::default());
+        app.manage(ProviderRegistry::new());
+        let handle = app.handle().clone();
+
+        let provider = claude_provider_with_capture(wrapper).await;
+        {
+            let registry: tauri::State<'_, ProviderRegistry> = handle.state();
+            registry
+                .set_claude(provider.clone() as Arc<dyn AgentProvider>)
+                .await;
+        }
+
+        // Seed a legacy row: upsert never writes permission_mode, so it is
+        // NULL — the pre-column shape.
+        let thread = ThreadId("chat-pane-legacy-null-pm".into());
+        {
+            let db: tauri::State<'_, DatabaseStore> = handle.state();
+            db.upsert_agent_chat_session(&thread.0, "ws-1", Some(&cwd.to_string_lossy()), "claude")
+                .unwrap();
+            assert_eq!(
+                db.get_agent_chat_session(&thread.0)
+                    .unwrap()
+                    .permission_mode,
+                None,
+                "precondition: the row starts with a NULL permission_mode"
+            );
+        }
+
+        ensure_live_session(&handle, ProviderKind::Claude, &thread)
+            .await
+            .expect("auto-resume should succeed");
+
+        // The start-session carried the Claude provider default rather than
+        // launching in `default` mode.
+        let captured = read_capture(&capture);
+        assert_eq!(captured.len(), 1, "exactly one start-session was sent");
+        let params = &captured[0]["params"];
+        assert_eq!(
+            params["permissionMode"].as_str(),
+            Some("bypassPermissions"),
+            "NULL permission_mode must resolve to the Claude provider default"
+        );
+
+        // And the row was healed so future rebuilds + the frontend seed agree.
+        let db: tauri::State<'_, DatabaseStore> = handle.state();
+        assert_eq!(
+            db.get_agent_chat_session(&thread.0)
+                .unwrap()
+                .permission_mode
+                .as_deref(),
+            Some("bypassPermissions"),
+            "the NULL row must be healed to the resolved default"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn ensure_live_session_is_a_noop_when_session_already_live() {
         let tmp = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Problem

Long-lived chat threads (typically the default thread at the project root) started prompting for approval on every Edit/Bash even though the composer's permission picker showed **Full access**. Re-picking Full access made it go away — per thread.

## Root cause

- `agent_chat_sessions.permission_mode` was added via `ALTER TABLE` after chat shipped, so rows created before the migration read back `NULL`. Worktree threads are newer and always have the mode persisted — which is why only old root-project threads were affected.
- `ensure_live_session` rebuilt sessions with that raw `NULL`, so the Claude adapter passed no `permissionMode` to the sidecar and the SDK launched in its prompting `default` mode.
- The frontend seeds the picker to the provider default (`bypassPermissions`, "Full access") for the same `NULL` rows — UI and live session desync.
- The v0.13.2 dead-run watchdog (#160/#162) made `has_session` report watchdog-dead sessions as absent, so these silent DB-row rebuilds now fire mid-run instead of only after an app restart, turning the latent NULL-row bug into a constant one.
- Re-picking Full access "fixed" a thread because the picker path restarts with an explicit mode **and persists it**, healing the row.

## Fix

- `ensure_live_session` resolves a `NULL` persisted `permission_mode` to the provider default (`bypassPermissions` for Claude, `danger-full-access` for Codex, none for OpenCode) and best-effort heals the row so future rebuilds and the picker seed agree.
- One-time idempotent backfill migration sets existing `NULL` rows to the provider default the UI already displayed for them.
- Feature-doc note in `docs/features/agent-chat.md`.

## Tests

- New integration test: NULL-mode row → `ensure_live_session` against the fake sidecar → asserts the spawned session carries `permissionMode: "bypassPermissions"` and the row heals.
- New migration unit test: claude/codex NULL rows backfilled, opencode stays NULL, non-NULL rows untouched.
- Full `cargo test --no-fail-fast`: 2165 lib tests + all integration suites green, 0 failures.