### PR TITLE
feat(chat): fuzzy-search the "Run in" project picker

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -1635,6 +1635,27 @@ discriminated `location` prop so one component serves both surfaces:
   `onSelectHomeWorkspace` — the location popover never creates hidden
   workspaces.
 
+**Location popover is keyboard-first.** The "Run in" popover is a cmdk
+`Command` with `shouldFilter={false}` plus a `CommandInput`
+("Search projects…"), so opening it focuses the search field and the
+whole flow is type → `Enter` with no mouse. Radix's default
+auto-focus is deliberately NOT overridden here (unlike the checkout /
+branch popovers, which use `focusCmdkRootOnOpen`) — the input is the
+first focusable child and forwards arrow/Enter to cmdk itself.
+Filtering + ranking is `fuzzyFilter` from `src/lib/fuzzy.ts` (shared
+scored subsequence matcher, also used by the GitHub issue/PR pickers):
+prefix beats substring beats scattered subsequence, word-boundary and
+camelCase hits score like initials (`hap` → `hermes-agent-personal`),
+shorter candidates win ties. The haystack is the display name; a query
+containing `/` switches it to the full project path, which is how two
+checkouts of the same repo are disambiguated. Matching name AND path
+at once was tried and reverted — a short query is a subsequence of
+nearly every long path, so the list stops narrowing. "Home directory
+(~)" is filtered as a row like any other (it matches `home` and `~`),
+while "Open another project…" sits outside `CommandList` and is never
+filtered — it has to stay reachable exactly when nothing matched. The
+query resets on close so the next open starts from the full list.
+
 **Pane-surface state + branch display.** `AgentChatPane` keeps
 `checkoutMode`/`worktreeName`/`baseBranch` as pane-local `useState`
 (per-pane lifetime; there is no draft to persist into), and seeds

--- a/src/components/chat/pickers/ThreadScopeRow.test.tsx
+++ b/src/components/chat/pickers/ThreadScopeRow.test.tsx
@@ -257,6 +257,157 @@ describe("ThreadScopeRow", () => {
     });
   });
 
+  describe("location control — type-to-filter", () => {
+    /** Three sibling projects, so a query has something to narrow. */
+    function seedProjects() {
+      currentWorkspaces = [
+        makeWs({
+          workspace_id: "ws-bar",
+          cwd: "/projects/bar",
+          project_root: "/projects/bar",
+        }),
+        makeWs({
+          workspace_id: "ws-codemux",
+          cwd: "/projects/codemux",
+          project_root: "/projects/codemux",
+        }),
+        makeWs({
+          workspace_id: "ws-site",
+          cwd: "/projects/codemux-sitev2",
+          project_root: "/projects/codemux-sitev2",
+        }),
+      ];
+    }
+
+    async function openPicker() {
+      const user = userEvent.setup();
+      const rendered = renderRow();
+      await user.click(screen.getByText("foo"));
+      const input = await screen.findByPlaceholderText("Search projects…");
+      return { user, input, ...rendered };
+    }
+
+    it("focuses the search input when the popover opens", async () => {
+      seedProjects();
+      const { input } = await openPicker();
+      await waitFor(() => expect(input).toHaveFocus());
+    });
+
+    it("narrows the list to fuzzy matches and hides the rest", async () => {
+      seedProjects();
+      const { user } = await openPicker();
+      await user.keyboard("codemux");
+      await waitFor(() => expect(screen.queryByText("bar")).toBeNull());
+      expect(screen.getByText("codemux")).toBeInTheDocument();
+      expect(screen.getByText("codemux-sitev2")).toBeInTheDocument();
+      expect(screen.queryByText("Home directory (~)")).toBeNull();
+    });
+
+    it("switches to path matching once the query contains a slash", async () => {
+      currentWorkspaces = [
+        makeWs({
+          workspace_id: "ws-a",
+          cwd: "/work/alpha/app",
+          project_root: "/work/alpha/app",
+        }),
+        makeWs({
+          workspace_id: "ws-b",
+          cwd: "/work/beta/app",
+          project_root: "/work/beta/app",
+        }),
+      ];
+      const { user, onChangeTarget } = await openPicker();
+      await user.keyboard("beta/");
+      await user.keyboard("{Enter}");
+      expect(onChangeTarget).toHaveBeenCalledWith({
+        kind: "project",
+        projectPath: "/work/beta/app",
+      });
+    });
+
+    it("does not let long paths defeat name filtering", async () => {
+      currentWorkspaces = [
+        makeWs({
+          workspace_id: "ws-deep",
+          cwd: "/home/user/dev/scratch/bar",
+          project_root: "/home/user/dev/scratch/bar",
+        }),
+        makeWs({
+          workspace_id: "ws-vexis",
+          cwd: "/projects/vexis",
+          project_root: "/projects/vexis",
+        }),
+      ];
+      const { user } = await openPicker();
+      // "ve" is a subsequence of `/home/user/dev/…` — name-only
+      // matching is what keeps that row out.
+      await user.keyboard("ve");
+      await waitFor(() => expect(screen.getByText("vexis")).toBeInTheDocument());
+      expect(screen.queryByText("bar")).toBeNull();
+    });
+
+    it("matches on scattered characters, not just prefixes", async () => {
+      seedProjects();
+      const { user } = await openPicker();
+      await user.keyboard("cdx");
+      await waitFor(() => expect(screen.queryByText("bar")).toBeNull());
+      expect(screen.getByText("codemux")).toBeInTheDocument();
+    });
+
+    it("Enter picks the top match without touching the mouse", async () => {
+      seedProjects();
+      const { user, onChangeTarget } = await openPicker();
+      await user.keyboard("codemux");
+      await waitFor(() => expect(screen.queryByText("bar")).toBeNull());
+      await user.keyboard("{Enter}");
+      expect(onChangeTarget).toHaveBeenCalledWith({
+        kind: "project",
+        projectPath: "/projects/codemux",
+      });
+    });
+
+    it("arrow keys move the highlight before Enter commits", async () => {
+      seedProjects();
+      const { user, onChangeTarget } = await openPicker();
+      await user.keyboard("codemux");
+      await waitFor(() => expect(screen.queryByText("bar")).toBeNull());
+      await user.keyboard("{ArrowDown}{Enter}");
+      expect(onChangeTarget).toHaveBeenCalledWith({
+        kind: "project",
+        projectPath: "/projects/codemux-sitev2",
+      });
+    });
+
+    it("keeps Home reachable by name", async () => {
+      seedProjects();
+      const { user, onChangeTarget } = await openPicker();
+      await user.keyboard("home");
+      await waitFor(() => expect(screen.queryByText("codemux")).toBeNull());
+      await user.keyboard("{Enter}");
+      expect(onChangeTarget).toHaveBeenCalledWith({ kind: "home" });
+    });
+
+    it("shows an empty state but keeps the open-project escape hatch", async () => {
+      seedProjects();
+      const { user } = await openPicker();
+      await user.keyboard("zzzz");
+      await waitFor(() =>
+        expect(screen.getByText(/No projects match/)).toBeInTheDocument(),
+      );
+      expect(screen.getByText("Open another project…")).toBeInTheDocument();
+    });
+
+    it("resets the query so the next open starts from the full list", async () => {
+      seedProjects();
+      const { user } = await openPicker();
+      await user.keyboard("codemux");
+      await waitFor(() => expect(screen.queryByText("bar")).toBeNull());
+      await user.keyboard("{Escape}");
+      await user.click(screen.getByText("foo"));
+      expect(await screen.findByText("bar")).toBeInTheDocument();
+    });
+  });
+
   describe("checkout control", () => {
     it("selecting 'New worktree' calls onChangeCheckoutMode('worktree')", async () => {
       const user = userEvent.setup();

--- a/src/components/chat/pickers/ThreadScopeRow.tsx
+++ b/src/components/chat/pickers/ThreadScopeRow.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/popover";
 import { ProjectAvatar } from "@/components/ui/project-avatar";
 import { useProjectActions } from "@/hooks/use-project-actions";
+import { fuzzyFilter, fuzzyMatch } from "@/lib/fuzzy";
 import { basename } from "@/lib/path";
 import { cn } from "@/lib/utils";
 import {
@@ -302,6 +303,7 @@ function LocationControl({
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const [projectAvatars, setProjectAvatars] = useState<
     Record<string, ProjectAvatarState>
   >({});
@@ -349,8 +351,36 @@ function LocationControl({
   const showHomeOption =
     location.kind === "draft" || isHome || firstHomeWorkspaceId !== null;
 
+  // Type-to-filter: rank by fuzzy score so `cdx` or the initials of a
+  // hyphenated name land on the right row without reaching for the
+  // mouse. A query containing `/` switches the haystack from the
+  // display name to the full path — that's how you disambiguate two
+  // checkouts of the same repo. (Matching name AND path unconditionally
+  // does not narrow: a short query is a subsequence of nearly every
+  // long path.) Home matches its own synonyms ("home", "~") and always
+  // sorts first when it survives — it is a fixed destination, not a
+  // project.
+  const projectRows = useMemo(() => {
+    const byPath = query.includes("/");
+    return fuzzyFilter(
+      groups.filter((g) => g.projectPath !== homeDir),
+      query,
+      (g) => (byPath ? g.projectPath : g.projectName),
+    );
+  }, [groups, homeDir, query]);
+  const homeVisible =
+    showHomeOption && fuzzyMatch("home directory ~", query.trim());
+  const noMatches = !homeVisible && projectRows.length === 0;
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    // Every open starts from the full list — a stale query from last
+    // time would silently hide projects.
+    if (!next) setQuery("");
+  };
+
   const handleSelectHome = () => {
-    setOpen(false);
+    handleOpenChange(false);
     if (location.kind === "draft") {
       location.onChangeTarget({ kind: "home" });
       return;
@@ -365,7 +395,7 @@ function LocationControl({
   };
 
   const handleSelectProject = (targetProjectPath: string) => {
-    setOpen(false);
+    handleOpenChange(false);
     if (location.kind === "draft") {
       location.onChangeTarget({
         kind: "project",
@@ -385,7 +415,7 @@ function LocationControl({
       : "Project";
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button type="button" disabled={disabled} className={GHOST_BTN}>
           {isHome ? (
@@ -397,70 +427,99 @@ function LocationControl({
           <ChevronDown className="size-2.5 opacity-45" />
         </button>
       </PopoverTrigger>
-      <PopoverContent
-        className="w-[250px] p-1.5"
-        align="start"
-        side="top"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
-      >
-        <div className="px-2 pb-1 pt-1 font-mono text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground">
-          Run in
-        </div>
-        {showHomeOption && (
-          <button
-            type="button"
-            onClick={handleSelectHome}
-            className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-xs font-medium text-foreground transition-colors hover:bg-foreground/[0.08]"
+      {/* No `onOpenAutoFocus` override here (unlike the sibling
+          controls): this popover owns a `CommandInput`, so Radix's
+          default auto-focus lands on the input — which is exactly
+          what we want, since it both takes the query and forwards
+          arrow/Enter to cmdk. */}
+      <PopoverContent className="w-[250px] p-0" align="start" side="top">
+        {/* `shouldFilter={false}`: cmdk's built-in scorer ranks by its
+            own rules; we filter with `fuzzyFilter` so a project's
+            path is a (penalized) second haystack and initials-style
+            queries win. cmdk still owns highlight + Enter. */}
+        <Command shouldFilter={false} loop>
+          <div className="px-2.5 pb-1 pt-2 font-mono text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Run in
+          </div>
+          <CommandInput
+            placeholder="Search projects…"
+            value={query}
+            onValueChange={setQuery}
+            className="text-xs"
+          />
+          <CommandList
+            className="max-h-[280px] overflow-y-auto p-1.5 pb-0 [scrollbar-width:thin]"
+            onWheel={(e) => e.stopPropagation()}
           >
-            <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-              <Home className="size-3" />
-            </span>
-            <span className="min-w-0 flex-1 truncate">Home directory (~)</span>
-            {isHome && (
-              <Check className="size-3.5 shrink-0 text-accent-ember" />
+            {noMatches && (
+              <div className="px-2 py-3 text-center text-[11.5px] text-muted-foreground">
+                No projects match “{query.trim()}”
+              </div>
             )}
-          </button>
-        )}
-        {groups
-          .filter((g) => g.projectPath !== homeDir)
-          .map((g) => {
-            const active = g.projectPath === activeProjectPath;
-            const avatar = projectAvatars[g.projectPath] ?? EMPTY_AVATAR;
-            return (
-              <button
-                key={g.projectPath}
-                type="button"
-                onClick={() => handleSelectProject(g.projectPath)}
-                className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-xs font-medium text-foreground transition-colors hover:bg-foreground/[0.08]"
+            {homeVisible && (
+              <CommandItem
+                value="home-directory"
+                onSelect={handleSelectHome}
+                className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-xs font-medium text-foreground"
               >
-                <ProjectAvatar
-                  name={g.projectName}
-                  color={avatar.color}
-                  imageUrl={avatar.image}
-                  cacheBust={avatar.imageVersion}
-                  size="md"
-                  shape="square"
-                />
-                <span className="min-w-0 flex-1 truncate">{g.projectName}</span>
-                {active && <Check className="size-3.5 shrink-0 text-accent-ember" />}
-              </button>
-            );
-          })}
-        <div className="my-1 h-px bg-border" />
-        <button
-          type="button"
-          onClick={async () => {
-            setOpen(false);
-            const result = await openProject();
-            if (result.success && result.path) {
-              handleSelectProject(result.path);
-            }
-          }}
-          className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[11.5px] text-muted-foreground transition-colors hover:bg-foreground/[0.08] hover:text-foreground"
-        >
-          <FolderPlus className="size-3.5" />
-          Open another project…
-        </button>
+                <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                  <Home className="size-3" />
+                </span>
+                <span className="min-w-0 flex-1 truncate">
+                  Home directory (~)
+                </span>
+                {isHome && (
+                  <Check className="size-3.5 shrink-0 text-accent-ember" />
+                )}
+              </CommandItem>
+            )}
+            {projectRows.map((g) => {
+              const active = g.projectPath === activeProjectPath;
+              const avatar = projectAvatars[g.projectPath] ?? EMPTY_AVATAR;
+              return (
+                <CommandItem
+                  key={g.projectPath}
+                  value={g.projectPath}
+                  onSelect={() => handleSelectProject(g.projectPath)}
+                  className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-xs font-medium text-foreground"
+                >
+                  <ProjectAvatar
+                    name={g.projectName}
+                    color={avatar.color}
+                    imageUrl={avatar.image}
+                    cacheBust={avatar.imageVersion}
+                    size="md"
+                    shape="square"
+                  />
+                  <span className="min-w-0 flex-1 truncate">
+                    {g.projectName}
+                  </span>
+                  {active && (
+                    <Check className="size-3.5 shrink-0 text-accent-ember" />
+                  )}
+                </CommandItem>
+              );
+            })}
+          </CommandList>
+          {/* Outside the list, and never filtered: the escape hatch has
+              to stay reachable precisely when nothing matched. */}
+          <div className="mt-1.5 border-t border-border p-1.5">
+            <button
+              type="button"
+              onClick={async () => {
+                handleOpenChange(false);
+                const result = await openProject();
+                if (result.success && result.path) {
+                  handleSelectProject(result.path);
+                }
+              }}
+              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[11.5px] text-muted-foreground transition-colors hover:bg-foreground/[0.08] hover:text-foreground"
+            >
+              <FolderPlus className="size-3.5" />
+              Open another project…
+            </button>
+          </div>
+        </Command>
       </PopoverContent>
     </Popover>
   );

--- a/src/components/github/issue-picker.tsx
+++ b/src/components/github/issue-picker.tsx
@@ -3,16 +3,7 @@ import { cn } from "@/lib/utils";
 import { CircleDot, CircleCheck, Search, Loader2 } from "lucide-react";
 import { listGithubIssues, listGithubIssuesByPath } from "@/tauri/commands";
 import type { GitHubIssue } from "@/tauri/types";
-
-function fuzzyMatch(text: string, query: string): boolean {
-  const lower = text.toLowerCase();
-  const q = query.toLowerCase();
-  let qi = 0;
-  for (let i = 0; i < lower.length && qi < q.length; i++) {
-    if (lower[i] === q[qi]) qi++;
-  }
-  return qi === q.length;
-}
+import { fuzzyMatch } from "@/lib/fuzzy";
 
 function IssueRow({
   issue,

--- a/src/components/github/pr-picker.tsx
+++ b/src/components/github/pr-picker.tsx
@@ -4,6 +4,7 @@ import { Search, Loader2 } from "lucide-react";
 import { PrStatusIcon, type PrStatusState } from "@/components/github/pr-status-icon";
 import { listPullRequests, getGithubPrByPath } from "@/tauri/commands";
 import type { PullRequestInfo } from "@/tauri/types";
+import { fuzzyMatch } from "@/lib/fuzzy";
 
 /**
  * Pull-request picker, mirroring `IssuePickerPanel`.
@@ -20,16 +21,6 @@ import type { PullRequestInfo } from "@/tauri/types";
  * GitPullRequest, draft → muted GitPullRequestDraft, closed → red
  * GitPullRequestClosed.
  */
-
-function fuzzyMatch(text: string, query: string): boolean {
-  const lower = text.toLowerCase();
-  const q = query.toLowerCase();
-  let qi = 0;
-  for (let i = 0; i < lower.length && qi < q.length; i++) {
-    if (lower[i] === q[qi]) qi++;
-  }
-  return qi === q.length;
-}
 
 /** Collapse the `state` string + `is_draft` flag into the single
  *  state token `PrStatusIcon` understands. A draft only matters while

--- a/src/lib/fuzzy.test.ts
+++ b/src/lib/fuzzy.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyFilter, fuzzyMatch, fuzzyScore } from "./fuzzy";
+
+/** The real project list from the "Run in" picker. */
+const PROJECTS = [
+  "vexis-agent",
+  "codemux",
+  "vexis-agent-site",
+  "codemux-sitev2",
+  "ai-project_25-26",
+  "dpcode",
+  "odysseus",
+  "passpage",
+  "partpilot · pandora",
+  "ai-solutions-belgium",
+  "partpilot",
+  "hermes-agent",
+  "world-bench",
+  "openclaw",
+  "hermes-agent-personal",
+  "rgbpc",
+];
+
+function rank(query: string): string[] {
+  return fuzzyFilter(PROJECTS, query, (name) => name);
+}
+
+describe("fuzzyMatch", () => {
+  it("matches an exact string", () => {
+    expect(fuzzyMatch("codemux", "codemux")).toBe(true);
+  });
+
+  it("matches a prefix", () => {
+    expect(fuzzyMatch("codemux", "cod")).toBe(true);
+  });
+
+  it("matches a scattered subsequence", () => {
+    expect(fuzzyMatch("codemux", "cdx")).toBe(true);
+  });
+
+  it("is case-insensitive both ways", () => {
+    expect(fuzzyMatch("Home directory (~)", "HOME")).toBe(true);
+    expect(fuzzyMatch("CODEMUX", "cdx")).toBe(true);
+  });
+
+  it("rejects out-of-order characters", () => {
+    expect(fuzzyMatch("codemux", "xoc")).toBe(false);
+  });
+
+  it("rejects characters that are not present", () => {
+    expect(fuzzyMatch("codemux", "codez")).toBe(false);
+  });
+
+  it("rejects a query longer than the text", () => {
+    expect(fuzzyMatch("cod", "codemux")).toBe(false);
+  });
+
+  it("matches everything on an empty query", () => {
+    expect(fuzzyMatch("codemux", "")).toBe(true);
+  });
+});
+
+describe("fuzzyScore", () => {
+  it("returns null for a non-match", () => {
+    expect(fuzzyScore("codemux", "zzz")).toBeNull();
+  });
+
+  it("scores a prefix above a mid-string substring", () => {
+    const prefix = fuzzyScore("codemux", "co")!;
+    const middle = fuzzyScore("dpcode", "co")!;
+    expect(prefix).toBeGreaterThan(middle);
+  });
+
+  it("scores a substring above a scattered subsequence", () => {
+    const substring = fuzzyScore("dpcode", "code")!;
+    const scattered = fuzzyScore("codemux-sitev2", "cdmx")!;
+    expect(substring).toBeGreaterThan(scattered);
+  });
+
+  it("rewards word-boundary hits (typing initials)", () => {
+    const initials = fuzzyScore("hermes-agent-personal", "hap")!;
+    const buried = fuzzyScore("hermes-agent-personal", "rmp")!;
+    expect(initials).toBeGreaterThan(buried);
+  });
+
+  it("rewards camelCase humps", () => {
+    expect(fuzzyScore("agentChatPane", "acp")).toBeGreaterThan(
+      fuzzyScore("agentchatpane", "acp")!,
+    );
+  });
+
+  it("prefers the shorter candidate on an equal match", () => {
+    expect(fuzzyScore("codemux", "co")!).toBeGreaterThan(
+      fuzzyScore("codemux-sitev2", "co")!,
+    );
+  });
+});
+
+describe("fuzzyFilter", () => {
+  it("returns every item, in order, for an empty query", () => {
+    expect(fuzzyFilter(PROJECTS, "", (n) => n)).toEqual(PROJECTS);
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(fuzzyFilter(PROJECTS, "  codemux  ", (n) => n)[0]).toBe("codemux");
+  });
+
+  it("puts the exact project first when typing its prefix", () => {
+    expect(rank("cod")[0]).toBe("codemux");
+    expect(rank("odys")[0]).toBe("odysseus");
+    expect(rank("rgb")[0]).toBe("rgbpc");
+  });
+
+  it("narrows a prefix to the projects that share it", () => {
+    expect(rank("codemux")).toEqual(["codemux", "codemux-sitev2"]);
+  });
+
+  it("finds a project from the first letters of its words", () => {
+    expect(rank("hap")[0]).toBe("hermes-agent-personal");
+    expect(rank("asb")[0]).toBe("ai-solutions-belgium");
+    expect(rank("vas")[0]).toBe("vexis-agent-site");
+  });
+
+  it("drops non-matching projects entirely", () => {
+    expect(rank("zzz")).toEqual([]);
+    expect(rank("openclaw")).toEqual(["openclaw"]);
+  });
+
+  it("matches whatever haystack the caller selects", () => {
+    const rows = [
+      { name: "passpage", path: "/home/zeus/projects/passpage" },
+      { name: "odysseus", path: "/home/zeus/greek/odysseus" },
+    ];
+    expect(fuzzyFilter(rows, "greek", (r) => r.path).map((r) => r.name)).toEqual(
+      ["odysseus"],
+    );
+    expect(fuzzyFilter(rows, "greek", (r) => r.name)).toEqual([]);
+  });
+});

--- a/src/lib/fuzzy.ts
+++ b/src/lib/fuzzy.ts
@@ -1,0 +1,109 @@
+/**
+ * Scored subsequence ("fuzzy") matching for type-to-filter pickers.
+ *
+ * The rule every picker in the app shares: a query matches when its
+ * characters appear in order somewhere in the candidate, so `cdx`
+ * finds `codemux` and `vas` finds `vexis-agent-site`. On top of that
+ * bare test, `fuzzyScore` ranks matches so the row a user *meant*
+ * lands first:
+ *
+ *  - whole-query prefix beats whole-query substring beats a scattered
+ *    subsequence (`co` → `codemux` before `openclaw`),
+ *  - characters landing on a word boundary (`-`, `_`, `.`, `/`, space)
+ *    or a camelCase hump score like initials, which is what makes
+ *    typing the first letter of each word work,
+ *  - adjacent matches beat scattered ones, and long gaps are
+ *    penalized,
+ *  - on an otherwise equal match, the shorter candidate wins.
+ *
+ * Scores are only comparable within one candidate list — treat them as
+ * a sort key, never as a quality threshold.
+ */
+
+/** Characters that make the NEXT character read as the start of a word. */
+const BOUNDARY_CHARS = new Set([" ", "-", "_", ".", "/", "\\", ":", "@", "~", "("]);
+
+/** True when `text[index]` is a camelCase hump (`agentChat` → `C`). */
+function isCamelHump(text: string, index: number): boolean {
+  if (index === 0) return false;
+  const ch = text[index];
+  const prev = text[index - 1];
+  return ch >= "A" && ch <= "Z" && prev >= "a" && prev <= "z";
+}
+
+/**
+ * Score `query` against `text`, or `null` when `query` is not a
+ * subsequence of `text`. An empty query scores `0` (matches
+ * everything). Higher is better; see the module doc for the ranking
+ * rules.
+ */
+export function fuzzyScore(text: string, query: string): number | null {
+  if (query.length === 0) return 0;
+  const haystack = text.toLowerCase();
+  const needle = query.toLowerCase();
+  if (needle.length > haystack.length) return null;
+
+  let score = 0;
+  let cursor = 0;
+  let previous = -2;
+
+  for (let qi = 0; qi < needle.length; qi++) {
+    const at = haystack.indexOf(needle[qi], cursor);
+    if (at === -1) return null;
+
+    if (at === 0) score += 16;
+    else if (BOUNDARY_CHARS.has(haystack[at - 1])) score += 12;
+    else if (isCamelHump(text, at)) score += 8;
+
+    if (at === previous + 1) score += 8;
+    // Skipping characters to reach this match is weak evidence —
+    // capped so one long gap doesn't sink an otherwise good row.
+    score -= Math.min(at - cursor, 8);
+
+    cursor = at + 1;
+    previous = at;
+  }
+
+  if (haystack.startsWith(needle)) score += 40;
+  else if (haystack.includes(needle)) score += 20;
+
+  // Tie-break toward the tighter candidate: `co` should rank
+  // `codemux` above `codemux-sitev2`.
+  score -= Math.min(haystack.length - needle.length, 30) * 0.1;
+
+  return score;
+}
+
+/** `true` when `query`'s characters appear in order inside `text`. */
+export function fuzzyMatch(text: string, query: string): boolean {
+  return fuzzyScore(text, query) !== null;
+}
+
+/**
+ * Filter + rank `items` by `query`, best first, matching against the
+ * string `toText` returns. Ties keep the input order
+ * (`Array.prototype.sort` is stable), so a caller's own ordering —
+ * recency, activity — survives an empty or ambiguous query.
+ *
+ * Match ONE haystack per item. Folding a second one in (a full path
+ * next to a name) sounds helpful and isn't: subsequence matching over
+ * a long path matches almost any short query, so the list stops
+ * narrowing. Pick the haystack the query is aimed at instead — see
+ * `ThreadScopeRow`'s `/`-switches-to-paths rule.
+ */
+export function fuzzyFilter<T>(
+  items: readonly T[],
+  query: string,
+  toText: (item: T) => string,
+): T[] {
+  const trimmed = query.trim();
+  if (trimmed === "") return [...items];
+
+  const scored: { item: T; score: number }[] = [];
+  for (const item of items) {
+    const score = fuzzyScore(toText(item), trimmed);
+    if (score !== null) scored.push({ item, score });
+  }
+
+  return scored.sort((a, b) => b.score - a.score).map((entry) => entry.item);
+}


### PR DESCRIPTION
## Why

Starting a new agent chat meant scanning an unfiltered project list and clicking the right row. With a dozen-plus projects that is a mouse trip every time.

## What

The "Run in" popover is now a cmdk `Command` with a `Search projects…` input:

- opening it focuses the search field — type → `↑/↓` → `Enter`, no mouse in the flow
- "Home directory (~)" filters like any other row (matches `home`, `~`)
- "Open another project…" sits outside the list and is never filtered — it has to stay reachable exactly when nothing matched
- the query resets on close, so the next open starts from the full list

Ranking lives in a new `src/lib/fuzzy.ts`: a scored subsequence matcher where prefix beats substring beats scattered match, word-boundary and camelCase hits score like initials (`hap` → `hermes-agent-personal`, `vas` → `vexis-agent-site`), and shorter candidates win ties. It also replaces the two copy-pasted `fuzzyMatch` helpers in the GitHub issue/PR pickers.

## One reverted approach, worth knowing

Matching each project against its name **and** its full path was the obvious first cut, and it doesn't narrow anything — a short query like `ve` is a subsequence of nearly every long path, so the whole list survived (caught in the browser, not in tests). Matching is name-only now; a query containing `/` switches the haystack to paths, which is how two checkouts of the same repo get disambiguated. Both behaviors are pinned by tests.

## Verification

- `npm run check` clean; 3082 tests pass (21 new for the matcher, 10 for the picker)
- Drove the real UI in the browser pane: typed `ve` → narrowed to `vexis` alone → `Enter` → scope switched and the checkout/branch controls appeared
- `npm run verify`'s Rust half fails in this worktree for an unrelated reason (`src-tauri/binaries/` sidecar absent in a fresh worktree); the diff is frontend-only