### PR TITLE
feat(sidebar): hover details card for workspaces

### DIFF
--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -120,12 +120,12 @@ visual only — nothing is archived, closed, or deleted.
   archive, delete) shared with the old row, including the delete/push-confirm
   dialogs.
 - **Hover details** (`workspace-hover-card.tsx`): resting the pointer on any
-  workspace surface — an active card, a settled one-line row, or a collapsed
-  rail avatar — opens a shared read-only `HoverCard` to the right (350ms open,
-  120ms close, `side="right" align="start"`, 290px). It exists because every
-  sidebar surface is lossy: the card truncates its title and drops
-  `git_behind` / `git_changed_files` entirely, the settled row shows only a
-  title, and the rail shows nothing but an avatar. Contents, all conditional
+  workspace surface — an active card, a settled or snoozed one-line row, or a
+  collapsed rail avatar — opens a shared read-only `HoverCard` to the right
+  (350ms open, 120ms close, `side="right" align="start"`, 290px). It exists
+  because every sidebar surface is lossy: the card truncates its title and
+  drops `git_behind` / `git_changed_files` entirely, the settled and snoozed
+  rows show only a title, and the rail shows nothing but an avatar. Contents, all conditional
   except the header and Location: repo eyebrow + provider marks + agent state
   (with client-derived elapsed), the **full** untruncated title, the linked
   issue's number + title, then label/value rows — Branch, Uncommitted `+A −D`,
@@ -494,8 +494,9 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
 - Rail: one avatar button per active (neither settled nor snoozed) workspace,
   with individual status dots, select-without-expand, and the shared footer
   destinations.
-- Hover details on every workspace surface (card, settled row, rail avatar) —
-  full title, complete git picture, PR/issue, ports, device, and path on disk.
+- Hover details on every workspace surface (card, settled row, snoozed row,
+  rail avatar) — full title, complete git picture, PR/issue, ports, device,
+  and path on disk.
 - Per-workspace agent status covers both terminal and Agent Chat (Beta) agents
   (chat sessions publish into the same `pane_statuses` snapshot).
 - The done-review checkmark **survives an app restart**. `save_persisted_state`
@@ -530,7 +531,7 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
   card. The backend now persists `last_active_at`, which would fix this; the
   card just doesn't read it yet (the settled shelf does, via `workEndedAt`).
   The hover card's elapsed reading inherits exactly this limitation (it reads
-  the same store, sampled once at open rather than off a ticking clock).
+  the same store, ticking on the shared coarse clock while the card is open).
 - Shelf collapse state (Settled open, Snoozed closed) and the settled paging
   window are **component state** — not persisted, and reset on every mount.
 - Multi-selection is session-only and cleared by a plain click, an activation,
@@ -668,7 +669,7 @@ quietly rather than loudly.
 - `src/components/layout/sidebar-inbox-card.tsx` — the workspace card + Settle/Snooze action pair + unread/Woke markers + context menu wiring
 - `src/components/layout/sidebar-snooze.ts` — pure, clock-free wake presets + `formatWakeLabel` + `formatTimeUntil`
 - `src/components/layout/workspace-inbox-menu.tsx` — the shared right-click menu for all three row shapes
-- `src/components/layout/workspace-hover-card.tsx` — the shared hover-details card for cards, settled rows, and rail avatars
+- `src/components/layout/workspace-hover-card.tsx` — the shared hover-details card for cards, settled/snoozed rows, and rail avatars
 - `src/components/layout/sidebar-inbox-jump.ts` — visual-order jump targets for Alt+1..9
 - `src/lib/keybind-registry.ts` — `workspaceJump1..9` actions (default `Alt+1..9`)
 - `src/lib/use-coarse-clock.ts` — the single ~30s clock behind every elapsed label and sweep

--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -137,7 +137,8 @@ visual only — nothing is archived, closed, or deleted.
   It reuses the `DetailRow` label/value shape from the context bar's popover
   (`WorkspaceStatusCluster`), and needs **no new Tauri command** — every field
   is already on `WorkspaceSnapshot` or in `appState.detected_ports`. The card
-  is `pointer-events-none` (a detail surface, not an interactive one) and its
+  keeps pointer events enabled so the path and branch can be selected and
+  copied (Radix holds it open while the cursor crosses into it), and its
   body is a separate component so Radix's unmount-when-closed keeps a sidebar
   of N workspaces from subscribing N× to the ports/hosts stores at rest. It
   mounts *inside* `WorkspaceInboxMenu` on a different node than

--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -119,6 +119,29 @@ visual only — nothing is archived, closed, or deleted.
   is the same `WorkspaceContextMenuItems` (rename, editors, move-to-host,
   archive, delete) shared with the old row, including the delete/push-confirm
   dialogs.
+- **Hover details** (`workspace-hover-card.tsx`): resting the pointer on any
+  workspace surface — an active card, a settled one-line row, or a collapsed
+  rail avatar — opens a shared read-only `HoverCard` to the right (350ms open,
+  120ms close, `side="right" align="start"`, 290px). It exists because every
+  sidebar surface is lossy: the card truncates its title and drops
+  `git_behind` / `git_changed_files` entirely, the settled row shows only a
+  title, and the rail shows nothing but an avatar. Contents, all conditional
+  except the header and Location: repo eyebrow + provider marks + agent state
+  (with client-derived elapsed), the **full** untruncated title, the linked
+  issue's number + title, then label/value rows — Branch, Uncommitted `+A −D`,
+  Changed files, Ahead, Behind (or a single "Working tree · clean" row when
+  there is nothing to report), Pull request, Issue, Port(s) (capped at 3 with
+  a `+N` overflow), Location (`This device` / host name / `host · in place`),
+  Notifications muted — and finally the real path on disk (`worktree_path ??
+  remote_cwd ?? cwd`, `$HOME` collapsed to `~`, wrapped not truncated).
+  It reuses the `DetailRow` label/value shape from the context bar's popover
+  (`WorkspaceStatusCluster`), and needs **no new Tauri command** — every field
+  is already on `WorkspaceSnapshot` or in `appState.detected_ports`. The card
+  is `pointer-events-none` (a detail surface, not an interactive one) and its
+  body is a separate component so Radix's unmount-when-closed keeps a sidebar
+  of N workspaces from subscribing N× to the ports/hosts stores at rest. It
+  mounts *inside* `WorkspaceInboxMenu` on a different node than
+  `ContextMenuTrigger`, so the two `asChild` triggers never collide.
 - **Settle / un-settle** (`sidebar-inbox-store.ts`): Settle collapses the card
   (~200ms height/opacity), then moves it onto the "Settled" shelf as a compact
   one-line row (repo avatar · violet merge icon when its PR merged · title ·
@@ -429,7 +452,9 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
 - **Workspace strip** (`sidebar-rail-workspaces.tsx`): one 28px button per
   **active (unsettled) workspace** — repo avatar with that workspace's own
   status dot (red pulse = needs you, amber = working, green = done-review,
-  none = idle), right-side tooltip = workspace title. Clicking selects the
+  none = idle), and the shared right-side **hover card** (it replaced the
+  title-only tooltip — a 28px avatar is the sidebar's least legible surface,
+  so it benefits most). Clicking selects the
   workspace **without expanding**; the selected button gets the neutral
   border + lighter fill. The strip scrolls (scrollbar hidden); the repo filter
   does not apply here. **Both** parking lifecycles hide a button — settled and
@@ -468,6 +493,8 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
 - Rail: one avatar button per active (neither settled nor snoozed) workspace,
   with individual status dots, select-without-expand, and the shared footer
   destinations.
+- Hover details on every workspace surface (card, settled row, rail avatar) —
+  full title, complete git picture, PR/issue, ports, device, and path on disk.
 - Per-workspace agent status covers both terminal and Agent Chat (Beta) agents
   (chat sessions publish into the same `pane_statuses` snapshot).
 - The done-review checkmark **survives an app restart**. `save_persisted_state`
@@ -501,6 +528,8 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
   review, or any workspace after an app restart, shows no elapsed label on its
   card. The backend now persists `last_active_at`, which would fix this; the
   card just doesn't read it yet (the settled shelf does, via `workEndedAt`).
+  The hover card's elapsed reading inherits exactly this limitation (it reads
+  the same store, sampled once at open rather than off a ticking clock).
 - Shelf collapse state (Settled open, Snoozed closed) and the settled paging
   window are **component state** — not persisted, and reset on every mount.
 - Multi-selection is session-only and cleared by a plain click, an activation,
@@ -638,6 +667,7 @@ quietly rather than loudly.
 - `src/components/layout/sidebar-inbox-card.tsx` — the workspace card + Settle/Snooze action pair + unread/Woke markers + context menu wiring
 - `src/components/layout/sidebar-snooze.ts` — pure, clock-free wake presets + `formatWakeLabel` + `formatTimeUntil`
 - `src/components/layout/workspace-inbox-menu.tsx` — the shared right-click menu for all three row shapes
+- `src/components/layout/workspace-hover-card.tsx` — the shared hover-details card for cards, settled rows, and rail avatars
 - `src/components/layout/sidebar-inbox-jump.ts` — visual-order jump targets for Alt+1..9
 - `src/lib/keybind-registry.ts` — `workspaceJump1..9` actions (default `Alt+1..9`)
 - `src/lib/use-coarse-clock.ts` — the single ~30s clock behind every elapsed label and sweep

--- a/src/components/layout/sidebar-inbox-card.tsx
+++ b/src/components/layout/sidebar-inbox-card.tsx
@@ -17,6 +17,7 @@ import {
   normalizePrState,
 } from "@/components/github/pr-status-icon";
 import { WorkspaceInboxMenu } from "./workspace-inbox-menu";
+import { WorkspaceHoverCard } from "./workspace-hover-card";
 import { activateWorkspace } from "@/tauri/commands";
 import { useChatDraftStore } from "@/stores/chat-draft-store";
 import {
@@ -177,15 +178,11 @@ export function SidebarInboxCard({
 
   // While an agent is live and a linked issue exists, the card title IS the
   // work (issue title); the worktree name stays reachable via the branch on
-  // the meta line + the title tooltip. Idle cards keep the workspace name.
+  // the meta line + the hover card. Idle cards keep the workspace name.
   const displayTitle =
     status !== null && workspace.linked_issue
       ? workspace.linked_issue.title
       : workspace.title;
-  const titleTooltip =
-    status !== null && workspace.linked_issue && workspace.git_branch
-      ? workspace.git_branch
-      : undefined;
 
   const prState = normalizePrState(workspace.pr_state);
   const prMerged = prState === "merged";
@@ -313,6 +310,10 @@ export function SidebarInboxCard({
           justUnsettled && "rise-in",
         )}
       >
+        {/* Hover details live on the inner card, not on the animation wrapper
+            above — that wrapper is already the ContextMenuTrigger, and two
+            `asChild` triggers must not compose onto the same node. */}
+        <WorkspaceHoverCard workspace={workspace} repo={repo} status={status}>
             <div
               role="button"
               tabIndex={0}
@@ -483,7 +484,6 @@ export function SidebarInboxCard({
                   />
                 )}
                 <span
-                  title={titleTooltip}
                   className={cn(
                     "truncate text-[13px] leading-[1.35] text-foreground",
                     // The extra weight is what makes an unread card readable
@@ -574,6 +574,7 @@ export function SidebarInboxCard({
                 )}
               </div>
             </div>
+        </WorkspaceHoverCard>
       </div>
     </WorkspaceInboxMenu>
   );

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -1476,6 +1476,27 @@ describe("SidebarInbox — snooze shelf", () => {
     expect(screen.getByText("Come back later")).toBeInTheDocument();
   });
 
+  it("snoozed rows pass the workspace's live agent status to the hover card", async () => {
+    // Same contract as the settled rows: a snoozed "review" workspace stays
+    // snoozed (only working/permission wake it early), so its row must hand
+    // the hover card the real computed status rather than hard-coding idle.
+    const base = Date.now();
+    persistInbox({
+      snoozed: [{ id: "ws-1", at: base, until: base + 3 * 3_600_000 }],
+    });
+    workspaces = [
+      makeWorkspace({ title: "Deferred work", surfaces: surfaceWithPane("p1") }),
+    ];
+    paneStatuses = { p1: "review" };
+    const { container } = await flushRender();
+
+    fireEvent.click(screen.getByRole("button", { name: "Snoozed (1)" }));
+    expect(
+      container.querySelector('[data-snoozed-row="ws-1"]'),
+    ).not.toBeNull();
+    expect(hoverCardStatus["ws-1"]).toBe("review");
+  });
+
   it("wakes a snoozed workspace whose wake time has already passed", async () => {
     const base = Date.now();
     persistInbox({ snoozed: [{ id: "ws-1", at: base - 1000, until: base - 1 }] });

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -63,6 +63,24 @@ vi.mock("@/hooks/use-project-actions", () => ({
   useProjectActions: () => ({ openProject: vi.fn() }),
 }));
 
+// Record the status each row hands its hover card (the card content itself is
+// unmounted while closed, so a render-through wrapper is the observable seam),
+// then delegate to the real component.
+let hoverCardStatus: Record<string, unknown> = {};
+vi.mock("./workspace-hover-card", async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import("./workspace-hover-card")>();
+  return {
+    ...mod,
+    WorkspaceHoverCard: (
+      props: Parameters<typeof mod.WorkspaceHoverCard>[0],
+    ) => {
+      hoverCardStatus[props.workspace.workspace_id] = props.status;
+      return <mod.WorkspaceHoverCard {...props} />;
+    },
+  };
+});
+
 vi.mock("@/stores/hosts-store", () => ({
   useHosts: () => [],
 }));
@@ -242,6 +260,7 @@ beforeEach(() => {
   paneStatuses = {};
   activeWorkspaceId = "";
   wsCounter = 0;
+  hoverCardStatus = {};
 });
 
 afterEach(async () => {
@@ -872,6 +891,25 @@ describe("SidebarInbox — settle / un-settle", () => {
 
     expect(screen.queryByText("Settled")).not.toBeInTheDocument();
     expect(container.querySelector('[data-inbox-card="ws-1"]')).not.toBeNull();
+  });
+
+  it("settled rows pass the workspace's live agent status to the hover card", async () => {
+    // Regression: settled rows hard-coded status={null}, so the hover card
+    // read "Idle" even while the workspace's agent was in "review". A settled
+    // "review" workspace stays settled (only working/permission resurface),
+    // so its row must still surface the real computed status.
+    persistedSettled = JSON.stringify([{ id: "ws-1", at: Date.now() }]);
+    workspaces = [
+      makeWorkspace({ title: "Finished work", surfaces: surfaceWithPane("p1") }),
+    ];
+    paneStatuses = { p1: "review" };
+    const { container } = await renderInbox();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-settled-row="ws-1"]')).not.toBeNull();
+    expect(hoverCardStatus["ws-1"]).toBe("review");
   });
 
   it("settled rows have the workspace context menu with Un-settle on top", async () => {

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -552,6 +552,10 @@ interface SnoozeRowProps {
   repo: InboxRepo;
   isActive: boolean;
   selected: boolean;
+  /** Live agent status for the hover card — same contract as `SettledRow`.
+   *  A snoozed "review" agent stays snoozed (only working/permission wake it
+   *  early), so the row must not hard-code idle. */
+  status: ActivePaneStatus | null;
   /** Time until the workspace comes back ("3h", "2d") — a snoozed row's whole
    *  story is its return ticket, so it shows time-until, not time-since. */
   timeUntil: string;
@@ -568,6 +572,7 @@ function SnoozeRow({
   repo,
   isActive,
   selected,
+  status,
   timeUntil,
   onWake,
   onSelect,
@@ -597,6 +602,11 @@ function SnoozeRow({
         onMarkUnread: () => onMarkUnread(workspace.workspace_id),
       }}
     >
+    {/* Same hover-details coverage as a settled row — a snoozed row is just as
+        lossy (one line, no meta), and the same bare-div nesting keeps the
+        ContextMenuTrigger and the hover trigger off one shared node. */}
+    <div>
+    <WorkspaceHoverCard workspace={workspace} repo={repo} status={status}>
       <div
         role="button"
         tabIndex={0}
@@ -660,6 +670,8 @@ function SnoozeRow({
           Wake now
         </button>
       </div>
+    </WorkspaceHoverCard>
+    </div>
     </WorkspaceInboxMenu>
   );
 }
@@ -1582,6 +1594,11 @@ export function SidebarInbox() {
                   repo={repo}
                   isActive={workspace.workspace_id === activeWorkspaceId}
                   selected={selectedIds.has(workspace.workspace_id)}
+                  status={
+                    paneStatuses
+                      ? getWorkspaceStatus(workspace.surfaces, paneStatuses)
+                      : null
+                  }
                   timeUntil={formatTimeUntil(entry.until - now)}
                   onWake={(id) => wake(id, "user")}
                   onSelect={handleSelect}

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -51,6 +51,7 @@ import {
   formatTimeUntil,
   type SnoozePreset,
 } from "./sidebar-snooze";
+import { WorkspaceHoverCard } from "./workspace-hover-card";
 import { activateWorkspace } from "@/tauri/commands";
 import {
   normalizePrState,
@@ -456,6 +457,11 @@ function SettledRow({
         onMarkUnread: () => onMarkUnread(workspace.workspace_id),
       }}
     >
+    {/* Settled rows show only a title, so the hover card carries even more
+        weight here than on an active card. Nested one level in so it never
+        shares a node with the ContextMenuTrigger above. */}
+    <div>
+    <WorkspaceHoverCard workspace={workspace} repo={repo} status={null}>
     <div
       role="button"
       tabIndex={0}
@@ -527,6 +533,8 @@ function SettledRow({
         <Undo2 className="h-2.5 w-2.5" />
         Un-settle
       </button>
+    </div>
+    </WorkspaceHoverCard>
     </div>
     </WorkspaceInboxMenu>
   );

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -412,6 +412,10 @@ interface SettledRowProps {
   repo: InboxRepo;
   isActive: boolean;
   selected: boolean;
+  /** Live agent status for the hover card — a settled workspace can still be
+   *  running (e.g. a "review" agent stays settled), so the row must not hard-
+   *  code idle. */
+  status: ActivePaneStatus | null;
   /** Elapsed-since-work-ended label ("2h"), or null when unknown. */
   time: string | null;
   justSettled: boolean;
@@ -425,6 +429,7 @@ function SettledRow({
   repo,
   isActive,
   selected,
+  status,
   time,
   justSettled,
   onUnsettle,
@@ -458,10 +463,12 @@ function SettledRow({
       }}
     >
     {/* Settled rows show only a title, so the hover card carries even more
-        weight here than on an active card. Nested one level in so it never
-        shares a node with the ContextMenuTrigger above. */}
+        weight here than on an active card. The bare div is intentional: it
+        takes the ContextMenuTrigger's `asChild` so the hover trigger below
+        never composes onto the same node, and the settled list is a plain
+        block container, so the extra block wrapper is layout-neutral. */}
     <div>
-    <WorkspaceHoverCard workspace={workspace} repo={repo} status={null}>
+    <WorkspaceHoverCard workspace={workspace} repo={repo} status={status}>
     <div
       role="button"
       tabIndex={0}
@@ -1604,6 +1611,11 @@ export function SidebarInbox() {
                   repo={repo}
                   isActive={workspace.workspace_id === activeWorkspaceId}
                   selected={selectedIds.has(workspace.workspace_id)}
+                  status={
+                    paneStatuses
+                      ? getWorkspaceStatus(workspace.surfaces, paneStatuses)
+                      : null
+                  }
                   time={formatElapsed(now - resolveSettledTimestamp(entry))}
                   justSettled={justSettledId === workspace.workspace_id}
                   onUnsettle={handleUnsettle}

--- a/src/components/layout/sidebar-rail-workspaces.tsx
+++ b/src/components/layout/sidebar-rail-workspaces.tsx
@@ -1,10 +1,6 @@
 import { startTransition, useEffect, useMemo } from "react";
 import { ProjectAvatar } from "@/components/ui/project-avatar";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { WorkspaceHoverCard } from "./workspace-hover-card";
 import {
   useAppStore,
   useHomeDir,
@@ -61,9 +57,11 @@ function RailWorkspaceItem({
     review: "bg-status-open",
   };
 
+  // Collapsed to a 28px avatar, the rail shows nothing but a status dot — so
+  // the same hover card the expanded inbox uses is the only way to tell two
+  // workspaces of one project apart without expanding the sidebar.
   return (
-    <Tooltip delayDuration={300}>
-      <TooltipTrigger asChild>
+    <WorkspaceHoverCard workspace={workspace} repo={repo} status={status}>
         <button
           type="button"
           data-rail-ws={workspace.workspace_id}
@@ -93,11 +91,7 @@ function RailWorkspaceItem({
             />
           )}
         </button>
-      </TooltipTrigger>
-      <TooltipContent side="right" className="text-xs">
-        {workspace.title}
-      </TooltipContent>
-    </Tooltip>
+    </WorkspaceHoverCard>
   );
 }
 

--- a/src/components/layout/workspace-hover-card.test.tsx
+++ b/src/components/layout/workspace-hover-card.test.tsx
@@ -1,6 +1,7 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, act } from "@testing-library/react";
+import { useSidebarDensityStore } from "@/stores/sidebar-density-store";
 import type {
   AppStateSnapshot,
   PortInfoSnapshot,
@@ -10,6 +11,7 @@ import type { HostView } from "@/tauri/commands";
 
 let detectedPorts: PortInfoSnapshot[] = [];
 let hosts: HostView[] = [];
+let homeDir: string | null = "/home/u";
 
 vi.mock("@/stores/app-store", () => {
   const state = () =>
@@ -21,7 +23,7 @@ vi.mock("@/stores/app-store", () => {
       vi.fn((selector: (s: unknown) => unknown) => selector(state())),
       { getState: state },
     ),
-    useHomeDir: () => "/home/u",
+    useHomeDir: () => homeDir,
   };
 });
 
@@ -104,6 +106,7 @@ function valueFor(label: string): string {
 beforeEach(() => {
   detectedPorts = [];
   hosts = [];
+  homeDir = "/home/u";
 });
 
 afterEach(cleanup);
@@ -151,6 +154,29 @@ describe("WorkspaceHoverCardBody — header", () => {
 
     renderBody(makeWorkspace(), null);
     expect(screen.getByText("Idle")).toBeInTheDocument();
+  });
+
+  it("ticks the elapsed label on the coarse clock while the card stays open", () => {
+    // Regression: elapsed was stamped once per mount, so "Working 1m" froze
+    // for as long as the pointer rested on the card.
+    vi.useFakeTimers();
+    try {
+      useSidebarDensityStore.setState({
+        statusSince: {
+          "ws-1": { status: "working", at: Date.now() - 60_000 },
+        },
+      });
+      renderBody(makeWorkspace(), "working");
+      expect(screen.getByText("1m")).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(4 * 60_000);
+      });
+      expect(screen.getByText("5m")).toBeInTheDocument();
+    } finally {
+      useSidebarDensityStore.setState({ statusSince: {} });
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -300,6 +326,25 @@ describe("WorkspaceHoverCardBody — location, mute, path", () => {
     expect(
       screen.getByText("~/.codemux/worktrees/myapp/feat-x"),
     ).toBeInTheDocument();
+  });
+
+  it("keeps a sibling-prefix path absolute (home /home/u vs /home/u2)", () => {
+    // Regression: a bare startsWith(homeDir) shortened /home/u2/project to
+    // "~2/project". Only a real path-separator boundary counts as home.
+    renderBody(makeWorkspace({ cwd: "/home/u2/project" }));
+    expect(screen.getByText("/home/u2/project")).toBeInTheDocument();
+    expect(screen.queryByText("~2/project")).not.toBeInTheDocument();
+  });
+
+  it("collapses a path that IS the home dir to a bare ~", () => {
+    renderBody(makeWorkspace({ cwd: "/home/u" }));
+    expect(screen.getByText("~")).toBeInTheDocument();
+  });
+
+  it("shortens under a home dir reported with a trailing separator", () => {
+    homeDir = "/home/u/";
+    renderBody(makeWorkspace({ cwd: "/home/u/projects/myapp" }));
+    expect(screen.getByText("~/projects/myapp")).toBeInTheDocument();
   });
 
   it("falls back to the remote cwd for an attach-in-place workspace", () => {

--- a/src/components/layout/workspace-hover-card.test.tsx
+++ b/src/components/layout/workspace-hover-card.test.tsx
@@ -1,0 +1,318 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import type {
+  AppStateSnapshot,
+  PortInfoSnapshot,
+  WorkspaceSnapshot,
+} from "@/tauri/types";
+import type { HostView } from "@/tauri/commands";
+
+let detectedPorts: PortInfoSnapshot[] = [];
+let hosts: HostView[] = [];
+
+vi.mock("@/stores/app-store", () => {
+  const state = () =>
+    ({
+      appState: { detected_ports: detectedPorts } as unknown as AppStateSnapshot,
+    }) as unknown;
+  return {
+    useAppStore: Object.assign(
+      vi.fn((selector: (s: unknown) => unknown) => selector(state())),
+      { getState: state },
+    ),
+    useHomeDir: () => "/home/u",
+  };
+});
+
+vi.mock("@/stores/hosts-store", () => ({
+  useHosts: () => hosts,
+}));
+
+vi.mock("./use-project-appearance", () => ({
+  useProjectAppearance: () => ({
+    customColor: null,
+    imageUrl: null,
+    imageVersion: 0,
+  }),
+}));
+
+import { WorkspaceHoverCardBody } from "./workspace-hover-card";
+
+function makeWorkspace(
+  overrides: Partial<WorkspaceSnapshot> = {},
+): WorkspaceSnapshot {
+  return {
+    workspace_id: "ws-1",
+    title: "my-workspace",
+    workspace_type: "standard",
+    cwd: "/home/u/projects/myapp",
+    project_root: "/home/u/projects/myapp",
+    git_branch: "main",
+    git_ahead: 0,
+    git_behind: 0,
+    git_additions: 0,
+    git_deletions: 0,
+    git_changed_files: 0,
+    notification_count: 0,
+    notifications_muted: false,
+    latest_agent_state: null,
+    worktree_path: null,
+    pr_number: null,
+    pr_state: null,
+    pr_url: null,
+    linked_issue: null,
+    tabs: [],
+    active_tab_id: "",
+    active_surface_id: "",
+    surfaces: [],
+    ...overrides,
+  };
+}
+
+function makePort(overrides: Partial<PortInfoSnapshot> = {}): PortInfoSnapshot {
+  return {
+    port: 3000,
+    pid: 1,
+    process_name: "node",
+    workspace_id: "ws-1",
+    label: null,
+    source: null,
+    ...overrides,
+  };
+}
+
+function renderBody(
+  workspace: WorkspaceSnapshot,
+  status: Parameters<typeof WorkspaceHoverCardBody>[0]["status"] = null,
+) {
+  return render(
+    <WorkspaceHoverCardBody
+      workspace={workspace}
+      repo={{ name: "myapp", path: "/home/u/projects/myapp" }}
+      status={status}
+    />,
+  );
+}
+
+/** The value rendered next to a given label row. */
+function valueFor(label: string): string {
+  const labelEl = screen.getByText(label);
+  return labelEl.nextElementSibling?.textContent ?? "";
+}
+
+beforeEach(() => {
+  detectedPorts = [];
+  hosts = [];
+});
+
+afterEach(cleanup);
+
+describe("WorkspaceHoverCardBody — header", () => {
+  it("shows the repo name and the FULL title (the row truncates it)", () => {
+    renderBody(
+      makeWorkspace({
+        title: "a-very-long-workspace-name-the-sidebar-row-cannot-show",
+      }),
+    );
+    expect(screen.getByText("myapp")).toBeInTheDocument();
+    expect(
+      screen.getByText("a-very-long-workspace-name-the-sidebar-row-cannot-show"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the linked issue number and title under the workspace title", () => {
+    renderBody(
+      makeWorkspace({
+        linked_issue: {
+          number: 42,
+          title: "Fix the flaky sidebar test",
+          state: "Open",
+          labels: [],
+        },
+      }),
+    );
+    expect(screen.getByText("#42")).toBeInTheDocument();
+    expect(screen.getByText(/Fix the flaky sidebar test/)).toBeInTheDocument();
+  });
+
+  it("labels each agent status with its own tone, and idle when there is none", () => {
+    const { unmount } = renderBody(makeWorkspace(), "working");
+    expect(screen.getByText("Working")).toHaveClass("text-status-working");
+    unmount();
+
+    const needs = renderBody(makeWorkspace(), "permission");
+    expect(screen.getByText("Needs you")).toHaveClass("text-status-attention");
+    needs.unmount();
+
+    const review = renderBody(makeWorkspace(), "review");
+    expect(screen.getByText("Done · review")).toHaveClass("text-status-open");
+    review.unmount();
+
+    renderBody(makeWorkspace(), null);
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+  });
+});
+
+describe("WorkspaceHoverCardBody — git rows", () => {
+  it("surfaces behind + changed-file counts the sidebar row never shows", () => {
+    renderBody(
+      makeWorkspace({
+        git_branch: "feature/x",
+        git_ahead: 2,
+        git_behind: 3,
+        git_additions: 10,
+        git_deletions: 4,
+        git_changed_files: 6,
+      }),
+    );
+    expect(valueFor("Branch")).toBe("feature/x");
+    expect(valueFor("Uncommitted")).toBe("+10 −4");
+    expect(valueFor("Changed files")).toBe("6");
+    expect(valueFor("Ahead")).toBe("↑2");
+    expect(valueFor("Behind")).toBe("↓3");
+  });
+
+  it("states a clean working tree outright rather than showing nothing", () => {
+    renderBody(makeWorkspace({ git_branch: "main" }));
+    expect(valueFor("Working tree")).toBe("clean");
+    expect(screen.queryByText("Uncommitted")).not.toBeInTheDocument();
+    expect(screen.queryByText("Changed files")).not.toBeInTheDocument();
+  });
+
+  it("omits ahead/behind rows when there is nothing to report", () => {
+    renderBody(makeWorkspace({ git_ahead: 0, git_behind: 0 }));
+    expect(screen.queryByText("Ahead")).not.toBeInTheDocument();
+    expect(screen.queryByText("Behind")).not.toBeInTheDocument();
+  });
+
+  it("drops every git row for a non-git workspace", () => {
+    renderBody(
+      makeWorkspace({
+        is_git: false,
+        git_branch: "main",
+        git_additions: 5,
+        git_changed_files: 2,
+      }),
+    );
+    for (const label of [
+      "Branch",
+      "Uncommitted",
+      "Changed files",
+      "Working tree",
+    ]) {
+      expect(screen.queryByText(label)).not.toBeInTheDocument();
+    }
+  });
+});
+
+describe("WorkspaceHoverCardBody — PR, issue, ports", () => {
+  it("shows PR number and state with the shared PR tone", () => {
+    renderBody(makeWorkspace({ pr_number: 140, pr_state: "merged" }));
+    expect(valueFor("Pull request")).toBe("#140 · merged");
+    expect(screen.getByText("#140 · merged")).toHaveClass("text-accent-violet");
+  });
+
+  it("tones an open issue as success and a closed one as muted", () => {
+    const { unmount } = renderBody(
+      makeWorkspace({
+        linked_issue: { number: 7, title: "t", state: "Open", labels: [] },
+      }),
+    );
+    expect(screen.getByText("#7 · Open")).toHaveClass("text-success");
+    unmount();
+
+    renderBody(
+      makeWorkspace({
+        linked_issue: { number: 7, title: "t", state: "Closed", labels: [] },
+      }),
+    );
+    expect(screen.getByText("#7 · Closed")).toHaveClass("text-muted-foreground");
+  });
+
+  it("lists this workspace's ports only, singular label for one", () => {
+    detectedPorts = [
+      makePort({ port: 3000 }),
+      makePort({ port: 5173, workspace_id: "other-ws" }),
+    ];
+    renderBody(makeWorkspace());
+    expect(valueFor("Port")).toBe(":3000");
+  });
+
+  it("caps the port list at three and counts the overflow", () => {
+    detectedPorts = [3000, 3001, 3002, 3003, 3004].map((port) =>
+      makePort({ port }),
+    );
+    renderBody(makeWorkspace());
+    expect(valueFor("Ports")).toBe(":3000 :3001 :3002 +2");
+  });
+
+  it("omits the ports row when none are detected", () => {
+    renderBody(makeWorkspace());
+    expect(screen.queryByText("Port")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ports")).not.toBeInTheDocument();
+  });
+});
+
+describe("WorkspaceHoverCardBody — location, mute, path", () => {
+  it("reads 'This device' for a local workspace", () => {
+    renderBody(makeWorkspace());
+    expect(valueFor("Location")).toBe("This device");
+  });
+
+  it("names the host for a remote workspace", () => {
+    hosts = [{ id: 3, name: "beelink" } as HostView];
+    renderBody(makeWorkspace({ host_id: 3 }));
+    expect(valueFor("Location")).toBe("beelink");
+    expect(screen.getByText("beelink")).toHaveClass("text-status-remote");
+  });
+
+  it("still reads as remote when the hosts list has not resolved the name yet", () => {
+    // hosts load asynchronously; an unresolved lookup must not claim "local".
+    hosts = [];
+    renderBody(makeWorkspace({ host_id: 9 }));
+    expect(valueFor("Location")).toBe("Another device");
+    expect(screen.getByText("Another device")).toHaveClass("text-status-remote");
+  });
+
+  it("marks an attach-in-place workspace as running on the host", () => {
+    hosts = [{ id: 3, name: "beelink" } as HostView];
+    renderBody(makeWorkspace({ host_id: 3, attach_only: true }));
+    expect(valueFor("Location")).toBe("beelink · in place");
+  });
+
+  it("shows the muted row only when notifications are muted", () => {
+    const { unmount } = renderBody(makeWorkspace({ notifications_muted: true }));
+    expect(valueFor("Notifications")).toBe("muted");
+    unmount();
+
+    renderBody(makeWorkspace({ notifications_muted: false }));
+    expect(screen.queryByText("Notifications")).not.toBeInTheDocument();
+  });
+
+  it("prefers the worktree path and collapses $HOME to ~", () => {
+    renderBody(
+      makeWorkspace({
+        cwd: "/home/u/projects/myapp",
+        worktree_path: "/home/u/.codemux/worktrees/myapp/feat-x",
+      }),
+    );
+    expect(
+      screen.getByText("~/.codemux/worktrees/myapp/feat-x"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the remote cwd for an attach-in-place workspace", () => {
+    hosts = [{ id: 1, name: "box" } as HostView];
+    renderBody(
+      makeWorkspace({
+        host_id: 1,
+        attach_only: true,
+        worktree_path: null,
+        remote_cwd: "/srv/work/myapp",
+      }),
+    );
+    // Not under $HOME, so it stays absolute rather than gaining a bogus "~".
+    expect(screen.getByText("/srv/work/myapp")).toBeInTheDocument();
+  });
+});

--- a/src/components/layout/workspace-hover-card.tsx
+++ b/src/components/layout/workspace-hover-card.tsx
@@ -13,6 +13,7 @@ import {
 import { useAppStore, useHomeDir } from "@/stores/app-store";
 import { useHosts } from "@/stores/hosts-store";
 import { getWorkspaceProviders } from "@/lib/pane-status";
+import { useCoarseClock } from "@/lib/use-coarse-clock";
 import {
   formatElapsed,
   useSidebarDensityStore,
@@ -31,8 +32,8 @@ export interface HoverCardRepo {
 interface Props {
   workspace: WorkspaceSnapshot;
   repo: HoverCardRepo;
-  /** Derived agent status, when the caller already subscribes to it. The rail
-   *  and the inbox card both have it; settled rows pass null. */
+  /** Derived agent status. Every caller — rail, inbox card, settled row —
+   *  computes it from the live pane statuses; null means genuinely idle. */
   status: ActivePaneStatus | null;
   children: React.ReactNode;
 }
@@ -44,10 +45,21 @@ const OPEN_DELAY_MS = 350;
 const CLOSE_DELAY_MS = 120;
 
 /** Collapse `$HOME` to `~` so long worktree paths stay readable in the narrow
- *  card. Falls back to the raw path when the home dir isn't known yet. */
+ *  card. Only a real home-directory boundary counts: with home `/home/u`, a
+ *  sibling like `/home/u2/project` must stay absolute, so the character after
+ *  the prefix has to be a path separator (or the path IS home). Accepts both
+ *  `/` and `\` since remote workspaces can live on Windows hosts. Falls back
+ *  to the raw path when the home dir isn't known yet. */
 function shortenPath(path: string, homeDir: string | null): string {
-  if (!homeDir || !path.startsWith(homeDir)) return path;
-  return `~${path.slice(homeDir.length)}`;
+  if (!homeDir) return path;
+  // A reported home dir may carry a trailing separator ("/home/u/"); strip it
+  // so the boundary check below sees the bare prefix.
+  const home = homeDir.replace(/[/\\]+$/, "");
+  if (home.length === 0 || !path.startsWith(home)) return path;
+  const next = path[home.length];
+  if (next === undefined) return "~"; // the path IS the home dir
+  if (next !== "/" && next !== "\\") return path; // sibling prefix, not home
+  return `~${path.slice(home.length)}`;
 }
 
 const STATUS_LABEL: Record<ActivePaneStatus, string> = {
@@ -86,10 +98,11 @@ export function WorkspaceHoverCard({
         side="right"
         align="start"
         sideOffset={10}
-        // Not interactive: the card is a read-only detail surface, so let
-        // pointer events fall through to whatever is underneath rather than
-        // trapping the cursor on the way to the content area.
-        className="pointer-events-none w-[290px] p-0"
+        // Pointer events stay enabled so the path and branch can be selected
+        // and copied. Radix keeps the card open while the cursor crosses into
+        // it (closeDelay), and side="right" floats it over the main pane —
+        // never between the cursor and another sidebar row.
+        className="w-[290px] p-0"
       >
         <WorkspaceHoverCardBody
           workspace={workspace}
@@ -141,10 +154,13 @@ export function WorkspaceHoverCardBody({
 
   // Elapsed since the current state began. Stamped client-side (the backend
   // sends no status-changed-at), so it reads "just now" after an app restart.
-  // Read at open time rather than off a ticking clock — the card is short-lived.
+  // Ticks on the shared coarse (~30s) clock so a pointer resting on the card
+  // never shows a frozen "4m" — and since Radix unmounts closed content, the
+  // interval only runs while a card is actually open.
   const stateSince =
     status !== null ? (statusSince?.at ?? null) : (settledAt ?? null);
-  const elapsed = stateSince != null ? formatElapsed(Date.now() - stateSince) : null;
+  const now = useCoarseClock(stateSince != null);
+  const elapsed = stateSince != null ? formatElapsed(now - stateSince) : null;
 
   const isGit = workspace.is_git !== false;
   const hasUncommitted =

--- a/src/components/layout/workspace-hover-card.tsx
+++ b/src/components/layout/workspace-hover-card.tsx
@@ -1,0 +1,336 @@
+import { useMemo } from "react";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { ProjectAvatar } from "@/components/ui/project-avatar";
+import { ProviderLogo } from "@/components/chat/provider-logo";
+import {
+  normalizePrState,
+  prStatusTextClass,
+} from "@/components/github/pr-status-icon";
+import { useAppStore, useHomeDir } from "@/stores/app-store";
+import { useHosts } from "@/stores/hosts-store";
+import { getWorkspaceProviders } from "@/lib/pane-status";
+import {
+  formatElapsed,
+  useSidebarDensityStore,
+} from "@/stores/sidebar-density-store";
+import { useProjectAppearance } from "./use-project-appearance";
+import { cn } from "@/lib/utils";
+import type { ActivePaneStatus, WorkspaceSnapshot } from "@/tauri/types";
+
+/** Project identity for the hovered workspace — same shape the inbox card
+ *  and the rail already resolve from the grouping pipeline. */
+export interface HoverCardRepo {
+  name: string;
+  path: string;
+}
+
+interface Props {
+  workspace: WorkspaceSnapshot;
+  repo: HoverCardRepo;
+  /** Derived agent status, when the caller already subscribes to it. The rail
+   *  and the inbox card both have it; settled rows pass null. */
+  status: ActivePaneStatus | null;
+  children: React.ReactNode;
+}
+
+/** How long the pointer must rest on a row before the card opens. Long enough
+ *  that sweeping the mouse down the sidebar never flashes a card, short enough
+ *  that a deliberate hover feels instant. */
+const OPEN_DELAY_MS = 350;
+const CLOSE_DELAY_MS = 120;
+
+/** Collapse `$HOME` to `~` so long worktree paths stay readable in the narrow
+ *  card. Falls back to the raw path when the home dir isn't known yet. */
+function shortenPath(path: string, homeDir: string | null): string {
+  if (!homeDir || !path.startsWith(homeDir)) return path;
+  return `~${path.slice(homeDir.length)}`;
+}
+
+const STATUS_LABEL: Record<ActivePaneStatus, string> = {
+  working: "Working",
+  permission: "Needs you",
+  review: "Done · review",
+};
+
+const STATUS_TONE: Record<ActivePaneStatus, string> = {
+  working: "text-status-working",
+  permission: "text-status-attention",
+  review: "text-status-open",
+};
+
+/**
+ * Hover details for a sidebar workspace. The sidebar row is deliberately terse
+ * — a truncated title, a branch, and a couple of counters — so everything the
+ * row had to drop lands here: the full title, the linked issue, the complete
+ * git picture (including `behind` and changed-file counts the row never shows),
+ * PR state, detected ports, which device it runs on, and the real path on disk.
+ *
+ * Wraps its children as the trigger. Mount it INSIDE the context-menu wrapper
+ * (on a different element than `ContextMenuTrigger`) so the two `asChild`
+ * triggers never compose onto the same node.
+ */
+export function WorkspaceHoverCard({
+  workspace,
+  repo,
+  status,
+  children,
+}: Props) {
+  return (
+    <HoverCard openDelay={OPEN_DELAY_MS} closeDelay={CLOSE_DELAY_MS}>
+      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardContent
+        side="right"
+        align="start"
+        sideOffset={10}
+        // Not interactive: the card is a read-only detail surface, so let
+        // pointer events fall through to whatever is underneath rather than
+        // trapping the cursor on the way to the content area.
+        className="pointer-events-none w-[290px] p-0"
+      >
+        <WorkspaceHoverCardBody
+          workspace={workspace}
+          repo={repo}
+          status={status}
+        />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+/** The card's contents, split out so its stores are only subscribed while a
+ *  card is actually open — Radix unmounts closed content, so a sidebar of 20
+ *  workspaces pays for zero of these hooks at rest. Exported so tests can
+ *  assert on the rows without driving Radix's hover timers. */
+export function WorkspaceHoverCardBody({
+  workspace,
+  repo,
+  status,
+}: {
+  workspace: WorkspaceSnapshot;
+  repo: HoverCardRepo;
+  status: ActivePaneStatus | null;
+}) {
+  const appearance = useProjectAppearance(repo.path);
+  const homeDir = useHomeDir();
+  const hosts = useHosts();
+  // Select the raw slice, then narrow in a memo: a selector that returns a
+  // fresh array every call breaks `useSyncExternalStore`'s snapshot equality
+  // and spins React into an infinite re-render.
+  const detectedPorts = useAppStore((s) => s.appState?.detected_ports);
+  const ports = useMemo(
+    () =>
+      (detectedPorts ?? []).filter(
+        (p) => p.workspace_id === workspace.workspace_id,
+      ),
+    [detectedPorts, workspace.workspace_id],
+  );
+  const statusSince = useSidebarDensityStore(
+    (s) => s.statusSince[workspace.workspace_id],
+  );
+  const settledAt = useSidebarDensityStore(
+    (s) => s.settledAt[workspace.workspace_id],
+  );
+
+  const providers = getWorkspaceProviders(workspace.surfaces);
+  const prState = normalizePrState(workspace.pr_state);
+  const issue = workspace.linked_issue;
+
+  // Elapsed since the current state began. Stamped client-side (the backend
+  // sends no status-changed-at), so it reads "just now" after an app restart.
+  // Read at open time rather than off a ticking clock — the card is short-lived.
+  const stateSince =
+    status !== null ? (statusSince?.at ?? null) : (settledAt ?? null);
+  const elapsed = stateSince != null ? formatElapsed(Date.now() - stateSince) : null;
+
+  const isGit = workspace.is_git !== false;
+  const hasUncommitted =
+    workspace.git_additions > 0 || workspace.git_deletions > 0;
+
+  // `host_id` alone decides remote-ness. The hosts list loads asynchronously,
+  // so a name may not be resolvable yet — fall back to a neutral label rather
+  // than letting an unresolved lookup claim the workspace is local.
+  const isRemote = workspace.host_id != null;
+  const host = isRemote
+    ? (hosts.find((h) => h.id === workspace.host_id) ?? null)
+    : null;
+  const location = isRemote
+    ? `${host?.name ?? "Another device"}${workspace.attach_only ? " · in place" : ""}`
+    : "This device";
+
+  // The worktree checkout is the path the user actually works in; remote_cwd
+  // is the real path on the host for an attach-in-place workspace.
+  const path = workspace.worktree_path ?? workspace.remote_cwd ?? workspace.cwd;
+
+  return (
+    <>
+      <div className="border-b px-3.5 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <ProjectAvatar
+            name={repo.name}
+            color={appearance.customColor}
+            imageUrl={appearance.imageUrl}
+            cacheBust={appearance.imageVersion}
+            size="sm"
+            shape="square"
+            className="font-bold"
+          />
+          <span className="min-w-0 flex-1 truncate text-[11px] font-semibold tracking-[0.01em] text-muted-foreground/80">
+            {repo.name}
+          </span>
+          {providers.map((p) => (
+            <ProviderLogo
+              key={p}
+              provider={p}
+              className="h-[13px] w-[13px] shrink-0 opacity-80"
+            />
+          ))}
+          <span
+            className={cn(
+              "shrink-0 text-[10.5px] font-semibold",
+              status ? STATUS_TONE[status] : "text-muted-foreground/70",
+            )}
+          >
+            {status ? STATUS_LABEL[status] : "Idle"}
+            {elapsed && (
+              <span className="ml-1 font-normal tabular-nums opacity-70">
+                {elapsed}
+              </span>
+            )}
+          </span>
+        </div>
+        {/* Full title — the row truncates it, so this is often the whole
+            reason the user hovered. */}
+        <div className="mt-1 text-[12.5px] font-bold leading-[1.35] text-foreground">
+          {workspace.title}
+        </div>
+        {issue && (
+          <div className="mt-0.5 text-[11px] leading-snug text-muted-foreground">
+            <span className="font-mono">#{issue.number}</span> {issue.title}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-0.5 p-1.5">
+        {isGit && workspace.git_branch && (
+          <DetailRow label="Branch" value={workspace.git_branch} muted />
+        )}
+        {isGit && hasUncommitted && (
+          <DetailRow
+            label="Uncommitted"
+            value={`+${workspace.git_additions} −${workspace.git_deletions}`}
+          />
+        )}
+        {isGit && workspace.git_changed_files > 0 && (
+          <DetailRow
+            label="Changed files"
+            value={String(workspace.git_changed_files)}
+            muted
+          />
+        )}
+        {isGit && workspace.git_ahead > 0 && (
+          <DetailRow
+            label="Ahead"
+            value={`↑${workspace.git_ahead}`}
+            valueClassName="text-success"
+          />
+        )}
+        {isGit && workspace.git_behind > 0 && (
+          <DetailRow
+            label="Behind"
+            value={`↓${workspace.git_behind}`}
+            valueClassName="text-warning"
+          />
+        )}
+        {/* A clean tree is worth stating outright — the row shows nothing at
+            all in that case, which is ambiguous with "stats hidden". */}
+        {isGit &&
+          !hasUncommitted &&
+          workspace.git_changed_files === 0 &&
+          workspace.git_branch && (
+            <DetailRow label="Working tree" value="clean" muted />
+          )}
+        {prState && (
+          <DetailRow
+            label="Pull request"
+            value={`#${workspace.pr_number ?? ""} · ${prState}`}
+            valueClassName={prStatusTextClass(workspace.pr_state) ?? undefined}
+          />
+        )}
+        {issue && (
+          <DetailRow
+            label="Issue"
+            value={`#${issue.number} · ${issue.state}`}
+            valueClassName={
+              issue.state === "Open" ? "text-success" : "text-muted-foreground"
+            }
+          />
+        )}
+        {ports.length > 0 && (
+          <DetailRow
+            label={ports.length === 1 ? "Port" : "Ports"}
+            value={ports
+              .slice(0, 3)
+              .map((p) => `:${p.port}`)
+              .join(" ")
+              .concat(ports.length > 3 ? ` +${ports.length - 3}` : "")}
+            valueClassName="text-status-remote"
+          />
+        )}
+        <DetailRow
+          label="Location"
+          value={location}
+          valueClassName={isRemote ? "text-status-remote" : undefined}
+          muted={!isRemote}
+        />
+        {workspace.notifications_muted && (
+          <DetailRow label="Notifications" value="muted" muted />
+        )}
+      </div>
+
+      {/* Real path on disk, last: the least-scannable line, and the one users
+          most often want to copy or confirm. Wraps rather than truncates. */}
+      <div className="border-t px-3.5 py-2">
+        <div className="break-all font-mono text-[10px] leading-relaxed text-muted-foreground/70">
+          {shortenPath(path, homeDir)}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  valueClassName,
+  muted,
+}: {
+  label: string;
+  value: string;
+  /** Explicit tone class for the value (warning/success/PR-state).
+   *  Falls back to `muted` when omitted. */
+  valueClassName?: string;
+  muted?: boolean;
+}) {
+  return (
+    // The label is short and known; the value can be a long worktree branch.
+    // So the label holds its width and the VALUE truncates — the reverse
+    // would leave you reading "Bran…" next to the thing you came to see.
+    <div className="flex items-center gap-3 rounded-md px-2 py-1.5">
+      <span className="shrink-0 text-[11.5px] text-muted-foreground">
+        {label}
+      </span>
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-right font-mono text-[11px] tabular-nums",
+          valueClassName ?? (muted ? "text-muted-foreground" : "text-foreground"),
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Why

Every sidebar surface is lossy. An inbox card truncates its title and never renders `git_behind` or `git_changed_files` at all — both already ride on `WorkspaceSnapshot` and were displayed nowhere. A settled row shows only a title. A collapsed rail avatar shows nothing but a status dot, behind a title-only tooltip.

Resting the pointer on any of the three now opens a shared read-only `HoverCard` to the right (350ms open, 290px, `side="right" align="start"`).

## What it shows

Header — repo eyebrow, provider marks, agent state with elapsed, the **full untruncated title**, and the linked issue's number + title.

Rows, all conditional except Location — Branch, Uncommitted `+A −D`, Changed files, Ahead, Behind (or a single "Working tree · clean" row when there is nothing to report), Pull request, Issue, Port(s) capped at 3 with a `+N` overflow, Location (`This device` / host name / `host · in place`), Notifications muted.

Footer — the real path on disk (`worktree_path ?? remote_cwd ?? cwd`), `$HOME` collapsed to `~`, wrapped rather than truncated.

**No new Tauri command.** Every field is already on `WorkspaceSnapshot` or in `appState.detected_ports`. Styling reuses the `DetailRow` label/value shape from the context bar's popover rather than inventing a second vocabulary.

## Implementation notes

- The body is a separate component so Radix's unmount-when-closed keeps a sidebar of N workspaces from subscribing N times to the ports/hosts stores at rest.
- Ports are selected as a raw slice and narrowed in a `useMemo`. Filtering inside the zustand selector returns a fresh array per call, which breaks `useSyncExternalStore` snapshot equality and spins React into an infinite re-render loop — this crashed the card tree during development and was caught only by running the real app.
- Remote-ness keys off `host_id` alone. The hosts list loads asynchronously, so an unresolved name falls back to "Another device" rather than letting a failed lookup claim the workspace is local.
- Mounted inside `WorkspaceInboxMenu` on a different node than `ContextMenuTrigger`, so the two `asChild` triggers never compose onto one element.
- The label holds its width and the value truncates. The reverse rendered long worktree branches as `Bran…` next to the thing you came to see.
- The card is `pointer-events-none` — a detail surface, not an interactive one. Reviewers may want to overrule this: it means you cannot mouse in to select the branch name or path.

Removes the rail's title-only tooltip and the card's redundant native `title` attribute, which would have raced the hover card on the same element.

## Verification

- `npm run check` clean.
- `npm run test` — 210 files, 3069 tests pass, including 19 new ones covering the git rows, clean-tree fallback, non-git workspaces, PR/issue tones, port capping, the async-host fallback, mute, and path shortening.
- Visually confirmed in the dev build across all three surfaces (inbox card, settled row, collapsed rail), with instrumented `pointerenter` proving real mouse input opens it.
- Zero raw Tailwind palette utilities — status/accent tokens only, per the design system.
- `npm run verify` does **not** complete in this worktree: `cargo check` fails on a missing `src-tauri/binaries/agent-browser` sidecar. Pre-existing environment gap, unrelated — this branch touches no Rust.

Docs updated in `docs/features/sidebar.md` (inbox section, rail section, What Works, Constraints, Touch Points).