### PR TITLE
Move New Chat to the top of the session-history dropdown

### DIFF
--- a/docs/features/gui-chrome.md
+++ b/docs/features/gui-chrome.md
@@ -90,9 +90,9 @@ titlebar tab share one implementation (see "Important Touch Points").
 - Single `h-10` titlebar for a real, non-OpenFlow chat workspace with the Beta
   flag on; legacy `h-9` chrome is byte-identical with the flag off.
 - Pill tabs with status dots, active-tab close, and a chat-tab chevron opening
-  the shared session-history dropdown (grouped sessions, active-session dot,
-  delete-on-hover, "+ New Chat", and a "Restore checkpoint" footer item when a
-  run-start checkpoint exists).
+  the shared session-history dropdown ("+ New Chat" and a "Restore checkpoint"
+  item at the top when a run-start checkpoint exists, then the grouped sessions
+  with active-session dot and delete-on-hover).
 - `+` launcher covering GUI chat presets, CLI agents (with Shift-split),
   Terminal/Browser panes, and Manage presets.
 - Inline ember chat favorite; rehomed right-panel toggle + RunButton. (The

--- a/src/components/chat/SessionSelector.tsx
+++ b/src/components/chat/SessionSelector.tsx
@@ -31,7 +31,7 @@ export interface SessionSelectorProps {
    *  fresh one with the record's `sdk_session_id` passed through as
    *  the SDK `resume` field. */
   onSelect: (record: AgentChatSessionRecord) => void;
-  /** Called when the user clicks "New Chat" at the bottom of the
+  /** Called when the user clicks "New Chat" at the top of the
    *  dropdown. */
   onNewChat: () => void;
   /**

--- a/src/components/chat/session-history-menu.tsx
+++ b/src/components/chat/session-history-menu.tsx
@@ -99,13 +99,14 @@ export interface SessionHistoryListProps {
   onDelete: (threadId: string) => void;
   /** Close the surrounding menu after an action. */
   closeMenu: () => void;
-  /** Optional footer item (e.g. "Restore checkpoint") rendered above the
-   *  New Chat row. Provide a full `DropdownMenuItem` node. */
+  /** Optional item (e.g. "Restore checkpoint") rendered at the top of the
+   *  menu, just below the New Chat row and above the history separator.
+   *  Provide a full `DropdownMenuItem` node. */
   footerItem?: React.ReactNode;
 }
 
 /**
- * The grouped session list + New Chat footer. Renders INSIDE a
+ * The New Chat row + grouped session list. Renders INSIDE a
  * `DropdownMenuContent`, so both consumers wrap it in their own
  * `DropdownMenu`. One source of truth for the list markup + row
  * behavior (delete-on-hover, active highlight, resume-on-click).
@@ -124,6 +125,18 @@ export function SessionHistoryList({
 
   return (
     <>
+      <DropdownMenuItem
+        onSelect={() => {
+          onNewChat();
+          closeMenu();
+        }}
+        data-testid="session-selector-new-chat"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        New Chat
+      </DropdownMenuItem>
+      {footerItem}
+      <DropdownMenuSeparator />
       {loading && sessions.length === 0 && (
         <div className="px-2 py-4 text-center text-xs text-muted-foreground">
           Loading…
@@ -157,18 +170,6 @@ export function SessionHistoryList({
           ))}
         </div>
       ))}
-      <DropdownMenuSeparator />
-      {footerItem}
-      <DropdownMenuItem
-        onSelect={() => {
-          onNewChat();
-          closeMenu();
-        }}
-        data-testid="session-selector-new-chat"
-      >
-        <Plus className="h-3.5 w-3.5" />
-        New Chat
-      </DropdownMenuItem>
     </>
   );
 }


### PR DESCRIPTION
## Summary

In the Agent Chat session-history dropdown (chat-tab chevron / legacy SessionSelector), the **+ New Chat** action rendered at the bottom, below all grouped history rows — with a long history you had to scroll all the way down just to start a fresh thread.

This moves **New Chat** (and the optional **Restore checkpoint** item) to the top of the dropdown, above the separator and the grouped session list, so it's always visible without scrolling.

## Changes

- `src/components/chat/session-history-menu.tsx` — `SessionHistoryList` now renders New Chat first, then the optional footer item, then a separator, then loading/empty states and the grouped sessions. JSDoc updated to match.
- `src/components/chat/SessionSelector.tsx` — prop comment updated ("bottom" → "top").
- `docs/features/gui-chrome.md` — dropdown description updated to the new ordering.

Both consumers (legacy per-pane `SessionSelector` and the GUI-chrome title-bar chat tab) share `SessionHistoryList`, so both get the fix from the single change.

## Verification

- `npm run check` — passes
- `npm run test` — 196 files, 2843 tests, all passing
- Visual check in the dev mock runtime: opened the chat-tab dropdown; New Chat + Restore checkpoint render at the top with the grouped history below