### PR TITLE
Remove separator line above agent chat composer

### DIFF
--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -2897,10 +2897,10 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
               />
             </div>
           )}
-          {/* Composer region (design D10): a hairline lifts the whole
-              composer column — AskUserQuestion panel, debug banner, and
-              the composer card — off the scrolling transcript. */}
-          <div className="border-t border-border/50 pt-3.5">
+          {/* Composer region (design D10): groups the whole composer
+              column — AskUserQuestion panel, debug banner, and the
+              composer card — below the scrolling transcript. */}
+          <div className="pt-3.5">
             {pendingInputPanelEl}
             {debugBannerEl}
             {composerEl}


### PR DESCRIPTION
Removes the hairline separator that rendered above the composer/input field in the Agent Chat pane. The wrapper div and its top padding are kept so layout spacing is unchanged — only the visible line is gone.

- `src/components/chat/AgentChatPane.tsx`: dropped `border-t border-border/50` from the composer-region wrapper and updated the comment accordingly.

Verified: `npm run check` clean, Composer/AgentChatPane test suites pass (254 tests).