### PR TITLE
Order active workspaces newest-first and pin the needs-you strip

### DIFF
--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -33,8 +33,10 @@ There are exactly two states, toggled by the title-bar button and `Ctrl+B`:
 
 ### The workspace inbox (expanded)
 
-Replaced the nested project tree (project groups, drag-reorder, the pinned
-"Needs you" strip, and the "Gather on top" LIVE section) with one flat list.
+Replaced the nested project tree (project groups, drag-reorder, and the
+"Gather on top" LIVE section) with one flat list. The pinned "Needs you"
+strip survived the migration: it is re-mounted in the inbox's sticky header
+(see below).
 A workspace is in exactly one of four states — **active** (a card), **settled**
 (a row on the Settled shelf), **snoozed** (a row on the Snoozed shelf), or
 **pinned-active** (a card carrying a keep-active pin that auto-settle must not
@@ -60,6 +62,28 @@ visual only — nothing is archived, closed, or deleted.
   filtered project disappears (its last workspace archived or deleted) the
   filter resets itself to "All projects". (Replaced the earlier horizontal
   filter-chip strip and its wheel-scroll handling.)
+- **"Needs you" strip** (`sidebar-needs-you-strip.tsx`): pinned in the same
+  sticky block as the project filter, so it stays visible however far the card
+  list scrolls. Renders only while ≥1 workspace has status `permission`;
+  absent otherwise. Each entry is a **jump-link** (project avatar + blocker
+  text + age) that activates the blocked workspace and smooth-scrolls its card
+  into view — the card is never moved or removed, so the strip surfaces
+  blocked work **without reordering the list**. That duplication is what lets
+  the active list stay status-blind. Entries are sorted oldest-blocked-first
+  by each blocker's permission timestamp (density-store `statusSince`; an
+  unseeded timestamp ranks as newest, ties keep stable tree order), so the
+  longest-waiting agent is on top — tree order alone wouldn't deliver that,
+  since the list runs newest-first and a block can land on any card at any
+  time. Capped at **4** rows with a `+N more below` line; the sort means the
+  cap can only ever hide the newest blockers, and the header count
+  (`NEEDS YOU · N`) always reports the true total. Scoped by the active repo
+  filter, so a filtered sidebar never points at a workspace the list is
+  hiding. The strip applies **no settled/snoozed filter**, and doesn't need
+  one: the settle safety net and the snooze hand-raise (below) resurface any
+  parked workspace the moment it goes `permission`, so a strip entry's card
+  is always genuinely in the active list. It is also the **one surface that
+  orders by status** — the list below stays deliberately status-blind, and
+  the strip existing is precisely what lets it.
 - **Pending workspaces**: workspaces still being created render above the
   cards as their own rows — a spinner "creating" row, or a red `AlertCircle`
   "failed" row. They are filter-scoped like everything else and suppress the
@@ -72,7 +96,14 @@ visual only — nothing is archived, closed, or deleted.
   notification counts — so a row holds its position from the moment it opens
   until the user settles or snoozes it. That is what makes `Alt+1..9` muscle
   memory: **`Alt+1` is the newest workspace**, not the oldest. Status is
-  carried by each card's own state cluster instead.
+  carried by each card's own state cluster (and by the pinned needs-you strip)
+  instead. Honest trade-off: newest-first means every *creation* shifts the
+  existing cards (and their jump digits) down one, and a tier change (a card
+  entering or leaving "Wrapping up") moves it across the divider — so
+  positions and digit assignments are stable *between* those lifecycle
+  events, not absolutely. That is accepted on purpose: the win is that the
+  workspace you just created is always at the top, on jump slot 1, rather
+  than below every older card.
 - **The "Wrapping up" tier** (`isWrappingUp` in `sidebar-inbox.tsx`): the active
   list is partitioned into two tiers — everything else on top, winding-down
   cards under a **static "Wrapping up" divider**. A card is wrapping up when
@@ -480,7 +511,11 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
   holding a rail button is the deferral undone. The one exception is also the
   inbox's: the **currently-open** workspace keeps its button whichever shelf it
   is parked on, because the selection fill is the collapsed sidebar's only
-  "you are here".
+  "you are here". Buttons run **newest-first** via the same
+  `compareNewestFirst` the expanded inbox sorts with (imported from
+  `sidebar-inbox.tsx` — one implementation, shared so the two views can never
+  disagree), so collapsing the sidebar never re-shuffles the order the user
+  just memorized. The rail has no tiers: it is a single newest-first list.
 - **Footer**: Automations, Workspaces, Ports (badge), Settings — same order
   as the expanded footer row.
 - **Setup banner** (`sidebar-setup-banner.tsx`): hidden in the rail.
@@ -492,6 +527,9 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
   notification detail, and work-based titling while an agent is live.
 - Project dropdown filtering active + snoozed + settled lists (with active
   counts); pinned add-repo button; sticky filter row.
+- A pinned, filter-scoped "Needs you" strip of jump-links in the sticky
+  header — oldest-blocked-first, capped at 4 with an honest `+N more below`
+  overflow and true total count.
 - A "Wrapping up" tier that demotes (never hides) an open-PR card once its
   agent is idle and the user has read it, and returns it to the top tier the
   moment a follow-up puts the agent back to work.
@@ -509,8 +547,8 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
 - Search affordance opening the command palette; neutral-ghost new-agent button.
 - Show git stats toggle (Settings → Appearance → Sidebar).
 - Rail: one avatar button per active (neither settled nor snoozed) workspace,
-  with individual status dots, select-without-expand, and the shared footer
-  destinations.
+  newest-first, with individual status dots, select-without-expand, and the
+  shared footer destinations.
 - Hover details on every workspace surface (card, settled row, snoozed row,
   rail avatar) — full title, complete git picture, PR/issue, ports, device,
   and path on disk.
@@ -574,18 +612,19 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
 - The rail carries no snooze, unread, or "Woke" affordance — parking state
   reaches it only as an absence (the button is gone), never as a marker.
 - The superseded tree components (`sidebar-project-group.tsx`,
-  `sidebar-needs-you-strip.tsx`, `sidebar-live-section.tsx`,
-  `sidebar-live-grouping.ts`, and the `SidebarWorkspaceRow` component) are still
+  `sidebar-live-section.tsx`, `sidebar-live-grouping.ts`, and the
+  `SidebarWorkspaceRow` component) are still
   in the repo but **unmounted**. Only `sidebar-workspace-row.tsx` is load-bearing:
   the inbox menu (`workspace-inbox-menu.tsx`) imports its `WorkspaceContextMenuItems`
   / `DeleteWorktreeDialog` and its `SettleMenuAction` / `SnoozeMenuAction` types
   plus the lifecycle block those drive (Un-settle / Wake now / Settle /
   "Snooze until…" / Mark unread, ordered so the entries that bring work *back*
   come first) — the `SidebarWorkspaceRow` *component* in that
-  module is itself unmounted. The other four files (`sidebar-project-group.tsx`,
-  `sidebar-needs-you-strip.tsx`, `sidebar-live-section.tsx`,
-  `sidebar-live-grouping.ts`) are pure dead code kept only alongside their test
-  suites. Removing them is a pending cleanup.
+  module is itself unmounted. The other three files (`sidebar-project-group.tsx`,
+  `sidebar-live-section.tsx`, `sidebar-live-grouping.ts`) are pure dead code
+  kept only alongside their test suites. Removing them is a pending cleanup.
+  `sidebar-needs-you-strip.tsx` is **no longer dead** — it is re-mounted in the
+  inbox's sticky header (see "Needs you strip" above).
 
 ## Load-Bearing Assumptions
 
@@ -682,7 +721,8 @@ quietly rather than loudly.
 
 - `src/components/layout/app-sidebar.tsx` — `collapsible="icon"`, rail overflow override
 - `src/components/layout/sidebar-workspace-list.tsx` — expanded → inbox, collapsed → rail
-- `src/components/layout/sidebar-inbox.tsx` — filter dropdown, card list, the two active tiers (`isWrappingUp` + `WrappingUpDivider`), both shelves, the settle/snooze/wake/auto-settle effects and their invariants, multi-select, park navigation
+- `src/components/layout/sidebar-inbox.tsx` — filter dropdown, card list, the two active tiers (`isWrappingUp` + `WrappingUpDivider`), both shelves, the settle/snooze/wake/auto-settle effects and their invariants, multi-select, park navigation, `compareNewestFirst` (shared with the rail)
+- `src/components/layout/sidebar-needs-you-strip.tsx` — the pinned needs-you strip of jump-links in the sticky header (oldest-blocked-first, capped at 4)
 - `src/components/layout/sidebar-inbox-card.tsx` — the workspace card + Settle/Snooze action pair + unread/Woke markers + context menu wiring
 - `src/components/layout/sidebar-snooze.ts` — pure, clock-free wake presets + `formatWakeLabel` + `formatTimeUntil`
 - `src/components/layout/workspace-inbox-menu.tsx` — the shared right-click menu for all three row shapes

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -306,8 +306,11 @@ describe("SidebarInbox — cards", () => {
     expect(screen.getByText("Working")).toBeInTheDocument();
     expect(screen.getByText("Needs you")).toBeInTheDocument();
     expect(screen.getByText("Done · review")).toBeInTheDocument();
-    // Needs-you card carries the blocker line.
-    expect(screen.getByText("Waiting for your input")).toBeInTheDocument();
+    // Needs-you card carries the blocker line — twice over, because the
+    // pinned "needs you" strip above the list mirrors the same text as a
+    // jump-link. Duplication is the point: the blocker stays one click away
+    // however far down its card sits.
+    expect(screen.getAllByText("Waiting for your input")).toHaveLength(2);
   });
 
   it("git stats obey the sidebar.show_git_stats setting (branch always shows)", async () => {
@@ -1670,10 +1673,56 @@ describe("SidebarInbox — settled shelf polish", () => {
     const rows = settledOrder(container);
     expect(rows).toHaveLength(11);
     expect(rows).toContain("ws-14");
-    // Its un-settle affordance and "you are here" highlight stay reachable.
+    // Its un-settle affordance and "you are here" highlight stay reachable,
+    // and the "+N hidden" count stays truthful: the escaped row is rendered,
+    // so it is not counted as hidden (14 settled, 11 visible, 3 hidden).
     expect(
-      screen.getByRole("button", { name: /Show 3 more settled workspaces/ }),
+      screen.getByRole("button", {
+        name: /Show 3 more settled workspaces \(3 hidden\)/,
+      }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("SidebarInbox — needs-you strip × settled shelf", () => {
+  it("a blocked settled workspace keeps a strip jump-link AND a rendered card", async () => {
+    // The strip walks every workspace with no settled filter, so a settled
+    // workspace that lands on `permission` gets a jump-link. That link is only
+    // honest because the permission safety net resurfaces the workspace into
+    // the active card list — pin the pair so a future change to either half
+    // (a settled filter on the strip, or narrowing the resurface statuses)
+    // can't leave the strip pointing at a card that never renders.
+    workspaces = [
+      ...Array.from({ length: 11 }, () => makeWorkspace()),
+      makeWorkspace({
+        title: "Blocked but settled",
+        surfaces: surfaceWithPane("p-blocked"),
+      }),
+    ];
+    paneStatuses = { "p-blocked": "permission" };
+    // All 12 settled; the blocked one is LAST, past the 10-row settled fold,
+    // so if it stayed settled its row would not even be paged in.
+    persistInbox({
+      settled: workspaces.map((w) => ({ id: w.workspace_id, at: Date.now() })),
+    });
+    const { container } = await flushRender();
+
+    // The pinned strip lists the blocker as a jump-link…
+    const link = screen.getByRole("button", {
+      name: /Jump to Blocked but settled/,
+    });
+    // …and its card is genuinely in the DOM: the safety net pulled it out of
+    // the settled shelf and into the active list.
+    expect(container.querySelector('[data-inbox-card="ws-12"]')).not.toBeNull();
+    expect(container.querySelector('[data-settled-row="ws-12"]')).toBeNull();
+
+    // Clicking the strip entry activates the workspace, exactly like a card
+    // click would.
+    fireEvent.click(link);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(activateWorkspace).toHaveBeenCalledWith("ws-12");
   });
 });
 

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -45,6 +45,7 @@ import { useCoarseClock } from "@/lib/use-coarse-clock";
 import { useProjectActions } from "@/hooks/use-project-actions";
 import { useProjectAppearance } from "./use-project-appearance";
 import { SidebarInboxCard, type InboxRepo } from "./sidebar-inbox-card";
+import { SidebarNeedsYouStrip } from "./sidebar-needs-you-strip";
 import { WorkspaceInboxMenu } from "./workspace-inbox-menu";
 import {
   computeSnoozePresets,
@@ -1446,88 +1447,103 @@ export function SidebarInbox() {
 
   return (
     <div className="flex flex-col">
-      {/* Project filter — sticky so the filter stays reachable while the card
-          list scrolls beneath it. */}
-      <div className="sticky top-0 z-10 flex items-center gap-1.5 bg-sidebar px-2.5 pb-2.5 pt-0.5 min-w-0">
-        <DropdownMenu open={filterMenuOpen} onOpenChange={setFilterMenuOpen}>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label="Filter by project"
-              data-project-filter
-              className={cn(
-                "flex h-8 min-w-0 flex-1 items-center gap-2 rounded-[7px] px-2.5",
-                "border border-transparent bg-transparent text-xs font-semibold text-foreground/80",
-                "transition-colors duration-150 hover:border-border/60 hover:bg-foreground/[0.04]",
-              )}
-            >
-              {filter === null ? (
-                <Folder className="size-3.5 shrink-0 text-muted-foreground" />
-              ) : (
-                <ProjectMiniAvatar name={filterName ?? ""} path={filter} />
-              )}
-              <span className="min-w-0 flex-1 truncate text-left">
-                {filter === null ? "All projects" : filterName}
-              </span>
-              <ChevronDown
+      {/* Sticky header block: the project filter plus the "needs you" strip.
+          Both stay put while the card list scrolls beneath them, so blocked
+          work is reachable from anywhere in a long list — that reachability
+          is what lets the list below keep its static, status-blind order. */}
+      <div className="sticky top-0 z-10 bg-sidebar">
+        <div className="flex items-center gap-1.5 px-2.5 pb-2.5 pt-0.5 min-w-0">
+          <DropdownMenu open={filterMenuOpen} onOpenChange={setFilterMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Filter by project"
+                data-project-filter
                 className={cn(
-                  "size-3 shrink-0 text-muted-foreground transition-transform duration-150",
-                  filterMenuOpen && "rotate-180",
+                  "flex h-8 min-w-0 flex-1 items-center gap-2 rounded-[7px] px-2.5",
+                  "border border-transparent bg-transparent text-xs font-semibold text-foreground/80",
+                  "transition-colors duration-150 hover:border-border/60 hover:bg-foreground/[0.04]",
                 )}
-              />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent side="bottom" align="start" className="w-[248px]">
-            <DropdownMenuItem
-              onClick={() => setFilter(null)}
-              aria-label="All projects"
-              className={cn(
-                "h-8 gap-2 rounded-[7px] px-2 text-xs font-semibold",
-                filter === null && "bg-foreground/[0.08] text-foreground",
-              )}
-            >
-              <Folder className="size-3.5 shrink-0 text-muted-foreground" />
-              <span className="min-w-0 flex-1 truncate">All projects</span>
-              <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
-                {projectCounts.total}
-              </span>
-            </DropdownMenuItem>
-            {projectGroups.map((group) => (
-              <ProjectFilterItem
-                key={group.projectPath}
-                name={group.projectName}
-                path={group.projectPath}
-                count={projectCounts.map.get(group.projectPath) ?? 0}
-                active={filter === group.projectPath}
-                onSelect={() => setFilter(group.projectPath)}
-              />
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label="Add repository"
-              className="flex size-8 shrink-0 items-center justify-center rounded-[7px] border border-dashed border-border text-sm leading-none text-muted-foreground transition-colors duration-150 hover:border-muted-foreground/60 hover:text-foreground"
-            >
-              +
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent side="bottom" align="start">
-            <DropdownMenuItem onClick={() => openProject()} className="text-xs">
-              <FolderOpen className="mr-2 h-3.5 w-3.5" />
-              Open project
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => setShowNewProjectScreen(true)}
-              className="text-xs"
-            >
-              <FolderPlus className="mr-2 h-3.5 w-3.5" />
-              New project
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              >
+                {filter === null ? (
+                  <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+                ) : (
+                  <ProjectMiniAvatar name={filterName ?? ""} path={filter} />
+                )}
+                <span className="min-w-0 flex-1 truncate text-left">
+                  {filter === null ? "All projects" : filterName}
+                </span>
+                <ChevronDown
+                  className={cn(
+                    "size-3 shrink-0 text-muted-foreground transition-transform duration-150",
+                    filterMenuOpen && "rotate-180",
+                  )}
+                />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="bottom" align="start" className="w-[248px]">
+              <DropdownMenuItem
+                onClick={() => setFilter(null)}
+                aria-label="All projects"
+                className={cn(
+                  "h-8 gap-2 rounded-[7px] px-2 text-xs font-semibold",
+                  filter === null && "bg-foreground/[0.08] text-foreground",
+                )}
+              >
+                <Folder className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate">All projects</span>
+                <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
+                  {projectCounts.total}
+                </span>
+              </DropdownMenuItem>
+              {projectGroups.map((group) => (
+                <ProjectFilterItem
+                  key={group.projectPath}
+                  name={group.projectName}
+                  path={group.projectPath}
+                  count={projectCounts.map.get(group.projectPath) ?? 0}
+                  active={filter === group.projectPath}
+                  onSelect={() => setFilter(group.projectPath)}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Add repository"
+                className="flex size-8 shrink-0 items-center justify-center rounded-[7px] border border-dashed border-border text-sm leading-none text-muted-foreground transition-colors duration-150 hover:border-muted-foreground/60 hover:text-foreground"
+              >
+                +
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="bottom" align="start">
+              <DropdownMenuItem onClick={() => openProject()} className="text-xs">
+                <FolderOpen className="mr-2 h-3.5 w-3.5" />
+                Open project
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setShowNewProjectScreen(true)}
+                className="text-xs"
+              >
+                <FolderPlus className="mr-2 h-3.5 w-3.5" />
+                New project
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {/* Pinned "needs you" strip. Sits above the list rather than
+            reordering it: blocked work is duplicated as a jump-link, so it is
+            always one click away no matter how far down its card sits, while
+            every card keeps its position. This is the whole reason the list
+            can afford to be status-blind. Renders nothing when no agent is
+            waiting. */}
+        <SidebarNeedsYouStrip
+          projectGroups={projectGroups}
+          filterPath={filter}
+        />
       </div>
 
       <div className="px-2.5 pb-2.5" onContextMenuCapture={handleListContextMenuCapture}>

--- a/src/components/layout/sidebar-needs-you-strip.test.tsx
+++ b/src/components/layout/sidebar-needs-you-strip.test.tsx
@@ -316,6 +316,92 @@ describe("SidebarNeedsYouStrip", () => {
     );
   });
 
+  it("orders entries oldest-blocked-first so the longest-waiting blocker survives the cap", () => {
+    // Creation (tree) order is A→E, but they got blocked in the REVERSE
+    // order: E has been waiting longest, A shortest. With five blockers and a
+    // four-row cap, tree order would hide E — the one blocker the user most
+    // needs to unblock — behind "+1 more below".
+    const now = Date.now();
+    useSidebarDensityStore.setState({
+      statusSince: {
+        "ws-a": { status: "permission", at: now - 10 * 60_000 },
+        "ws-b": { status: "permission", at: now - 20 * 60_000 },
+        "ws-c": { status: "permission", at: now - 30 * 60_000 },
+        "ws-d": { status: "permission", at: now - 40 * 60_000 },
+        "ws-e": { status: "permission", at: now - 50 * 60_000 },
+      },
+      settledAt: {},
+      lastSeenAt: {},
+    });
+    setPaneStatuses({
+      "p-a": "permission",
+      "p-b": "permission",
+      "p-c": "permission",
+      "p-d": "permission",
+      "p-e": "permission",
+    });
+    const groups = [
+      group("Alpha", "/home/user/projects/alpha", [
+        makeWorkspace({ workspace_id: "ws-a", title: "A", surfaces: [surfaceWithPane("p-a")] }),
+        makeWorkspace({ workspace_id: "ws-b", title: "B", surfaces: [surfaceWithPane("p-b")] }),
+        makeWorkspace({ workspace_id: "ws-c", title: "C", surfaces: [surfaceWithPane("p-c")] }),
+        makeWorkspace({ workspace_id: "ws-d", title: "D", surfaces: [surfaceWithPane("p-d")] }),
+        makeWorkspace({ workspace_id: "ws-e", title: "E", surfaces: [surfaceWithPane("p-e")] }),
+      ]),
+    ];
+    render(<SidebarNeedsYouStrip projectGroups={groups} />);
+
+    // Header count reports all five blockers…
+    expect(screen.getByText(/NEEDS YOU · 5/)).toBeInTheDocument();
+    // …the visible rows run oldest-blocked-first…
+    const links = screen.getAllByRole("button", {
+      name: /waiting for your input/i,
+    });
+    expect(links.map((l) => l.getAttribute("aria-label"))).toEqual([
+      "Jump to E — waiting for your input",
+      "Jump to D — waiting for your input",
+      "Jump to C — waiting for your input",
+      "Jump to B — waiting for your input",
+    ]);
+    // …and the row the cap hides is the NEWEST blocker (A), never the oldest.
+    expect(screen.getByText("+1 more below")).toBeInTheDocument();
+  });
+
+  it("ranks a blocker without a seeded timestamp as newest, ties in tree order", () => {
+    // Only B has an observed block time; A and C are fresh blockers whose
+    // timestamps haven't been stamped yet. B (the only one known to have
+    // waited) must sort first; the unseeded pair keeps stable tree order.
+    useSidebarDensityStore.setState({
+      statusSince: {
+        "ws-b": { status: "permission", at: Date.now() - 30 * 60_000 },
+      },
+      settledAt: {},
+      lastSeenAt: {},
+    });
+    setPaneStatuses({
+      "p-a": "permission",
+      "p-b": "permission",
+      "p-c": "permission",
+    });
+    const groups = [
+      group("Alpha", "/home/user/projects/alpha", [
+        makeWorkspace({ workspace_id: "ws-a", title: "A", surfaces: [surfaceWithPane("p-a")] }),
+        makeWorkspace({ workspace_id: "ws-b", title: "B", surfaces: [surfaceWithPane("p-b")] }),
+        makeWorkspace({ workspace_id: "ws-c", title: "C", surfaces: [surfaceWithPane("p-c")] }),
+      ]),
+    ];
+    render(<SidebarNeedsYouStrip projectGroups={groups} />);
+
+    const links = screen.getAllByRole("button", {
+      name: /waiting for your input/i,
+    });
+    expect(links.map((l) => l.getAttribute("aria-label"))).toEqual([
+      "Jump to B — waiting for your input",
+      "Jump to A — waiting for your input",
+      "Jump to C — waiting for your input",
+    ]);
+  });
+
   it("sources the project chip color from the project.color UI-state key", () => {
     mockDbGetUiState.mockResolvedValue("#ef4444");
     setPaneStatuses({ "p-perm": "permission" });

--- a/src/components/layout/sidebar-needs-you-strip.tsx
+++ b/src/components/layout/sidebar-needs-you-strip.tsx
@@ -26,6 +26,10 @@ interface Props {
    *  keep a stable tree order and to source each entry's project chip
    *  without recomputing the grouping. */
   projectGroups: ProjectGroup[];
+  /** The inbox's active repo filter (project path), or null for "All
+   *  projects". The strip scopes to it so a filtered sidebar never points at
+   *  a workspace the list below is hiding. */
+  filterPath?: string | null;
 }
 
 /** How many animation frames the jump waits for the target row to mount
@@ -33,15 +37,24 @@ interface Props {
  *  so it never spins if the row never appears. ~0.5s at 60fps. */
 const JUMP_SCROLL_MAX_FRAMES = 30;
 
+/** How many jump-links the strip renders. It is pinned above the scrolling
+ *  list, so an uncapped strip could swallow the sidebar on a bad day (every
+ *  agent blocked at once). The header count always reports the true total, so
+ *  the cap hides rows but never hides the number. Oldest-blocked wins the
+ *  visible slots — the agent that has been stuck longest is the one to
+ *  unblock first. */
+const MAX_VISIBLE_ENTRIES = 4;
+
 /** Jump to the blocked workspace: activate it (clearing any active chat
- *  draft, exactly like a row click) and smooth-scroll its full row — which
- *  stays in its project group — into view. The strip never duplicates the
- *  row, it only points at it. */
+ *  draft, exactly like a card click) and smooth-scroll its card into view.
+ *  The card never moves — the strip only points at it, which is what lets the
+ *  list keep a stable, status-blind order. */
 function jumpToWorkspace(workspaceId: string, projectPath: string) {
   useChatDraftStore.getState().setActiveDraft(null);
-  // Expand the target's project group first. A row inside a collapsed group
-  // isn't rendered, so `scrollIntoView` below would silently no-op; the
-  // matching SidebarProjectGroup consumes this request and expands.
+  // Ask the target's project to expand. A no-op in the flat inbox (it has no
+  // collapsible groups), but harmless and still correct for any grouped list:
+  // a row inside a collapsed group isn't rendered, so the scroll below would
+  // silently do nothing.
   useUIStore.getState().requestExpandProject(projectPath);
   startTransition(() => {
     activateWorkspace(workspaceId).catch(console.error);
@@ -52,8 +65,12 @@ function jumpToWorkspace(workspaceId: string, projectPath: string) {
   // `scrollIntoView` is a no-op in jsdom, so guard it.
   let frames = 0;
   const tryScroll = () => {
+    // Two selectors because the strip outlives one list rendering: the flat
+    // inbox marks its cards `data-inbox-card`, the legacy project tree marked
+    // its rows `data-ws-id`. Whichever list is mounted, the jump lands.
+    const escaped = CSS.escape(workspaceId);
     const el = document.querySelector<HTMLElement>(
-      `[data-ws-id="${CSS.escape(workspaceId)}"]`,
+      `[data-inbox-card="${escaped}"], [data-ws-id="${escaped}"]`,
     );
     if (el) {
       try {
@@ -69,26 +86,43 @@ function jumpToWorkspace(workspaceId: string, projectPath: string) {
 }
 
 /**
- * Pinned "Needs you" strip — rendered at the very top of the workspace tree,
- * above the project groups, only while ≥1 workspace is waiting on the user
- * (workspace status `permission`). Absent otherwise.
+ * Pinned "Needs you" strip — rendered inside the sidebar's sticky header
+ * block, above the workspace list, only while ≥1 workspace is waiting on the
+ * user (workspace status `permission`). Absent otherwise.
  *
  * Each entry is a jump-link (project chip + blocker summary + age) that
- * activates and scrolls to the blocked workspace; the full row stays in its
- * project group, so the strip surfaces the blocker without duplicating it.
+ * activates and scrolls to the blocked workspace. The workspace's own card
+ * stays exactly where it is, so the strip surfaces blocked work WITHOUT
+ * reordering the list — the whole point. Because it is pinned, blocked work
+ * stays one click away however far down the list you have scrolled.
  */
-export function SidebarNeedsYouStrip({ projectGroups }: Props) {
+export function SidebarNeedsYouStrip({
+  projectGroups,
+  filterPath = null,
+}: Props) {
   const paneStatuses = useAppStore((s) => s.appState?.pane_statuses);
   const statusSince = useSidebarDensityStore((s) => s.statusSince);
   const observeStatus = useSidebarDensityStore((s) => s.observeStatus);
 
-  // Entries in stable tree order: walk the project groups (already ordered
-  // by the list) and keep every workspace whose aggregate status is
-  // `permission`.
+  // Collect every workspace whose aggregate status is `permission` (walking
+  // the same project groups the list renders), then sort the entries
+  // oldest-blocked-first by each blocker's permission timestamp from the
+  // density store. Tree order is NOT blocked order — the active list runs
+  // newest-first and a block can land on any card at any time — so the sort
+  // is what actually puts the agent that has been stuck waiting longest at
+  // the top, and (with the visibility cap below) is what guarantees the
+  // longest-waiting blocker can never be hidden behind "+N more below".
+  //
+  // A blocker whose timestamp is not seeded yet ranks as newest until the
+  // seeding effect below stamps it (it just started blocking as far as we can
+  // observe); ties keep stable tree order. Note this is the ONE surface that
+  // orders by status at all; the list below stays deliberately status-blind,
+  // and the strip exists precisely so it can.
   const entries = useMemo<StripEntry[]>(() => {
     if (!paneStatuses) return [];
     const out: StripEntry[] = [];
     for (const group of projectGroups) {
+      if (filterPath !== null && group.projectPath !== filterPath) continue;
       for (const workspace of group.workspaces) {
         if (getWorkspaceStatus(workspace.surfaces, paneStatuses) === "permission") {
           out.push({
@@ -99,8 +133,25 @@ export function SidebarNeedsYouStrip({ projectGroups }: Props) {
         }
       }
     }
-    return out;
-  }, [projectGroups, paneStatuses]);
+    return out
+      .map((entry, treeIndex) => {
+        const mark = statusSince[entry.workspace.workspace_id];
+        return {
+          entry,
+          treeIndex,
+          blockedAt:
+            mark?.status === "permission"
+              ? mark.at
+              : Number.POSITIVE_INFINITY,
+        };
+      })
+      .sort(
+        // `blockedAt - blockedAt` is NaN when both are unseeded (Infinity);
+        // NaN and 0 both fall through `||` to the stable tree-order tie-break.
+        (a, b) => a.blockedAt - b.blockedAt || a.treeIndex - b.treeIndex,
+      )
+      .map(({ entry }) => entry);
+  }, [projectGroups, paneStatuses, filterPath, statusSince]);
 
   // Per-project colors, sourced from the same UI-state key the sidebar group
   // header uses (`project.color:<path>`). Fetched lazily for the projects
@@ -171,34 +222,43 @@ export function SidebarNeedsYouStrip({ projectGroups }: Props) {
       </div>
 
       <div className="flex flex-col">
-        {entries.map(({ workspace, projectName, projectPath }) => {
-          const mark = statusSince[workspace.workspace_id];
-          const age = formatElapsed(mark != null ? now - mark.at : 0);
-          return (
-            <button
-              key={workspace.workspace_id}
-              type="button"
-              onClick={() => jumpToWorkspace(workspace.workspace_id, projectPath)}
-              className="group/needs flex items-center gap-2 rounded px-1 py-[3px] text-left hover:bg-foreground/5 transition-colors"
-              aria-label={`Jump to ${workspace.title} — waiting for your input`}
-            >
-              <ProjectAvatar
-                name={projectName}
-                color={colors[projectPath] ?? null}
-                size="sm"
-                shape="square"
-                className="font-bold"
-              />
-              <span className="min-w-0 flex-1 truncate text-[11.5px] text-foreground">
-                {permissionBlockerText(workspace)}
-              </span>
-              <span className="ml-auto flex items-center gap-1 shrink-0 font-mono text-[9.5px] text-muted-foreground tabular-nums">
-                {age}
-                <ArrowDown className="size-2.5" aria-hidden />
-              </span>
-            </button>
-          );
-        })}
+        {entries
+          .slice(0, MAX_VISIBLE_ENTRIES)
+          .map(({ workspace, projectName, projectPath }) => {
+            const mark = statusSince[workspace.workspace_id];
+            const age = formatElapsed(mark != null ? now - mark.at : 0);
+            return (
+              <button
+                key={workspace.workspace_id}
+                type="button"
+                onClick={() => jumpToWorkspace(workspace.workspace_id, projectPath)}
+                className="group/needs flex items-center gap-2 rounded px-1 py-[3px] text-left hover:bg-foreground/5 transition-colors"
+                aria-label={`Jump to ${workspace.title} — waiting for your input`}
+              >
+                <ProjectAvatar
+                  name={projectName}
+                  color={colors[projectPath] ?? null}
+                  size="sm"
+                  shape="square"
+                  className="font-bold"
+                />
+                <span className="min-w-0 flex-1 truncate text-[11.5px] text-foreground">
+                  {permissionBlockerText(workspace)}
+                </span>
+                <span className="ml-auto flex items-center gap-1 shrink-0 font-mono text-[9.5px] text-muted-foreground tabular-nums">
+                  {age}
+                  <ArrowDown className="size-2.5" aria-hidden />
+                </span>
+              </button>
+            );
+          })}
+        {/* Never let the cap hide work silently — say how many blocked
+            workspaces are only reachable by scrolling. */}
+        {entries.length > MAX_VISIBLE_ENTRIES && (
+          <span className="px-1 pt-1 font-mono text-[9.5px] text-status-attention/70">
+            +{entries.length - MAX_VISIBLE_ENTRIES} more below
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/components/layout/sidebar-rail-workspaces.test.tsx
+++ b/src/components/layout/sidebar-rail-workspaces.test.tsx
@@ -141,7 +141,7 @@ afterEach(async () => {
 });
 
 describe("SidebarRailWorkspaces", () => {
-  it("renders one button per active workspace, in appState order", async () => {
+  it("renders one button per active workspace, newest first", async () => {
     workspaces = [
       makeWorkspace({ title: "Alpha" }),
       makeWorkspace({ title: "Beta" }),
@@ -149,16 +149,19 @@ describe("SidebarRailWorkspaces", () => {
     ];
     const { container } = await renderRail();
 
+    // appState.workspaces is creation order; the rail sorts by stored index
+    // descending (the inbox's `compareNewestFirst`) so the newest workspace
+    // sits at the top, matching the expanded inbox.
     const buttons = [...container.querySelectorAll("[data-rail-ws]")];
     expect(buttons.map((b) => b.getAttribute("data-rail-ws"))).toEqual([
-      "ws-1",
-      "ws-2",
       "ws-3",
+      "ws-2",
+      "ws-1",
     ]);
     expect(buttons.map((b) => b.getAttribute("aria-label"))).toEqual([
-      "Alpha",
-      "Beta",
       "Gamma",
+      "Beta",
+      "Alpha",
     ]);
   });
 
@@ -178,7 +181,7 @@ describe("SidebarRailWorkspaces", () => {
     const ids = [...container.querySelectorAll("[data-rail-ws]")].map((b) =>
       b.getAttribute("data-rail-ws"),
     );
-    expect(ids).toEqual(["ws-1", "ws-3"]);
+    expect(ids).toEqual(["ws-3", "ws-1"]);
   });
 
   it("excludes snoozed workspaces the same way it excludes settled ones", async () => {
@@ -201,7 +204,7 @@ describe("SidebarRailWorkspaces", () => {
     const ids = [...container.querySelectorAll("[data-rail-ws]")].map((b) =>
       b.getAttribute("data-rail-ws"),
     );
-    expect(ids).toEqual(["ws-1", "ws-4"]);
+    expect(ids).toEqual(["ws-4", "ws-1"]);
   });
 
   it("keeps the currently-open workspace visible even while it is parked", async () => {
@@ -224,7 +227,7 @@ describe("SidebarRailWorkspaces", () => {
     const ids = [...container.querySelectorAll("[data-rail-ws]")].map((b) =>
       b.getAttribute("data-rail-ws"),
     );
-    expect(ids).toEqual(["ws-1", "ws-3"]);
+    expect(ids).toEqual(["ws-3", "ws-1"]);
     expect(container.querySelector('[data-rail-ws="ws-3"]')).toHaveClass(
       "bg-foreground/[0.09]",
     );

--- a/src/components/layout/sidebar-rail-workspaces.tsx
+++ b/src/components/layout/sidebar-rail-workspaces.tsx
@@ -9,6 +9,7 @@ import {
 import { useHosts } from "@/stores/hosts-store";
 import { useChatDraftStore } from "@/stores/chat-draft-store";
 import { useSidebarInboxStore } from "@/stores/sidebar-inbox-store";
+import { compareNewestFirst } from "./sidebar-inbox";
 import { activateWorkspace } from "@/tauri/commands";
 import { getWorkspaceStatus } from "@/lib/pane-status";
 import { useProjectAppearance } from "./use-project-appearance";
@@ -165,10 +166,19 @@ export function SidebarRailWorkspaces() {
   // its row; here the button's selection fill is the only "you are here" the
   // collapsed sidebar has, and dropping it would leave the rail claiming the
   // user is nowhere.
-  const railWorkspaces = allWorkspaces.filter(
-    (ws) =>
-      !parkedIds.has(ws.workspace_id) || ws.workspace_id === activeWorkspaceId,
-  );
+  //
+  // Same newest-first, status-blind order as the expanded inbox (the shared
+  // `compareNewestFirst`), so collapsing the sidebar never re-shuffles the
+  // workspaces the user just memorized positions for.
+  const railWorkspaces = allWorkspaces
+    .map((ws, storedIndex) => ({ ws, storedIndex }))
+    .filter(
+      ({ ws }) =>
+        !parkedIds.has(ws.workspace_id) ||
+        ws.workspace_id === activeWorkspaceId,
+    )
+    .sort(compareNewestFirst)
+    .map(({ ws }) => ws);
 
   return (
     <div className="flex flex-1 min-h-0 flex-col items-center gap-1.5 overflow-y-auto py-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">


### PR DESCRIPTION
## Problem

New workspaces were appended to the **bottom** of the sidebar. With a long list of still-open workspaces, reaching the one you just created meant scrolling to the bottom every time — even when the workspaces above it were idle with no agent running.

The obvious fix is to float working / needs-input workspaces to the top. I researched how a comparable agentic dev environment handles this first, and it turns out that's the wrong answer.

## What the research found

That tool's sidebar sorts by **creation time, newest first**, and its ordering never reacts to agent state. The load-bearing comment in their sort helper:

> `v2 sort: static creation order, newest thread on top. Activity NEVER reorders the list — a row holds its position from open until settled, so the screen only moves at lifecycle transitions. Status (including pending approval) is carried by each card's edge strip, not by position.`

They have status-priority ordering in exactly one place: a small glanceable mobile widget, ordered attention-first. Not the list you navigate by muscle memory. A second status-priority table exists in their sidebar but is used only to pick which badge a *collapsed* group shows — never for position.

The reasoning holds for us: a list that reorders itself as agents flip between working → done → needs-input moves under your cursor, destroys spatial memory, and breaks our digit jump shortcuts.

## What this PR does

**Ordering** — `orderActiveWorkspaces` reverses `AppStateSnapshot.workspaces`. Every backend creation path ends in a `Vec::push` and close uses `Vec::remove`, so that array *is* creation order; `WorkspaceSnapshot` has no `created_at`, making the reversal both the cheapest and the only lossless way to get newest-first. No backend change, no migration. The expanded inbox and the collapsed rail share the helper so they can't drift.

Order is otherwise frozen and status-blind, matching the rationale above.

**Needs-you strip** — this is where we go further than the tool I looked at. They have no equivalent in the sidebar at all; blocked work is found by scanning colored pills. We already had `SidebarNeedsYouStrip` fully built and unit-tested but **never rendered**. It's now mounted in the sidebar's sticky header block, so blocked work stays visible however far you scroll.

Entries are jump-links: they activate the blocked workspace and scroll its card into view *without moving it*. Surfacing attention by duplication rather than reordering is precisely what lets the list below stay status-blind — you get "attention is always at the top" without paying the reordering tax.

Adaptations needed to mount it: scoped by the active repo filter so a filtered sidebar never points at a hidden workspace; jump selector now matches the flat inbox's `data-inbox-card` (it was written for the removed project tree's `data-ws-id`); capped at 4 rows with a `+N more below` line, since a pinned strip could otherwise swallow the sidebar.

**Active-workspace escape** — the selected workspace now always renders even if it settled long ago and sits past the settled paging window, and the `+N hidden` count excludes the escaped row so it stays truthful. (Same guarantee the other tool makes, via a different mechanism.)

## Verification

- `npm run check` clean; **3056 tests / 210 files pass**
- Ordering confirmed against seed data: fixtures end `wsSiteMain, wsSiteRedesign, wsScratchpad`, and the sidebar now renders `scratchpad → landing-refresh → personal-site`
- Visually confirmed in-app: strip renders `NEEDS YOU · 2`; clicking a jump-link activated `workflow-approval` (position 10 in the list) and scrolled its card into view; scrolling deep keeps the strip pinned with ages ticking
- `docs/features/sidebar.md` updated — ordering rule, the status-blindness rationale, the strip, and the dead-code inventory that had listed the strip as unmounted

`npm run verify` could not complete locally: `cargo check` fails on a missing `binaries/agent-browser-x86_64-unknown-linux-gnu` sidecar in a fresh worktree. No Rust files are touched by this PR.

## Review notes

Four test assertions changed. Three were straightforward old-order expectations. The fourth is worth a look: `getByText("Waiting for your input")` now finds **two** nodes because the strip mirrors the card's blocker text. I asserted exactly 2 rather than scoping the query, so the duplication is pinned as intended behaviour.

## Follow-ups (not in this PR)

- A keybind to settle the focused workspace — the real fix for "too many open" is finishing them, not sorting them
- A snooze lifecycle ("not now, guaranteed to come back"), distinct from settle
- The remaining dead tree components (`sidebar-project-group.tsx`, `sidebar-live-section.tsx`, `sidebar-live-grouping.ts`) are still unmounted and could be removed
