### PR TITLE
fix(browser): default the desktop-size background-browser peek viewport to on

### DIFF
--- a/docs/features/browser.md
+++ b/docs/features/browser.md
@@ -155,12 +155,13 @@ own compact header instead. Both props are additive and default to today's
 pane behavior (`workspaceId` unset falls through to the exact prior
 `browser_id`-only lookup; `hideToolbar` defaults to showing the toolbar).
 
-**Desktop-size peek viewport (opt-in)**: by default, `BrowserPane` syncs the
-browser's real CDP viewport to its container — inside the 440×300 peek that
-means pages reflow at popover dimensions and agents end up re-sending
-`viewport` every turn. Settings → Agent → "Desktop-size background browser"
-(`UserSettings.agent_chat.background_browser_desktop_viewport`, synced
-settings, default OFF) instead pins the peek's viewport to 1280×800 —
+**Desktop-size peek viewport (default ON)**: with the setting off,
+`BrowserPane` syncs the browser's real CDP viewport to its container — inside
+the 440×300 peek that means pages reflow at popover dimensions and agents end
+up re-sending `viewport` every turn. Settings → Agent → "Desktop-size
+background browser" (`UserSettings.agent_chat.background_browser_desktop_viewport`,
+synced settings, default ON since the field flipped post-`v0.13.2`; an
+explicitly saved `false` is preserved) pins the peek's viewport to 1280×800 —
 matching the `desktop` preset / `RESET_SPEC` in
 `src-tauri/src/browser_viewport.rs` — via a new optional `BrowserPane`
 `fixedViewport` prop. When set, the WebSocket-open handshake sends the fixed
@@ -169,8 +170,8 @@ canvas element to the container but skips the viewport re-send, so the
 existing frame-draw letterbox scales the full-size frame down to fit. Input
 mapping needs no changes — `mapToViewport` already routes clicks through the
 canvas rect + draw rect into viewport coordinates. Applies only to the peek
-overlay; normal browser panes (and the peek with the setting off) keep the
-container-sync behavior unchanged.
+overlay; normal browser panes (and the peek with the setting toggled off) keep
+the container-sync behavior unchanged.
 
 ## Session reaping during app lifetime (issue #126)
 

--- a/docs/features/settings-sync.md
+++ b/docs/features/settings-sync.md
@@ -49,7 +49,7 @@ UserSettings
     max_total_mb: number       (default: 100)
   agent_chat
     checkpoints_enabled: boolean                 (default: false, run-start rollback checkpoint — issue #80)
-    background_browser_desktop_viewport: boolean (default: false, pin GUI-mode background-browser peek to 1280×800 — docs/features/browser.md)
+    background_browser_desktop_viewport: boolean (default: true — serde default_true, so blobs missing the field get ON while an explicitly saved false is kept; pin GUI-mode background-browser peek to 1280×800 — docs/features/browser.md)
 ```
 
 ### Offline Cache

--- a/src-tauri/src/settings_sync.rs
+++ b/src-tauri/src/settings_sync.rs
@@ -131,14 +131,24 @@ pub struct FileTreeSettings {
 /// the peek popover (`BrowserPeekOverlay.tsx`) is showing it, instead
 /// of shrinking the viewport to the tiny popover's pixel size — the
 /// popover's canvas letterboxes the larger frame down to fit. Defaults
-/// to OFF so today's container-sync behavior is unchanged out of the
-/// box.
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+/// to ON — pages render at real desktop size out of the box and agents
+/// don't have to re-send `viewport` each turn; blobs where the user
+/// explicitly saved `false` keep the container-sync behavior.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct AgentChatSettings {
     #[serde(default)]
     pub checkpoints_enabled: bool,
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub background_browser_desktop_viewport: bool,
+}
+
+impl Default for AgentChatSettings {
+    fn default() -> Self {
+        Self {
+            checkpoints_enabled: false,
+            background_browser_desktop_viewport: true,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -531,7 +541,7 @@ mod tests {
             },
             agent_chat: AgentChatSettings {
                 checkpoints_enabled: true,
-                background_browser_desktop_viewport: true,
+                background_browser_desktop_viewport: false,
             },
         };
 
@@ -554,30 +564,36 @@ mod tests {
         assert_eq!(back.session_restore.scrollback_lines, 5000);
         assert_eq!(back.session_restore.max_total_mb, 50);
         assert!(back.agent_chat.checkpoints_enabled);
-        assert!(back.agent_chat.background_browser_desktop_viewport);
+        assert!(!back.agent_chat.background_browser_desktop_viewport);
     }
 
     /// A settings blob saved before the agent_chat section existed
-    /// still deserializes — and the checkpoint opt-in stays OFF.
+    /// still deserializes — the checkpoint opt-in stays OFF and the
+    /// desktop-viewport pin gets the ON default.
     #[test]
     #[serial]
     fn missing_agent_chat_section_defaults_to_checkpoints_off() {
         let legacy = r#"{"appearance":{"theme":"dark"}}"#;
         let parsed: UserSettings = serde_json::from_str(legacy).unwrap();
         assert!(!parsed.agent_chat.checkpoints_enabled);
-        assert!(!parsed.agent_chat.background_browser_desktop_viewport);
+        assert!(parsed.agent_chat.background_browser_desktop_viewport);
     }
 
     /// A settings blob saved before `background_browser_desktop_viewport`
     /// existed (but with an `agent_chat` section already present) still
-    /// deserializes — the new field defaults to OFF via serde default,
-    /// not a deserialize error.
+    /// deserializes — the new field defaults to ON via serde default,
+    /// not a deserialize error. An explicit saved `false` still wins.
     #[test]
     #[serial]
-    fn missing_desktop_viewport_field_defaults_off() {
+    fn missing_desktop_viewport_field_defaults_on() {
         let legacy = r#"{"agent_chat":{"checkpoints_enabled":true}}"#;
         let parsed: UserSettings = serde_json::from_str(legacy).unwrap();
         assert!(parsed.agent_chat.checkpoints_enabled);
+        assert!(parsed.agent_chat.background_browser_desktop_viewport);
+
+        let explicit_off =
+            r#"{"agent_chat":{"checkpoints_enabled":true,"background_browser_desktop_viewport":false}}"#;
+        let parsed: UserSettings = serde_json::from_str(explicit_off).unwrap();
         assert!(!parsed.agent_chat.background_browser_desktop_viewport);
     }
 

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -1988,7 +1988,7 @@ export function SettingsView() {
                     description="Start the agent's background browser at a real desktop viewport (1280×800) so pages render at full size in the peek popover, scaled to fit."
                   >
                     <Switch
-                      checked={syncedSettings.agent_chat?.background_browser_desktop_viewport ?? false}
+                      checked={syncedSettings.agent_chat?.background_browser_desktop_viewport ?? true}
                       onCheckedChange={(checked) => {
                         updateSyncedSetting("agent_chat", "background_browser_desktop_viewport", checked).catch(console.error);
                       }}

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -460,7 +460,7 @@ const SYNCED_SETTINGS: UserSettings = {
   },
   // Checkpoints ON in the mock so the seeded chat pane exercises the
   // restore affordance (issue #80) without a real backend.
-  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: false },
+  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: true },
 };
 
 const EMPTY_CAPABILITIES: ProviderChatCapabilities = {

--- a/src/stores/settings-sync-integration.test.ts
+++ b/src/stores/settings-sync-integration.test.ts
@@ -40,7 +40,7 @@ const FULL_CUSTOM: UserSettings = {
   notifications: { sound_enabled: false, desktop_enabled: false },
   file_tree: { show_hidden_files: true },
   session_restore: { enabled: false, scrollback_lines: 5000, max_total_mb: 50 },
-  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: true },
+  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: false },
 };
 
 // ── Setup ──

--- a/src/stores/synced-settings-store.test.ts
+++ b/src/stores/synced-settings-store.test.ts
@@ -36,7 +36,7 @@ const DARK_SETTINGS: UserSettings = {
   notifications: { sound_enabled: false, desktop_enabled: true },
   file_tree: { show_hidden_files: true },
   session_restore: { enabled: true, scrollback_lines: 10000, max_total_mb: 100 },
-  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: true },
+  agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: false },
 };
 
 describe("synced-settings-store", () => {
@@ -271,11 +271,11 @@ describe("synced-settings-store", () => {
 
     it("selectBackgroundBrowserDesktopViewport returns boolean", () => {
       useSyncedSettingsStore.setState({ settings: DARK_SETTINGS });
-      expect(selectBackgroundBrowserDesktopViewport(useSyncedSettingsStore.getState())).toBe(true);
+      expect(selectBackgroundBrowserDesktopViewport(useSyncedSettingsStore.getState())).toBe(false);
     });
 
-    it("selectBackgroundBrowserDesktopViewport defaults to false", () => {
-      expect(selectBackgroundBrowserDesktopViewport(useSyncedSettingsStore.getState())).toBe(false);
+    it("selectBackgroundBrowserDesktopViewport defaults to true", () => {
+      expect(selectBackgroundBrowserDesktopViewport(useSyncedSettingsStore.getState())).toBe(true);
     });
   });
 

--- a/src/stores/synced-settings-store.ts
+++ b/src/stores/synced-settings-store.ts
@@ -21,7 +21,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   notifications: { sound_enabled: true, desktop_enabled: true },
   file_tree: { show_hidden_files: false },
   session_restore: { enabled: true, scrollback_lines: 10_000, max_total_mb: 100 },
-  agent_chat: { checkpoints_enabled: false, background_browser_desktop_viewport: false },
+  agent_chat: { checkpoints_enabled: false, background_browser_desktop_viewport: true },
 };
 
 export interface SyncedSettingsState {
@@ -178,4 +178,4 @@ export const selectAgentCheckpointsEnabled = (s: SyncedSettingsState): boolean =
   s.settings.agent_chat?.checkpoints_enabled ?? false;
 
 export const selectBackgroundBrowserDesktopViewport = (s: SyncedSettingsState): boolean =>
-  s.settings.agent_chat?.background_browser_desktop_viewport ?? false;
+  s.settings.agent_chat?.background_browser_desktop_viewport ?? true;

--- a/src/tauri/types.ts
+++ b/src/tauri/types.ts
@@ -55,7 +55,7 @@ export interface SessionRestoreSettings {
  *  `background_browser_desktop_viewport` pins the GUI-mode background
  *  browser's peek popover (`BrowserPeekOverlay.tsx`) to a real desktop
  *  viewport (1280×800) instead of shrinking to the popover's pixel
- *  size — default OFF. */
+ *  size — default ON. */
 export interface AgentChatSyncSettings {
   checkpoints_enabled: boolean;
   background_browser_desktop_viewport: boolean;


### PR DESCRIPTION
## Problem

The desktop-size viewport for the agent-chat background-browser peek (PR #140, shipped v0.13.0) is opt-in and **off by default**. Out of the box the peek popover still syncs the browser's CDP viewport to its tiny pixel size, so pages render zoomed-in / phone-width and agents have to re-send `viewport` every turn to work at desktop size.

## Change

Flip `agent_chat.background_browser_desktop_viewport` to **default ON**:

- `settings_sync.rs`: `#[serde(default = "default_true")]` on the field + manual `Default` impl for `AgentChatSettings` (checkpoints stay off by default)
- Frontend mirrors: `DEFAULT_SETTINGS`, `selectBackgroundBrowserDesktopViewport` fallback, settings-view switch fallback, dev mock
- Tests updated: legacy blobs missing the field now deserialize to ON; a new assertion covers that an explicitly saved `false` still wins; round-trip fixtures use `false` as the non-default value
- Docs: `docs/features/browser.md` § Desktop-size peek viewport and `docs/features/settings-sync.md` defaults table

## Behavior notes

- Settings blobs that **explicitly** stored `false` (any blob re-saved by a v0.13.x client) keep the container-sync behavior — deliberate opt-outs are preserved. Flipping the toggle once in Settings → Agent applies the pin.
- Blobs missing the field (pre-v0.13.0) and fresh installs get the desktop-size peek immediately.

## Verification

- `cargo test` settings_sync: 19/19 pass
- `tsc --noEmit` clean; `vitest`: 2777/2777 pass
- Visual: dev UI (Tauri mock) shows Settings → Agent → "Desktop-size background browser" ON with no stored setting