### PR TITLE
Remove tooltip hover popup animation

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -40,7 +40,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm",
           className
         )}
         {...props}


### PR DESCRIPTION
## What

Tooltips (the hover popup shown on sidebar action buttons, status icons, etc.) animated in and out on hover — fading, zooming, and sliding into place. This removes that animation so tooltips appear and disappear instantly.

## Change

In the shared `TooltipContent` (`src/components/ui/tooltip.tsx`), stripped the enter/exit animation utilities:

- `data-[state=delayed-open]:animate-in` / `data-open:animate-in` + `fade-in-0` + `zoom-in-95`
- `data-closed:animate-out` + `fade-out-0` + `zoom-out-95`
- `data-[side=*]:slide-in-from-*`
- the now-unused `origin-(--radix-tooltip-content-transform-origin)` (only mattered for the zoom transform)

All structural/styling classes (layout, colors, radius, kbd handling) are untouched, so every tooltip in the app now shows without motion.