### PR TITLE
feat(chat): show real image thumbnails in attachment chips

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -161,6 +161,18 @@ The chat pane stack:
   images via paste / drop / picker. Inline chips, send-time injection,
   expand, caps, gif guard, chip tooltips. See
   `docs/research/step-8-attachments.md`.
+  - **Image chips show the image, not a generic icon.** `AttachmentChip`
+    builds an object URL from the attachment's in-memory
+    `resolvedImage.bytes` (already kept for the optimistic user bubble,
+    so this costs no IPC) and renders a 30×22px thumbnail in the icon
+    slot; the chip swaps from the pill radius to `rounded-md` with a 3px
+    inset so the preview reads as a picture, and the hover tooltip adds a
+    ≤260×180px preview above the filename/token lines. Two pasted
+    screenshots were previously indistinguishable — both chips read
+    `pasted-image.png` behind the same icon. The URL is revoked on
+    unmount; missing bytes, an image that fails to decode, or an
+    environment without `URL.createObjectURL` (jsdom) all fall back to
+    the original icon pill.
   - **Ctrl+V image paste has a Linux clipboard fallback.** WebKit2GTK
     strips image payloads from the JS `paste` event, so `Composer`'s
     handler tries `e.clipboardData.items` first (works in the browser

--- a/src/components/chat/AttachmentChip.test.tsx
+++ b/src/components/chat/AttachmentChip.test.tsx
@@ -237,6 +237,95 @@ describe("AttachmentChip", () => {
     });
   });
 
+  describe("image thumbnail preview", () => {
+    /** jsdom implements neither half of the object-URL API, so patch both
+     *  onto the real `URL` and assert the created URL is used and revoked. */
+    function stubObjectUrls() {
+      const created: Blob[] = [];
+      const revoked: string[] = [];
+      URL.createObjectURL = vi.fn((blob: Blob) => {
+        created.push(blob);
+        return `blob:mock-${created.length}`;
+      });
+      URL.revokeObjectURL = vi.fn((url: string) => void revoked.push(url));
+      return { created, revoked };
+    }
+
+    afterEach(() => {
+      // Unmount before dropping the stubs — the cleanup effect calls
+      // revokeObjectURL, and this hook runs before the file-level cleanup.
+      cleanup();
+      Reflect.deleteProperty(URL, "createObjectURL");
+      Reflect.deleteProperty(URL, "revokeObjectURL");
+    });
+
+    const imageAttachment = () =>
+      makeAttachment({
+        kind: "image",
+        ref: "image:att-1",
+        metadata: { label: "pasted-image.png", bytes: 2048 },
+        resolvedImage: {
+          mime: "image/png",
+          bytes: new Uint8Array([1, 2, 3, 4]),
+        },
+      });
+
+    it("renders the actual image instead of the generic icon", () => {
+      const { created } = stubObjectUrls();
+      const { getByTestId } = render(
+        <AttachmentChip attachment={imageAttachment()} onRemove={vi.fn()} />,
+      );
+      const thumb = getByTestId("attachment-chip-thumbnail");
+      expect(thumb).toHaveAttribute("src", "blob:mock-1");
+      expect(created[0].type).toBe("image/png");
+    });
+
+    it("switches the chip to the rounded-rect preview shape", () => {
+      stubObjectUrls();
+      const { getByRole } = render(
+        <AttachmentChip attachment={imageAttachment()} onRemove={vi.fn()} />,
+      );
+      const chip = getByRole("status");
+      expect(chip).toHaveAttribute("data-preview", "true");
+      expect(chip.className).toContain("rounded-md");
+      expect(chip.className).not.toContain("rounded-full");
+    });
+
+    it("revokes the object URL on unmount so removed chips don't leak", () => {
+      const { revoked } = stubObjectUrls();
+      const { unmount } = render(
+        <AttachmentChip attachment={imageAttachment()} onRemove={vi.fn()} />,
+      );
+      unmount();
+      expect(revoked).toEqual(["blob:mock-1"]);
+    });
+
+    it("falls back to the icon chip when the image fails to decode", () => {
+      stubObjectUrls();
+      const { getByTestId, queryByTestId, getByRole } = render(
+        <AttachmentChip attachment={imageAttachment()} onRemove={vi.fn()} />,
+      );
+      fireEvent.error(getByTestId("attachment-chip-thumbnail"));
+      expect(queryByTestId("attachment-chip-thumbnail")).toBeNull();
+      expect(getByRole("status").className).toContain("rounded-full");
+    });
+
+    it("keeps the icon while the bytes are still resolving", () => {
+      stubObjectUrls();
+      const { getByTestId, queryByTestId } = render(
+        <AttachmentChip
+          attachment={makeAttachment({
+            kind: "image",
+            metadata: { label: "pasted-image.png", isLoading: true },
+          })}
+          onRemove={vi.fn()}
+        />,
+      );
+      expect(getByTestId("attachment-chip-spinner")).toBeInTheDocument();
+      expect(queryByTestId("attachment-chip-thumbnail")).toBeNull();
+    });
+  });
+
   it("exposes the kind via data-attachment-kind for parent styling", () => {
     const { container } = render(
       <AttachmentChip attachment={makeAttachment()} onRemove={vi.fn()} />,

--- a/src/components/chat/AttachmentChip.tsx
+++ b/src/components/chat/AttachmentChip.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import {
   ChevronsUpDown,
   CircleDot,
@@ -100,6 +101,45 @@ function estimateTokens(att: Attachment): number {
   return 0;
 }
 
+/** Object URL for a staged image's in-memory bytes, so an image chip can
+ *  show the actual picture instead of a generic icon — two pasted
+ *  screenshots are otherwise indistinguishable in the strip.
+ *
+ *  The bytes already live on the attachment (`resolvedImage`, kept in
+ *  memory for the optimistic user bubble), so this costs no IPC. Returns
+ *  null when the bytes haven't resolved yet, the attachment isn't an
+ *  image, or the environment has no object-URL support (jsdom under
+ *  vitest) — callers fall back to the icon. The URL is revoked on
+ *  unmount / bytes change so removing a chip doesn't leak it. */
+function useImagePreviewUrl(attachment: Attachment): string | null {
+  const image =
+    attachment.kind === "image" ? attachment.resolvedImage : undefined;
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!image || typeof URL.createObjectURL !== "function") {
+      setUrl(null);
+      return;
+    }
+    let objectUrl: string;
+    try {
+      objectUrl = URL.createObjectURL(
+        new Blob([image.bytes], { type: image.mime }),
+      );
+    } catch {
+      setUrl(null);
+      return;
+    }
+    setUrl(objectUrl);
+    return () => {
+      URL.revokeObjectURL(objectUrl);
+      setUrl(null);
+    };
+  }, [image]);
+
+  return url;
+}
+
 interface AttachmentChipProps {
   attachment: Attachment;
   onRemove: (id: string) => void;
@@ -144,6 +184,14 @@ export function AttachmentChip({
     ? "Show filenames only"
     : "Show full diff";
 
+  // Image chips lead with a live thumbnail of the pasted/picked image.
+  // `previewFailed` covers a decode error on an otherwise-valid blob so a
+  // bad image degrades to the icon rather than a broken-image glyph.
+  const previewUrl = useImagePreviewUrl(attachment);
+  const [previewFailed, setPreviewFailed] = useState(false);
+  const showPreview =
+    previewUrl !== null && !previewFailed && !metadata.isLoading;
+
   const chip = (
     <div
       className={cn(
@@ -151,7 +199,14 @@ export function AttachmentChip({
         // each staged ref the card look the design applies to the
         // green issue chip; the per-kind tint below sets both fill and
         // border colour.
-        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs",
+        "inline-flex items-center border text-xs",
+        // With a thumbnail the chip drops the full pill radius and insets
+        // the preview by 3px — a rounded rect reads as "this is a
+        // picture", and a 22px-tall thumbnail inside a pill would poke
+        // through the corner arc.
+        showPreview
+          ? "gap-2 rounded-md py-[3px] pl-[3px] pr-2"
+          : "gap-1.5 rounded-full px-2.5 py-1",
         classNameForAttachment(attachment),
       )}
       role="status"
@@ -159,12 +214,22 @@ export function AttachmentChip({
       data-attachment-kind={attachment.kind}
       data-truncated={isTruncatedFile || undefined}
       data-expanded={expandActive || undefined}
+      data-preview={showPreview || undefined}
     >
       {metadata.isLoading ? (
         <Loader2
           className="h-3 w-3 animate-spin"
           aria-hidden
           data-testid="attachment-chip-spinner"
+        />
+      ) : showPreview ? (
+        <img
+          src={previewUrl}
+          alt=""
+          aria-hidden
+          data-testid="attachment-chip-thumbnail"
+          className="h-[22px] w-[30px] shrink-0 rounded-[3px] border border-foreground/10 object-cover"
+          onError={() => setPreviewFailed(true)}
         />
       ) : (
         <Icon className="h-3 w-3" aria-hidden />
@@ -235,6 +300,17 @@ export function AttachmentChip({
           data-testid="attachment-chip-tooltip"
           className="flex-col items-start gap-0.5 py-2"
         >
+          {/* The 30px chip thumbnail only carries colour/shape; hover
+              gives a preview big enough to actually read. */}
+          {showPreview && (
+            <img
+              src={previewUrl}
+              alt=""
+              aria-hidden
+              data-testid="attachment-chip-tooltip-preview"
+              className="mb-1 max-h-[180px] max-w-[260px] rounded border border-foreground/10 object-contain"
+            />
+          )}
           <div className="font-mono text-[11px] truncate max-w-[260px]">
             {metadata.label}
           </div>


### PR DESCRIPTION
## Problem

Every pasted image staged the same generic image icon behind the same `pasted-image.png` label, so two attachments in the composer strip were impossible to tell apart.

## Change

Image chips now render the actual image:

- **30×22px thumbnail** in the chip's icon slot, built from the attachment's in-memory `resolvedImage.bytes` — already retained for the optimistic user bubble, so this costs no extra IPC or disk read.
- A chip with a preview swaps the full pill radius for `rounded-md` with a 3px inset. A 22px-tall thumbnail inside a `rounded-full` pill pokes through the corner arc, and a rounded rect reads as "picture" anyway. Chip height goes 24px → 28px; non-image chips are byte-identical.
- **Hover tooltip gains a ≤260×180px preview** above the existing filename / token-estimate / size lines. 30px is enough to tell two screenshots apart by colour; the tooltip is where you actually read one.

## Robustness

- Object URL is revoked on unmount, so removing a chip doesn't leak it.
- Unresolved bytes (still staging), a decode failure, or an environment without `URL.createObjectURL` (jsdom under vitest) all fall back to the original icon pill.

## Verification

- `npm run check` clean; 3056 frontend tests pass across 209 files.
- 5 new `AttachmentChip` tests: thumbnail render, chip shape swap, URL revocation on unmount, decode-failure fallback, loading state.
- Visually verified in the dev-mock UI with two pasted images (chip strip + hover preview).

`npm run verify` can't complete its Rust half in a fresh worktree — `src-tauri/binaries/agent-browser-x86_64-unknown-linux-gnu` is absent, which is a worktree bootstrap gap unrelated to this frontend-only change.

## Docs

`docs/features/agent-chat.md` — new bullet under Attachments.