### PR TITLE
Add user-configurable default viewport for agent browser sessions

### DIFF
--- a/docs/features/browser.md
+++ b/docs/features/browser.md
@@ -171,7 +171,46 @@ existing frame-draw letterbox scales the full-size frame down to fit. Input
 mapping needs no changes — `mapToViewport` already routes clicks through the
 canvas rect + draw rect into viewport coordinates. Applies only to the peek
 overlay; normal browser panes (and the peek with the setting toggled off) keep
-the container-sync behavior unchanged.
+the container-sync behavior unchanged. When a user default viewport is
+configured (next section), the peek pins to that instead of 1280×800 —
+`DESKTOP_PEEK_VIEWPORT` is only the fallback.
+
+## User default viewport (`browser.default_viewport`)
+
+Settings → Browser → "Default viewport" (`UserSettings.browser
+.default_viewport`, synced settings, default unset). Motivation: the built-in
+1280×800 baseline reads as "zoomed in" to users on larger monitors — agent
+screenshots for PRs/issues show the narrow-desktop responsive layout instead
+of what the user sees in their own browser. Setting e.g. QHD (2560×1440) makes
+agent screenshots match the user's screen proportions. Cosmetic cost only:
+frames/screenshots scale ~linearly with pixel count, and model-side vision
+downscales past ~1.15 MP anyway, so agent token cost is unchanged.
+
+The value is a `browser_viewport::parse_spec` string — preset name or `WxH`.
+Consumption points (all lenient — an invalid synced value degrades to the
+1280×800 baseline, never errors):
+
+- **Fresh daemon launch** (`AgentBrowserManager::run_command`): when the
+  session's `running` flag flips false→true, the configured viewport is
+  applied via a `set viewport` command BEFORE the requested action, so even a
+  first-command screenshot renders at the user's size. Fires once per daemon
+  lifetime and only when the setting is present; skipped for `viewport`
+  (explicit size wins) and `close` (don't boot a daemon to resize it). An
+  agent's own later `viewport` calls are never stomped.
+- **`viewport reset`** (CLI `codemux browser viewport reset` + MCP
+  `browser_viewport {preset: "reset"}`): resolves through
+  `browser_viewport::parse_spec_configured`, which lands on the configured
+  default (`configured_default_spec`) instead of the hard-coded `RESET_SPEC`.
+  Both `viewport-presets` listings report the actual reset target. The CLI is
+  the same binary as the app, so it reads the same on-disk settings cache.
+- **Peek overlay pin** (`BrowserPeekOverlay.tsx`): with "Desktop-size
+  background browser" ON, the `fixedViewport` prop uses
+  `parseViewportString(browser.default_viewport)` (WxH strings only on the
+  frontend) with `DESKTOP_PEEK_VIEWPORT` (1280×800) as fallback, keeping the
+  peek consistent with what the agent's screenshots show.
+
+Visible browser panes still sync the viewport to their container size —
+the default only governs headless/background sessions and the reset target.
 
 ## Session reaping during app lifetime (issue #126)
 

--- a/docs/features/browser.md
+++ b/docs/features/browser.md
@@ -196,7 +196,12 @@ Consumption points (all lenient — an invalid synced value degrades to the
   first-command screenshot renders at the user's size. Fires once per daemon
   lifetime and only when the setting is present; skipped for `viewport`
   (explicit size wins) and `close` (don't boot a daemon to resize it). An
-  agent's own later `viewport` calls are never stomped.
+  agent's own later `viewport` calls are never stomped. A `close` action
+  resets the session's `running`/`pid` state (the agent-facing `close`
+  routes through `run_command`, not `AgentBrowserManager::close`, so the
+  session-map entry outlives the daemon) — this keeps the once-per-daemon
+  guarantee honest across an agent's open → close → open sequence: the
+  reopened daemon gets the default re-applied.
 - **`viewport reset`** (CLI `codemux browser viewport reset` + MCP
   `browser_viewport {preset: "reset"}`): resolves through
   `browser_viewport::parse_spec_configured`, which lands on the configured

--- a/docs/features/settings-sync.md
+++ b/docs/features/settings-sync.md
@@ -49,7 +49,9 @@ UserSettings
     max_total_mb: number       (default: 100)
   agent_chat
     checkpoints_enabled: boolean                 (default: false, run-start rollback checkpoint — issue #80)
-    background_browser_desktop_viewport: boolean (default: true — serde default_true, so blobs missing the field get ON while an explicitly saved false is kept; pin GUI-mode background-browser peek to 1280×800 — docs/features/browser.md)
+    background_browser_desktop_viewport: boolean (default: true — serde default_true, so blobs missing the field get ON while an explicitly saved false is kept; pin GUI-mode background-browser peek to the default viewport — docs/features/browser.md)
+  browser
+    default_viewport: string | null              (default: null — preferred starting viewport for agent-browser sessions, a "WxH" string like "2560x1440" or a preset name; applied to freshly launched daemons and used as the `viewport reset` target so agent screenshots match the user's screen. Invalid values degrade to the built-in 1280×800 baseline, never error — docs/features/browser.md)
 ```
 
 ### Offline Cache
@@ -105,7 +107,7 @@ Opened via the settings button or command palette. The Settings panel has 12 sec
 | Projects | Editor & Workflow | Setup/teardown/run scripts | No (local) |
 | Git | Editor & Workflow | Default base branch | Yes |
 | Agent | Editor & Workflow | AI commit/resolver config + auto-MCP toggle | No (local except auto-MCP) |
-| Browser | Editor & Workflow | Browser data management (clear cookies / all data) | No |
+| Browser | Editor & Workflow | Default agent-browser viewport + browser data management (clear cookies / all data) | Partial (default_viewport syncs) |
 | Session Restore | Editor & Workflow | Enable/disable, scrollback lines, disk limit | Yes |
 
 The `file_tree.show_hidden_files` setting is synced but is **not exposed in the Settings panel** — the toggle lives directly in the right-sidebar file tree panel header (`file-tree-panel.tsx`). It still syncs across devices via `synced-settings-store`.

--- a/src-tauri/src/agent_browser.rs
+++ b/src-tauri/src/agent_browser.rs
@@ -1768,7 +1768,38 @@ impl AgentBrowserManager {
         // daemon on first invocation, so it's effectively "running" as soon as
         // we call it. Setting this early prevents a concurrent start_stream
         // (from BrowserPane mounting) from killing the daemon mid-command.
-        self.sessions.lock().await.entry(browser_id.to_string()).and_modify(|s| s.running = true);
+        // Capture the prior flag so the fresh-launch viewport default below
+        // fires exactly once per daemon lifetime.
+        let was_running = {
+            let mut sessions = self.sessions.lock().await;
+            match sessions.get_mut(browser_id) {
+                Some(s) => std::mem::replace(&mut s.running, true),
+                None => false,
+            }
+        };
+
+        // User-configured default viewport (`browser.default_viewport`,
+        // synced settings): apply it to a freshly launched daemon BEFORE the
+        // requested action, so even a first-command screenshot renders at
+        // the user's preferred size (e.g. 2560×1440 to match their monitor)
+        // instead of the agent-browser built-in. Only when the setting is
+        // present — unset keeps today's behavior byte-for-byte. Skipped for:
+        // - "viewport": the caller is setting an explicit size anyway;
+        // - "close": don't boot a daemon just to resize-then-kill it.
+        // Never re-applied to a running daemon, so an agent's own viewport
+        // choice survives subsequent commands. Best-effort: a failure here
+        // must not block the real action.
+        if !was_running && action != "viewport" && action != "close" {
+            if let Some(spec) = crate::browser_viewport::configured_default_viewport() {
+                let bid = browser_id.to_string();
+                let vp_params = crate::browser_viewport::socket_action(spec);
+                let _ = tokio::task::spawn_blocking(move || {
+                    execute_agent_browser_action(&bid, "viewport", vp_params, port)
+                })
+                .await;
+            }
+        }
+
         // Run the (timeout-bounded) CLI work on a blocking thread so a slow
         // agent-browser round-trip never stalls the async executor.
         let browser_id = browser_id.to_string();

--- a/src-tauri/src/agent_browser.rs
+++ b/src-tauri/src/agent_browser.rs
@@ -1762,21 +1762,52 @@ impl AgentBrowserManager {
         Ok(())
     }
 
+    /// Record that a command is about to run and return whether the daemon
+    /// was already considered running.
+    ///
+    /// For every action except "close" this marks the session running BEFORE
+    /// the blocking CLI call. The CLI auto-starts the daemon on first
+    /// invocation, so it's effectively "running" as soon as we call it.
+    /// Setting this early prevents a concurrent start_stream (from
+    /// BrowserPane mounting) from killing the daemon mid-command. The prior
+    /// flag is returned so the fresh-launch viewport default in run_command
+    /// fires exactly once per daemon lifetime.
+    ///
+    /// "close" only reads the flag: the early-mark exists to protect a
+    /// daemon we want alive, which is pointless when we're about to kill it
+    /// ourselves — and marking it running would leave a stale `true` behind.
+    async fn note_action_start(&self, browser_id: &str, action: &str) -> bool {
+        let mut sessions = self.sessions.lock().await;
+        match sessions.get_mut(browser_id) {
+            Some(s) => {
+                if action == "close" {
+                    s.running
+                } else {
+                    std::mem::replace(&mut s.running, true)
+                }
+            }
+            None => false,
+        }
+    }
+
+    /// Reset session state after a "close" action so the next command sees a
+    /// fresh daemon (and re-applies the default viewport). Called
+    /// unconditionally — even if the close reported an error the daemon
+    /// state is unknown at worst, and both consumers of `running` tolerate a
+    /// stale `false`: start_stream re-probes the socket, and a redundant
+    /// viewport apply on a still-live daemon is harmless right after the
+    /// agent chose to close it. The port allocation / map entry stays intact.
+    async fn note_close_finished(&self, browser_id: &str) {
+        let mut sessions = self.sessions.lock().await;
+        if let Some(s) = sessions.get_mut(browser_id) {
+            s.running = false;
+            s.pid = None;
+        }
+    }
+
     pub async fn run_command(&self, browser_id: &str, action: &str, params: serde_json::Value) -> Result<BrowserAutomationResult, String> {
         let port = self.allocate_port(browser_id).await?;
-        // Mark running BEFORE the blocking CLI call. The CLI auto-starts the
-        // daemon on first invocation, so it's effectively "running" as soon as
-        // we call it. Setting this early prevents a concurrent start_stream
-        // (from BrowserPane mounting) from killing the daemon mid-command.
-        // Capture the prior flag so the fresh-launch viewport default below
-        // fires exactly once per daemon lifetime.
-        let was_running = {
-            let mut sessions = self.sessions.lock().await;
-            match sessions.get_mut(browser_id) {
-                Some(s) => std::mem::replace(&mut s.running, true),
-                None => false,
-            }
-        };
+        let was_running = self.note_action_start(browser_id, action).await;
 
         // User-configured default viewport (`browser.default_viewport`,
         // synced settings): apply it to a freshly launched daemon BEFORE the
@@ -1802,13 +1833,22 @@ impl AgentBrowserManager {
 
         // Run the (timeout-bounded) CLI work on a blocking thread so a slow
         // agent-browser round-trip never stalls the async executor.
-        let browser_id = browser_id.to_string();
-        let action = action.to_string();
-        tokio::task::spawn_blocking(move || {
-            execute_agent_browser_action(&browser_id, &action, params, port)
+        let owned_browser_id = browser_id.to_string();
+        let owned_action = action.to_string();
+        let result = tokio::task::spawn_blocking(move || {
+            execute_agent_browser_action(&owned_browser_id, &owned_action, params, port)
         })
         .await
-        .map_err(|e| format!("agent-browser action task failed: {e}"))?
+        .map_err(|e| format!("agent-browser action task failed: {e}"))?;
+
+        // The agent-facing "close" goes through this path (not close()), so
+        // reset the state here — otherwise the entry keeps running = true and
+        // a later open on the fresh daemon would skip the default viewport.
+        if action == "close" {
+            self.note_close_finished(browser_id).await;
+        }
+
+        result
     }
 
     pub async fn get_screenshot(&self, browser_id: &str) -> Result<String, String> {
@@ -2710,6 +2750,41 @@ mod tests {
         let p1 = mgr.allocate_port("workspace-x").await.unwrap();
         let p2 = mgr.allocate_port("workspace-x").await.unwrap();
         assert_eq!(p1, p2, "Same session key must return same port");
+    }
+
+    /// Regression test for the open→close→open gap: the agent-facing
+    /// "close" runs through run_command (not close()), so the session entry
+    /// used to keep running = true after a close. The second open then
+    /// skipped the fresh-launch default-viewport apply even though it booted
+    /// a brand-new daemon. Locks in the state transitions via the helpers
+    /// run_command itself calls, without shelling out to agent-browser.
+    #[tokio::test]
+    async fn close_resets_running_so_reopen_reapplies_default_viewport() {
+        let mgr = AgentBrowserManager::new();
+        mgr.allocate_port("ws-reopen").await.unwrap();
+
+        // First command on a fresh daemon: not yet running → default
+        // viewport would be applied.
+        assert!(!mgr.note_action_start("ws-reopen", "open").await);
+        // Second command on the running daemon: no re-apply.
+        assert!(mgr.note_action_start("ws-reopen", "open").await);
+        // Close sees a running daemon and must NOT flip the flag itself.
+        assert!(mgr.note_action_start("ws-reopen", "close").await);
+        assert!(
+            mgr.note_action_start("ws-reopen", "close").await,
+            "close must only read the running flag, not modify it",
+        );
+        // After the close action completes, state resets...
+        mgr.note_close_finished("ws-reopen").await;
+        {
+            let sessions = mgr.sessions.lock().await;
+            let s = sessions.get("ws-reopen").expect("entry survives close");
+            assert!(!s.running);
+            assert!(s.pid.is_none());
+        }
+        // ...so the next open counts as a fresh daemon again and the
+        // default viewport would be re-applied.
+        assert!(!mgr.note_action_start("ws-reopen", "open").await);
     }
 
     #[tokio::test]

--- a/src-tauri/src/browser_viewport.rs
+++ b/src-tauri/src/browser_viewport.rs
@@ -93,11 +93,66 @@ pub const PRESETS: &[Preset] = &[
     },
 ];
 
-/// The "reset" target — back to the safe default viewport. This matches
-/// the in-app default that `BrowserPane.tsx` initialises with, so issuing
-/// `viewport reset` leaves the page rendering at the same baseline as a
-/// fresh browser pane.
+/// The built-in "reset" baseline. This matches the in-app default that
+/// `BrowserPane.tsx` initialises with, so issuing `viewport reset` leaves
+/// the page rendering at the same baseline as a fresh browser pane.
+/// When the user configured `browser.default_viewport` (synced settings),
+/// reset lands on that instead — see [`configured_default_spec`].
 pub const RESET_SPEC: ViewportSpec = ViewportSpec::new(1280, 800, 1.0);
+
+/// Resolve the user's `browser.default_viewport` setting string into a
+/// concrete spec, falling back to [`RESET_SPEC`] when unset or invalid.
+///
+/// Pure — takes the raw setting value so it stays unit-testable without
+/// touching the on-disk settings cache. `"reset"` is rejected here (it
+/// would be self-referential as a *default*), and any parse failure
+/// falls back silently: the setting syncs across devices, so a bad
+/// value must degrade to the baseline rather than break startup.
+pub fn resolve_default(raw: Option<&str>) -> ViewportSpec {
+    raw.map(str::trim)
+        .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("reset"))
+        .and_then(|s| parse_spec(s, None).ok())
+        .unwrap_or(RESET_SPEC)
+}
+
+/// The user-configured default viewport from the synced-settings cache,
+/// or `None` when unset/invalid. `Some` means the user explicitly chose
+/// a default (e.g. `"2560x1440"` to match their monitor) — fresh
+/// agent-browser daemons get it applied at launch.
+pub fn configured_default_viewport() -> Option<ViewportSpec> {
+    let raw = crate::settings_sync::load_cache()?.browser.default_viewport?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("reset") {
+        return None;
+    }
+    parse_spec(trimmed, None).ok()
+}
+
+/// The spec `viewport reset` should return to: the user-configured
+/// default when present, the built-in [`RESET_SPEC`] baseline otherwise.
+pub fn configured_default_spec() -> ViewportSpec {
+    configured_default_viewport().unwrap_or(RESET_SPEC)
+}
+
+/// [`parse_spec`], except `"reset"` resolves to the user-configured
+/// default viewport ([`configured_default_spec`]) instead of the
+/// hard-coded baseline. Use this at the CLI / MCP surfaces where
+/// "reset" means "back to *my* default"; keep `parse_spec` for pure,
+/// setting-independent parsing (and tests).
+pub fn parse_spec_configured(
+    input: &str,
+    dpr_override: Option<f64>,
+) -> Result<ViewportSpec, ParseError> {
+    if input.trim().eq_ignore_ascii_case("reset") {
+        let mut spec = configured_default_spec();
+        if let Some(dpr) = dpr_override {
+            validate_dpr(dpr)?;
+            spec.dpr = dpr;
+        }
+        return Ok(spec);
+    }
+    parse_spec(input, dpr_override)
+}
 
 /// Errors `parse_spec` can surface back to the CLI.
 #[derive(Debug, PartialEq)]
@@ -279,6 +334,35 @@ mod tests {
         let total = names.len();
         names.dedup();
         assert_eq!(names.len(), total, "duplicate preset name in PRESETS");
+    }
+
+    #[test]
+    fn resolve_default_unset_falls_back_to_reset_spec() {
+        assert_eq!(resolve_default(None), RESET_SPEC);
+        assert_eq!(resolve_default(Some("")), RESET_SPEC);
+        assert_eq!(resolve_default(Some("   ")), RESET_SPEC);
+    }
+
+    #[test]
+    fn resolve_default_parses_custom_dimensions() {
+        let spec = resolve_default(Some("2560x1440"));
+        assert_eq!((spec.width, spec.height, spec.dpr), (2560, 1440, 1.0));
+    }
+
+    #[test]
+    fn resolve_default_accepts_preset_names() {
+        let spec = resolve_default(Some("desktop-large"));
+        assert_eq!((spec.width, spec.height), (1920, 1080));
+    }
+
+    /// Bad synced values (typos, other-device garbage) must degrade to
+    /// the baseline, never error — and a literal "reset" would be
+    /// self-referential as a default, so it's treated as unset too.
+    #[test]
+    fn resolve_default_invalid_or_reset_falls_back() {
+        assert_eq!(resolve_default(Some("not-a-preset")), RESET_SPEC);
+        assert_eq!(resolve_default(Some("0x0")), RESET_SPEC);
+        assert_eq!(resolve_default(Some("reset")), RESET_SPEC);
     }
 
     #[test]

--- a/src-tauri/src/browser_viewport.rs
+++ b/src-tauri/src/browser_viewport.rs
@@ -100,32 +100,36 @@ pub const PRESETS: &[Preset] = &[
 /// reset lands on that instead — see [`configured_default_spec`].
 pub const RESET_SPEC: ViewportSpec = ViewportSpec::new(1280, 800, 1.0);
 
-/// Resolve the user's `browser.default_viewport` setting string into a
-/// concrete spec, falling back to [`RESET_SPEC`] when unset or invalid.
+/// Resolve a raw `browser.default_viewport` setting string into a spec,
+/// or `None` when the value is unset or unusable.
 ///
-/// Pure — takes the raw setting value so it stays unit-testable without
-/// touching the on-disk settings cache. `"reset"` is rejected here (it
-/// would be self-referential as a *default*), and any parse failure
-/// falls back silently: the setting syncs across devices, so a bad
-/// value must degrade to the baseline rather than break startup.
-pub fn resolve_default(raw: Option<&str>) -> ViewportSpec {
+/// This is the single source of truth for interpreting the setting —
+/// pure, so it stays unit-testable without touching the on-disk settings
+/// cache. Empty/whitespace values and a literal `"reset"` (which would
+/// be self-referential as a *default*) count as unset; any parse
+/// failure also yields `None`: the setting syncs across devices, so a
+/// bad value must degrade silently rather than break startup.
+pub fn resolve_default_setting(raw: Option<&str>) -> Option<ViewportSpec> {
     raw.map(str::trim)
         .filter(|s| !s.is_empty() && !s.eq_ignore_ascii_case("reset"))
         .and_then(|s| parse_spec(s, None).ok())
-        .unwrap_or(RESET_SPEC)
 }
 
-/// The user-configured default viewport from the synced-settings cache,
-/// or `None` when unset/invalid. `Some` means the user explicitly chose
-/// a default (e.g. `"2560x1440"` to match their monitor) — fresh
-/// agent-browser daemons get it applied at launch.
+/// Convenience over [`resolve_default_setting`]: same resolution, but
+/// falls back to the built-in [`RESET_SPEC`] baseline when the setting
+/// is unset or invalid — documenting the fallback contract in one place.
+pub fn resolve_default(raw: Option<&str>) -> ViewportSpec {
+    resolve_default_setting(raw).unwrap_or(RESET_SPEC)
+}
+
+/// Cache-reading wrapper around [`resolve_default_setting`]: reads the
+/// user's `browser.default_viewport` from the synced-settings cache and
+/// resolves it. `Some` means the user explicitly chose a default (e.g.
+/// `"2560x1440"` to match their monitor) — fresh agent-browser daemons
+/// get it applied at launch.
 pub fn configured_default_viewport() -> Option<ViewportSpec> {
-    let raw = crate::settings_sync::load_cache()?.browser.default_viewport?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("reset") {
-        return None;
-    }
-    parse_spec(trimmed, None).ok()
+    let cached = crate::settings_sync::load_cache()?;
+    resolve_default_setting(cached.browser.default_viewport.as_deref())
 }
 
 /// The spec `viewport reset` should return to: the user-configured
@@ -363,6 +367,27 @@ mod tests {
         assert_eq!(resolve_default(Some("not-a-preset")), RESET_SPEC);
         assert_eq!(resolve_default(Some("0x0")), RESET_SPEC);
         assert_eq!(resolve_default(Some("reset")), RESET_SPEC);
+    }
+
+    /// Exercises the shared pure core directly — `resolve_default`,
+    /// `configured_default_viewport`, and `configured_default_spec` all
+    /// delegate here, so this covers the logic that actually ships.
+    #[test]
+    fn resolve_default_setting_some_or_none() {
+        let spec = resolve_default_setting(Some("2560x1440")).expect("custom WxH should resolve");
+        assert_eq!((spec.width, spec.height, spec.dpr), (2560, 1440, 1.0));
+
+        let spec = resolve_default_setting(Some("desktop-large")).expect("preset should resolve");
+        assert_eq!((spec.width, spec.height), (1920, 1080));
+
+        // Unset, blank, self-referential "reset", and unparseable values
+        // all count as "no configured default".
+        assert_eq!(resolve_default_setting(None), None);
+        assert_eq!(resolve_default_setting(Some("")), None);
+        assert_eq!(resolve_default_setting(Some("   ")), None);
+        assert_eq!(resolve_default_setting(Some("reset")), None);
+        assert_eq!(resolve_default_setting(Some("not-a-preset")), None);
+        assert_eq!(resolve_default_setting(Some("0x0")), None);
     }
 
     #[test]

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -620,8 +620,11 @@ async fn run_control_cli(cli: Cli) -> Result<bool, String> {
                     // Resolve preset / WxH locally first so we can surface
                     // a friendly error (with the full preset list) instead
                     // of letting the socket call return a generic "Unknown
-                    // action" message.
-                    let resolved = crate::browser_viewport::parse_spec(&spec, dpr)
+                    // action" message. The `_configured` variant makes
+                    // `reset` land on the user's `browser.default_viewport`
+                    // setting (read from the settings cache — the CLI is
+                    // the same binary) instead of the hard-coded baseline.
+                    let resolved = crate::browser_viewport::parse_spec_configured(&spec, dpr)
                         .map_err(|e| e.to_string())?;
                     // Shared socket-action builder — keeps CLI and MCP
                     // payloads byte-identical so a future field bump
@@ -656,12 +659,15 @@ async fn run_control_cli(cli: Cli) -> Result<bool, String> {
                             "description": p.description,
                         }))
                         .collect();
+                    // `reset` reports the *actual* reset target — the
+                    // user's configured default viewport when set.
+                    let reset_spec = crate::browser_viewport::configured_default_spec();
                     Ok::<_, String>(json!({
                         "presets": json_presets,
                         "reset": {
-                            "width": crate::browser_viewport::RESET_SPEC.width,
-                            "height": crate::browser_viewport::RESET_SPEC.height,
-                            "dpr": crate::browser_viewport::RESET_SPEC.dpr,
+                            "width": reset_spec.width,
+                            "height": reset_spec.height,
+                            "dpr": reset_spec.dpr,
                         },
                         "custom": "Use `WxH` like `390x844` for a custom viewport, plus `--dpr N` for retina.",
                     }))

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -1034,10 +1034,12 @@ async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
         "browser_viewport" => {
             // Validate locally so an agent gets a typed error with the
             // preset list instead of a generic "Unknown action" bounce
-            // from the agent-browser subprocess.
+            // from the agent-browser subprocess. The `_configured`
+            // variant resolves 'reset' to the user's
+            // `browser.default_viewport` setting when present.
             let preset_arg = arguments.get("preset").and_then(Value::as_str).unwrap_or("");
             let dpr = arguments.get("dpr").and_then(Value::as_f64);
-            match crate::browser_viewport::parse_spec(preset_arg, dpr) {
+            match crate::browser_viewport::parse_spec_configured(preset_arg, dpr) {
                 Ok(spec) => {
                     // Shared socket-action builder — see cli.rs for the
                     // matching call site. Both surfaces MUST go through
@@ -1075,12 +1077,15 @@ async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
                     })
                 })
                 .collect();
+            // `reset` reports the *actual* reset target — the user's
+            // configured `browser.default_viewport` when set.
+            let reset_spec = crate::browser_viewport::configured_default_spec();
             Ok(json!({
                 "presets": json_presets,
                 "reset": {
-                    "width": crate::browser_viewport::RESET_SPEC.width,
-                    "height": crate::browser_viewport::RESET_SPEC.height,
-                    "dpr": crate::browser_viewport::RESET_SPEC.dpr,
+                    "width": reset_spec.width,
+                    "height": reset_spec.height,
+                    "dpr": reset_spec.dpr,
                 },
                 "custom": "Pass a 'WxH' string like '390x844' to browser_viewport for custom dimensions.",
             }))

--- a/src-tauri/src/settings_sync.rs
+++ b/src-tauri/src/settings_sync.rs
@@ -26,6 +26,27 @@ pub struct UserSettings {
     pub session_restore: SessionRestoreSettings,
     #[serde(default)]
     pub agent_chat: AgentChatSettings,
+    #[serde(default)]
+    pub browser: BrowserSettings,
+}
+
+/// Agent-browser behavior knobs.
+///
+/// `default_viewport` is the user's preferred starting viewport for
+/// agent-browser sessions, as a spec string accepted by
+/// `browser_viewport::parse_spec` — a preset name (`"desktop-large"`)
+/// or custom `"WxH"` (`"2560x1440"`). When set, a freshly launched
+/// agent-browser daemon gets this viewport applied before its first
+/// action, and `viewport reset` returns to it instead of the built-in
+/// `RESET_SPEC` baseline — so screenshots the agent takes match the
+/// user's own screen proportions. `None` (the default) keeps today's
+/// behavior everywhere (1280×800 baseline). Invalid strings are
+/// treated as unset rather than erroring — settings blobs sync across
+/// devices and a bad value must never break browser startup.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct BrowserSettings {
+    #[serde(default)]
+    pub default_viewport: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -543,6 +564,9 @@ mod tests {
                 checkpoints_enabled: true,
                 background_browser_desktop_viewport: false,
             },
+            browser: BrowserSettings {
+                default_viewport: Some("2560x1440".into()),
+            },
         };
 
         let json = serde_json::to_string(&s).unwrap();
@@ -565,6 +589,21 @@ mod tests {
         assert_eq!(back.session_restore.max_total_mb, 50);
         assert!(back.agent_chat.checkpoints_enabled);
         assert!(!back.agent_chat.background_browser_desktop_viewport);
+        assert_eq!(back.browser.default_viewport.as_deref(), Some("2560x1440"));
+    }
+
+    /// A settings blob saved before the `browser` section existed still
+    /// deserializes — `default_viewport` stays unset (built-in baseline).
+    #[test]
+    #[serial]
+    fn missing_browser_section_defaults_to_no_viewport() {
+        let legacy = r#"{"appearance":{"theme":"dark"}}"#;
+        let parsed: UserSettings = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.browser.default_viewport, None);
+
+        let explicit = r#"{"browser":{"default_viewport":"1920x1080"}}"#;
+        let parsed: UserSettings = serde_json::from_str(explicit).unwrap();
+        assert_eq!(parsed.browser.default_viewport.as_deref(), Some("1920x1080"));
     }
 
     /// A settings blob saved before the agent_chat section existed

--- a/src/components/browser/BrowserPeekOverlay.tsx
+++ b/src/components/browser/BrowserPeekOverlay.tsx
@@ -12,16 +12,22 @@ import { cn } from "@/lib/utils";
 import { useActiveWorkspaceId, useAppStore } from "@/stores/app-store";
 import { useBrowserPeekStore } from "@/stores/browser-peek-store";
 import {
+  parseViewportString,
   selectBackgroundBrowserDesktopViewport,
+  selectBrowserDefaultViewport,
   useSyncedSettingsStore,
 } from "@/stores/synced-settings-store";
 import { createBrowserPane } from "@/tauri/commands";
 
-/** Pinned viewport for the "Desktop-size background browser" setting.
- *  Matches the `desktop` preset / `RESET_SPEC` in
+/** Fallback pinned viewport for the "Desktop-size background browser"
+ *  setting when no `browser.default_viewport` is configured. Matches
+ *  the `desktop` preset / `RESET_SPEC` in
  *  `src-tauri/src/browser_viewport.rs` (1280×800 @ 1× DPR), so the peek
  *  shows pages at the same baseline agents get from
- *  `codemux browser viewport reset`. */
+ *  `codemux browser viewport reset`. With a configured default (e.g.
+ *  `"2560x1440"` to match the user's monitor) the peek pins to that
+ *  instead — same size the backend applies to fresh daemons — so the
+ *  peek and the agent's screenshots stay consistent. */
 const DESKTOP_PEEK_VIEWPORT = { width: 1280, height: 800 };
 
 /**
@@ -60,6 +66,9 @@ export function BrowserPeekOverlay() {
   const desktopViewport = useSyncedSettingsStore(
     selectBackgroundBrowserDesktopViewport,
   );
+  const defaultViewportRaw = useSyncedSettingsStore(selectBrowserDefaultViewport);
+  const pinnedViewport =
+    parseViewportString(defaultViewportRaw) ?? DESKTOP_PEEK_VIEWPORT;
   const panelRef = useRef<HTMLDivElement>(null);
 
   const open = guiChrome && isOpen && !!session && !!activeWorkspaceId;
@@ -171,7 +180,7 @@ export function BrowserPeekOverlay() {
           focused={false}
           visible={open}
           hideToolbar
-          fixedViewport={desktopViewport ? DESKTOP_PEEK_VIEWPORT : undefined}
+          fixedViewport={desktopViewport ? pinnedViewport : undefined}
         />
       </div>
     </div>

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -59,6 +59,7 @@ import {
   selectTerminalCursorStyle,
   selectDefaultEditor,
   selectDefaultBaseBranch,
+  selectBrowserDefaultViewport,
 } from "@/stores/synced-settings-store";
 import {
   useSettingsStore,
@@ -563,10 +564,23 @@ function formatBytes(bytes: number): string {
   return `${(bytes / Math.pow(k, i)).toFixed(i > 0 ? 1 : 0)} ${units[i]}`;
 }
 
+/** Options for the default agent-browser viewport. "default" maps to
+ *  null (built-in 1280×800 baseline); other values are `WxH` spec
+ *  strings stored verbatim in `browser.default_viewport` and consumed
+ *  by the Rust side (fresh-daemon apply + `viewport reset` target). */
+const DEFAULT_VIEWPORT_OPTIONS = [
+  { value: "default", label: "Default (1280×800)" },
+  { value: "1920x1080", label: "Full HD (1920×1080)" },
+  { value: "2560x1440", label: "QHD (2560×1440)" },
+  { value: "3840x2160", label: "4K (3840×2160)" },
+] as const;
+
 function BrowserSection() {
   const [dataSize, setDataSize] = useState<number | null>(null);
   const [clearing, setClearing] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const defaultViewport = useSyncedSettingsStore(selectBrowserDefaultViewport);
+  const updateSyncedSetting = useSyncedSettingsStore((s) => s.updateSetting);
 
   const refreshSize = () => {
     getBrowserDataSize().then(setDataSize).catch(() => setDataSize(0));
@@ -611,6 +625,40 @@ function BrowserSection() {
         description="Manage the built-in browser profile used by agents and browser panes."
       />
       <div className="space-y-1">
+        <SettingRow
+          label="Default viewport"
+          description="Starting page size for agent browser sessions and the 'viewport reset' target. Match your monitor so agent screenshots look like your own browser."
+        >
+          <Select
+            value={defaultViewport ?? "default"}
+            onValueChange={(v) => {
+              updateSyncedSetting(
+                "browser",
+                "default_viewport",
+                v === "default" ? null : v,
+              ).catch(console.error);
+            }}
+          >
+            <SelectTrigger className="w-48 h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {DEFAULT_VIEWPORT_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+              {/* A custom value set elsewhere (CLI, another device) that
+                  isn't one of the canned options still renders instead of
+                  showing an empty trigger. */}
+              {defaultViewport !== null &&
+                !DEFAULT_VIEWPORT_OPTIONS.some((o) => o.value === defaultViewport) && (
+                  <SelectItem value={defaultViewport}>{defaultViewport}</SelectItem>
+                )}
+            </SelectContent>
+          </Select>
+        </SettingRow>
+        <Separator />
         <SettingRow
           label="Profile storage"
           description="Total size of cached browser data, screenshots, and session files."
@@ -2147,7 +2195,7 @@ export function SettingsView() {
                       GUI-chrome surface. */}
                   <SettingRow
                     label="Desktop-size background browser"
-                    description="Start the agent's background browser at a real desktop viewport (1280×800) so pages render at full size in the peek popover, scaled to fit."
+                    description="Pin the agent's background browser to a real desktop viewport (the Browser section's default viewport, 1280×800 out of the box) so pages render at full size in the peek popover, scaled to fit."
                   >
                     <Switch
                       checked={syncedSettings.agent_chat?.background_browser_desktop_viewport ?? true}

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -463,6 +463,7 @@ const SYNCED_SETTINGS: UserSettings = {
   // Checkpoints ON in the mock so the seeded chat pane exercises the
   // restore affordance (issue #80) without a real backend.
   agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: true },
+  browser: { default_viewport: null },
 };
 
 const EMPTY_CAPABILITIES: ProviderChatCapabilities = {

--- a/src/stores/settings-sync-integration.test.ts
+++ b/src/stores/settings-sync-integration.test.ts
@@ -41,6 +41,7 @@ const FULL_CUSTOM: UserSettings = {
   file_tree: { show_hidden_files: true },
   session_restore: { enabled: false, scrollback_lines: 5000, max_total_mb: 50 },
   agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: false },
+  browser: { default_viewport: null },
 };
 
 // ── Setup ──

--- a/src/stores/synced-settings-store.test.ts
+++ b/src/stores/synced-settings-store.test.ts
@@ -24,6 +24,8 @@ import {
   selectNotificationSoundEnabled,
   selectDesktopNotificationsEnabled,
   selectBackgroundBrowserDesktopViewport,
+  selectBrowserDefaultViewport,
+  parseViewportString,
 } from "./synced-settings-store";
 import type { UserSettings } from "@/tauri/types";
 
@@ -37,6 +39,7 @@ const DARK_SETTINGS: UserSettings = {
   file_tree: { show_hidden_files: true },
   session_restore: { enabled: true, scrollback_lines: 10000, max_total_mb: 100 },
   agent_chat: { checkpoints_enabled: true, background_browser_desktop_viewport: false },
+  browser: { default_viewport: "2560x1440" },
 };
 
 describe("synced-settings-store", () => {
@@ -276,6 +279,30 @@ describe("synced-settings-store", () => {
 
     it("selectBackgroundBrowserDesktopViewport defaults to true", () => {
       expect(selectBackgroundBrowserDesktopViewport(useSyncedSettingsStore.getState())).toBe(true);
+    });
+
+    it("selectBrowserDefaultViewport returns the raw spec string", () => {
+      useSyncedSettingsStore.setState({ settings: DARK_SETTINGS });
+      expect(selectBrowserDefaultViewport(useSyncedSettingsStore.getState())).toBe("2560x1440");
+    });
+
+    it("selectBrowserDefaultViewport defaults to null", () => {
+      expect(selectBrowserDefaultViewport(useSyncedSettingsStore.getState())).toBe(null);
+    });
+  });
+
+  describe("parseViewportString", () => {
+    it("parses WxH strings", () => {
+      expect(parseViewportString("2560x1440")).toEqual({ width: 2560, height: 1440 });
+      expect(parseViewportString(" 1920X1080 ")).toEqual({ width: 1920, height: 1080 });
+    });
+
+    it("returns null for unset, preset names, and garbage", () => {
+      expect(parseViewportString(null)).toBe(null);
+      expect(parseViewportString("")).toBe(null);
+      expect(parseViewportString("desktop-large")).toBe(null);
+      expect(parseViewportString("0x0")).toBe(null);
+      expect(parseViewportString("99999x99999")).toBe(null);
     });
   });
 

--- a/src/stores/synced-settings-store.ts
+++ b/src/stores/synced-settings-store.ts
@@ -22,6 +22,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   file_tree: { show_hidden_files: false },
   session_restore: { enabled: true, scrollback_lines: 10_000, max_total_mb: 100 },
   agent_chat: { checkpoints_enabled: false, background_browser_desktop_viewport: true },
+  browser: { default_viewport: null },
 };
 
 export interface SyncedSettingsState {
@@ -179,3 +180,24 @@ export const selectAgentCheckpointsEnabled = (s: SyncedSettingsState): boolean =
 
 export const selectBackgroundBrowserDesktopViewport = (s: SyncedSettingsState): boolean =>
   s.settings.agent_chat?.background_browser_desktop_viewport ?? true;
+
+/** Raw `browser.default_viewport` spec string (`"2560x1440"` etc.), or
+ *  null for the built-in baseline. Returns the primitive so zustand's
+ *  reference equality works — parse with `parseViewportString`. */
+export const selectBrowserDefaultViewport = (s: SyncedSettingsState): string | null =>
+  s.settings.browser?.default_viewport ?? null;
+
+/** Parse a `"WxH"` viewport string into dimensions. Returns null for
+ *  anything else (unset, preset names, garbage from another device) so
+ *  callers fall back to their own baseline — mirrors the lenient
+ *  degrade-to-default behavior of `browser_viewport::resolve_default`
+ *  on the Rust side. */
+export function parseViewportString(raw: string | null): { width: number; height: number } | null {
+  if (!raw) return null;
+  const m = /^(\d{2,4})x(\d{2,4})$/.exec(raw.trim().toLowerCase());
+  if (!m) return null;
+  const width = Number(m[1]);
+  const height = Number(m[2]);
+  if (width < 10 || height < 10 || width > 7680 || height > 7680) return null;
+  return { width, height };
+}

--- a/src/tauri/types.ts
+++ b/src/tauri/types.ts
@@ -61,6 +61,17 @@ export interface AgentChatSyncSettings {
   background_browser_desktop_viewport: boolean;
 }
 
+/** Mirrors src-tauri/src/settings_sync.rs:BrowserSettings.
+ *  `default_viewport` is the preferred starting viewport for
+ *  agent-browser sessions — a `"WxH"` string like `"2560x1440"` (or a
+ *  preset name) applied to freshly launched daemons and used as the
+ *  `viewport reset` target, so agent screenshots match the user's own
+ *  screen proportions. `null` (default) keeps the built-in 1280×800
+ *  baseline. */
+export interface BrowserSyncSettings {
+  default_viewport: string | null;
+}
+
 export interface UserSettings {
   appearance: AppearanceSettings;
   editor: EditorSettings;
@@ -71,6 +82,7 @@ export interface UserSettings {
   file_tree: FileTreeSyncSettings;
   session_restore: SessionRestoreSettings;
   agent_chat: AgentChatSyncSettings;
+  browser: BrowserSyncSettings;
 }
 
 // ── Resource Monitor ──


### PR DESCRIPTION
## Motivation

The agent browser's built-in 1280×800 baseline reads as "zoomed in" on larger monitors — screenshots the agent takes while testing issues/PRs show the narrow-desktop responsive layout instead of what the user sees in their own browser. This adds a synced setting so the default matches the user's screen (e.g. QHD 2560×1440 for a 27" 1440p display).

## What's new

**Settings → Browser → "Default viewport"** (`UserSettings.browser.default_viewport`, synced): Default (1280×800) / Full HD (1920×1080) / QHD (2560×1440) / 4K (3840×2160). The stored value is any `browser_viewport::parse_spec` string (preset name or `WxH`).

Consumption points:

- **Fresh daemon launch** (`AgentBrowserManager::run_command`): when a session's `running` flag flips false→true, the configured viewport is applied via `set viewport` *before* the requested action — so even a first-command screenshot renders at the user's size. Fires once per daemon lifetime, only when the setting is present; skipped for explicit `viewport` and `close` actions, and never re-applied to a running daemon, so an agent's own viewport choices (e.g. mobile testing) are never stomped.
- **`viewport reset`** (CLI `codemux browser viewport reset` + MCP `browser_viewport {preset:"reset"}`): resolves through new `parse_spec_configured` → lands on the configured default instead of the hard-coded `RESET_SPEC`. Both `viewport-presets` listings report the actual reset target.
- **Peek overlay** (`BrowserPeekOverlay.tsx`): the "Desktop-size background browser" pin now uses the configured default (`parseViewportString`, 1280×800 fallback), keeping the popup consistent with what screenshots show.

## Safety

- Unset (the default) keeps prior behavior byte-for-byte.
- Invalid synced values (garbage from another device) degrade to the 1280×800 baseline instead of erroring — a bad blob can never break browser startup.
- Old settings blobs deserialize via serde defaults (back-compat tested).

## Verification

- `cargo check` clean; lib tests: browser_viewport 30/30, settings_sync 20/20, agent_browser 61/61
- `tsc --noEmit` clean; frontend suite 204 files / 2969 tests passed
- Live UI check in the dev mock: the select renders, opens, and persists the QHD selection; `codemux browser viewport reset` returns 1280×800 with no setting configured

Docs: new "User default viewport" section in `docs/features/browser.md`; schema + UI table updated in `docs/features/settings-sync.md`.