### PR TITLE
fix(composer): align caret and selection with painted text

### DIFF
--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -2352,7 +2352,19 @@ export function Composer({
               }
               rows={1}
               className={cn(
-                "relative w-full resize-none bg-transparent px-3 py-2.5",
+                // `block` is load-bearing: a `<textarea>` defaults to
+                // `inline-block`, so it sits on a line box and its
+                // vertical position is resolved via baseline alignment.
+                // The mirror behind it is an absolutely-positioned block
+                // pinned to the container top. Baseline-aligned inline
+                // boxes are computed differently across rendering engines
+                // (notably WebKitGTK, which powers the desktop build) than
+                // Chromium, which drifts the caret/selection off the
+                // painted text. Forcing `block` pins the textarea to the
+                // container top on every engine so the two layers stay
+                // glued, and drops the phantom line-box descent that
+                // otherwise made this box a few px too tall.
+                "relative block w-full resize-none bg-transparent px-3 py-2.5",
                 // Transparent text — the colored mirror behind shows
                 // through. Caret stays visible via `caret-foreground`.
                 "text-sm text-transparent caret-foreground",


### PR DESCRIPTION
## Problem

In the agent chat composer, the text caret and the native selection highlight sat a few pixels **above** the visible text on the desktop build. The composer layers a transparent \`<textarea>\` over a block-level mirror \`<div>\` that paints the highlighted text (skill tokens, file/issue/PR chips). The caret and selection belong to the textarea; the readable text belongs to the mirror. When the two layers drift vertically, the caret and highlight no longer land on the text.

## Root cause

A \`<textarea>\` defaults to \`display: inline-block\`, so it participates in a **line box** and resolves its vertical position through **baseline alignment**. The mirror is an absolutely-positioned **block** pinned to the container top. Those two positioning models agree in Chromium but diverge in **WebKitGTK**, which renders the desktop app — floating the caret/selection off the painted text.

This is why it was invisible in \`npm run dev\` (Chromium) and only showed up in the packaged desktop app.

## Fix

Force the textarea to \`display: block\`. It no longer sits on a line box, so its top is pinned to the container top on every engine, deterministically matching the block mirror. As a bonus this drops a phantom line-box descent that made the container a few px too tall.

## Verification

- textarea \`display\` → \`block\`; textarea top === mirror top; textarea height === mirror height
- container height corrected (dropped the extra line-box descent)
- selection hugs the text with no regression in Chromium
- \`tsc\` clean; full chat test suite (725 tests) passes
- confirmed fixed in the WebKitGTK desktop build