### PR TITLE
GUI-styled titlebar for new-workspace drafts

### DIFF
--- a/docs/features/gui-chrome.md
+++ b/docs/features/gui-chrome.md
@@ -27,8 +27,12 @@ predicate lives in the shared `useGuiChrome()` hook
 (`src/hooks/use-gui-chrome.ts`) so other GUI-mode-only surfaces gate on the
 identical rule — currently the background-browser inline chip, context-bar
 indicator, and peek overlay (`docs/features/browser.md` § "Background
-browser in GUI mode"). When false it returns the byte-identical legacy
-`h-9` bar; when true it composes discrete slots left-to-right:
+browser in GUI mode"). A live lazy-creation draft renders the same `h-10`
+shell with **draft slots** instead, gated on the sibling
+`useDraftGuiChrome()` predicate (`enableAgentChat && lazyDraftActive` —
+mutually exclusive with `guiChrome`; see "Draft titlebar variant" below).
+When neither predicate holds it returns the byte-identical legacy `h-9`
+bar; in workspace GUI chrome it composes discrete slots left-to-right:
 
 `[sidebar-width cluster: sidebar toggle] | [tabs] [+ launcher] | [pinned preset tiles] …drag spacer… [right-panel toggle] [RunButton split] [ResourceMonitor] [IdeLauncher compact] [sep] [WindowControls]`
 
@@ -77,9 +81,26 @@ sidebar boundary so tabs start where the content pane starts (design:
   their legacy default rendering for the flag-off `PresetBar`, preserving
   the byte-identical contract.
 - **Row suppression** — `WorkspaceMain` (`workspace-main.tsx`) drops `TabBar`
-  and `PresetBar` when the flag is on; `PaneNode` (`isSurfaceRoot` +
-  `enableAgentChat`) suppresses `AgentChatPaneHeader` for a **sole-root**
-  `agent_chat` pane. Split panes keep their per-pane header.
+  and `PresetBar` when the flag is on (both on the real-workspace branch and
+  the draft branch); `PaneNode` (`isSurfaceRoot` + `enableAgentChat`)
+  suppresses `AgentChatPaneHeader` for a **sole-root** `agent_chat` pane.
+  Split panes keep their per-pane header. `DraftChatSurface` likewise
+  suppresses its placeholder `DraftSurfaceHeader` band in GUI mode.
+- **Draft titlebar variant** — while a lazy-creation draft is the active
+  surface (`useDraftGuiChrome()`), the `h-10` bar renders
+  `TitleBarDraftSlots` in place of the workspace slots: a single static
+  "Agent Chat" pill in the active-tab style plus `DraftAgentLauncher`
+  (`agent-launcher.tsx`) — a `+` popover whose GUI/CLI rows materialise the
+  draft via the shared `launchDraftWithPreset` helper
+  (`src/lib/agent-chat/draft-preset-launch.ts`, also used by the legacy
+  draft `PresetBar`). The launcher hides on a Home-target draft and disables
+  while a materialise is in flight, mirroring the legacy draft PresetBar's
+  rules. Workspace-scoped right-cluster controls (right-panel toggle,
+  `RunButton`, `IdeLauncher`) are suppressed — the backend's "active
+  workspace" during a draft is whatever was focused before the draft opened,
+  not what's on screen. This keeps the titlebar silhouette identical across
+  the draft → materialised transition, so pressing "+" no longer flashes the
+  legacy `h-9` bar + `PresetBar` rows.
 
 Session-switch / new-chat orchestration, checkpoint restore, and the
 session-history list are extracted so the legacy per-pane header and the
@@ -111,10 +132,12 @@ titlebar tab share one implementation (see "Important Touch Points").
 
 ## Current Constraints
 
-- **Draft (lazy-creation) workspaces keep legacy chrome.** A live chat draft
-  keeps the `TabBar`/`PresetBar` rows and the `h-9` bar so the draft surface's
-  own PresetBar stays coherent; GUI chrome is gated off while a draft is
-  active.
+- **Draft chrome is a reduced titlebar, not full workspace chrome.** A live
+  chat draft renders the GUI-styled `h-10` draft variant (static pill +
+  draft launcher), but `useGuiChrome()` itself still resolves `false` during
+  a draft — workspace-scoped GUI surfaces (titlebar tabs, background-browser
+  chip, context-bar indicator, right-cluster controls) stay off because the
+  backend's active workspace is not what's on screen.
 - **OpenFlow workspaces are untouched** — they keep their dedicated chrome.
 - **A sole-root chat pane loses its per-pane split/close buttons** (the
   suppressed `AgentChatPaneHeader`); splitting is done from the launcher
@@ -135,10 +158,14 @@ for the full pipeline (Claude-only `Workflow` tool tap, the in-thread
 ## Important Touch Points
 
 - `src/hooks/use-gui-chrome.ts` — the shared `guiChrome` predicate (single
-  source of truth, extracted from `title-bar.tsx`).
-- `src/components/layout/title-bar.tsx` — consumes `useGuiChrome()` for the
-  slot-composition branch, `RightPanelToggle`, `PinnedChatFavorite`,
-  `TitleBarWorkspaceSlots`.
+  source of truth, extracted from `title-bar.tsx`) plus the sibling
+  `useDraftGuiChrome()` draft predicate.
+- `src/components/layout/title-bar.tsx` — consumes `useGuiChrome()` +
+  `useDraftGuiChrome()` for the slot-composition branch, `RightPanelToggle`,
+  `PinnedChatFavorite`, `TitleBarWorkspaceSlots`, `TitleBarDraftSlots`.
+- `src/lib/agent-chat/draft-preset-launch.ts` — shared
+  materialise-with-preset action behind both the legacy draft `PresetBar`
+  and `DraftAgentLauncher`.
 - `src/components/layout/title-bar-tabs.tsx` — pill tab strip + active chat tab
   (chevron dropdown, checkpoint dialog). The inline subagents pill that used to
   live here was removed by PR #143 — see `src/components/chat/SubagentActivityBar.tsx`.

--- a/src/components/chat/DraftChatSurface.test.tsx
+++ b/src/components/chat/DraftChatSurface.test.tsx
@@ -246,6 +246,21 @@ describe("DraftChatSurface", () => {
       expect(header.className).toContain("border-b");
     });
 
+    it("suppresses the header band in GUI chrome (Agent Chat Beta ON) — the titlebar draft pill covers it", async () => {
+      const { useFeatureFlags } = await import("@/stores/feature-flags");
+      useFeatureFlags.setState({ enableAgentChat: true });
+      try {
+        const draft = useChatDraftStore.getState().getOrCreateHomeDraft();
+        useChatDraftStore.getState().setActiveDraft(draft.draftId);
+        const { queryByTestId, getByText } = renderSurface();
+        expect(queryByTestId("draft-surface-header")).toBeNull();
+        // The landing itself still renders.
+        expect(getByText("What should we do today?")).toBeInTheDocument();
+      } finally {
+        useFeatureFlags.setState({ enableAgentChat: false });
+      }
+    });
+
     it("the header band sits ABOVE the home landing in DOM order", () => {
       // Visual hierarchy: the header is the first child of the
       // surface root; the chat-home wrapper comes after. If these

--- a/src/components/chat/DraftChatSurface.tsx
+++ b/src/components/chat/DraftChatSurface.tsx
@@ -48,6 +48,7 @@ import {
   useChatDraftStore,
   type ChatDraft,
 } from "@/stores/chat-draft-store";
+import { useFeatureFlags } from "@/stores/feature-flags";
 import {
   selectCapabilities,
   selectModel,
@@ -984,9 +985,16 @@ function DraftChatSurfaceInner({ draft }: { draft: ChatDraft }) {
     />
   );
 
+  // GUI chrome (Agent Chat Beta) suppresses the placeholder header the
+  // same way it suppresses AgentChatPaneHeader for a sole-root chat
+  // pane — the titlebar's "Agent Chat" draft pill covers the label
+  // (see TitleBarDraftSlots in title-bar.tsx). Legacy chrome keeps the
+  // h-7 band so the draft doesn't look "naked" next to a real pane.
+  const enableAgentChat = useFeatureFlags((s) => s.enableAgentChat);
+
   return (
     <div className="flex h-full w-full flex-col bg-background">
-      <DraftSurfaceHeader />
+      {!enableAgentChat && <DraftSurfaceHeader />}
       <div className="flex-1 min-h-0 overflow-hidden">
         {pending ? (
           <DraftPendingConversation pending={pending} composer={composerEl} />

--- a/src/components/layout/agent-launcher.test.tsx
+++ b/src/components/layout/agent-launcher.test.tsx
@@ -16,6 +16,12 @@ const mocks = vi.hoisted(() => ({
   createTab: vi.fn().mockResolvedValue("tab-new"),
   createBrowserPane: vi.fn().mockResolvedValue("pane-b"),
   setShowSettings: vi.fn(),
+  launchDraftWithPreset: vi.fn().mockResolvedValue({
+    success: true,
+    workspaceId: "ws-new",
+    paneId: "pane-new",
+    threadId: "thread-1",
+  }),
 }));
 
 vi.mock("@/hooks/use-preset-store", () => ({
@@ -29,6 +35,10 @@ vi.mock("@/tauri/commands", () => ({
   createBrowserPane: (...a: unknown[]) => mocks.createBrowserPane(...a),
 }));
 
+vi.mock("@/lib/agent-chat/draft-preset-launch", () => ({
+  launchDraftWithPreset: (...a: unknown[]) => mocks.launchDraftWithPreset(...a),
+}));
+
 vi.mock("@/lib/toast", () => ({
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn(), warning: vi.fn() },
 }));
@@ -40,7 +50,8 @@ vi.mock("@/stores/ui-store", () => ({
 }));
 
 import { useTitlebarPinsStore } from "@/stores/titlebar-pins-store";
-import { AgentLauncher } from "./agent-launcher";
+import type { ChatDraft, DraftId } from "@/stores/chat-draft-store";
+import { AgentLauncher, DraftAgentLauncher } from "./agent-launcher";
 
 function mkPreset(p: Partial<TerminalPreset> & { id: string; name: string }): TerminalPreset {
   return {
@@ -94,6 +105,27 @@ function makeWorkspace(): WorkspaceSnapshot {
   };
 }
 
+function makeDraft(overrides: Partial<ChatDraft> = {}): ChatDraft {
+  return {
+    draftId: "draft-1" as DraftId,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    target: { kind: "project", projectPath: "/p" },
+    provider: "claude",
+    model: null,
+    effort: null,
+    contextWindow: null,
+    permissionMode: null,
+    mode: "default",
+    inputDraft: "",
+    threadId: "thread-1",
+    promotedTo: null,
+    materializedTo: null,
+    promoting: false,
+    lastSendError: null,
+    ...overrides,
+  };
+}
+
 function openLauncher() {
   const trigger = screen.getByTestId("agent-launcher-trigger");
   act(() => {
@@ -122,6 +154,7 @@ beforeEach(() => {
   mocks.applyPreset.mockClear();
   mocks.createTab.mockClear();
   mocks.createBrowserPane.mockClear();
+  mocks.launchDraftWithPreset.mockClear();
   localStorage.clear();
   useTitlebarPinsStore.setState({ pinnedIds: [] });
 });
@@ -203,6 +236,77 @@ describe("AgentLauncher", () => {
       fireEvent.click(screen.getByText("Terminal"));
     });
     expect(mocks.createTab).toHaveBeenCalledWith("ws-1", "terminal");
+  });
+});
+
+// GUI draft chrome — the `+` launcher rendered in the titlebar's draft
+// variant. Picking a preset materialises the draft (shared
+// `launchDraftWithPreset` path with the legacy draft PresetBar).
+describe("DraftAgentLauncher", () => {
+  function openDraftLauncher() {
+    const trigger = screen.getByTestId("draft-agent-launcher-trigger");
+    act(() => {
+      fireEvent.pointerDown(trigger, { button: 0, pointerType: "mouse" });
+      fireEvent.click(trigger);
+    });
+  }
+
+  it("renders nothing for a Home-target draft (same rule as the legacy draft PresetBar)", () => {
+    const { container } = render(
+      <DraftAgentLauncher draft={makeDraft({ target: { kind: "home" } })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("lists GUI + CLI presets but no Panes section (no live surface yet)", () => {
+    render(<DraftAgentLauncher draft={makeDraft()} />);
+    openDraftLauncher();
+    expect(screen.getByText("GUI")).toBeInTheDocument();
+    expect(screen.getByText("CLI agents")).toBeInTheDocument();
+    expect(screen.getByText("Chat Agent")).toBeInTheDocument();
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+    expect(screen.queryByText("Terminal")).toBeNull();
+    expect(screen.queryByText("Browser")).toBeNull();
+    expect(screen.getByText("Manage presets…")).toBeInTheDocument();
+  });
+
+  it("materialises the draft with the chosen CLI preset", () => {
+    render(<DraftAgentLauncher draft={makeDraft()} />);
+    openDraftLauncher();
+    act(() => {
+      fireEvent.click(screen.getByTestId("draft-launcher-cli-builtin-claude"));
+    });
+    expect(mocks.launchDraftWithPreset).toHaveBeenCalledTimes(1);
+    const [draftId, preset] = mocks.launchDraftWithPreset.mock.calls[0] as [
+      string,
+      TerminalPreset,
+    ];
+    expect(draftId).toBe("draft-1");
+    expect(preset.id).toBe("builtin-claude");
+    // Workspace-scoped launch paths must NOT fire from a draft.
+    expect(mocks.applyPreset).not.toHaveBeenCalled();
+    expect(mocks.agentChatCreatePane).not.toHaveBeenCalled();
+  });
+
+  it("materialises the draft with the chosen GUI preset", () => {
+    render(<DraftAgentLauncher draft={makeDraft()} />);
+    openDraftLauncher();
+    act(() => {
+      fireEvent.click(
+        screen.getByTestId("draft-launcher-gui-builtin-chat-agent"),
+      );
+    });
+    expect(mocks.launchDraftWithPreset).toHaveBeenCalledTimes(1);
+    const [, preset] = mocks.launchDraftWithPreset.mock.calls[0] as [
+      string,
+      TerminalPreset,
+    ];
+    expect(preset.id).toBe("builtin-chat-agent");
+  });
+
+  it("disables the trigger while the draft is promoting", () => {
+    render(<DraftAgentLauncher draft={makeDraft({ promoting: true })} />);
+    expect(screen.getByTestId("draft-agent-launcher-trigger")).toBeDisabled();
   });
 });
 

--- a/src/components/layout/agent-launcher.tsx
+++ b/src/components/layout/agent-launcher.tsx
@@ -17,8 +17,10 @@ import {
 } from "@/components/ui/popover";
 import { PresetIcon } from "@/components/icons/preset-icon";
 import { usePresetStore } from "@/hooks/use-preset-store";
+import { launchDraftWithPreset } from "@/lib/agent-chat/draft-preset-launch";
 import { cn } from "@/lib/utils";
 import { toast } from "@/lib/toast";
+import type { ChatDraft } from "@/stores/chat-draft-store";
 import { useTitlebarPinsStore } from "@/stores/titlebar-pins-store";
 import { useUIStore } from "@/stores/ui-store";
 import {
@@ -253,6 +255,129 @@ export function AgentLauncher({ workspace }: AgentLauncherProps) {
                 <span className="flex-1">Browser</span>
               </CommandItem>
             </CommandGroup>
+            <CommandSeparator />
+            <CommandGroup>
+              <CommandItem value="manage presets" onSelect={managePresets}>
+                <Settings className="h-4 w-4" />
+                <span className="flex-1">Manage presets…</span>
+                <ExternalLink className="h-3 w-3 text-muted-foreground/70" />
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface DraftAgentLauncherProps {
+  draft: ChatDraft;
+}
+
+/**
+ * The `+` launcher for the GUI-chrome DRAFT titlebar variant (see
+ * `useDraftGuiChrome` in src/hooks/use-gui-chrome.ts). Replaces the
+ * legacy draft `PresetBar` row: picking a preset here materialises the
+ * draft via `launchDraftWithPreset` — committing the composed prompt
+ * (possibly empty) into a fresh workspace spawning only that preset's
+ * pane — instead of launching onto an existing workspace.
+ *
+ * Mirrors the legacy draft PresetBar's rules: hidden on a Home-target
+ * draft (CLI presets need project context, and a Chat Agent click
+ * would duplicate the chat being composed — picking a project via
+ * Thread Scope makes it appear), and disabled while a materialise is
+ * in flight so presets can't be swapped mid-flight. No Panes section
+ * — there is no live surface to split or add tabs to yet.
+ */
+export function DraftAgentLauncher({ draft }: DraftAgentLauncherProps) {
+  const [open, setOpen] = useState(false);
+  const presetStore = usePresetStore();
+
+  const presets = presetStore?.presets ?? [];
+  const chatPresets = presets.filter((p) => p.kind === "chat_agent");
+  const cliPresets = presets
+    .filter((p) => p.kind === "cli")
+    .sort((a, b) => Number(b.pinned) - Number(a.pinned));
+
+  // Same gate as the legacy draft PresetBar (`isHomeDraft return null`).
+  if (draft.target.kind === "home") return null;
+
+  const launch = (preset: TerminalPreset) => {
+    setOpen(false);
+    void launchDraftWithPreset(draft.draftId, preset).then((result) => {
+      if (!result.success) {
+        toast.error(`${preset.name}: ${result.error ?? "Send failed"}`);
+      }
+    });
+  };
+
+  const managePresets = () => {
+    setOpen(false);
+    useUIStore.getState().setShowSettings(true, "presets");
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Launch an agent"
+          data-testid="draft-agent-launcher-trigger"
+          disabled={draft.promoting}
+          className={cn(
+            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-colors",
+            open
+              ? "bg-accent text-foreground"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            draft.promoting && "opacity-40 pointer-events-none",
+          )}
+        >
+          <Plus className="h-4 w-4" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="w-80 overflow-hidden p-0"
+        data-testid="draft-agent-launcher-popover"
+      >
+        <Command>
+          <CommandInput placeholder="Start with an agent…" />
+          <CommandList className="max-h-80">
+            <CommandEmpty>No matches.</CommandEmpty>
+            {chatPresets.length > 0 && (
+              <CommandGroup heading="GUI">
+                {chatPresets.map((preset) => (
+                  <CommandItem
+                    key={preset.id}
+                    value={`gui ${preset.name}`}
+                    onSelect={() => launch(preset)}
+                    data-testid={`draft-launcher-gui-${preset.id}`}
+                  >
+                    <PresetIcon icon={preset.icon} className="h-4 w-4" />
+                    <span className="flex-1 truncate">{preset.name}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+            {cliPresets.length > 0 && (
+              <CommandGroup heading="CLI agents">
+                {cliPresets.map((preset) => (
+                  <CommandItem
+                    key={preset.id}
+                    value={`cli ${preset.name}`}
+                    onSelect={() => launch(preset)}
+                    data-testid={`draft-launcher-cli-${preset.id}`}
+                  >
+                    <PresetIcon icon={preset.icon} className="h-4 w-4" />
+                    <span className="flex-1 truncate">{preset.name}</span>
+                    <span className="font-mono text-[10px] text-muted-foreground/70">
+                      ↗ terminal
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
             <CommandSeparator />
             <CommandGroup>
               <CommandItem value="manage presets" onSelect={managePresets}>

--- a/src/components/layout/preset-bar.tsx
+++ b/src/components/layout/preset-bar.tsx
@@ -35,10 +35,7 @@ import { Button } from "@/components/ui/button";
 import { PresetIcon } from "@/components/icons/preset-icon";
 import { RunButton } from "./run-button";
 import { cn } from "@/lib/utils";
-import { materializeWithPreset } from "@/lib/agent-chat/materialize";
-import { resolveSkillBodies } from "@/lib/agent-chat/skill-tokens";
-import { useAgentChatStore } from "@/stores/agent-chat-store";
-import { selectActiveSkills, useSkillsStore } from "@/stores/skills-store";
+import { launchDraftWithPreset } from "@/lib/agent-chat/draft-preset-launch";
 import {
   useChatDraftStore,
   type DraftId,
@@ -326,48 +323,12 @@ function PresetBarImpl({
 
   const handleLaunchDraft = (preset: TerminalPreset) => {
     if (!draftId) return;
-    // Re-read fresh state at click time so same-tick composer
-    // keystrokes are captured as the initial prompt.
-    const state = useChatDraftStore.getState();
-    const draft = state.draftsById[draftId];
-    if (!draft) return;
-    const chat = useAgentChatStore.getState();
-
-    const skillBodies = resolveSkillBodies(
-      draft.inputDraft,
-      selectActiveSkills(useSkillsStore.getState()),
-    );
-
-    void materializeWithPreset(
-      draft,
-      preset,
-      draft.inputDraft,
-      {
-        markPromoting: state.markPromoting,
-        markMaterialized: state.markMaterialized,
-        markPromoted: state.markPromoted,
-        markSendFailed: state.markSendFailed,
-        ensureThread: chat.ensureThread,
-        appendUserMessage: chat.appendUserMessage,
-        removeUserMessageByNonce: chat.removeUserMessageByNonce,
-        setModel: chat.setModel,
-        setPermissionMode: chat.setPermissionMode,
-        setSessionLaunchMode: chat.setSessionLaunchMode,
-        setEffort: chat.setEffort,
-        setContextWindow: chat.setContextWindow,
-        setMode: chat.setMode,
-      },
-      skillBodies,
-    ).then((result) => {
-      if (result.success) {
-        // Same transition cleanup DraftChatSurface uses on composer
-        // submit: clear the active draft immediately so the router
-        // swaps to the live workspace; sweep the draft entry after
-        // the 5s grace period.
-        const draftIdToClear = draft.draftId;
-        state.setActiveDraft(null);
-        setTimeout(() => state.clearDraft(draftIdToClear), 5000);
-      } else {
+    // Shared with the GUI-chrome DraftAgentLauncher — reads fresh
+    // draft state at click time (same-tick composer keystrokes are
+    // captured as the initial prompt), materialises, then runs the
+    // same transition cleanup DraftChatSurface uses on submit.
+    void launchDraftWithPreset(draftId, preset).then((result) => {
+      if (!result.success) {
         toast.error(`${preset.name}: ${result.error ?? "Send failed"}`);
       }
     });

--- a/src/components/layout/title-bar.test.tsx
+++ b/src/components/layout/title-bar.test.tsx
@@ -24,6 +24,7 @@ vi.mock("./title-bar-tabs", () => ({
 }));
 vi.mock("./agent-launcher", () => ({
   AgentLauncher: () => <div data-testid="agent-launcher" />,
+  DraftAgentLauncher: () => <div data-testid="draft-agent-launcher" />,
 }));
 vi.mock("./run-button", () => ({
   RunButton: () => <div data-testid="run-button" />,
@@ -99,11 +100,30 @@ vi.mock("@/stores/app-store", () => ({
   ),
 }));
 
-vi.mock("@/stores/chat-draft-store", () => ({
-  useChatDraftStore: vi.fn((sel: (s: unknown) => unknown) =>
-    sel({ activeDraftId: state.activeDraftId }),
-  ),
-}));
+vi.mock("@/stores/chat-draft-store", () => {
+  interface MockDraftState {
+    activeDraftId: string | null;
+    draftsById: Record<string, unknown>;
+  }
+  const snapshot = (): MockDraftState => ({
+    activeDraftId: state.activeDraftId,
+    draftsById: state.activeDraftId
+      ? {
+          [state.activeDraftId]: {
+            draftId: state.activeDraftId,
+            target: { kind: "project", projectPath: "/p" },
+            promoting: false,
+          },
+        }
+      : {},
+  });
+  return {
+    useChatDraftStore: vi.fn((sel: (s: unknown) => unknown) => sel(snapshot())),
+    // Mirror the real selector so TitleBarDraftSlots resolves the draft.
+    selectActiveDraft: (s: MockDraftState) =>
+      s.activeDraftId ? s.draftsById[s.activeDraftId] ?? null : null,
+  };
+});
 
 vi.mock("@/stores/feature-flags", () => ({
   useFeatureFlags: vi.fn((sel: (s: unknown) => unknown) =>
@@ -243,12 +263,34 @@ describe("TitleBar chrome gating", () => {
     expect(queryByTestId("agent-launcher")).toBeNull();
   });
 
-  it("keeps the legacy bar while a lazy-creation draft is active", () => {
+  it("renders the GUI draft chrome (draft pill + draft launcher) while a lazy-creation draft is active", () => {
+    // Regression coverage: the draft used to fall back to the legacy
+    // h-9 bar + PresetBar rows, so pressing "+" flashed the old chrome
+    // until the first prompt materialised the workspace.
     state.enableAgentChat = true;
     state.enableLazy = true;
     state.activeDraftId = "draft-1";
-    const { queryByTestId } = renderBar();
+    const { getByTestId, queryByTestId } = renderBar();
+    expect(getByTestId("titlebar-draft-tab")).toBeInTheDocument();
+    expect(getByTestId("draft-agent-launcher")).toBeInTheDocument();
+    // Workspace slots + workspace-scoped controls stay off — the
+    // backend's "active workspace" is whatever was focused before the
+    // draft opened, which is not what's on screen.
     expect(queryByTestId("titlebar-tabs")).toBeNull();
+    expect(queryByTestId("agent-launcher")).toBeNull();
+    expect(queryByTestId("run-button")).toBeNull();
+    // Shared shell bits still render.
+    expect(getByTestId("titlebar-sidebar-cluster")).toBeInTheDocument();
+    expect(getByTestId("window-controls")).toBeInTheDocument();
+  });
+
+  it("keeps the legacy bar for a draft when the Beta flag is off", () => {
+    state.enableAgentChat = false;
+    state.enableLazy = true;
+    state.activeDraftId = "draft-1";
+    const { queryByTestId } = renderBar();
+    expect(queryByTestId("titlebar-draft-tab")).toBeNull();
+    expect(queryByTestId("draft-agent-launcher")).toBeNull();
   });
 });
 

--- a/src/components/layout/title-bar.tsx
+++ b/src/components/layout/title-bar.tsx
@@ -4,13 +4,14 @@ import {
   ChevronDown,
   ExternalLink,
   FileDiff,
+  MessageSquare,
 } from "lucide-react";
 import { WindowControls } from "./window-chrome";
 import { isRemoteClient } from "@/components/remote/is-remote-client";
 import { RemoteConnectionChip } from "@/components/remote/remote-connection-indicator";
 import { ResourceMonitor } from "./resource-monitor";
 import { TitleBarTabs } from "./title-bar-tabs";
-import { AgentLauncher } from "./agent-launcher";
+import { AgentLauncher, DraftAgentLauncher } from "./agent-launcher";
 import { RunButton } from "./run-button";
 import {
   DropdownMenu,
@@ -34,7 +35,11 @@ import {
   useActiveWorkspaceId,
   useAppStore,
 } from "@/stores/app-store";
-import { useGuiChrome } from "@/hooks/use-gui-chrome";
+import { useDraftGuiChrome, useGuiChrome } from "@/hooks/use-gui-chrome";
+import {
+  selectActiveDraft,
+  useChatDraftStore,
+} from "@/stores/chat-draft-store";
 import { usePresetStore } from "@/hooks/use-preset-store";
 import { useSidebarGapWidth } from "@/hooks/use-sidebar-gap-width";
 import { useTitlebarPinsStore } from "@/stores/titlebar-pins-store";
@@ -413,6 +418,36 @@ function TitleBarWorkspaceSlots() {
   );
 }
 
+// ── Draft slots (GUI chrome, lazy-creation draft) ──
+//
+// The draft counterpart of `TitleBarWorkspaceSlots`: while a chat draft
+// is the active surface there is no workspace (so no backend tabs to
+// pill-ify), just the one draft being composed. Render a single static
+// "Agent Chat" pill in the active-tab style plus the draft `+` launcher
+// (materialise-with-preset — the GUI replacement for the legacy draft
+// PresetBar row). Keeps the titlebar silhouette identical to the
+// post-materialise workspace chrome, so sending the first prompt no
+// longer swaps the whole top bar.
+function TitleBarDraftSlots() {
+  const draft = useChatDraftStore(selectActiveDraft);
+  if (!draft) return null;
+  return (
+    <div
+      className="flex min-w-0 items-center gap-1"
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <div
+        data-testid="titlebar-draft-tab"
+        className="flex h-7 shrink-0 items-center gap-1.5 rounded-lg bg-background pl-2.5 pr-2.5 text-xs font-semibold text-foreground"
+      >
+        <MessageSquare className="h-3 w-3" />
+        <span>Agent Chat</span>
+      </div>
+      <DraftAgentLauncher draft={draft} />
+    </div>
+  );
+}
+
 // ── Title Bar ──
 
 interface TitleBarProps {
@@ -427,13 +462,15 @@ export function TitleBar({ sidebarOpen, onToggleSidebar }: TitleBarProps) {
   const sidebarGapWidth = useSidebarGapWidth();
 
   // GUI chrome renders for a real, non-OpenFlow workspace when the Agent
-  // Chat Beta is on. A live lazy-creation draft (no workspace yet) keeps
-  // the legacy bar so the draft surface's own PresetBar stays coherent;
-  // OpenFlow keeps its dedicated chrome untouched. Shared with other
-  // GUI-mode-only surfaces via `useGuiChrome` (see hook doc comment).
+  // Chat Beta is on; a live lazy-creation draft renders the same h-10
+  // shell with draft slots instead (mutually exclusive predicates — see
+  // the hook doc comments). OpenFlow keeps its dedicated chrome
+  // untouched. Shared with other GUI-mode-only surfaces via
+  // `useGuiChrome`.
   const guiChrome = useGuiChrome();
+  const draftGuiChrome = useDraftGuiChrome();
 
-  if (!guiChrome) {
+  if (!guiChrome && !draftGuiChrome) {
     return (
       <div
         data-tauri-drag-region
@@ -493,8 +530,10 @@ export function TitleBar({ sidebarOpen, onToggleSidebar }: TitleBarProps) {
         <SidebarToggleButton open={sidebarOpen} onToggle={onToggleSidebar} />
       </div>
 
-      {/* Workspace slots — tabs (scrollable) + launcher + pinned tiles */}
-      <TitleBarWorkspaceSlots />
+      {/* Workspace slots — tabs (scrollable) + launcher + pinned tiles.
+          Draft chrome renders its single "Agent Chat" pill + draft
+          launcher instead (no workspace, no backend tabs yet). */}
+      {guiChrome ? <TitleBarWorkspaceSlots /> : <TitleBarDraftSlots />}
 
       {/* Draggable spacer — the calm middle stays a window drag region.
           Tauri v2's injected mousedown handler only checks the direct
@@ -506,17 +545,23 @@ export function TitleBar({ sidebarOpen, onToggleSidebar }: TitleBarProps) {
       <div data-tauri-drag-region className="flex-1 self-stretch" />
 
       {/* Right cluster — rehomed right-panel toggle + Run split button,
-          then the standard monitor / IDE / window controls. */}
+          then the standard monitor / IDE / window controls. The
+          workspace-scoped controls (panel toggle / Run / IDE) are
+          suppressed in draft chrome: the backend's "active workspace"
+          is whatever was focused before the draft opened, which is NOT
+          what's on screen — acting on it here would be misleading. */}
       <div
         className="flex shrink-0 items-center gap-1.5 pr-0.5"
         onPointerDown={(e) => e.stopPropagation()}
       >
-        {activeWorkspaceId && <RightPanelToggle workspaceId={activeWorkspaceId} />}
-        {activeWorkspaceId && (
+        {guiChrome && activeWorkspaceId && (
+          <RightPanelToggle workspaceId={activeWorkspaceId} />
+        )}
+        {guiChrome && activeWorkspaceId && (
           <RunButton workspaceId={activeWorkspaceId} variant="split" />
         )}
         <ResourceMonitor />
-        <IdeLauncher compact />
+        {guiChrome && <IdeLauncher compact />}
         {/* The separator only divides the content cluster from the native
             window controls — on the web remote client those controls render
             nothing, so the separator would dangle at the right edge. Hide it

--- a/src/components/layout/workspace-main.test.tsx
+++ b/src/components/layout/workspace-main.test.tsx
@@ -175,6 +175,29 @@ describe("WorkspaceMain chrome rows", () => {
   });
 });
 
+describe("WorkspaceMain draft branch chrome", () => {
+  it("renders the legacy PresetBar above the draft surface when the Beta is OFF", () => {
+    state.enableLazy = true;
+    state.activeDraftId = "draft-1";
+    state.enableAgentChat = false;
+    const { getByTestId } = render(<WorkspaceMain />);
+    expect(getByTestId("preset-bar")).toBeInTheDocument();
+    expect(getByTestId("draft-surface")).toBeInTheDocument();
+  });
+
+  it("drops the legacy PresetBar for a draft when the Beta is ON (the GUI draft titlebar owns preset launch)", () => {
+    // Regression coverage: the draft branch used to render PresetBar
+    // unconditionally, so pressing "+" in GUI mode flashed the legacy
+    // preset strip until the workspace materialised.
+    state.enableLazy = true;
+    state.activeDraftId = "draft-1";
+    state.enableAgentChat = true;
+    const { queryByTestId, getByTestId } = render(<WorkspaceMain />);
+    expect(queryByTestId("preset-bar")).toBeNull();
+    expect(getByTestId("draft-surface")).toBeInTheDocument();
+  });
+});
+
 describe("WorkspaceMain right-panel stale-tab guard", () => {
   it("coerces a persisted 'orchestration' tab to 'files' when no workflow run exists", () => {
     state.rightPanelTabs = { "ws-1": "orchestration" };

--- a/src/components/layout/workspace-main.tsx
+++ b/src/components/layout/workspace-main.tsx
@@ -137,9 +137,11 @@ export function WorkspaceMain() {
 
   // Lazy-workspace-creation: when the flag is on and a client-side
   // chat draft is active, render the draft surface in place of the
-  // workspace pane tree. PresetBar sits ABOVE the branch so it's
-  // present on both drafts and real workspaces — a preset click on a
-  // draft materialises the workspace via `materializeWithPreset`.
+  // workspace pane tree. In legacy chrome the PresetBar sits above the
+  // draft (a preset click materialises the workspace via
+  // `materializeWithPreset`); in GUI chrome that row is dropped — the
+  // titlebar's draft variant hosts the same materialise-with-preset
+  // affordance via `DraftAgentLauncher` (see title-bar.tsx).
   const lazyEnabled = useFeatureFlags((s) => s.enableLazyWorkspaceCreation);
   // GUI chrome (Agent Chat Beta): the title bar absorbs the tab strip +
   // preset launcher, so those stacked rows drop here. Off ⇒ legacy chrome
@@ -152,11 +154,13 @@ export function WorkspaceMain() {
   if (lazyEnabled && activeDraftId && activeDraft) {
     return (
       <div className="flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden">
-        <PresetBar
-          workspaceId={null}
-          draftId={activeDraft.draftId}
-          disabled={activeDraft.promoting}
-        />
+        {!enableAgentChat && (
+          <PresetBar
+            workspaceId={null}
+            draftId={activeDraft.draftId}
+            disabled={activeDraft.promoting}
+          />
+        )}
         <div className="flex-1 min-h-0 overflow-hidden">
           <DraftChatSurface />
         </div>

--- a/src/hooks/use-gui-chrome.ts
+++ b/src/hooks/use-gui-chrome.ts
@@ -6,9 +6,12 @@ import type { PaneNodeSnapshot } from "@/tauri/types";
 /**
  * GUI chrome predicate (see `docs/features/gui-chrome.md`): renders for a
  * real, non-OpenFlow workspace when the Agent Chat Beta is on. A live
- * lazy-creation draft (no workspace yet) keeps the legacy chrome so the
- * draft surface's own PresetBar stays coherent; OpenFlow keeps its
- * dedicated chrome untouched.
+ * lazy-creation draft (no workspace yet) resolves `false` here — the
+ * draft renders its own GUI-styled titlebar variant instead (see
+ * `useDraftGuiChrome` below), and workspace-scoped GUI surfaces (the
+ * background browser chip, context-bar indicator, titlebar tabs) must
+ * stay off while the draft covers the workspace pane tree. OpenFlow
+ * keeps its dedicated chrome untouched.
  *
  * Extracted from `title-bar.tsx` (the original single call site) so other
  * GUI-mode-only surfaces — the background browser chip and context-bar
@@ -39,6 +42,29 @@ export function useGuiChrome(): boolean {
     activeWorkspaceType != null &&
     activeWorkspaceType !== "open_flow"
   );
+}
+
+/**
+ * Draft counterpart of `useGuiChrome`: true while the Agent Chat Beta
+ * is on AND a lazy-creation draft is the active surface. Mutually
+ * exclusive with `useGuiChrome` (whose `!lazyDraftActive` guard covers
+ * exactly this window). Drives `TitleBar`'s GUI-styled draft variant —
+ * the `h-10` bar with an "Agent Chat" pill and the draft agent
+ * launcher — so a "+" new-workspace draft no longer flashes the legacy
+ * `h-9` bar + `PresetBar` rows before the workspace materialises.
+ */
+export function useDraftGuiChrome(): boolean {
+  const enableAgentChat = useFeatureFlags((s) => s.enableAgentChat);
+  const lazyEnabled = useFeatureFlags((s) => s.enableLazyWorkspaceCreation);
+  // Require the draft ENTRY, not just the id — mirrors WorkspaceMain's
+  // `activeDraftId && activeDraft` guard so the titlebar and the main
+  // surface can never disagree about whether a draft is on screen
+  // (e.g. a stale persisted `activeDraftId` whose entry was swept).
+  // Primitive boolean selector, so backend ticks don't re-render.
+  const hasActiveDraft = useChatDraftStore(
+    (s) => s.activeDraftId !== null && s.draftsById[s.activeDraftId] != null,
+  );
+  return enableAgentChat && lazyEnabled && hasActiveDraft;
 }
 
 /** Recursively find the pane node with the given id under `node`,

--- a/src/lib/agent-chat/draft-preset-launch.ts
+++ b/src/lib/agent-chat/draft-preset-launch.ts
@@ -1,0 +1,73 @@
+import { materializeWithPreset } from "./materialize";
+import type { MaterializeResult } from "./materialize";
+import { resolveSkillBodies } from "./skill-tokens";
+import { useAgentChatStore } from "@/stores/agent-chat-store";
+import { useChatDraftStore, type DraftId } from "@/stores/chat-draft-store";
+import { selectActiveSkills, useSkillsStore } from "@/stores/skills-store";
+import type { TerminalPreset } from "@/tauri/types";
+
+/** Grace period between promoting a draft and sweeping its entry, so
+ *  any in-flight UI can still observe the promotion before cleanup.
+ *  Matches `CLEAR_AFTER_PROMOTION_MS` in DraftChatSurface. */
+export const CLEAR_AFTER_PROMOTION_MS = 5000;
+
+/**
+ * Materialise an active draft by clicking a preset: commit the draft
+ * (spawning only that preset's pane) via `materializeWithPreset`, then
+ * run the same transition cleanup DraftChatSurface uses on composer
+ * submit — clear the active draft immediately so the router swaps to
+ * the live workspace, and sweep the draft entry after the grace period.
+ *
+ * Shared by the legacy `PresetBar` (draft mode) and the GUI-chrome
+ * `DraftAgentLauncher` so both entry points stay behaviourally
+ * identical. Reads fresh store state at call time so same-tick
+ * composer keystrokes are captured as the initial prompt. The caller
+ * owns error surfacing (toast) — this helper only reports the result.
+ */
+export async function launchDraftWithPreset(
+  draftId: DraftId,
+  preset: TerminalPreset,
+): Promise<MaterializeResult> {
+  const state = useChatDraftStore.getState();
+  const draft = state.draftsById[draftId];
+  if (!draft) return { success: false, error: "Draft no longer exists" };
+  const chat = useAgentChatStore.getState();
+
+  const skillBodies = resolveSkillBodies(
+    draft.inputDraft,
+    selectActiveSkills(useSkillsStore.getState()),
+  );
+
+  const result = await materializeWithPreset(
+    draft,
+    preset,
+    draft.inputDraft,
+    {
+      markPromoting: state.markPromoting,
+      markMaterialized: state.markMaterialized,
+      markPromoted: state.markPromoted,
+      markSendFailed: state.markSendFailed,
+      ensureThread: chat.ensureThread,
+      appendUserMessage: chat.appendUserMessage,
+      removeUserMessageByNonce: chat.removeUserMessageByNonce,
+      setModel: chat.setModel,
+      setPermissionMode: chat.setPermissionMode,
+      setSessionLaunchMode: chat.setSessionLaunchMode,
+      setEffort: chat.setEffort,
+      setContextWindow: chat.setContextWindow,
+      setMode: chat.setMode,
+    },
+    skillBodies,
+  );
+
+  if (result.success) {
+    const draftIdToClear = draft.draftId;
+    state.setActiveDraft(null);
+    setTimeout(
+      () => useChatDraftStore.getState().clearDraft(draftIdToClear),
+      CLEAR_AFTER_PROMOTION_MS,
+    );
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Problem

With the Agent Chat GUI enabled, pressing **+** for a new workspace opened the draft composer under the **legacy** chrome — the old h-9 titlebar plus the horizontal PresetBar strip. Only after sending the first prompt (workspace materialised) did the UI swap to the collapsed h-10 GUI titlebar. The draft → workspace transition flashed a completely different top bar.

This was a documented constraint in `docs/features/gui-chrome.md` ("Draft (lazy-creation) workspaces keep legacy chrome"), kept because the GUI titlebar slots all assumed a real workspace id.

## Fix

The draft now renders the same h-10 GUI shell from the moment **+** is pressed:

- **`useDraftGuiChrome()`** (new, `src/hooks/use-gui-chrome.ts`) — Beta on + active draft entry; mutually exclusive with `useGuiChrome()`, which keeps resolving `false` during drafts so workspace-scoped GUI surfaces (browser chip, context-bar indicator, titlebar tabs) stay off.
- **`TitleBarDraftSlots`** (`title-bar.tsx`) — static "Agent Chat" pill in the active-tab style + the new draft launcher. Workspace-scoped right-cluster controls (panel toggle / Run / IDE) are suppressed: the backend's "active workspace" during a draft is whatever was focused before, not what's on screen.
- **`DraftAgentLauncher`** (`agent-launcher.tsx`) — same `+` popover look as the workspace launcher, but picking a GUI/CLI preset **materialises the draft** with that agent. Hidden on Home-target drafts and disabled while promoting, mirroring the legacy draft PresetBar rules. No Panes section (no live surface yet).
- **`launchDraftWithPreset`** (new, `src/lib/agent-chat/draft-preset-launch.ts`) — the materialise-with-preset action extracted from PresetBar's inline handler, shared by both chromes so behaviour stays identical.
- **Row suppression** — `WorkspaceMain`'s draft branch drops the legacy PresetBar in GUI mode (same gating as the real-workspace branch); `DraftChatSurface` suppresses its placeholder header band (the titlebar pill covers it). Legacy chrome (Beta off) stays byte-identical.
- Docs: `docs/features/gui-chrome.md` constraint rewritten to the new reality.

## Testing

- `npm run check` clean; **202 test files / 2933 frontend tests pass**, including 10 new cases (title-bar draft chrome gating, workspace-main draft-branch row suppression, DraftAgentLauncher behaviour, DraftChatSurface header suppression).
- Rust untouched (`cargo test`: only known environment-dependent flakes, different test each run, all pass in isolation).
- Visually verified in the dev browser: pressing **+** now shows the collapsed GUI bar immediately, the draft launcher lists GUI/CLI agents and materialises correctly, and the draft → workspace transition keeps the same titlebar silhouette.