### PR TITLE
feat(chat): re-pin transcript to latest on prompt send

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -264,6 +264,19 @@ Contract preserved from the pre-redesign renderer:
   imperceptible in both scroll directions. (An earlier build set a blanket
   `overflow-anchor: none`, which disabled anchoring everywhere and let
   those settles drift the viewport hundreds of px per wheel batch.)
+- **Send re-pins to the tail (catch-up on send).** Sending a new prompt
+  from the composer always snaps the transcript to the bottom and
+  re-enters following-bottom mode — even when the reader had scrolled up
+  into history (where otherwise only the "Jump to latest" pill shows).
+  `AgentChatPane` bumps an incrementing `scrollToBottomSignal` in
+  `handleSubmit` (right after the optimistic user-message append, so the
+  jump lands on the fresh bubble; this also covers the one-click "Continue
+  run"), threaded through `ChatTranscript` → `MessageList`, where the
+  `ScrollToBottomOnSend` child fires the engine's own `scrollToEnd` (the
+  imperative API is what re-arms the state machine — a raw `scrollTop`
+  write would move the viewport but leave the engine unpinned). Only a
+  real send moves the viewport: streamed tokens and other re-renders keep
+  the same signal, so free-scroll while reading history is untouched.
 - **Turn anchoring is deliberately OFF** (`scrollAnchor={false}` on
   every row): with hundreds of pre-hydrated rows the engine's anchor
   handling scrolls the viewport to a stale early anchor when new items

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -505,6 +505,17 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   // scroller"), so a direct query by `data-subagent-card` always finds the
   // node.
   const paneRootRef = useRef<HTMLDivElement>(null);
+  // Send → jump-to-latest (catch-up on send). An incrementing counter
+  // forwarded to the transcript; bumping it snaps the viewport to the
+  // bottom and re-pins following-bottom mode. Sending a new prompt must
+  // always bring the reader to the latest content and keep them on the
+  // stream, even if they had scrolled up into history — see
+  // `ScrollToBottomOnSend` in MessageList.tsx.
+  const [scrollToBottomSignal, setScrollToBottomSignal] = useState(0);
+  const requestScrollToBottom = useCallback(
+    () => setScrollToBottomSignal((n) => n + 1),
+    [],
+  );
   // Live handles for an in-flight jump (rAF settle loop + highlight
   // timeout), cancelled on a re-jump, a thread switch, and unmount — the
   // same hygiene as MessageList's / MessageTrail's own settle loops.
@@ -1180,6 +1191,11 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
           ? crypto.randomUUID()
           : `nonce-${Date.now()}-${Math.random().toString(36).slice(2)}`;
       appendUserMessage(threadId, plan.text, clientNonce, imageDisplaySources);
+      // Catch up to the latest on send: snap the transcript to the bottom
+      // and re-pin following-bottom, even if the reader had scrolled up
+      // into history. Bumped in the same commit as the optimistic append
+      // so the jump lands on the freshly-added user bubble.
+      requestScrollToBottom();
       if (isContinue) {
         // Preserve the composer: `appendUserMessage` reset `inputDraft` to ""
         // as a side effect, so restore the user's in-progress text. Staged
@@ -1237,6 +1253,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     setInputDraft,
     clearStagedAttachments,
     updateStagedAttachment,
+    requestScrollToBottom,
   ]);
 
   /** One-click "Continue run" (issue #154): resume an interrupted run by
@@ -2743,6 +2760,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
               streaming={streaming || isSending}
               stalled={stalled}
               interrupted={interrupted}
+              scrollToBottomSignal={scrollToBottomSignal}
               sessionStartedAt={sessionStartedAt}
               provider={provider}
               onRespondToRequest={handleRespond}

--- a/src/components/chat/ChatTranscript.tsx
+++ b/src/components/chat/ChatTranscript.tsx
@@ -16,6 +16,10 @@ interface Props {
   /** True when the last run never cleanly settled — drives the
    *  "Run interrupted" tail divider. */
   interrupted?: boolean;
+  /** Send → jump-to-latest signal (incrementing). Forwarded to
+   *  MessageList: each bump re-pins the transcript tail so sending a new
+   *  prompt catches the reader up even from deep in history. */
+  scrollToBottomSignal?: number;
   /** Optional session-created timestamp for the top session-start marker
    *  (design D2). Forwarded to MessageList; Stage 3 wires the real value. */
   sessionStartedAt?: number;
@@ -50,6 +54,7 @@ export function ChatTranscript({
   streaming,
   stalled,
   interrupted,
+  scrollToBottomSignal,
   sessionStartedAt,
   provider,
   onRespondToRequest,
@@ -70,6 +75,7 @@ export function ChatTranscript({
         streaming={streaming}
         stalled={stalled}
         interrupted={interrupted}
+        scrollToBottomSignal={scrollToBottomSignal}
         sessionStartedAt={sessionStartedAt}
         provider={provider}
         onRespondToRequest={onRespondToRequest}

--- a/src/components/chat/MessageList.test.tsx
+++ b/src/components/chat/MessageList.test.tsx
@@ -28,6 +28,25 @@ vi.mock("@/assets/preset-icons/opencode.svg", () => ({
   default: "/mock/opencode.svg",
 }));
 
+// Send → jump-to-latest: `ScrollToBottomOnSend` calls the scroller
+// engine's imperative `scrollToEnd` (which snaps to the tail AND re-pins
+// following-bottom). Stub the hook so we can assert the wiring without a
+// live layout. `scrollToEnd` is a stable ref so the effect never refires
+// on unrelated re-renders (only on a real signal change).
+const { scrollToEndSpy } = vi.hoisted(() => ({ scrollToEndSpy: vi.fn() }));
+vi.mock("@/components/ui/message-scroller", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/components/ui/message-scroller")>();
+  return {
+    ...actual,
+    useMessageScroller: () => ({
+      scrollToEnd: scrollToEndSpy,
+      scrollToMessage: vi.fn(),
+      scrollToStart: vi.fn(),
+    }),
+  };
+});
+
 afterEach(() => cleanup());
 
 // The MessageScroller renders every row into the DOM (perf comes from
@@ -760,5 +779,77 @@ describe("MessageList dead-run detection (issue #154)", () => {
       renderList([userTurn], { interrupted: false, streaming: false });
       expect(screen.queryByTestId("run-interrupted-divider")).toBeNull();
     });
+  });
+});
+
+describe("MessageList send → jump-to-latest", () => {
+  const userTurn: ChatViewItem = {
+    kind: "user_message",
+    id: "um-1",
+    seq: 0,
+    text: "first prompt",
+  };
+  const nextTurn: ChatViewItem = {
+    kind: "user_message",
+    id: "um-2",
+    seq: 1,
+    text: "second prompt",
+  };
+
+  afterEach(() => scrollToEndSpy.mockClear());
+
+  it("does not force a scroll on the initial render", () => {
+    render(
+      <MessageList
+        messages={[userTurn]}
+        scrollToBottomSignal={0}
+        {...noopHandlers}
+      />,
+    );
+    expect(scrollToEndSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not force a scroll when messages change but the signal does not", () => {
+    const { rerender } = render(
+      <MessageList
+        messages={[userTurn]}
+        scrollToBottomSignal={3}
+        {...noopHandlers}
+      />,
+    );
+    scrollToEndSpy.mockClear();
+    // A streamed token (new/changed messages) must never yank a reader who
+    // is scrolled up in history — only an explicit send does.
+    rerender(
+      <MessageList
+        messages={[userTurn, nextTurn]}
+        scrollToBottomSignal={3}
+        {...noopHandlers}
+      />,
+    );
+    expect(scrollToEndSpy).not.toHaveBeenCalled();
+  });
+
+  it("snaps to the tail (instant) and re-pins following when the send signal increments", () => {
+    const { rerender } = render(
+      <MessageList
+        messages={[userTurn]}
+        scrollToBottomSignal={0}
+        {...noopHandlers}
+      />,
+    );
+    scrollToEndSpy.mockClear();
+    // Mirrors a send: the optimistic user bubble appends AND the signal
+    // bumps in the same commit.
+    rerender(
+      <MessageList
+        messages={[userTurn, nextTurn]}
+        scrollToBottomSignal={1}
+        {...noopHandlers}
+      />,
+    );
+    expect(scrollToEndSpy).toHaveBeenCalledTimes(1);
+    // `behavior: "auto"` = instant catch-up (no smooth-scroll lag on send).
+    expect(scrollToEndSpy).toHaveBeenCalledWith({ behavior: "auto" });
   });
 });

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -2,6 +2,7 @@ import { ArrowDown, TriangleAlert } from "lucide-react";
 import {
   memo,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   type CSSProperties,
@@ -14,6 +15,7 @@ import {
   MessageScrollerItem,
   MessageScrollerProvider,
   MessageScrollerViewport,
+  useMessageScroller,
 } from "@/components/ui/message-scroller";
 import type {
   ChatViewItem,
@@ -67,6 +69,13 @@ interface Props {
   /** True when the last run never cleanly settled (child exit / crash).
    *  Renders a "Run interrupted" tail divider while not streaming. */
   interrupted?: boolean;
+  /** Send → jump-to-latest signal. An incrementing counter bumped by the
+   *  composer send handlers (AgentChatPane): each increment snaps the
+   *  transcript to the bottom and re-pins following-bottom, so sending a
+   *  new prompt always catches the reader up to the latest content — even
+   *  when they had scrolled up into history. Absent / unchanged ⇒ no forced
+   *  scroll (free-scroll while reading history is preserved). */
+  scrollToBottomSignal?: number;
   /** Optional session-created timestamp for the top session-start marker
    *  (design D2). When absent a plain "Session started" divider renders.
    *  Stage 3 wires the real value through AgentChatPane. */
@@ -143,6 +152,7 @@ export function MessageList({
   streaming = false,
   stalled = null,
   interrupted = false,
+  scrollToBottomSignal,
   sessionStartedAt,
   provider,
   onRespondToRequest,
@@ -245,6 +255,10 @@ export function MessageList({
             provider, sibling of the viewport). Reads the active turn from
             `visibleMessageIds`; hides itself on short threads. */}
         <MessageTrail slots={slots} />
+        {/* Send → jump-to-latest. Reacts to the composer send signal by
+            re-pinning the tail through the engine's own imperative API
+            (inside the provider, so `useMessageScroller` resolves). */}
+        <ScrollToBottomOnSend signal={scrollToBottomSignal} />
         <MessageScrollerViewport
           style={transcriptFadeEnabled() ? WS_FADE_STYLE : undefined}
         >
@@ -325,6 +339,41 @@ export function MessageList({
       </MessageScroller>
     </MessageScrollerProvider>
   );
+}
+
+/**
+ * Send → jump-to-latest contract. When the user sends a new prompt from
+ * the composer, sending must always bring them to the latest content and
+ * keep them following the stream — even if they had scrolled up into
+ * history (where normally only the "Jump to latest" pill would show).
+ *
+ * `signal` is an incrementing counter the send handlers bump once per
+ * send (see `AgentChatPane`); the effect fires only on a real change
+ * (never on the initial value — the transcript already mounts pinned at
+ * the bottom, and unrelated re-renders keep the same value), so
+ * free-scroll while reading history is never disturbed. Each fire calls
+ * the scroller engine's own `scrollToEnd`, which both snaps to the tail
+ * and re-enters following-bottom mode — so any content that streams in
+ * afterward keeps auto-scrolling. Going through the engine's imperative
+ * API (not a raw `scrollTop` write) is what re-arms that state machine; a
+ * manual write would move the viewport but leave the engine unpinned.
+ * Lives inside the provider (a child of `MessageScroller`) so
+ * `useMessageScroller` resolves; renders nothing.
+ */
+function ScrollToBottomOnSend({ signal }: { signal?: number }) {
+  const { scrollToEnd } = useMessageScroller();
+  const prevSignalRef = useRef(signal);
+  useEffect(() => {
+    if (signal === prevSignalRef.current) return;
+    prevSignalRef.current = signal;
+    // Bumped in the same commit as the optimistic user-message append, so
+    // this effect runs with that row already in the DOM — the snap lands
+    // on it. Re-entering following-bottom also covers the content-
+    // visibility settle: as the fresh row measures, the engine keeps the
+    // tail pinned without any extra rAF here.
+    scrollToEnd({ behavior: "auto" });
+  }, [signal, scrollToEnd]);
+  return null;
 }
 
 /** Viewport edge fade (design `wsFade`): dissolve content at the top/bottom


### PR DESCRIPTION
## Problem

Sending a prompt while scrolled up in the Agent Chat transcript left the viewport where it was — only the "Jump to latest" pill showed, so you had to click it (or scroll) to catch up to your own message and the incoming response.

## Fix

Every composer send now snaps the transcript to the bottom and re-pins following-bottom mode:

- **`AgentChatPane.tsx`** — `handleSubmit` bumps an incrementing `scrollToBottomSignal` immediately after the optimistic user-message append, so the jump lands on the fresh bubble. Also covers the one-click "Continue run" path (it delegates to `handleSubmit`).
- **`MessageList.tsx`** — a new `ScrollToBottomOnSend` child reacts to the signal and calls the scroller engine's own `scrollToEnd()` — the same imperative API the Jump-to-latest pill uses — which re-arms the following-bottom state machine so content streaming in afterwards keeps auto-scrolling. (A raw `scrollTop` write would move the viewport but leave the engine unpinned.)
- **`ChatTranscript.tsx`** — forwards the signal.

Free-scroll while reading history is untouched: the signal fires only on send, never on re-renders or streamed messages, so the existing stick-to-bottom / 8px re-pin / `scrollAnchor={false}` contract is preserved.

## Not covered (intentionally)

The deferred-worktree first-send path only runs on an empty thread and activates a freshly-mounted pane that starts pinned at the bottom (`defaultScrollPosition="end"`), so a signal bump there would be inert.

## Testing

- 3 new tests in `MessageList.test.tsx` ("send → jump-to-latest"): no forced scroll on initial render, no forced scroll when messages change without the signal, snap + re-pin when the signal increments.
- `npm run check` + full frontend suite: 2780 tests / 191 files pass.
- Visual verification in the dev-mock UI: reproduced the scrolled-up-in-history state, sent a prompt, confirmed the viewport snapped to the new user bubble and followed the streamed reply to the tail.
- Docs updated: `docs/features/agent-chat.md` transcript-scroller section.