### PR TITLE
Remove scope hint line below the agent chat input

### DIFF
--- a/src/components/chat/pickers/ThreadScopeRow.test.tsx
+++ b/src/components/chat/pickers/ThreadScopeRow.test.tsx
@@ -174,35 +174,26 @@ describe("ThreadScopeRow", () => {
   });
 
   describe("home target", () => {
-    it("renders only the location control and the home scope hint — no checkout/branch controls", () => {
+    it("renders only the location control — no checkout/branch controls", () => {
       renderRow({ draftTarget: { kind: "home" }, projectPath: null });
       expect(screen.getByText("Home")).toBeInTheDocument();
       expect(screen.queryByText("Current checkout")).toBeNull();
       expect(screen.queryByText("New worktree")).toBeNull();
       expect(screen.queryByText(/^from$/)).toBeNull();
-      expect(
-        screen.getByText(/runs on your machine in the home directory/i),
-      ).toBeInTheDocument();
     });
   });
 
   describe("project target — current checkout", () => {
-    it("renders location, checkout, and branch controls with the current-checkout hint", () => {
+    it("renders location, checkout, and branch controls", () => {
       renderRow();
       expect(screen.getByText("foo")).toBeInTheDocument();
       expect(screen.getByText("Current checkout")).toBeInTheDocument();
       expect(screen.getByText("main")).toBeInTheDocument();
-      expect(
-        screen.getByText(/current checkout on main/i),
-      ).toBeInTheDocument();
     });
 
-    it("checkout mode renders the deferred-worktree hint when checkoutMode is 'worktree'", () => {
+    it("renders the worktree checkout control when checkoutMode is 'worktree'", () => {
       renderRow({ checkoutMode: "worktree", baseBranch: "develop" });
       expect(screen.getByText("New worktree")).toBeInTheDocument();
-      expect(
-        screen.getByText(/isolated worktree off develop in foo/i),
-      ).toBeInTheDocument();
     });
 
     it("hides checkout/branch controls when projectPath hasn't resolved yet", () => {
@@ -351,22 +342,16 @@ describe("ThreadScopeRow", () => {
   });
 
   describe("workspace mode (AgentChatPane empty state)", () => {
-    it("project pane renders location + checkout + branch controls with the project scope hint", () => {
+    it("project pane renders location + checkout + branch controls", () => {
       renderWorkspaceRow();
       expect(screen.getByText("foo")).toBeInTheDocument();
       expect(screen.getByText("Current checkout")).toBeInTheDocument();
-      expect(
-        screen.getByText(/current checkout on main/i),
-      ).toBeInTheDocument();
     });
 
-    it("home-rooted pane renders only the location control + home hint", () => {
+    it("home-rooted pane renders only the location control", () => {
       renderWorkspaceRow({ isHome: true });
       expect(screen.getByText("Home")).toBeInTheDocument();
       expect(screen.queryByText("Current checkout")).toBeNull();
-      expect(
-        screen.getByText(/runs on your machine in the home directory/i),
-      ).toBeInTheDocument();
     });
 
     it("picking a DIFFERENT project calls onSelectProject with its path", async () => {

--- a/src/components/chat/pickers/ThreadScopeRow.tsx
+++ b/src/components/chat/pickers/ThreadScopeRow.tsx
@@ -154,7 +154,6 @@ export function ThreadScopeRow({
       ? location.target.kind === "home"
       : location.isHome;
   const showProjectControls = !isHome && projectPath !== null;
-  const projectName = projectPath ? basename(projectPath) : "";
 
   // Non-git projects can't have worktrees or base branches — hide the
   // checkout + branch controls instead of letting a "New worktree" send
@@ -226,16 +225,6 @@ export function ThreadScopeRow({
     }
   }, [projectIsGit, checkoutMode, onChangeCheckoutMode]);
 
-  const scopeHint = isHome
-    ? "No project — this agent runs on your machine in the home directory (~). Just chat, run commands, or point it at files anywhere."
-    : !showProjectControls
-      ? null
-      : !projectIsGit
-        ? `Runs directly in ${projectName}’s folder. Not a git repository — initialize one to unlock isolated worktrees.`
-        : checkoutMode === "worktree"
-          ? `Creates an isolated worktree off ${baseBranch || "…"} in ${projectName}. Leave the name empty and it’s auto-named from your first message.`
-          : `Runs in ${projectName}’s current checkout on ${baseBranch || "…"}. Changes land directly in your working copy.`;
-
   return (
     <div className="rise-in flex flex-col items-center gap-3 px-1">
       <div className="flex w-full items-center justify-between gap-2.5">
@@ -275,11 +264,6 @@ export function ThreadScopeRow({
           </div>
         )}
       </div>
-      {scopeHint && (
-        <p className="text-center text-[11.5px] leading-[1.5] text-muted-foreground">
-          {scopeHint}
-        </p>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the explanatory hint paragraph rendered below the thread scope row on the agent chat input (e.g. the current-checkout note under the input field)
- All variants of the line are gone: current-checkout, worktree, non-git, and home-directory hints
- Drop the now-unused projectName helper and update ThreadScopeRow tests

## Testing
- tsc --noEmit clean
- Full vitest suite: 204 files / 2965 tests passing
- Verified visually in the browser pane: the new-agent screen shows the input card and scope controls with nothing beneath