### PR TITLE
Polish agent chat composer and model picker

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -1563,8 +1563,12 @@ the "no panes" home landing lives in `ChatHomeLanding.tsx`.
 BOTH first-send surfaces — `DraftChatSurface` (lazy-creation draft) and
 `AgentChatPane`'s new-thread empty state (`messages.length === 0` on a
 real workspace's pane) — render their scope controls **below** the
-composer as one shared borderless `ThreadScopeRow`
-(`src/components/chat/pickers/ThreadScopeRow.tsx`), threaded through
+composer as one shared `ThreadScopeRow`
+(`src/components/chat/pickers/ThreadScopeRow.tsx`) — rendered as a
+**scope strip**: a narrower bar attached flush under the composer card
+(inset each side by the card's 20px corner radius, bottom-only
+rounding, one tonal step less elevated — the shared `SCOPE_STRIP` /
+`SCOPE_STRIP_INSET` class constants), threaded through
 `Composer`'s `belowComposerSlot` prop (a sibling of `zone1Override`,
 which both surfaces now pass `null` while a project root resolves — the
 cwd label moved into the row's location control). Three states, matched
@@ -1757,8 +1761,9 @@ title-bar chat tab). See `docs/features/gui-chrome.md`.
 
 Design: `.design-import/Context Row.dc.html` (claude.ai/design handoff).
 Once a thread has messages, `AgentChatPane`'s `belowComposerSlot` swaps
-`ThreadScopeRow` for a read-only **Context Row** — the same outer
-layout (`flex justify-between px-1`), but scope is committed (the first
+`ThreadScopeRow` for a read-only **Context Row** — the same tucked
+scope-strip shell (`SCOPE_STRIP` / `SCOPE_STRIP_INSET` exported from
+`ThreadScopeRow.tsx`), but scope is committed (the first
 send locked it in) so the left side is no longer clickable:
 
 - **Left** — static ghost-styled spans: folder icon (home icon +

--- a/src-tauri/src/agent_provider/claude/capabilities.rs
+++ b/src-tauri/src/agent_provider/claude/capabilities.rs
@@ -2006,34 +2006,35 @@ mod tests {
             sdk_model("haiku", "Haiku", &[], None, None),
         ];
         let caps = build_capabilities_from_sdk(live);
-        let desc = |id: &str| {
+        let row = |id: &str| {
             caps.models
                 .iter()
                 .find(|m| m.id == id)
                 .unwrap_or_else(|| panic!("{id} row must exist"))
-                .description
-                .clone()
-                .unwrap_or_else(|| panic!("{id} row must carry a description"))
         };
-        // `default` and `opus` both resolve to Opus 4.8, which defaults to
-        // the 1M context window → the "with 1M context" qualifier.
+        // The backfilled version now lives in the promoted LABEL; the
+        // description keeps only the blurb. `default` resolves to the
+        // same concrete model as `opus`, so it folds into that twin,
+        // which leads the list with the Recommended marker.
+        assert!(caps.models.iter().all(|m| m.id != "default"));
+        assert_eq!(caps.models[0].id, "opus");
+        assert_eq!(caps.models[0].label, "Claude Opus 4.8");
         assert_eq!(
-            desc("default"),
-            "Opus 4.8 with 1M context · Best for everyday, complex tasks"
+            caps.models[0].description.as_deref(),
+            Some("Recommended · Best for everyday, complex tasks"),
         );
+        assert_eq!(row("fable").label, "Claude Fable 5");
         assert_eq!(
-            desc("opus"),
-            "Opus 4.8 with 1M context · Best for everyday, complex tasks"
+            row("fable").description.as_deref(),
+            Some("Most capable for the hardest, longest-running tasks"),
         );
-        // Fable/Sonnet also default to the 1M window in the maintained
-        // table, so they carry the qualifier too.
+        assert_eq!(row("sonnet").label, "Claude Sonnet 4.6");
+        assert_eq!(row("sonnet").description.as_deref(), Some("Fast and capable"));
+        assert_eq!(row("haiku").label, "Claude Haiku 4.5");
         assert_eq!(
-            desc("fable"),
-            "Fable 5 with 1M context · Most capable for the hardest, longest-running tasks"
+            row("haiku").description.as_deref(),
+            Some("Fastest and cheapest"),
         );
-        assert_eq!(desc("sonnet"), "Sonnet 4.6 with 1M context · Fast and capable");
-        // Haiku has no context-window options → no qualifier, blurb only.
-        assert_eq!(desc("haiku"), "Haiku 4.5 · Fastest and cheapest");
     }
 
     #[test]
@@ -2071,7 +2072,10 @@ mod tests {
     fn sdk_description_wins_verbatim_over_backfill() {
         // When the deployed CLI supplies its own description (the common
         // case — it packs the resolved version + blurb in there), that
-        // string wins verbatim over any maintained / alias backfill.
+        // string wins over any maintained / alias backfill as the SOURCE:
+        // the promoted label carries the CLI's version ("Opus 4.9" — NOT
+        // the canonical map's stale 4.8), and the description keeps the
+        // CLI's blurb.
         let sdk = SdkModelInfo {
             value: "opus".into(),
             display_name: "Opus".into(),
@@ -2082,9 +2086,10 @@ mod tests {
         };
         let caps = build_capabilities_from_sdk(vec![sdk]);
         let opus = caps.models.iter().find(|m| m.id == "opus").unwrap();
+        assert_eq!(opus.label, "Claude Opus 4.9");
         assert_eq!(
             opus.description.as_deref(),
-            Some("Opus 4.9 with 1M context · Freshest blurb from the CLI")
+            Some("Freshest blurb from the CLI")
         );
     }
 

--- a/src-tauri/src/agent_provider/claude/capabilities.rs
+++ b/src-tauri/src/agent_provider/claude/capabilities.rs
@@ -764,6 +764,10 @@ fn base_model_name(label: &str) -> &str {
 /// frontend's default selection, so new drafts default to the twin —
 /// a real roster id resolving to the same model). When no twin exists
 /// the promoted `default` row is kept so nothing launchable is lost.
+///
+/// Must run AFTER [`append_missing_maintained_families`]: when the CLI
+/// demotes a family into `default` (alias present, no concrete row),
+/// the twin only exists once the maintained entry has been appended.
 fn dedupe_default_alias(merged: &mut Vec<ChatModelInfo>) {
     let Some(default_idx) = merged
         .iter()
@@ -812,8 +816,15 @@ fn build_capabilities_from_sdk(
         .filter(|m| !m.value.is_empty())
         .map(|sdk| merge_sdk_with_maintained(sdk, &maintained))
         .collect();
-    dedupe_default_alias(&mut merged);
+    // Order matters: append the missing maintained families FIRST, then
+    // fold the `default` alias. The append exists precisely for the
+    // roster shape where the CLI demoted a family into its `default`
+    // alias (alias present, no concrete row) — deduping first would keep
+    // the promoted alias row and the append would then re-add the same
+    // concrete model, recreating the duplicate pair the dedupe exists to
+    // remove.
     append_missing_maintained_families(&mut merged);
+    dedupe_default_alias(&mut merged);
     ProviderChatCapabilities {
         models: merged,
         effort_granularity: EffortGranularity::PerSession,
@@ -1857,17 +1868,22 @@ mod tests {
             sdk_model("haiku", "Haiku", &[], None, None),
         ];
         let caps = build_capabilities_from_sdk(live);
-        let default = caps.models.iter().find(|m| m.id == "default").unwrap();
-        assert_eq!(default.default_effort.as_deref(), Some("high"));
+        // The `default` alias (no concrete Opus row live) folds into the
+        // appended maintained Opus entry, which leads the list with the
+        // Recommended marker — alias-effort resolution is covered by the
+        // surviving alias rows below.
+        assert!(caps.models.iter().all(|m| m.id != "default"));
+        assert_eq!(caps.models[0].id, "claude-opus-4-8");
         assert!(
-            default.context_window_options.is_empty(),
-            "`default` must not offer a context-window picker"
+            caps.models[0]
+                .description
+                .as_deref()
+                .is_some_and(|d| d.starts_with("Recommended")),
         );
-        // Fast mode is clamped off for Claude even though the SDK
-        // reported `supportsFastMode: Some(true)` for this row — the
-        // advertisement is not an entitlement check (silent standard
-        // fallback without Extra Usage), so the picker never shows it.
-        assert!(!default.supports_fast_mode);
+        // Fast mode stays clamped off for Claude — the SDK advertised
+        // `supportsFastMode: Some(true)` on the alias row, but neither
+        // the merge path nor the maintained twin surfaces it.
+        assert!(!caps.models[0].supports_fast_mode);
         let sonnet = caps.models.iter().find(|m| m.id == "sonnet").unwrap();
         assert_eq!(sonnet.default_effort.as_deref(), Some("high"));
         let haiku = caps.models.iter().find(|m| m.id == "haiku").unwrap();
@@ -1907,24 +1923,42 @@ mod tests {
         ];
         let caps = build_capabilities_from_sdk(live);
         let ids: Vec<&str> = caps.models.iter().map(|m| m.id.as_str()).collect();
-        // Live entries first, in the CLI's order. The pinned Fable id is
-        // normalized to its base id (`claude-fable-5`).
-        assert_eq!(&ids[..4], &["default", "claude-fable-5", "sonnet", "haiku"]);
-        // Every maintained Opus version appended afterwards.
+        // Regression for the append/dedupe ordering: the append runs
+        // FIRST, so the `default` alias (which resolves to Opus 4.8 via
+        // its canonical backfill) finds the appended maintained entry as
+        // its concrete twin and folds into it — one Opus 4.8 row, led by
+        // the Recommended marker, instead of a promoted alias row AND an
+        // appended duplicate with the same concrete name.
+        assert!(!ids.contains(&"default"));
+        assert_eq!(ids[0], "claude-opus-4-8");
+        // Remaining live entries keep the CLI's order. The pinned Fable
+        // id is normalized to its base id (`claude-fable-5`).
+        assert_eq!(&ids[1..4], &["claude-fable-5", "sonnet", "haiku"]);
+        // Every maintained Opus version stays selectable.
         for opus in ["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4-5"] {
             assert!(ids.contains(&opus), "{opus} should be appended");
         }
+        assert_eq!(
+            ids.iter().filter(|id| **id == "claude-opus-4-8").count(),
+            1,
+            "the alias fold must not leave a duplicate Opus 4.8 row"
+        );
         // Families already live must NOT be duplicated from the
         // maintained list (the maintained `claude-sonnet-4-6` /
         // `claude-haiku-4-5` ids stay out because the alias rows cover
         // those families).
         assert!(!ids.contains(&"claude-sonnet-4-6"));
         assert!(!ids.contains(&"claude-haiku-4-5"));
-        // Appended Opus keeps its precise maintained metadata.
+        // The folded twin keeps its precise maintained metadata and
+        // inherits the Recommended marker from the alias it absorbed.
         let opus48 = caps.models.iter().find(|m| m.id == "claude-opus-4-8").unwrap();
         assert_eq!(opus48.label, "Claude Opus 4.8");
         assert_eq!(opus48.default_effort.as_deref(), Some("high"));
         assert!(opus48.context_window_options.iter().any(|o| o.value == "1m"));
+        assert_eq!(
+            opus48.description.as_deref(),
+            Some("Recommended · Best for everyday, complex tasks"),
+        );
     }
 
     #[test]

--- a/src-tauri/src/agent_provider/claude/capabilities.rs
+++ b/src-tauri/src/agent_provider/claude/capabilities.rs
@@ -747,10 +747,59 @@ fn append_missing_maintained_families(merged: &mut Vec<ChatModelInfo>) {
     }
 }
 
+/// A promoted label without its qualifier — `"Claude Opus 5 (1M
+/// context)"` → `"Claude Opus 5"`. Used to detect when two picker rows
+/// resolve to the same concrete model.
+fn base_model_name(label: &str) -> &str {
+    label.split(" (").next().unwrap_or(label).trim()
+}
+
+/// Drop the `default` alias row when the roster already lists the
+/// concrete model it resolves to. The CLI's `default` tracks the user's
+/// configured default, which (after label promotion) renders as the
+/// same concrete name as its twin — two rows both titled
+/// "Claude Opus 5" read as a duplicate, and the picker contract is to
+/// list concrete models only. The twin inherits the "Recommended"
+/// marker and moves to the front of the list (`models[0]` feeds the
+/// frontend's default selection, so new drafts default to the twin —
+/// a real roster id resolving to the same model). When no twin exists
+/// the promoted `default` row is kept so nothing launchable is lost.
+fn dedupe_default_alias(merged: &mut Vec<ChatModelInfo>) {
+    let Some(default_idx) = merged
+        .iter()
+        .position(|m| m.id.eq_ignore_ascii_case("default"))
+    else {
+        return;
+    };
+    let default_base = base_model_name(&merged[default_idx].label).to_string();
+    let twin_idx = merged.iter().enumerate().position(|(i, m)| {
+        i != default_idx && base_model_name(&m.label) == default_base
+    });
+    let Some(twin_idx) = twin_idx else { return };
+
+    merged.remove(default_idx);
+    let twin_pos = if twin_idx > default_idx { twin_idx - 1 } else { twin_idx };
+    let twin = &mut merged[twin_pos];
+    let already_marked = twin
+        .description
+        .as_deref()
+        .is_some_and(|d| d.starts_with("Recommended"));
+    if !already_marked {
+        twin.description = Some(match twin.description.take() {
+            Some(d) => format!("Recommended · {d}"),
+            None => "Recommended".to_string(),
+        });
+    }
+    let twin_row = merged.remove(twin_pos);
+    merged.insert(0, twin_row);
+}
+
 /// Build a `ProviderChatCapabilities` bundle from the SDK's live model
-/// list, merging with hand-maintained per-id metadata. Models the live
-/// roster omits but the CLI still launches are appended afterwards —
-/// see [`append_missing_maintained_families`].
+/// list, merging with hand-maintained per-id metadata. The `default`
+/// alias row is folded into its concrete twin — see
+/// [`dedupe_default_alias`] — and models the live roster omits but the
+/// CLI still launches are appended afterwards — see
+/// [`append_missing_maintained_families`].
 fn build_capabilities_from_sdk(
     sdk_models: Vec<SdkModelInfo>,
 ) -> ProviderChatCapabilities {
@@ -763,6 +812,7 @@ fn build_capabilities_from_sdk(
         .filter(|m| !m.value.is_empty())
         .map(|sdk| merge_sdk_with_maintained(sdk, &maintained))
         .collect();
+    dedupe_default_alias(&mut merged);
     append_missing_maintained_families(&mut merged);
     ProviderChatCapabilities {
         models: merged,
@@ -830,6 +880,112 @@ fn alias_description_from_canonical(canonical: &ChatModelInfo) -> Option<String>
         version.to_string()
     };
     Some(format!("{prefix} · {blurb}"))
+}
+
+/// Derive the concrete `"Claude <Family> <Version>"` name an alias row
+/// resolves to from its version-bearing description — i.e. the leading
+/// segment of `"Opus 4.8 with 1M context · Best for everyday, complex
+/// tasks"` → `"Claude Opus 4.8"`. Parsing the description (live SDK
+/// data) rather than only the hardcoded alias table keeps the promoted
+/// label correct the day a newer CLI re-points an alias at a model the
+/// maintained list hasn't been bumped for. Returns `None` unless the
+/// segment is exactly a capitalized family word plus a numeric version,
+/// so free-form descriptions never get mangled into a fake model name.
+fn concrete_name_from_description(description: &str) -> Option<String> {
+    let first = description.split(" · ").next()?.trim();
+    let stripped = first.strip_suffix(" with 1M context").unwrap_or(first);
+    let mut words = stripped.split_whitespace();
+    let family = words.next()?;
+    let version = words.next()?;
+    if words.next().is_some() {
+        return None;
+    }
+    let family_ok = family
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_uppercase())
+        && family.chars().all(|c| c.is_ascii_alphabetic());
+    let version_ok = version.chars().any(|c| c.is_ascii_digit())
+        && version.chars().all(|c| c.is_ascii_digit() || c == '.');
+    (family_ok && version_ok).then(|| format!("Claude {family} {version}"))
+}
+
+/// Promote an alias row's picker presentation from the CLI's bare
+/// nickname to the concrete model name it resolves to. The CLI reports
+/// alias rows as `"Default (recommended)"` / `"Opus (1M context)"` /
+/// `"Fable"` — cryptic next to the concrete versioned names every other
+/// provider surfaces. After promotion:
+///
+///   default → `"Claude Opus 4.8"` + `"Recommended · <blurb>"`
+///   opus    → `"Claude Opus 4.8 (1M context)"` + `"<blurb>"`
+///   fable   → `"Claude Fable 5"` + `"<blurb>"`
+///
+/// The concrete name comes from the row's version-bearing description
+/// (see [`concrete_name_from_description`]), falling back to the
+/// canonical maintained entry's label. Non-alias rows and alias rows
+/// with no resolvable concrete name pass through untouched. The version
+/// segment promoted into the label is dropped from the description so
+/// the subtitle doesn't repeat it; the `default` alias keeps its
+/// "recommended" signal as a description prefix instead of a label
+/// suffix, while other qualifiers (`(1M context)`) stay on the label so
+/// twin rows resolving to the same concrete model remain telling apart.
+fn promote_alias_row(
+    base_id: &str,
+    label: String,
+    description: Option<String>,
+    maintained: &HashMap<String, ChatModelInfo>,
+) -> (String, Option<String>) {
+    let alias_canonical = canonical_id_for_alias(base_id);
+    // The CLI also reports FULL ids with nickname display names (e.g.
+    // id `claude-fable-5`, displayName "Fable"). A label with no digit
+    // carries no version, so it needs the same promotion; a label that
+    // already names a version ("Claude Opus 4.8") passes through.
+    let label_is_versionless = !label.chars().any(|c| c.is_ascii_digit());
+    if alias_canonical.is_none() && !label_is_versionless {
+        return (label, description);
+    }
+    let from_desc = description
+        .as_deref()
+        .and_then(concrete_name_from_description);
+    let desc_carries_name = from_desc.is_some();
+    let Some(concrete) = from_desc.or_else(|| {
+        alias_canonical
+            .and_then(|cid| maintained.get(cid))
+            .or_else(|| maintained.get(base_id))
+            .map(|c| c.label.clone())
+    }) else {
+        return (label, description);
+    };
+    let qualifier = label.find('(').map(|i| label[i..].trim().to_string());
+    let recommended = base_id.eq_ignore_ascii_case("default")
+        || qualifier
+            .as_deref()
+            .is_some_and(|q| q.eq_ignore_ascii_case("(recommended)"));
+    let promoted_label = match &qualifier {
+        Some(q) if !recommended => format!("{concrete} {q}"),
+        _ => concrete,
+    };
+    let blurb = description
+        .as_deref()
+        .map(|d| {
+            if desc_carries_name {
+                d.split_once(" · ")
+                    .map(|(_, rest)| rest.to_string())
+                    .unwrap_or_default()
+            } else {
+                d.to_string()
+            }
+        })
+        .filter(|s| !s.is_empty());
+    let promoted_description = if recommended {
+        Some(match blurb {
+            Some(b) => format!("Recommended · {b}"),
+            None => "Recommended".to_string(),
+        })
+    } else {
+        blurb
+    };
+    (promoted_label, promoted_description)
 }
 
 /// Merge a single SDK model record with hand-maintained metadata. The
@@ -921,6 +1077,9 @@ fn merge_sdk_with_maintained(
             .and_then(|cid| maintained.get(cid))
             .and_then(alias_description_from_canonical)
     };
+    // Alias rows render as concrete model names (see `promote_alias_row`);
+    // full-id rows keep the SDK label + description untouched.
+    let (label, description) = promote_alias_row(&base_id, label, description, maintained);
 
     ChatModelInfo {
         id: base_id,
@@ -1396,6 +1555,147 @@ mod tests {
             supports_adaptive_thinking: adaptive,
             supports_fast_mode: fast,
         }
+    }
+
+    #[test]
+    fn concrete_name_parses_only_version_segments() {
+        assert_eq!(
+            concrete_name_from_description("Opus 4.8 with 1M context · Best for everyday, complex tasks")
+                .as_deref(),
+            Some("Claude Opus 4.8"),
+        );
+        assert_eq!(
+            concrete_name_from_description("Haiku 4.5 · Fastest for quick answers").as_deref(),
+            Some("Claude Haiku 4.5"),
+        );
+        assert_eq!(
+            concrete_name_from_description("Fable 5 · Most capable for your hardest tasks")
+                .as_deref(),
+            Some("Claude Fable 5"),
+        );
+        // Free-form descriptions must never be mangled into a model name.
+        assert!(concrete_name_from_description("Best for everyday, complex tasks").is_none());
+        assert!(concrete_name_from_description("Fast responses").is_none());
+        assert!(concrete_name_from_description("").is_none());
+    }
+
+    #[test]
+    fn sdk_merge_promotes_alias_rows_to_concrete_names() {
+        // The deployed CLI reports aliases with nickname display names
+        // and version-bearing descriptions. The picker must render the
+        // concrete model name (parsed from the LIVE description, so a
+        // CLI that re-points an alias at a newer model than the
+        // maintained list knows stays correct), with the alias
+        // qualifier preserved.
+        let efforts = &["low", "medium", "high", "xhigh", "max"];
+        let mut default_row =
+            sdk_model("default", "Default (recommended)", efforts, Some(true), Some(false));
+        default_row.description =
+            "Opus 5 with 1M context · Best for everyday, complex tasks".into();
+        let mut opus_row = sdk_model("opus", "Opus (1M context)", efforts, Some(true), Some(false));
+        opus_row.description = "Opus 5 with 1M context · Best for everyday, complex tasks".into();
+        let mut fable_row = sdk_model("fable", "Fable", efforts, Some(true), None);
+        fable_row.description =
+            "Fable 5 · Most capable for your hardest and longest-running tasks".into();
+
+        let caps = build_capabilities_from_sdk(vec![default_row, opus_row, fable_row]);
+
+        // The `default` alias resolves to the same concrete model as the
+        // `opus` row, so it folds into that twin: no duplicate row, the
+        // twin leads the list (feeds the frontend default) and inherits
+        // the "Recommended" marker.
+        assert!(caps.models.iter().all(|m| m.id != "default"));
+        let opus_m = &caps.models[0];
+        assert_eq!(opus_m.id, "opus");
+        assert_eq!(opus_m.label, "Claude Opus 5 (1M context)");
+        assert_eq!(
+            opus_m.description.as_deref(),
+            Some("Recommended · Best for everyday, complex tasks"),
+        );
+
+        let fable_m = caps.models.iter().find(|m| m.id == "fable").unwrap();
+        assert_eq!(fable_m.label, "Claude Fable 5");
+        assert_eq!(
+            fable_m.description.as_deref(),
+            Some("Most capable for your hardest and longest-running tasks"),
+        );
+    }
+
+    #[test]
+    fn sdk_merge_promotes_full_id_rows_with_nickname_labels() {
+        // The CLI can report a FULL id with a bare nickname displayName
+        // (id `claude-fable-5`, displayName "Fable"). The versionless
+        // label promotes exactly like an alias row.
+        let mut fable = sdk_model(
+            "claude-fable-5",
+            "Fable",
+            &["low", "medium", "high", "xhigh", "max"],
+            Some(true),
+            None,
+        );
+        fable.description =
+            "Fable 5 · Most capable for your hardest and longest-running tasks".into();
+        let caps = build_capabilities_from_sdk(vec![fable]);
+        let m = caps.models.iter().find(|m| m.id == "claude-fable-5").unwrap();
+        assert_eq!(m.label, "Claude Fable 5");
+        assert_eq!(
+            m.description.as_deref(),
+            Some("Most capable for your hardest and longest-running tasks"),
+        );
+    }
+
+    #[test]
+    fn dedupe_keeps_default_row_when_no_twin_exists() {
+        // A roster where the configured default resolves to a model no
+        // other row lists: the promoted `default` row stays so the
+        // launchable selection isn't lost.
+        let mut default_row = sdk_model(
+            "default",
+            "Default (recommended)",
+            &["low", "medium", "high"],
+            Some(true),
+            None,
+        );
+        default_row.description = "Opus 5 with 1M context · Best for everyday, complex tasks".into();
+        let mut haiku = sdk_model("haiku", "Haiku", &["low"], Some(false), None);
+        haiku.description = "Haiku 4.5 · Fastest for quick answers".into();
+        let caps = build_capabilities_from_sdk(vec![default_row, haiku]);
+        let m = caps.models.iter().find(|m| m.id == "default").unwrap();
+        assert_eq!(m.label, "Claude Opus 5");
+        assert_eq!(
+            m.description.as_deref(),
+            Some("Recommended · Best for everyday, complex tasks"),
+        );
+    }
+
+    #[test]
+    fn sdk_merge_promotes_description_less_alias_from_canonical() {
+        // An alias row the SDK gave no description: the tier-3 backfill
+        // synthesizes a version-bearing description from the canonical
+        // maintained entry, and the promotion then lifts that same
+        // version into the label.
+        let sonnet = sdk_model("sonnet", "Sonnet", &["low", "medium", "high"], Some(true), None);
+        let caps = build_capabilities_from_sdk(vec![sonnet]);
+        let m = caps.models.iter().find(|m| m.id == "sonnet").unwrap();
+        assert_eq!(m.label, "Claude Sonnet 4.6");
+        // Blurb only — the version lives in the label now.
+        assert_eq!(m.description.as_deref(), Some("Fast and capable"));
+    }
+
+    #[test]
+    fn sdk_merge_leaves_full_id_rows_unpromoted() {
+        let mut row = sdk_model(
+            "claude-opus-4-8",
+            "Claude Opus 4.8",
+            &["low", "medium", "high", "xhigh", "max"],
+            Some(true),
+            Some(true),
+        );
+        row.description = "Best for everyday, complex tasks".into();
+        let caps = build_capabilities_from_sdk(vec![row]);
+        let m = caps.models.iter().find(|m| m.id == "claude-opus-4-8").unwrap();
+        assert_eq!(m.label, "Claude Opus 4.8");
+        assert_eq!(m.description.as_deref(), Some("Best for everyday, complex tasks"));
     }
 
     #[test]

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -245,6 +245,9 @@ type ThreadScopeRowStubProps = {
 };
 let lastThreadScopeRowProps: ThreadScopeRowStubProps | null = null;
 vi.mock("./pickers/ThreadScopeRow", () => ({
+  // Class-string constants consumed by the Context Row's strip shell.
+  SCOPE_STRIP: "scope-strip-stub",
+  SCOPE_STRIP_INSET: "scope-strip-inset-stub",
   ThreadScopeRow: (props: ThreadScopeRowStubProps) => {
     lastThreadScopeRowProps = props;
     return (

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -118,7 +118,11 @@ import {
 } from "./ComposerPendingInputPanel";
 import { defaultModelForProvider } from "./pickers/ModelPicker";
 import type { ActivePillMode } from "./pickers/ModePill";
-import { ThreadScopeRow } from "./pickers/ThreadScopeRow";
+import {
+  SCOPE_STRIP,
+  SCOPE_STRIP_INSET,
+  ThreadScopeRow,
+} from "./pickers/ThreadScopeRow";
 import { WorkspaceStatusCluster } from "./WorkspaceStatusCluster";
 import { useUIStore } from "@/stores/ui-store";
 
@@ -2704,37 +2708,39 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       // status cluster on the right that the old bottom
       // `WorkspaceContextBar` used to show (now hidden for this pane —
       // see `useAgentChatPaneActive`).
-      <div className="flex w-full items-center justify-between gap-2.5 px-1">
-        <div className="flex min-w-0 items-center gap-0.5 text-xs font-semibold text-foreground/90">
-          <span
-            className="inline-flex h-[27px] shrink-0 items-center gap-1.5 rounded-md px-2"
-            title={workspaceProjectRoot}
-          >
-            {isHomeWorkspace ? (
-              <Home className="size-3.5 text-status-remote" />
-            ) : (
-              <Folder className="size-3.5 text-muted-foreground" />
-            )}
-            <span className="max-w-[140px] truncate">
-              {isHomeWorkspace ? "Home" : basename(workspaceProjectRoot)}
-            </span>
-          </span>
-          {paneWorkspaceBranch && (
-            <>
-              <span className="select-none text-muted-foreground/50">·</span>
-              <span
-                className="inline-flex h-[27px] shrink-0 items-center gap-1.5 rounded-md px-2 font-mono"
-                title={`Branch: ${paneWorkspaceBranch}`}
-              >
-                <GitBranch className="size-3 text-muted-foreground" />
-                <span className="max-w-[160px] truncate">
-                  {paneWorkspaceBranch}
-                </span>
+      <div className={SCOPE_STRIP_INSET}>
+        <div className={SCOPE_STRIP}>
+          <div className="flex min-w-0 items-center gap-0.5 text-xs font-medium text-muted-foreground">
+            <span
+              className="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md px-2"
+              title={workspaceProjectRoot}
+            >
+              {isHomeWorkspace ? (
+                <Home className="size-3.5 text-status-remote" />
+              ) : (
+                <Folder className="size-3.5 text-muted-foreground" />
+              )}
+              <span className="max-w-[140px] truncate">
+                {isHomeWorkspace ? "Home" : basename(workspaceProjectRoot)}
               </span>
-            </>
-          )}
+            </span>
+            {paneWorkspaceBranch && (
+              <>
+                <span className="select-none text-muted-foreground/50">·</span>
+                <span
+                  className="inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md px-2 font-mono"
+                  title={`Branch: ${paneWorkspaceBranch}`}
+                >
+                  <GitBranch className="size-3 text-muted-foreground" />
+                  <span className="max-w-[160px] truncate">
+                    {paneWorkspaceBranch}
+                  </span>
+                </span>
+              </>
+            )}
+          </div>
+          <WorkspaceStatusCluster />
         </div>
-        <WorkspaceStatusCluster />
       </div>
     ) : undefined;
 

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -1978,7 +1978,9 @@ export function Composer({
             // the scope strip below reads as a layer tucked under it.
             // Focus sharpens the border rather than stacking a ring.
             "rounded-[20px] border border-border/80 bg-muted/40",
-            "shadow-[0_12px_28px_-18px_rgba(0,0,0,0.45)]",
+            // Geometry and color split so the tint stays a themeable
+            // utility rather than a baked-in rgba literal.
+            "shadow-[0_12px_28px_-18px] shadow-black/40",
             // Composer is mounted for the entire chat session and re-
             // renders frequently as the draft / attachments change.
             // `transition-all` would animate every property change;

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -247,7 +247,13 @@ interface Props {
   onModeRemove: () => void;
 }
 
-const MAX_ROWS_APPROX_PX = 32 + 7 * 20; // ~8 rows
+const MAX_ROWS_APPROX_PX = 20 + 10 * 20; // ~10 rows (200px of text + py-2.5)
+
+/** Resting height of the (empty) textarea box, padding included. Reserves
+ *  ~4 lines of space so the idle composer reads as a spacious prompt card
+ *  (140px tall with the 32px-control footer row) instead of a single-line
+ *  strip. The auto-grow effect only ever grows past this, never below it. */
+const MIN_TEXTAREA_PX = 94;
 
 export function Composer({
   draft,
@@ -313,7 +319,7 @@ export function Composer({
   // Kept hidden so the visible affordance stays the popup row.
   const imageInputRef = useRef<HTMLInputElement | null>(null);
 
-  // Auto-grow textarea up to ~8 rows.
+  // Auto-grow textarea from the resting min up to ~10 rows.
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
@@ -1966,11 +1972,13 @@ export function Composer({
           onDrop={handleDrop}
           className={cn(
             "relative",
-            // Composer card (design D10): 15px radius, a real hairline
-            // border on the slightly-elevated surface, and a soft
-            // shadow so the card lifts off the pane background. Focus
-            // sharpens the border rather than stacking a ring.
-            "rounded-[15px] border border-border bg-muted/40 shadow-sm",
+            // Composer card: soft 20px radius, a hairline border on
+            // the slightly-elevated surface, and a deep low-opacity
+            // shadow so the card lifts off the pane background and
+            // the scope strip below reads as a layer tucked under it.
+            // Focus sharpens the border rather than stacking a ring.
+            "rounded-[20px] border border-border/80 bg-muted/40",
+            "shadow-[0_12px_28px_-18px_rgba(0,0,0,0.45)]",
             // Composer is mounted for the entire chat session and re-
             // renders frequently as the draft / attachments change.
             // `transition-all` would animate every property change;
@@ -2378,7 +2386,13 @@ export function Composer({
                 "placeholder:text-muted-foreground/60",
                 "outline-none",
               )}
-              style={{ maxHeight: `${MAX_ROWS_APPROX_PX}px` }}
+              // min-height (rather than a floor in the auto-grow effect)
+              // so the imperative `style.height` can never shrink the box
+              // below the resting size.
+              style={{
+                minHeight: `${MIN_TEXTAREA_PX}px`,
+                maxHeight: `${MAX_ROWS_APPROX_PX}px`,
+              }}
             />
           </div>
           {showQueueHint ? (
@@ -2416,9 +2430,11 @@ export function Composer({
             modelPickerOpenSignal={modelPickerOpenSignal}
           />
         </div>
-        {belowComposerSlot ? (
-          <div className="pt-1.5">{belowComposerSlot}</div>
-        ) : null}
+        {/* No gap here — the scope strip / context strip attaches
+            flush to the card's bottom edge so it reads as a layer
+            sliding out from beneath the card. Slot content owns any
+            spacing it needs below itself. */}
+        {belowComposerSlot ?? null}
       </div>
     </div>
   );

--- a/src/components/chat/ComposerFooter.test.tsx
+++ b/src/components/chat/ComposerFooter.test.tsx
@@ -95,17 +95,17 @@ describe("ComposerFooter — Stage 3 refactor (unified + popup)", () => {
     expect(btn).toBeInTheDocument();
   });
 
-  it("the + button matches the Send button shape (h-7 w-7 circle)", () => {
+  it("the + button matches the Send button shape (h-8 w-8 circle)", () => {
     renderFooter({ onAttachClick: vi.fn() });
     const attach = screen.getByTestId("composer-attach-button");
     const send = screen.getByRole("button", { name: "Send" });
     // Both share the same fixed circle dimensions; identical shape
     // is what makes them read as a visual pair.
-    expect(attach.className).toContain("h-7");
-    expect(attach.className).toContain("w-7");
+    expect(attach.className).toContain("h-8");
+    expect(attach.className).toContain("w-8");
     expect(attach.className).toContain("rounded-full");
-    expect(send.className).toContain("h-7");
-    expect(send.className).toContain("w-7");
+    expect(send.className).toContain("h-8");
+    expect(send.className).toContain("w-8");
     expect(send.className).toContain("rounded-full");
   });
 

--- a/src/components/chat/ComposerFooter.tsx
+++ b/src/components/chat/ComposerFooter.tsx
@@ -94,8 +94,8 @@ export function ComposerFooter({
   const modeIsActive = mode !== "default";
 
   return (
-    <div className="flex items-center gap-1.5 px-3 pb-2 pt-1">
-      <div className="flex flex-wrap items-center gap-1.5 min-w-0">
+    <div className="flex items-center gap-1.5 px-2 pb-2 pt-1">
+      <div className="flex flex-wrap items-center gap-1 min-w-0">
         {onAttachClick && (
           <button
             type="button"
@@ -108,7 +108,7 @@ export function ComposerFooter({
               // diameter, same icon weight. Subtle muted fill so
               // the bold filled Send still reads as the primary
               // action on the right.
-              "inline-flex h-7 w-7 items-center justify-center rounded-full",
+              "inline-flex h-8 w-8 items-center justify-center rounded-full",
               // Transparent base border keeps the circle diameter fixed
               // (border-box) so the open state can add an ember border
               // without a 1px layout shift.
@@ -124,7 +124,7 @@ export function ComposerFooter({
             aria-expanded={attachOpen}
             title="Attach (file, folder, mode, …)"
           >
-            <Plus className="h-3.5 w-3.5" strokeWidth={2.5} />
+            <Plus className="h-4 w-4" strokeWidth={2.25} />
           </button>
         )}
 
@@ -160,12 +160,14 @@ export function ComposerFooter({
           onEffortChange={onEffortChange}
           onContextWindowChange={onContextWindowChange}
           disabled={controlsDisabled}
+          withSeparator
         />
         <SpeedPicker
           model={activeModel}
           value={fastMode}
           onChange={onFastModeChange}
           disabled={controlsDisabled}
+          withSeparator
         />
         {/* Permission picker stays visible when a mode pill is
             active — kept on-screen for discoverability — but goes
@@ -178,6 +180,7 @@ export function ComposerFooter({
           value={permissionMode}
           onChange={onPermissionModeChange}
           disabled={controlsDisabled || modeIsActive}
+          withSeparator
         />
         {/* Host (Local / Remote) is a *workspace* property, not a
             chat-session property: pushing a workspace to a remote
@@ -201,8 +204,9 @@ export function ComposerFooter({
               // as the one destructive action in the row. Distinct from
               // the neutral near-white Send so an in-flight turn is
               // obvious at a glance.
-              "inline-flex h-7 w-7 items-center justify-center rounded-full",
-              "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+              "inline-flex h-8 w-8 items-center justify-center rounded-full",
+              "bg-destructive/90 text-destructive-foreground shadow-xs shadow-destructive/25",
+              "transition-all duration-150 hover:scale-105 hover:bg-destructive active:scale-100",
             )}
             aria-label="Stop"
             title="Stop"
@@ -215,14 +219,18 @@ export function ComposerFooter({
             onClick={onSubmit}
             disabled={!canSubmit || streaming}
             className={cn(
-              "inline-flex h-7 w-7 items-center justify-center rounded-full",
-              "bg-foreground text-background hover:bg-foreground/90",
-              "disabled:opacity-40 disabled:cursor-not-allowed",
+              // Primary action: near-white filled circle with a soft
+              // tinted glow, a 150ms hover lift (scale) and a plain
+              // opacity fade when there's nothing to send.
+              "inline-flex h-8 w-8 items-center justify-center rounded-full",
+              "bg-primary/90 text-primary-foreground shadow-xs shadow-primary/25",
+              "transition-all duration-150 hover:scale-105 hover:bg-primary active:scale-100",
+              "disabled:opacity-30 disabled:shadow-none disabled:cursor-not-allowed disabled:hover:scale-100",
             )}
             aria-label="Send"
             title="Send"
           >
-            <ArrowUp className="h-3.5 w-3.5" strokeWidth={2.5} />
+            <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
           </button>
         )}
       </div>

--- a/src/components/chat/ComposerPendingInputPanel.tsx
+++ b/src/components/chat/ComposerPendingInputPanel.tsx
@@ -255,7 +255,7 @@ export function ComposerPendingInputPanel({ item, onSubmit }: Props) {
     return (
       <div className="w-full px-4 pb-2">
         <div className="mx-auto w-full max-w-[760px]">
-          <div className="rounded-[15px] border border-border bg-muted/40 shadow-sm px-4 py-3 text-xs text-muted-foreground">
+          <div className="rounded-[20px] border border-border bg-muted/40 shadow-sm px-4 py-3 text-xs text-muted-foreground">
             AskUserQuestion with no questions.
           </div>
         </div>
@@ -270,7 +270,7 @@ export function ComposerPendingInputPanel({ item, onSubmit }: Props) {
   return (
     <div className="w-full px-4 pb-2">
       <div className="mx-auto w-full max-w-[760px]">
-        <div className="rounded-[15px] border border-border bg-muted/40 shadow-sm px-4 py-3 space-y-3">
+        <div className="rounded-[20px] border border-border bg-muted/40 shadow-sm px-4 py-3 space-y-3">
           {/* Header row: optional uppercase header on the left, pagination on the right. */}
           <div className="flex items-center gap-2">
             <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/70">

--- a/src/components/chat/pickers/ModelPicker.test.tsx
+++ b/src/components/chat/pickers/ModelPicker.test.tsx
@@ -94,7 +94,18 @@ vi.mock("@/stores/provider-capabilities-store", () => ({
     state: typeof capsState,
     provider: "claude" | "codex",
   ) => state[provider],
-  selectModel: () => null,
+  // Mirror the real selector: exact id match, with the persisted
+  // `"default"` alias falling back to the roster's first row.
+  selectModel: (
+    caps: { models: Array<{ id: string }> } | null,
+    modelId: string | null,
+  ) => {
+    if (!caps || !modelId) return null;
+    return (
+      caps.models.find((m) => m.id === modelId) ??
+      (modelId === "default" ? caps.models[0] ?? null : null)
+    );
+  },
 }));
 
 afterEach(() => {

--- a/src/components/chat/pickers/ModelPicker.tsx
+++ b/src/components/chat/pickers/ModelPicker.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import type { AgentChatProviderKind } from "@/tauri/types";
 import { ProviderLogo } from "../provider-logo";
 import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { FOOTER_TRIGGER } from "./footer-trigger";
 
 // The model list + default-model / label helpers moved to
 // `@/lib/agent-chat/capability-defaults` in the Stage C Effort-lock
@@ -98,7 +99,7 @@ export function ModelPicker({
         <button
           type="button"
           disabled={disabled}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground outline-none disabled:opacity-50"
+          className={FOOTER_TRIGGER}
         >
           <ProviderLogo provider={provider} className="h-3 w-3" />
           <span className="max-w-[140px] truncate">

--- a/src/components/chat/pickers/MultiProviderModelPicker.test.tsx
+++ b/src/components/chat/pickers/MultiProviderModelPicker.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import type {
@@ -168,6 +168,22 @@ describe("MultiProviderModelPicker — trigger", () => {
     renderPicker({ provider: "claude", model: "claude-future-9000" });
     expect(screen.getByTestId("multi-provider-model-picker-trigger"))
       .toHaveTextContent("claude-future-9000");
+  });
+
+  it("resolves a dangling stored 'default' id to the first roster model", () => {
+    // Persisted drafts/threads from before the backend folded the
+    // "default" alias row out of the roster still carry that id. When
+    // the alias is absent, models[0] is the concrete model it resolved
+    // to — the trigger must show that model's label (and description
+    // tooltip), not the raw "default" string.
+    renderPicker({ provider: "claude", model: "default" });
+    const trigger = screen.getByTestId("multi-provider-model-picker-trigger");
+    expect(trigger).toHaveTextContent("Claude Opus 4.7");
+    expect(trigger).not.toHaveTextContent("default");
+    expect(trigger).toHaveAttribute(
+      "title",
+      "Claude Opus 4.7 · Opus 4.8 with 1M context · Best for everyday, complex tasks",
+    );
   });
 
   it("does not open when disabled", async () => {
@@ -605,6 +621,35 @@ describe("MultiProviderModelPicker — selection", () => {
     });
   });
 
+  it("highlights the first roster row when the stored id is a dangling 'default'", async () => {
+    // Same alias-fold scenario as the trigger test: the active-row
+    // comparison must run against the RESOLVED id, so the row for
+    // models[0] carries data-active instead of nothing highlighting.
+    const user = userEvent.setup();
+    renderPicker({ provider: "claude", model: "default" });
+    await openPicker(user);
+
+    const rows = screen.getAllByTestId("multi-provider-model-row");
+    const activeRows = rows.filter(
+      (r) => r.getAttribute("data-active") === "true",
+    );
+    expect(activeRows).toHaveLength(1);
+    expect(activeRows[0]?.textContent).toContain("Claude Opus 4.7");
+  });
+
+  it("does not highlight any row for a genuinely unknown stored id", async () => {
+    // The resolution fallback is scoped to the literal "default"
+    // alias — an unknown id must not silently claim models[0].
+    const user = userEvent.setup();
+    renderPicker({ provider: "claude", model: "claude-future-9000" });
+    await openPicker(user);
+
+    const rows = screen.getAllByTestId("multi-provider-model-row");
+    expect(
+      rows.filter((r) => r.getAttribute("data-active") === "true"),
+    ).toHaveLength(0);
+  });
+
   it("selecting an OpenCode federated model passes the namespaced slug", async () => {
     const user = userEvent.setup();
     const { onProviderModelChange } = renderPicker();
@@ -967,5 +1012,88 @@ describe("MultiProviderModelPicker — openSignal", () => {
     );
     await screen.findByPlaceholderText("Search models...");
     expect(isOpen()).toBe(true);
+  });
+});
+
+describe("MultiProviderModelPicker — jump shortcuts", () => {
+  // The handler is a window capture-phase listener, so we dispatch
+  // raw keydown events at the window. Digit detection is based on
+  // `event.code` (physical key), which lets us simulate layouts
+  // where the digit row is shifted: the produced `key` is then a
+  // non-digit character even though `code` is still "Digit1".
+  it("selects the Nth row via Ctrl+digit using event.code", async () => {
+    const user = userEvent.setup();
+    const { onProviderModelChange } = renderPicker({
+      provider: "claude",
+      model: "claude-opus-4-7",
+    });
+    await openPicker(user);
+
+    fireEvent.keyDown(window, { key: "2", code: "Digit2", ctrlKey: true });
+
+    expect(onProviderModelChange).toHaveBeenCalledWith(
+      "claude",
+      "claude-haiku-4-5",
+    );
+  });
+
+  it("fires even when the produced key is a non-digit character (shifted-digit layouts)", async () => {
+    const user = userEvent.setup();
+    const { onProviderModelChange } = renderPicker({
+      provider: "claude",
+      model: "claude-opus-4-7",
+    });
+    await openPicker(user);
+
+    // Layouts with a shifted digit row emit e.g. "&" for the physical
+    // 1 key when Shift is up; only `code` identifies the digit.
+    fireEvent.keyDown(window, { key: "&", code: "Digit1", ctrlKey: true });
+
+    expect(onProviderModelChange).toHaveBeenCalledWith(
+      "claude",
+      "claude-opus-4-7",
+    );
+  });
+
+  it("accepts numpad digits", async () => {
+    const user = userEvent.setup();
+    const { onProviderModelChange } = renderPicker({
+      provider: "claude",
+      model: "claude-opus-4-7",
+    });
+    await openPicker(user);
+
+    fireEvent.keyDown(window, { key: "2", code: "Numpad2", ctrlKey: true });
+
+    expect(onProviderModelChange).toHaveBeenCalledWith(
+      "claude",
+      "claude-haiku-4-5",
+    );
+  });
+
+  it("still rejects the shortcut when extra modifiers are held", async () => {
+    const user = userEvent.setup();
+    const { onProviderModelChange } = renderPicker({
+      provider: "claude",
+      model: "claude-opus-4-7",
+    });
+    await openPicker(user);
+
+    fireEvent.keyDown(window, {
+      key: "1",
+      code: "Digit1",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    fireEvent.keyDown(window, {
+      key: "1",
+      code: "Digit1",
+      ctrlKey: true,
+      altKey: true,
+    });
+    // No modifier at all: plain digit typing must reach the search box.
+    fireEvent.keyDown(window, { key: "1", code: "Digit1" });
+
+    expect(onProviderModelChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/chat/pickers/MultiProviderModelPicker.tsx
+++ b/src/components/chat/pickers/MultiProviderModelPicker.tsx
@@ -37,6 +37,7 @@ import type {
 
 import { ProviderLogo } from "../provider-logo";
 import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { FOOTER_TRIGGER } from "./footer-trigger";
 
 /**
  * Step 12 Stage 4 — unified provider + model picker.
@@ -183,6 +184,12 @@ interface ResolvedRow {
  *  uniform. */
 type RailKey = AgentChatProviderKind | "favorites";
 
+/** Platform check for the jump-shortcut modifier and its chip label
+ *  ("⌘1" on macOS, "Ctrl+1" elsewhere). */
+const IS_MAC =
+  typeof navigator !== "undefined" && /mac/i.test(navigator.platform);
+const JUMP_MOD_LABEL = IS_MAC ? "⌘" : "Ctrl+";
+
 export function MultiProviderModelPicker({
   provider,
   model,
@@ -320,6 +327,35 @@ export function MultiProviderModelPicker({
     });
   }, [query, railKey, rowsByProvider, favoritesSet, visibleProviders]);
 
+  // mod+1..9 jump shortcuts — bound to the first nine rows of the
+  // CURRENT list (search filter, rail tab, and favorites sort all
+  // respected, since `visibleRows` is the exact array the list
+  // renders). Window capture-phase listener so the shortcut fires
+  // even while the search input holds focus; registered only while
+  // the popover is open. Selecting closes the picker, same as a click.
+  const jumpRowsRef = useRef<ResolvedRow[]>([]);
+  jumpRowsRef.current = visibleRows.slice(0, 9);
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat) return;
+      const mod = IS_MAC
+        ? event.metaKey && !event.ctrlKey
+        : event.ctrlKey && !event.metaKey;
+      if (!mod || event.shiftKey || event.altKey) return;
+      if (!/^[1-9]$/.test(event.key)) return;
+      const row = jumpRowsRef.current[Number(event.key) - 1];
+      if (!row) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onProviderModelChange(row.provider, row.model.id);
+      setOpen(false);
+      setQuery("");
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [open, onProviderModelChange]);
+
   const selectedKey = `${provider}::${model ?? ""}`;
   const triggerLabel = useMemo(() => {
     const caps =
@@ -369,16 +405,11 @@ export function MultiProviderModelPicker({
           disabled={disabled}
           data-testid="multi-provider-model-picker-trigger"
           title={triggerTitle}
-          className={cn(
-            // Composer footer pill: bordered card chip on the base
-            // surface (design's model/effort/permission pills), the
-            // leading ProviderLogo standing in for the design's tinted
-            // dot. Rounded-lg + border distinguishes these session-
-            // config pills from the rounded-full scope pills above.
-            "inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1 text-xs font-medium",
-            "text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground",
-            "outline-none disabled:opacity-50",
-          )}
+          // Composer footer control: quiet ghost text (shared
+          // FOOTER_TRIGGER recipe), the leading ProviderLogo standing
+          // in for a tinted dot. Hairline pipes between footer
+          // controls — not per-pill borders — carry the separation.
+          className={FOOTER_TRIGGER}
         >
           <ProviderLogo provider={provider} className="h-3 w-3" />
           <span className="max-w-[180px] truncate">
@@ -398,11 +429,17 @@ export function MultiProviderModelPicker({
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[600px] max-w-[calc(100vw-2rem)] p-0"
+        // Compact popup: 400px wide (48px provider rail + fluid list),
+        // 384px tall — a scannable column instead of a wide panel.
+        className="w-[400px] max-w-[calc(100vw-2rem)] p-0"
         align="start"
         onOpenAutoFocus={focusCmdkRootOnOpen}
       >
-        <div className="grid grid-cols-[48px_1fr] h-[400px] overflow-hidden">
+        {/* `minmax(0,1fr)` (not bare `1fr`): grid items default to
+            min-width auto, so a long unbreakable subtitle line would
+            otherwise force the list column past the popup width and
+            clip the rows against the rail. */}
+        <div className="grid grid-cols-[48px_minmax(0,1fr)] h-[384px] overflow-hidden">
           <ProviderRail
             providers={visibleProviders}
             selected={railKey}
@@ -414,7 +451,7 @@ export function MultiProviderModelPicker({
               setQuery("");
             }}
           />
-          <div className="flex min-h-0 flex-col">
+          <div className="flex min-h-0 min-w-0 flex-col">
             <Command shouldFilter={false}>
               <CommandInput
                 placeholder="Search models..."
@@ -455,7 +492,7 @@ export function MultiProviderModelPicker({
                     query={query}
                   />
                 ) : (
-                  visibleRows.map((row) => {
+                  visibleRows.map((row, index) => {
                     const isActive =
                       row.provider === provider && row.model.id === model;
                     const key = pickerFavoriteKey(row.provider, row.model.id);
@@ -465,6 +502,9 @@ export function MultiProviderModelPicker({
                         row={row}
                         isActive={isActive}
                         isFavorite={favoritesSet.has(key)}
+                        jumpLabel={
+                          index < 9 ? `${JUMP_MOD_LABEL}${index + 1}` : null
+                        }
                         onSelect={() => {
                           onProviderModelChange(row.provider, row.model.id);
                           setOpen(false);
@@ -664,12 +704,16 @@ function ModelRow({
   row,
   isActive,
   isFavorite,
+  jumpLabel,
   onSelect,
   onToggleFavorite,
 }: {
   row: ResolvedRow;
   isActive: boolean;
   isFavorite: boolean;
+  /** "⌘N" / "Ctrl+N" chip for the first nine rows of the current
+   *  list, `null` beyond them. */
+  jumpLabel?: string | null;
   onSelect: () => void;
   onToggleFavorite: () => void;
 }) {
@@ -714,6 +758,15 @@ function ModelRow({
           </span>
         </div>
       </div>
+      {jumpLabel ? (
+        <kbd
+          aria-hidden
+          data-testid="model-row-jump-chip"
+          className="pointer-events-none mt-0.5 inline-flex h-4 shrink-0 select-none items-center self-start rounded-sm bg-muted px-1.5 font-sans text-[10px] font-medium text-muted-foreground"
+        >
+          {jumpLabel}
+        </kbd>
+      ) : null}
       {model.is_free ? (
         <span
           data-testid="model-row-free-badge"
@@ -737,16 +790,24 @@ function ModelRow({
         onPointerDown={(e) => e.stopPropagation()}
         onMouseDown={(e) => e.stopPropagation()}
         data-testid="model-row-favorite-toggle"
+        // The base CommandItem appends an invisible trailing CheckIcon
+        // (16px + flex gap) to every row unless the row carries its own
+        // trailing UI, detected via this slot — without it every row
+        // drags a ~24px phantom gutter on its right edge.
+        data-slot="command-shortcut"
         data-favorite={isFavorite || undefined}
         aria-pressed={isFavorite}
         aria-label={
           isFavorite ? "Remove from favorites" : "Add to favorites"
         }
         className={cn(
-          "shrink-0 rounded p-1 transition-opacity hover:bg-accent",
+          // Always visible (not hover-revealed): a dim outline star on
+          // every row keeps the favoriting affordance discoverable and
+          // the row layout stable.
+          "shrink-0 rounded p-1 transition-colors hover:bg-accent",
           isFavorite
-            ? "text-status-working opacity-100"
-            : "opacity-0 hover:opacity-100 group-hover:opacity-60 focus-visible:opacity-100",
+            ? "text-status-working"
+            : "text-muted-foreground/40 hover:text-foreground focus-visible:text-foreground",
         )}
       >
         <Star

--- a/src/components/chat/pickers/MultiProviderModelPicker.tsx
+++ b/src/components/chat/pickers/MultiProviderModelPicker.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/stores/picker-favorites-store";
 import {
   selectError,
+  selectModel,
   useProviderCapabilities,
 } from "@/stores/provider-capabilities-store";
 import type {
@@ -343,8 +344,15 @@ export function MultiProviderModelPicker({
         ? event.metaKey && !event.ctrlKey
         : event.ctrlKey && !event.metaKey;
       if (!mod || event.shiftKey || event.altKey) return;
-      if (!/^[1-9]$/.test(event.key)) return;
-      const row = jumpRowsRef.current[Number(event.key) - 1];
+      // Detect digits via `event.code` (physical key), not `event.key`
+      // (produced character): on layouts where the digit row is
+      // shifted, the unshifted keys emit non-digit characters — and
+      // Shift is rejected above — so a character-based check made the
+      // shortcut unreachable. `Digit1`..`Digit9` / `Numpad1`..`Numpad9`
+      // name the physical keys regardless of layout.
+      const digitMatch = /^(?:Digit|Numpad)([1-9])$/.exec(event.code);
+      if (!digitMatch) return;
+      const row = jumpRowsRef.current[Number(digitMatch[1]) - 1];
       if (!row) return;
       event.preventDefault();
       event.stopPropagation();
@@ -357,45 +365,43 @@ export function MultiProviderModelPicker({
   }, [open, onProviderModelChange]);
 
   const selectedKey = `${provider}::${model ?? ""}`;
+
+  // Caps bundle for the active provider, then a single roster
+  // resolution of the stored model id. Routed through `selectModel`
+  // (rather than a raw `find`) so a persisted `"default"` alias id —
+  // written back when the roster still led with that row, now folded
+  // out by the backend — resolves to the concrete `models[0]` row.
+  // The trigger label/subtitle/tooltip and the active-row highlight
+  // all derive from this one resolution so they can't disagree.
+  const capsForCurrentProvider =
+    provider === "claude"
+      ? claudeCaps
+      : provider === "codex"
+      ? codexCaps
+      : opencodeCaps;
+  const resolvedModel = useMemo(
+    () => selectModel(capsForCurrentProvider, model),
+    [capsForCurrentProvider, model],
+  );
+  const resolvedModelId = resolvedModel?.id ?? model;
+
   const triggerLabel = useMemo(() => {
-    const caps =
-      provider === "claude"
-        ? claudeCaps
-        : provider === "codex"
-        ? codexCaps
-        : opencodeCaps;
-    if (!caps && !model) return "Loading…";
-    const found = caps?.models.find((m) => m.id === model);
-    if (found) return found.label;
+    if (!capsForCurrentProvider && !model) return "Loading…";
+    if (resolvedModel) return resolvedModel.label;
     if (model) return model;
     return "Select model";
-  }, [provider, model, claudeCaps, codexCaps, opencodeCaps]);
+  }, [capsForCurrentProvider, model, resolvedModel]);
 
-  const triggerSubtitle = useMemo(() => {
-    const caps =
-      provider === "claude"
-        ? claudeCaps
-        : provider === "codex"
-        ? codexCaps
-        : opencodeCaps;
-    return caps?.models.find((m) => m.id === model)?.sub_provider ?? null;
-  }, [provider, model, claudeCaps, codexCaps, opencodeCaps]);
+  const triggerSubtitle = resolvedModel?.sub_provider ?? null;
 
   // The active model's resolved-version blurb, surfaced only in the
   // trigger's tooltip so the pill itself stays compact. Combines the
   // visible label with the description (e.g.
   // "Opus · Opus 4.8 with 1M context · Best for everyday, complex tasks").
   const triggerTitle = useMemo(() => {
-    const caps =
-      provider === "claude"
-        ? claudeCaps
-        : provider === "codex"
-        ? codexCaps
-        : opencodeCaps;
-    const description =
-      caps?.models.find((m) => m.id === model)?.description ?? null;
+    const description = resolvedModel?.description ?? null;
     return description ? `${triggerLabel} · ${description}` : triggerLabel;
-  }, [provider, model, claudeCaps, codexCaps, opencodeCaps, triggerLabel]);
+  }, [resolvedModel, triggerLabel]);
 
   return (
     <Popover open={open} onOpenChange={(v) => !disabled && setOpen(v)}>
@@ -493,8 +499,12 @@ export function MultiProviderModelPicker({
                   />
                 ) : (
                   visibleRows.map((row, index) => {
+                    // Compare against the resolved id (not the raw
+                    // stored one) so a persisted "default" alias
+                    // highlights the concrete row it resolved to.
                     const isActive =
-                      row.provider === provider && row.model.id === model;
+                      row.provider === provider &&
+                      row.model.id === resolvedModelId;
                     const key = pickerFavoriteKey(row.provider, row.model.id);
                     return (
                       <ModelRow

--- a/src/components/chat/pickers/PermissionModePicker.tsx
+++ b/src/components/chat/pickers/PermissionModePicker.tsx
@@ -16,6 +16,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { PermissionModeOption } from "@/tauri/types";
 import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { FOOTER_TRIGGER } from "./footer-trigger";
 
 /**
  * Capability-driven permission-mode picker.
@@ -35,6 +36,10 @@ interface Props {
   value: string | null;
   onChange: (mode: string) => void;
   disabled?: boolean;
+  /** Render a leading hairline pipe. Lives inside the picker (not the
+   *  footer) so the pipe disappears together with the control when the
+   *  capability gate hides it — no orphaned separators. */
+  withSeparator?: boolean;
 }
 
 function modeLabel(modes: PermissionModeOption[], value: string): string {
@@ -46,6 +51,7 @@ export function PermissionModePicker({
   value,
   onChange,
   disabled,
+  withSeparator,
 }: Props) {
   const [open, setOpen] = useState(false);
 
@@ -59,13 +65,13 @@ export function PermissionModePicker({
   const label = modeLabel(modes, current);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          disabled={disabled}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground outline-none disabled:opacity-50"
-        >
+    <>
+      {withSeparator && (
+        <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 self-center bg-border" />
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button type="button" disabled={disabled} className={FOOTER_TRIGGER}>
           <Lock className="h-3 w-3" />
           <span className="max-w-[140px] truncate">{label}</span>
           <ChevronDown className="h-2.5 w-2.5 opacity-40" />
@@ -109,7 +115,8 @@ export function PermissionModePicker({
             </CommandGroup>
           </CommandList>
         </Command>
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+    </>
   );
 }

--- a/src/components/chat/pickers/ReasoningPicker.tsx
+++ b/src/components/chat/pickers/ReasoningPicker.tsx
@@ -17,6 +17,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { ChatModelInfo } from "@/tauri/types";
 import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { FOOTER_TRIGGER } from "./footer-trigger";
 
 // Short description lines for each effort level. Verbs match
 // PermissionModePicker's density (two-line rows).
@@ -50,6 +51,10 @@ interface Props {
   /** Fires when the user picks a context-window row. */
   onContextWindowChange: (nextValue: string) => void;
   disabled?: boolean;
+  /** Render a leading hairline pipe. Lives inside the picker (not the
+   *  footer) so the pipe disappears together with the control when the
+   *  capability gate hides it — no orphaned separators. */
+  withSeparator?: boolean;
 }
 
 function effortLabel(labelMap: Record<string, string>, id: string): string {
@@ -91,6 +96,7 @@ export function ReasoningPicker({
   onEffortChange,
   onContextWindowChange,
   disabled,
+  withSeparator,
 }: Props) {
   const [open, setOpen] = useState(false);
 
@@ -147,13 +153,13 @@ export function ReasoningPicker({
   })();
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          disabled={disabled}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground outline-none disabled:opacity-50"
-        >
+    <>
+      {withSeparator && (
+        <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 self-center bg-border" />
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button type="button" disabled={disabled} className={FOOTER_TRIGGER}>
           <Brain className="h-3 w-3" />
           <span className="max-w-[200px] truncate">{pillLabel}</span>
           <ChevronDown className="h-2.5 w-2.5 opacity-40" />
@@ -254,7 +260,8 @@ export function ReasoningPicker({
             )}
           </CommandList>
         </Command>
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+    </>
   );
 }

--- a/src/components/chat/pickers/SpeedPicker.tsx
+++ b/src/components/chat/pickers/SpeedPicker.tsx
@@ -16,12 +16,17 @@ import { cn } from "@/lib/utils";
 import type { ChatModelInfo } from "@/tauri/types";
 
 import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { FOOTER_TRIGGER } from "./footer-trigger";
 
 interface Props {
   model: ChatModelInfo | null;
   value: boolean;
   onChange: (fastMode: boolean) => void;
   disabled?: boolean;
+  /** Render a leading hairline pipe. Lives inside the picker (not the
+   *  footer) so the pipe disappears together with the control when the
+   *  capability gate hides it — no orphaned separators. */
+  withSeparator?: boolean;
 }
 
 const OPTIONS = [
@@ -43,26 +48,38 @@ const OPTIONS = [
  * menu instead of a one-click toggle. The control only exists for models whose
  * live capability payload advertises support.
  */
-export function SpeedPicker({ model, value, onChange, disabled }: Props) {
+export function SpeedPicker({
+  model,
+  value,
+  onChange,
+  disabled,
+  withSeparator,
+}: Props) {
   const [open, setOpen] = useState(false);
 
   if (!model?.supports_fast_mode) return null;
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          disabled={disabled}
-          data-testid="speed-picker-trigger"
-          className={cn(
-            "inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors outline-none disabled:opacity-50",
-            value
-              ? "border-accent-ember/45 bg-accent-ember/15 text-accent-ember hover:bg-accent-ember/20"
-              : "border-border bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-          )}
-          aria-label={`Speed: ${value ? "Fast" : "Standard"}`}
-        >
+    <>
+      {withSeparator && (
+        <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 self-center bg-border" />
+      )}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            disabled={disabled}
+            data-testid="speed-picker-trigger"
+            className={cn(
+              FOOTER_TRIGGER,
+              // Fast mode is a billing-affecting state — keep the ember
+              // tint so an armed premium speed stays visible even in
+              // the quiet ghost row.
+              value &&
+                "bg-accent-ember/15 text-accent-ember hover:bg-accent-ember/20 hover:text-accent-ember",
+            )}
+            aria-label={`Speed: ${value ? "Fast" : "Standard"}`}
+          >
           <Zap className="h-3 w-3" fill={value ? "currentColor" : "none"} />
           <span>{value ? "Fast" : "Standard"}</span>
           <ChevronDown className="h-2.5 w-2.5 opacity-40" />
@@ -105,7 +122,8 @@ export function SpeedPicker({ model, value, onChange, disabled }: Props) {
             </CommandGroup>
           </CommandList>
         </Command>
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+    </>
   );
 }

--- a/src/components/chat/pickers/ThreadScopeRow.tsx
+++ b/src/components/chat/pickers/ThreadScopeRow.tsx
@@ -50,7 +50,18 @@ import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
 const EMPTY_WORKSPACES: WorkspaceSnapshot[] = [];
 
 const GHOST_BTN =
-  "inline-flex h-[27px] shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-foreground/90 outline-none transition-colors hover:bg-foreground/[0.07] disabled:cursor-not-allowed disabled:opacity-50";
+  "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground outline-none transition-colors hover:bg-foreground/[0.06] hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50";
+
+/** Scope-strip shell — the bar tucked under the composer card. Inset on
+ *  both sides by the card's 20px corner radius (so its edges land on the
+ *  card's bottom tangent points), bottom-only rounding, and one tonal
+ *  step less elevated than the card, which makes it read as a second
+ *  layer sliding out from beneath the composer rather than a floating
+ *  row. Shared with the running-thread Context Row so the layered
+ *  silhouette survives the first send. */
+export const SCOPE_STRIP_INSET = "w-full px-5";
+export const SCOPE_STRIP =
+  "flex w-full items-center justify-between gap-2.5 rounded-b-[14px] border border-t-0 border-border/70 bg-muted/20 px-2 py-1";
 
 function formatRelativeTime(unixSeconds: number): string {
   const now = Math.floor(Date.now() / 1000);
@@ -126,10 +137,9 @@ export interface ThreadScopeRowProps {
 }
 
 /**
- * Thread Scope redesign — the borderless scope row rendered BELOW the
- * composer (`Composer`'s `belowComposerSlot`): location · checkout on
- * the left, "from ⑂ branch" on the right, and a centered muted hint
- * underneath spelling out what a first send will do.
+ * Thread Scope redesign — the scope strip rendered BELOW the composer
+ * (`Composer`'s `belowComposerSlot`, attached flush via `SCOPE_STRIP`):
+ * location · checkout on the left, "from ⑂ branch" on the right.
  *
  * Rendered by BOTH first-send surfaces (see `ThreadScopeLocation`):
  * `DraftChatSurface` and `AgentChatPane`'s new-thread empty state.
@@ -226,9 +236,10 @@ export function ThreadScopeRow({
   }, [projectIsGit, checkoutMode, onChangeCheckoutMode]);
 
   return (
-    <div className="rise-in flex flex-col items-center gap-3 px-1">
-      <div className="flex w-full items-center justify-between gap-2.5">
-        <div className="flex min-w-0 items-center gap-0.5">
+    <div className="rise-in flex w-full flex-col items-center gap-3">
+      <div className={SCOPE_STRIP_INSET}>
+        <div className={SCOPE_STRIP}>
+          <div className="flex min-w-0 items-center gap-0.5">
           <LocationControl
             location={location}
             isHome={isHome}
@@ -248,21 +259,22 @@ export function ThreadScopeRow({
             </>
           )}
         </div>
-        {(showProjectControls || trailing) && (
-          <div className="flex shrink-0 items-center gap-1.5">
-            {showProjectControls && projectIsGit && projectPath && (
-              <BranchControl
-                projectPath={projectPath}
-                checkoutMode={checkoutMode}
-                baseBranch={baseBranch}
-                disabled={disabled}
-                onChangeCheckoutMode={onChangeCheckoutMode}
-                onChangeBaseBranch={onChangeBaseBranch}
-              />
-            )}
-            {trailing}
-          </div>
-        )}
+          {(showProjectControls || trailing) && (
+            <div className="flex shrink-0 items-center gap-1.5">
+              {showProjectControls && projectIsGit && projectPath && (
+                <BranchControl
+                  projectPath={projectPath}
+                  checkoutMode={checkoutMode}
+                  baseBranch={baseBranch}
+                  disabled={disabled}
+                  onChangeCheckoutMode={onChangeCheckoutMode}
+                  onChangeBaseBranch={onChangeBaseBranch}
+                />
+              )}
+              {trailing}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/chat/pickers/footer-trigger.ts
+++ b/src/components/chat/pickers/footer-trigger.ts
@@ -1,0 +1,8 @@
+/** Shared quiet trigger for the composer footer's session-config
+ *  controls (model / reasoning / speed / permission). Borderless ghost
+ *  text on the card surface — separation between controls comes from
+ *  the hairline pipes interleaved in the footer, not from per-pill
+ *  borders, so the row reads as one calm strip instead of a bank of
+ *  chips. */
+export const FOOTER_TRIGGER =
+  "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg px-2 text-xs font-medium text-muted-foreground transition-colors outline-none hover:bg-foreground/[0.06] hover:text-foreground disabled:opacity-50";

--- a/src/lib/agent-chat/capability-defaults.test.ts
+++ b/src/lib/agent-chat/capability-defaults.test.ts
@@ -147,6 +147,29 @@ describe("capability-defaults", () => {
     it("falls back to the raw id when caps are unhydrated", () => {
       expect(modelLabel("claude", "anything")).toBe("anything");
     });
+
+    it("resolves a dangling 'default' id to the first model's label", () => {
+      // Persisted drafts from before the alias fold store the id
+      // "default"; the roster no longer carries that row when a
+      // concrete twin exists, and models[0] is the model the alias
+      // resolved to.
+      useProviderCapabilities.setState({
+        claude: makeClaudeCaps([
+          makeModel({ id: "claude-opus-4-8", label: "Claude Opus 4.8" }),
+          makeModel({ id: "claude-haiku-4-5", label: "Claude Haiku 4.5" }),
+        ]),
+      });
+      expect(modelLabel("claude", "default")).toBe("Claude Opus 4.8");
+    });
+
+    it("does not remap other unknown ids to the first model", () => {
+      useProviderCapabilities.setState({
+        claude: makeClaudeCaps([
+          makeModel({ id: "claude-opus-4-8", label: "Claude Opus 4.8" }),
+        ]),
+      });
+      expect(modelLabel("claude", "mystery")).toBe("mystery");
+    });
   });
 
   describe("capabilityDefaults", () => {

--- a/src/lib/agent-chat/capability-defaults.ts
+++ b/src/lib/agent-chat/capability-defaults.ts
@@ -1,5 +1,6 @@
 import {
   selectCapabilities,
+  selectModel,
   useProviderCapabilities,
 } from "@/stores/provider-capabilities-store";
 import type { AgentChatProviderKind } from "@/tauri/types";
@@ -105,7 +106,10 @@ export function modelsForProvider(
 
 /** Look up a model's display label by id. Falls back to the raw id
  *  when the model is not in the capabilities payload (or caps haven't
- *  hydrated). */
+ *  hydrated). Routed through `selectModel` so a persisted `"default"`
+ *  id from before the alias fold resolves to `models[0]`'s label — the
+ *  concrete model the alias pointed at — instead of showing the raw
+ *  string. */
 export function modelLabel(
   provider: AgentChatProviderKind,
   modelId: string,
@@ -114,7 +118,7 @@ export function modelLabel(
     useProviderCapabilities.getState(),
     provider,
   );
-  return caps?.models.find((m) => m.id === modelId)?.label ?? modelId;
+  return selectModel(caps, modelId)?.label ?? modelId;
 }
 
 export interface CapabilityDefaults {

--- a/src/stores/provider-capabilities-store.test.ts
+++ b/src/stores/provider-capabilities-store.test.ts
@@ -189,6 +189,43 @@ describe("provider-capabilities-store", () => {
     expect(selectModel(caps, null)).toBeNull();
   });
 
+  it("selectModel resolves a dangling 'default' id to models[0]", () => {
+    // Persisted drafts/threads from before the backend folded the
+    // `"default"` alias row out of the roster still carry that id.
+    // When the alias is absent, models[0] is the concrete model it
+    // resolved to — selectModel must fall back to it rather than
+    // returning null and stranding the UI on a raw "default" string.
+    const caps = makeCaps("claude-opus-4-8");
+    expect(selectModel(caps, "default")?.id).toBe("claude-opus-4-8");
+  });
+
+  it("selectModel still prefers an actual 'default' roster row when present", () => {
+    // If the roster DOES contain a "default" row (concrete twin
+    // absent, so the backend kept the alias), exact match wins — the
+    // fallback only kicks in when the id is dangling.
+    const caps: ProviderChatCapabilities = {
+      ...makeCaps("claude-opus-4-8"),
+      models: [
+        ...makeCaps("claude-opus-4-8").models,
+        ...makeCaps("default").models,
+      ],
+    };
+    expect(selectModel(caps, "default")?.id).toBe("default");
+  });
+
+  it("selectModel does NOT fall back for other unknown ids", () => {
+    // The fallback is scoped to the literal historical alias. A
+    // genuinely unknown id must stay null so callers can surface it
+    // as unresolved instead of silently remapping to models[0].
+    const caps = makeCaps("claude-opus-4-8");
+    expect(selectModel(caps, "claude-future-9000")).toBeNull();
+  });
+
+  it("selectModel('default') on an empty roster returns null", () => {
+    const caps: ProviderChatCapabilities = { ...makeCaps("x"), models: [] };
+    expect(selectModel(caps, "default")).toBeNull();
+  });
+
   it("OpenCode model has sub_provider populated when injected", () => {
     // Pin the wire-shape contract: OpenCode entries must round-trip
     // `sub_provider` through the store untouched. The store doesn't

--- a/src/stores/provider-capabilities-store.ts
+++ b/src/stores/provider-capabilities-store.ts
@@ -121,13 +121,27 @@ export function selectError(
   }
 }
 
-/** Convenience selector: find a model by id within a provider's list. */
+/** Convenience selector: find a model by id within a provider's list.
+ *
+ *  One deliberate exception to the strict-match rule: the literal id
+ *  `"default"`. The roster used to lead with a `"default"` alias row,
+ *  so persisted drafts and thread records commonly store that id. The
+ *  backend now folds the alias out of the roster whenever a concrete
+ *  twin exists (`dedupe_default_alias`), which would leave those
+ *  persisted ids dangling. When `"default"` is absent, `models[0]` is
+ *  guaranteed to be the concrete model the alias resolved to, so we
+ *  fall back to it. Any other unknown id still returns `null` — only
+ *  the historical alias gets this treatment. */
 export function selectModel(
   caps: ProviderChatCapabilities | null,
   modelId: string | null | undefined,
 ) {
   if (!caps || !modelId) return null;
-  return caps.models.find((m) => m.id === modelId) ?? null;
+  const found = caps.models.find((m) => m.id === modelId) ?? null;
+  if (!found && modelId === "default") {
+    return caps.models[0] ?? null;
+  }
+  return found;
 }
 
 // ── Internal: per-provider state-update helpers ─────────────────────


### PR DESCRIPTION
## Composer

- **Taller resting composer** — the idle card is now 140px (reserves ~4 input lines) and auto-grows to ~10 rows before scrolling internally, instead of a single-line strip.
- **Softer shell** — 20px radius, hairline border, deep low-opacity shadow.
- **Ghost footer controls** — the model / reasoning / speed / permission pills are now borderless text controls sharing one `FOOTER_TRIGGER` recipe, separated by 16px hairline pipes. Pipes render inside the capability-gated pickers, so a hidden control can never orphan a separator. Send/stop grew to 32px circles with a hover scale.
- **Tucked scope strip** — the Thread Scope controls render as a narrower bar attached flush under the card (inset by exactly the corner radius, bottom-only rounding, one tonal step less elevated). The running-thread Context Row uses the same strip shell, so the layered silhouette survives the first send.

## Model picker

- **Concrete Claude names** — alias rows (`default`/`opus`/`fable`/`sonnet`/`haiku`) now render the concrete model they resolve to ("Claude Opus 5", "Claude Fable 5"), parsed from the row's live version-bearing description so a CLI that re-points an alias stays correct without a catalog bump; qualifiers survive ("(1M context)", Recommended). Full-id rows with nickname labels promote the same way.
- **No duplicate default row** — the `default` alias folds into its concrete twin, which leads the list with a Recommended marker (row is kept when no twin exists, so nothing launchable is lost).
- **Compact 400px popup** — plus `minmax(0,1fr)` + `min-w-0` so the list column can actually shrink; previously its min-content forced a 455px column that overflowed the popup and clipped the provider rail.
- **Ctrl/Cmd+1..9 jump shortcuts** — bound to the first nine rows of the live filtered list (search, rail tab, and favorites order respected) via a window capture-phase listener, so they fire while the search box is focused; selection closes the picker. Per-row kbd chips show the platform-correct label.
- **Always-visible favorite star** and removal of the invisible trailing check-icon gutter every row was dragging (via the base CommandItem's `command-shortcut` slot).

Codex and OpenCode rows were already fine and pass through untouched.

## Testing

- `tsc --noEmit` clean; frontend suite green (2965 tests), including updated ComposerFooter / AgentChatPane / picker specs
- New Rust unit tests for the alias-name parser, alias promotion, default-row dedupe, and the no-twin fallback
- Visually verified in the dev mock at multiple viewports: composer geometry (140px resting card, flush 0px strip seam, 20px insets), centered 16px separator pipes, 400px popup with intact rail, chip/star flush right