### PR TITLE
Section the "Run in" picker into Active / Settled

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -1694,10 +1694,17 @@ disguised as a scope control.
 **Location popover is keyboard-first.** The "Run in" popover is a cmdk
 `Command` with `shouldFilter={false}` plus a `CommandInput`
 ("Search projects…"), so opening it focuses the search field and the
-whole flow is type → `Enter` with no mouse. Radix's default
-auto-focus is deliberately NOT overridden here (unlike the checkout /
-branch popovers, which use `focusCmdkRootOnOpen`) — the input is the
-first focusable child and forwards arrow/Enter to cmdk itself.
+whole flow is type → `Enter` with no mouse. Every cmdk popover in the
+app routes Radix's open-autofocus through `focusCmdkOnOpen`
+(`src/components/chat/pickers/focus-cmdk-root.ts`): it targets the
+`[cmdk-input]` when the popover has one — the search field must own
+focus so typing filters immediately, and being a descendant of the
+root it still forwards arrow/Enter to cmdk — and falls back to the
+`[cmdk-root]` div on input-less pickers, which is what keeps arrow-key
+navigation alive there. The input MUST win when present: cmdk's root
+keydown only handles navigation keys, so focusing the root on an
+input-bearing popover would leave printable keystrokes with nowhere to
+go until the user clicked the search box.
 Filtering + ranking is `fuzzyFilter` from `src/lib/fuzzy.ts` (shared
 scored subsequence matcher, also used by the GitHub issue/PR pickers):
 prefix beats substring beats scattered subsequence, word-boundary and
@@ -1706,11 +1713,60 @@ shorter candidates win ties. The haystack is the display name; a query
 containing `/` switches it to the full project path, which is how two
 checkouts of the same repo are disambiguated. Matching name AND path
 at once was tried and reverted — a short query is a subsequence of
-nearly every long path, so the list stops narrowing. "Home directory
+nearly every long path, so the list stops narrowing (a query grazing
+the shared `/home/…/projects/` prefix would otherwise match every row).
+"Home directory
 (~)" is filtered as a row like any other (it matches `home` and `~`),
 while "Open another project…" sits outside `CommandList` and is never
 filtered — it has to stay reachable exactly when nothing matched. The
 query resets on close so the next open starts from the full list.
+
+**Location list — Active / Settled sections.** The "Run in" popover
+lists every project that has a live workspace, i.e. the same set the
+sidebar draws from. Because parking a workspace (settling OR snoozing —
+see `docs/features/sidebar.md`) hides its sidebar card without closing
+anything, that set only ever grows: a long-lived install accumulates a
+dozen-plus projects that are all still valid targets. A flat, unsorted,
+uncapped list buried the project you touched a minute ago below one you
+settled months ago. So the popover mirrors the sidebar's own vocabulary
+(`project-scope-list.ts`):
+
+- **Active** — at least one workspace is unparked (still has a sidebar
+  card). Ordered most-recently-active first, using the inbox store's
+  `activity` stamps. Unstamped projects rank last and keep their
+  app-state order, so the ordering is strictly better than insertion
+  order rather than dependent on a signal we can't guarantee.
+- **Settled · still open** — every workspace is parked. BOTH parked
+  lifecycles fold into this side of the partition — a project whose
+  workspaces are all *snoozed* must not read as Active any more than a
+  fully-settled one — and any future parked state must fold in the same
+  way (`partitionProjectScopes` documents the invariant). Deprioritized,
+  never hidden: starting a thread here is how you resurrect parked work.
+  Ordered most-recently-parked first and collapsed to
+  `SETTLED_COLLAPSED_COUNT` behind a "Show N more" row. The
+  currently-targeted project is always shown even from the hidden tail —
+  a checkmark the user can't see reads as a lost selection.
+- Section headings appear **only** when something is parked; otherwise
+  the popover stays the flat list it always was.
+- A search spans both sections: each is filtered + ranked by
+  `fuzzyFilter` separately (Active always above Settled), a non-empty
+  query reveals the full settled tail, and the "Show N more" row never
+  appears in search results. `CommandList` is capped + scrollable,
+  bounded by `--radix-popover-content-available-height` so the taller
+  sectioned popover can't clip off the top of a short window.
+- Avatar loading is scoped to the rows actually on screen (it used to
+  fetch 3 UI-state keys for EVERY known project on every open — 50+ IPC
+  round trips on a long-lived install); expanding or searching pays only
+  for what it newly reveals, and the per-open fetch generation resets so
+  appearance edits made elsewhere in the session are picked up.
+
+All signals come from `sidebar-inbox-store`, so the picker's order can't
+disagree with the sidebar. It reads that store but never writes it:
+selecting a parked project deliberately does **not** un-settle or wake
+it, because the inbox already resurfaces a parked workspace the moment
+its agent goes `working` — which is exactly what first send does.
+Un-parking on mere selection would also fire while the user is only
+browsing locations.
 
 **Pane-surface state.** `AgentChatPane` holds no scope state at all —
 no `checkoutMode`, no `worktreeName`, no `baseBranch`, no scope

--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -162,6 +162,13 @@ visual only — nothing is archived, closed, or deleted.
   now, then Settle, "Snooze until…", Mark unread — since a user who right-clicks
   a hidden row is usually there to undo the hiding. Every shape keeps
   rename / archive / delete / move-to-host below that.
+  Because a parked (settled or snoozed) workspace is still fully open, it also
+  stays a valid target in agent chat's "Run in" location picker, which reads
+  this same store to split its list into **Active** and **Settled · still
+  open** sections — both parked lifecycles fold into the parked side (see
+  `docs/features/agent-chat.md` → "Thread Scope"). The picker never writes the
+  store: selecting a parked project doesn't un-settle or wake it, because the
+  safety nets here already resurface it once its agent runs.
 - **Settled shelf ordering — by when work ENDED**: a settled entry records both
   `at` (when the sweep happened) and, when the caller knows it, `workEndedAt`
   (the workspace's backend `last_active_at` at settle time).

--- a/src/components/chat/pickers/ModelPicker.tsx
+++ b/src/components/chat/pickers/ModelPicker.tsx
@@ -16,7 +16,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { AgentChatProviderKind } from "@/tauri/types";
 import { ProviderLogo } from "../provider-logo";
-import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { focusCmdkOnOpen } from "./focus-cmdk-root";
 import { FOOTER_TRIGGER } from "./footer-trigger";
 
 // The model list + default-model / label helpers moved to
@@ -111,7 +111,7 @@ export function ModelPicker({
       <PopoverContent
         className="w-[300px] p-0"
         align="start"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         <Command>
           <CommandList className="max-h-[300px]">

--- a/src/components/chat/pickers/MultiProviderModelPicker.test.tsx
+++ b/src/components/chat/pickers/MultiProviderModelPicker.test.tsx
@@ -381,6 +381,31 @@ describe("MultiProviderModelPicker — provider rail", () => {
 });
 
 describe("MultiProviderModelPicker — search", () => {
+  it("focuses the search box on open so typing filters without a click", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await openPicker(user);
+
+    // The provider rail's buttons precede the input in the DOM, so a
+    // default first-tabbable autofocus would land on the rail — the
+    // open-autofocus handler must aim at the input itself.
+    const input = screen.getByPlaceholderText("Search models...");
+    expect(input).toHaveFocus();
+
+    // Deliberately NO click — keystrokes go wherever focus already is.
+    await user.keyboard("gpt");
+    expect(input).toHaveValue("gpt");
+    await waitFor(() => {
+      const rows = screen.getAllByTestId("multi-provider-model-row");
+      expect(rows.some((r) => r.textContent?.includes("GPT-5.4 (Codex)"))).toBe(
+        true,
+      );
+      expect(
+        rows.some((r) => r.textContent?.includes("Claude Opus 4.7")),
+      ).toBe(false);
+    });
+  });
+
   it("filtering by query collapses provider grouping into a flat list", async () => {
     const user = userEvent.setup();
     renderPicker({ provider: "claude" });

--- a/src/components/chat/pickers/MultiProviderModelPicker.tsx
+++ b/src/components/chat/pickers/MultiProviderModelPicker.tsx
@@ -37,7 +37,7 @@ import type {
 } from "@/tauri/types";
 
 import { ProviderLogo } from "../provider-logo";
-import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { focusCmdkOnOpen } from "./focus-cmdk-root";
 import { FOOTER_TRIGGER } from "./footer-trigger";
 
 /**
@@ -439,7 +439,7 @@ export function MultiProviderModelPicker({
         // 384px tall — a scannable column instead of a wide panel.
         className="w-[400px] max-w-[calc(100vw-2rem)] p-0"
         align="start"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         {/* `minmax(0,1fr)` (not bare `1fr`): grid items default to
             min-width auto, so a long unbreakable subtitle line would

--- a/src/components/chat/pickers/PermissionModePicker.tsx
+++ b/src/components/chat/pickers/PermissionModePicker.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import type { PermissionModeOption } from "@/tauri/types";
-import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { focusCmdkOnOpen } from "./focus-cmdk-root";
 import { FOOTER_TRIGGER } from "./footer-trigger";
 
 /**
@@ -80,7 +80,7 @@ export function PermissionModePicker({
       <PopoverContent
         className="w-[340px] p-0"
         align="start"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         <Command>
           <CommandList className="max-h-[300px]">

--- a/src/components/chat/pickers/ReasoningPicker.tsx
+++ b/src/components/chat/pickers/ReasoningPicker.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import type { ChatModelInfo } from "@/tauri/types";
-import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { focusCmdkOnOpen } from "./focus-cmdk-root";
 import { FOOTER_TRIGGER } from "./footer-trigger";
 
 // Short description lines for each effort level. Verbs match
@@ -168,7 +168,7 @@ export function ReasoningPicker({
       <PopoverContent
         className="w-[340px] p-0"
         align="start"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         <Command>
           {hasEffortSection && ultrathinkInBodyText ? (

--- a/src/components/chat/pickers/SpeedPicker.tsx
+++ b/src/components/chat/pickers/SpeedPicker.tsx
@@ -15,7 +15,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { ChatModelInfo } from "@/tauri/types";
 
-import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { focusCmdkOnOpen } from "./focus-cmdk-root";
 import { FOOTER_TRIGGER } from "./footer-trigger";
 
 interface Props {
@@ -88,7 +88,7 @@ export function SpeedPicker({
       <PopoverContent
         className="w-[300px] p-0"
         align="start"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         <Command>
           <CommandList>

--- a/src/components/chat/pickers/ThreadScopeRow.test.tsx
+++ b/src/components/chat/pickers/ThreadScopeRow.test.tsx
@@ -66,6 +66,7 @@ vi.mock("@/hooks/use-project-actions", () => ({
 
 vi.mock("@/tauri/commands", () => ({
   dbGetUiState: vi.fn().mockResolvedValue(null),
+  dbSetUiState: vi.fn().mockResolvedValue(undefined),
   listBranchesDetailed: vi.fn(),
   // Probe fallback used by ThreadScopeRow when no workspace row carries
   // the project's `is_git` flag. Defaults to true (git repo) so the
@@ -75,7 +76,46 @@ vi.mock("@/tauri/commands", () => ({
 }));
 
 import { ThreadScopeRow, type ThreadScopeRowProps } from "./ThreadScopeRow";
-import { listBranchesDetailed } from "@/tauri/commands";
+import {
+  dbGetUiState,
+  dbSetUiState,
+  listBranchesDetailed,
+} from "@/tauri/commands";
+import {
+  SETTLED_UI_STATE_KEY,
+  __resetSidebarInboxStoreForTests,
+  type SettledEntry,
+  type SnoozeEntry,
+} from "@/stores/sidebar-inbox-store";
+import { SETTLED_COLLAPSED_COUNT } from "./project-scope-list";
+
+/** Seed the persisted sidebar-inbox blob the picker loads on mount. Keyed so
+ *  the per-project avatar reads (same command, different keys) still get null. */
+function seedInbox(opts: {
+  settled?: SettledEntry[];
+  snoozed?: SnoozeEntry[];
+  activity?: Record<string, number>;
+}) {
+  const blob = JSON.stringify({
+    settled: opts.settled ?? [],
+    snoozed: opts.snoozed ?? [],
+    keepActive: [],
+    activity: opts.activity ?? {},
+  });
+  vi.mocked(dbGetUiState).mockImplementation((key: string) =>
+    Promise.resolve(key === SETTLED_UI_STATE_KEY ? blob : null),
+  );
+}
+
+/** Project roots listed in the open "Run in" popover, in DOM order. Reads the
+ *  row's `data-project-path` rather than its text, which is prefixed by the
+ *  avatar's initial glyph. Excludes the pinned Home row and the "Show N more"
+ *  affordance, neither of which carries the attribute. */
+function listedProjects(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>("[data-project-path]"),
+  ).map((el) => el.dataset.projectPath ?? "");
+}
 
 afterEach(() => cleanup());
 
@@ -127,6 +167,9 @@ function renderRow(
 describe("ThreadScopeRow", () => {
   beforeEach(() => {
     currentWorkspaces = [];
+    __resetSidebarInboxStoreForTests();
+    vi.mocked(dbGetUiState).mockReset().mockResolvedValue(null);
+    vi.mocked(dbSetUiState).mockReset().mockResolvedValue(undefined);
     mockOpenProject.mockReset().mockResolvedValue({ success: false });
     vi.mocked(listBranchesDetailed).mockReset().mockResolvedValue([
       branch("main", { last_commit_unix: NOW - 3600 }),
@@ -254,6 +297,19 @@ describe("ThreadScopeRow", () => {
       await waitFor(() => expect(input).toHaveFocus());
     });
 
+    it("types straight into the focused input — no click needed first", async () => {
+      seedProjects();
+      const { user, input } = await openPicker();
+      // Deliberately NO click: keystrokes go wherever focus already is.
+      // The popover's open-autofocus must land on the input itself — cmdk's
+      // root only handles navigation keys, so if focus sat anywhere else
+      // these printable keystrokes would go nowhere.
+      await user.keyboard("codemux");
+      expect(input).toHaveValue("codemux");
+      await waitFor(() => expect(screen.queryByText("bar")).toBeNull());
+      expect(screen.getByText("codemux")).toBeInTheDocument();
+    });
+
     it("narrows the list to fuzzy matches and hides the rest", async () => {
       seedProjects();
       const { user } = await openPicker();
@@ -305,6 +361,17 @@ describe("ThreadScopeRow", () => {
       await user.keyboard("ve");
       await waitFor(() => expect(screen.getByText("vexis")).toBeInTheDocument());
       expect(screen.queryByText("bar")).toBeNull();
+    });
+
+    it("does not let a query grazing the shared path prefix match every row", async () => {
+      // Every row's path starts with "/projects/" — because a slash-less
+      // query matches display names only, typing the shared prefix must
+      // match NOTHING rather than everything at the same score.
+      seedProjects();
+      const { user } = await openPicker();
+      await user.keyboard("projects");
+      await waitFor(() => expect(listedProjects()).toEqual([]));
+      expect(screen.getByText(/No projects match/)).toBeInTheDocument();
     });
 
     it("matches on scattered characters, not just prefixes", async () => {
@@ -366,6 +433,222 @@ describe("ThreadScopeRow", () => {
       await user.keyboard("{Escape}");
       await user.click(screen.getByText("foo"));
       expect(await screen.findByText("bar")).toBeInTheDocument();
+    });
+  });
+
+  // The picker lists every project that has a live workspace, which on a
+  // long-lived install is a lot of projects — settling a workspace parks its
+  // sidebar card but closes nothing, so it stays a valid "Run in" target
+  // forever. These cover the sectioning that keeps that list legible.
+  describe("location picker — Active / Settled sections", () => {
+    function projectWs(name: string, id?: string) {
+      return makeWs({
+        workspace_id: id ?? `ws-${name}`,
+        cwd: `/projects/${name}`,
+        project_root: `/projects/${name}`,
+      });
+    }
+
+    async function openPicker() {
+      const user = userEvent.setup();
+      renderRow();
+      await user.click(screen.getByText("foo"));
+      await screen.findByText("Run in");
+      return user;
+    }
+
+    it("stays a flat, heading-free list when nothing is settled", async () => {
+      currentWorkspaces = [projectWs("foo"), projectWs("bar")];
+      await openPicker();
+      expect(screen.queryByText("Active")).toBeNull();
+      expect(screen.queryByText(/Settled/)).toBeNull();
+    });
+
+    it("splits settled projects into their own labelled section", async () => {
+      currentWorkspaces = [projectWs("foo"), projectWs("bar")];
+      seedInbox({ settled: [{ id: "ws-bar", at: 1_000 }] });
+      await openPicker();
+      await waitFor(() => expect(screen.getByText("Active")).toBeInTheDocument());
+      // The heading says the part a bare "Settled" label would leave the user
+      // guessing about — these projects are parked, not closed.
+      expect(screen.getByText(/still open/)).toBeInTheDocument();
+      expect(screen.getByText("bar")).toBeInTheDocument();
+    });
+
+    it("keeps a project Active while any of its worktrees is unsettled", async () => {
+      currentWorkspaces = [
+        projectWs("foo"),
+        projectWs("bar", "ws-bar-main"),
+        projectWs("bar", "ws-bar-wt"),
+      ];
+      seedInbox({ settled: [{ id: "ws-bar-wt", at: 1_000 }] });
+      await openPicker();
+      await waitFor(() => expect(screen.getByText("bar")).toBeInTheDocument());
+      expect(screen.queryByText(/still open/)).toBeNull();
+    });
+
+    it("parks a project whose every workspace is snoozed — snooze folds into the partition", async () => {
+      currentWorkspaces = [projectWs("foo"), projectWs("napping")];
+      seedInbox({
+        snoozed: [{ id: "ws-napping", at: 1_000, until: 999_999_999 }],
+      });
+      await openPicker();
+      // The fully-snoozed project must not read as Active: it lands in the
+      // parked section alongside settled projects.
+      await waitFor(() => expect(screen.getByText("Active")).toBeInTheDocument());
+      expect(screen.getByText(/still open/)).toBeInTheDocument();
+      expect(screen.getByText("napping")).toBeInTheDocument();
+      expect(listedProjects()).toEqual([
+        "/projects/foo",
+        "/projects/napping",
+      ]);
+    });
+
+    it("orders Active projects most-recently-active first", async () => {
+      currentWorkspaces = [
+        projectWs("stale"),
+        projectWs("foo"),
+        projectWs("fresh"),
+      ];
+      seedInbox({
+        activity: { "ws-stale": 1_000, "ws-foo": 5_000, "ws-fresh": 9_000 },
+      });
+      await openPicker();
+      await waitFor(() =>
+        expect(listedProjects()).toEqual([
+          "/projects/fresh",
+          "/projects/foo",
+          "/projects/stale",
+        ]),
+      );
+    });
+
+    it("collapses a long settled tail behind 'Show N more'", async () => {
+      const settledCount = SETTLED_COLLAPSED_COUNT + 3;
+      currentWorkspaces = [
+        projectWs("foo"),
+        ...Array.from({ length: settledCount }, (_, i) => projectWs(`old${i}`)),
+      ];
+      seedInbox({
+        settled: Array.from({ length: settledCount }, (_, i) => ({
+          id: `ws-old${i}`,
+          at: 1_000 + i,
+        })),
+      });
+      const user = await openPicker();
+      const showMore = await screen.findByText(
+        `Show ${settledCount - SETTLED_COLLAPSED_COUNT} more`,
+      );
+      // foo (active) + the collapsed settled head.
+      expect(listedProjects()).toHaveLength(1 + SETTLED_COLLAPSED_COUNT);
+      await user.click(showMore);
+      await waitFor(() =>
+        expect(listedProjects()).toHaveLength(1 + settledCount),
+      );
+    });
+
+    it("never hides the targeted project in the collapsed settled tail", async () => {
+      const settledCount = SETTLED_COLLAPSED_COUNT + 3;
+      // Newest-settled first, so "foo" (settled longest ago) lands last.
+      currentWorkspaces = [
+        projectWs("foo"),
+        ...Array.from({ length: settledCount }, (_, i) => projectWs(`old${i}`)),
+      ];
+      seedInbox({
+        settled: [
+          ...Array.from({ length: settledCount }, (_, i) => ({
+            id: `ws-old${i}`,
+            at: 5_000 + i,
+          })),
+          { id: "ws-foo", at: 1_000 },
+        ],
+      });
+      await openPicker();
+      await waitFor(() => expect(listedProjects()).toContain("/projects/foo"));
+      expect(listedProjects()).toHaveLength(SETTLED_COLLAPSED_COUNT + 1);
+    });
+
+    it("search reaches a project buried in the collapsed settled tail", async () => {
+      const settledCount = SETTLED_COLLAPSED_COUNT + 4;
+      currentWorkspaces = [
+        projectWs("foo"),
+        ...Array.from({ length: settledCount }, (_, i) => projectWs(`old${i}`)),
+      ];
+      seedInbox({
+        settled: Array.from({ length: settledCount }, (_, i) => ({
+          id: `ws-old${i}`,
+          at: 1_000 + i,
+        })),
+      });
+      const user = await openPicker();
+      // Settled sorts newest-settled first, so the EARLIEST-settled project
+      // (old0) is the one that falls into the hidden tail.
+      const buried = "old0";
+      await waitFor(() =>
+        expect(listedProjects()).not.toContain(`/projects/${buried}`),
+      );
+      await user.type(screen.getByPlaceholderText("Search projects…"), buried);
+      await waitFor(() =>
+        expect(listedProjects()).toEqual([`/projects/${buried}`]),
+      );
+      // The "Show N more" affordance must not leak into search results —
+      // a non-empty query reveals the whole section instead.
+      expect(screen.queryByText(/Show \d+ more/)).toBeNull();
+    });
+
+    it("selecting a settled project does not un-settle it (first send resurfaces it)", async () => {
+      currentWorkspaces = [projectWs("foo"), projectWs("bar")];
+      seedInbox({ settled: [{ id: "ws-bar", at: 1_000 }] });
+      const user = await openPicker();
+      await waitFor(() => expect(screen.getByText("bar")).toBeInTheDocument());
+      await user.click(screen.getByText("bar"));
+      expect(vi.mocked(dbSetUiState)).not.toHaveBeenCalled();
+    });
+
+    it("only loads avatars for rows on screen, not every known project", async () => {
+      const settledCount = SETTLED_COLLAPSED_COUNT + 5;
+      currentWorkspaces = [
+        projectWs("foo"),
+        ...Array.from({ length: settledCount }, (_, i) => projectWs(`old${i}`)),
+      ];
+      seedInbox({
+        settled: Array.from({ length: settledCount }, (_, i) => ({
+          id: `ws-old${i}`,
+          at: 1_000 + i,
+        })),
+      });
+      const user = await openPicker();
+      await waitFor(() =>
+        expect(listedProjects()).toHaveLength(1 + SETTLED_COLLAPSED_COUNT),
+      );
+
+      const avatarKeys = () =>
+        new Set(
+          vi
+            .mocked(dbGetUiState)
+            .mock.calls.map(([key]) => key)
+            .filter((key) => key.startsWith("project.color:")),
+        );
+      // Only the active row + the collapsed settled head — the buried tail
+      // costs nothing until it is revealed.
+      expect(avatarKeys().size).toBe(1 + SETTLED_COLLAPSED_COUNT);
+      expect(avatarKeys()).not.toContain(
+        `project.color:/projects/old${settledCount - 1 - SETTLED_COLLAPSED_COUNT}`,
+      );
+
+      await user.click(
+        screen.getByText(`Show ${settledCount - SETTLED_COLLAPSED_COUNT} more`),
+      );
+      await waitFor(() => expect(avatarKeys().size).toBe(1 + settledCount));
+    });
+
+    it("keeps 'Open another project…' reachable outside the scrolling list", async () => {
+      currentWorkspaces = Array.from({ length: 20 }, (_, i) => projectWs(`p${i}`))
+        .concat(projectWs("foo"));
+      await openPicker();
+      const action = screen.getByText("Open another project…");
+      expect(action).toBeInTheDocument();
+      expect(action.closest("[data-slot='command-list']")).toBeNull();
     });
   });
 

--- a/src/components/chat/pickers/ThreadScopeRow.tsx
+++ b/src/components/chat/pickers/ThreadScopeRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Check,
   ChevronDown,
@@ -33,8 +33,10 @@ import {
   useAppStore,
   useHomeDir,
   useProjectGroupedWorkspaces,
+  type ProjectGroup,
 } from "@/stores/app-store";
 import { useHosts } from "@/stores/hosts-store";
+import { useSidebarInboxStore } from "@/stores/sidebar-inbox-store";
 import type { DraftTarget } from "@/stores/chat-draft-store";
 import {
   checkIsGitRepo,
@@ -43,7 +45,11 @@ import {
 } from "@/tauri/commands";
 import type { BranchDetail, WorkspaceSnapshot } from "@/tauri/types";
 
-import { focusCmdkRootOnOpen } from "./focus-cmdk-root";
+import { focusCmdkOnOpen } from "./focus-cmdk-root";
+import {
+  partitionProjectScopes,
+  visibleSettledProjects,
+} from "./project-scope-list";
 
 // Module-scoped stable empty array — returning a fresh `[]` literal
 // from a Zustand selector triggers React's "getSnapshot should be
@@ -52,6 +58,17 @@ const EMPTY_WORKSPACES: WorkspaceSnapshot[] = [];
 
 const GHOST_BTN =
   "inline-flex h-6 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground outline-none transition-colors hover:bg-foreground/[0.06] hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50";
+
+/** Location-picker row geometry, shared by the Home row and the project
+ *  rows so both sections line up on the same baseline. */
+const PICKER_ITEM =
+  "flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-xs font-medium text-foreground";
+/** Tints `CommandItem`'s built-in trailing check (its last child) to the
+ *  accent the location picker has always used for "this is the current
+ *  target". Falls back to the neutral check if the selector ever stops
+ *  matching, so the affordance can't disappear. */
+const CHECKED_ACCENT =
+  "data-[checked=true]:[&>svg:last-child]:text-accent-ember";
 
 /** Scope-strip shell — the bar tucked under the composer card. Inset on
  *  both sides by the card's 20px corner radius (so its edges land on the
@@ -265,6 +282,7 @@ function LocationControl({
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [settledExpanded, setSettledExpanded] = useState(false);
   const [projectAvatars, setProjectAvatars] = useState<
     Record<string, ProjectAvatarState>
   >({});
@@ -275,30 +293,31 @@ function LocationControl({
   const groups = useProjectGroupedWorkspaces(workspaces, homeDir, hosts);
   const { openProject } = useProjectActions();
 
+  // Sidebar-inbox state drives the Active/Settled split and both sections'
+  // recency order — see `project-scope-list.ts`. Read-only here: selecting a
+  // settled project deliberately does NOT un-settle it, because the inbox
+  // already resurfaces a settled workspace the moment its agent goes
+  // `working`, which is exactly what first send does. Un-settling on mere
+  // selection would also fire while the user is only browsing locations.
+  const settled = useSidebarInboxStore((s) => s.settled);
+  const snoozed = useSidebarInboxStore((s) => s.snoozed);
+  const activity = useSidebarInboxStore((s) => s.activity);
+  const loadInbox = useSidebarInboxStore((s) => s.load);
+  // Idempotent + memoized at module scope. The sidebar normally loads this
+  // first, but the picker must not depend on a sidebar being mounted.
   useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    (async () => {
-      const entries = await Promise.all(
-        groups.map(async (g) => {
-          const [color, image, imageVersion] = await Promise.all([
-            dbGetUiState(`project.color:${g.projectPath}`).catch(() => null),
-            dbGetUiState(`project.image:${g.projectPath}`).catch(() => null),
-            dbGetUiState(`project.image.v:${g.projectPath}`).catch(() => null),
-          ]);
-          return [
-            g.projectPath,
-            { color: color || null, image: image || null, imageVersion: imageVersion || null },
-          ] as const;
-        }),
-      );
-      if (cancelled) return;
-      setProjectAvatars(Object.fromEntries(entries));
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [open, groups]);
+    void loadInbox();
+  }, [loadInbox]);
+
+  // Home has its own pinned row above the sections — never list it twice.
+  const projectGroups = useMemo(
+    () => groups.filter((g) => g.projectPath !== homeDir),
+    [groups, homeDir],
+  );
+  const sections = useMemo(
+    () => partitionProjectScopes(projectGroups, settled, snoozed, activity),
+    [projectGroups, settled, snoozed, activity],
+  );
 
   // Type-to-filter: rank by fuzzy score so `cdx` or the initials of a
   // hyphenated name land on the right row without reaching for the
@@ -308,23 +327,104 @@ function LocationControl({
   // does not narrow: a short query is a subsequence of nearly every
   // long path.) Home matches its own synonyms ("home", "~") and always
   // sorts first when it survives — it is a fixed destination, not a
-  // project.
-  const projectRows = useMemo(() => {
+  // project. Each section is filtered separately: a search spans both,
+  // ranking within a section, with Active always above Settled.
+  const searching = query.trim() !== "";
+  const scopeHaystack = useMemo(() => {
     const byPath = query.includes("/");
-    return fuzzyFilter(
-      groups.filter((g) => g.projectPath !== homeDir),
-      query,
-      (g) => (byPath ? g.projectPath : g.projectName),
-    );
-  }, [groups, homeDir, query]);
+    return (g: ProjectGroup) => (byPath ? g.projectPath : g.projectName);
+  }, [query]);
+  const activeRows = useMemo(
+    () => fuzzyFilter(sections.active, query, scopeHaystack),
+    [sections.active, query, scopeHaystack],
+  );
+  const settledRows = useMemo(
+    () => fuzzyFilter(sections.settled, query, scopeHaystack),
+    [sections.settled, query, scopeHaystack],
+  );
+  // Collapsed settled tail — a search or an explicit expand reveals the
+  // whole section, so the "Show N more" row can never leak into (or hide)
+  // search results.
+  const visibleSettled = useMemo(
+    () =>
+      visibleSettledProjects(settledRows, {
+        expanded: settledExpanded,
+        searching,
+        activeProjectPath,
+      }),
+    [settledRows, settledExpanded, searching, activeProjectPath],
+  );
+  const hiddenSettledCount = settledRows.length - visibleSettled.length;
+  // Section headings only earn their space once something is actually
+  // settled; with an empty settled set the picker stays the flat list it
+  // always was.
+  const showSectionHeadings = sections.settled.length > 0;
+
   const homeVisible = fuzzyMatch("home directory ~", query.trim());
-  const noMatches = !homeVisible && projectRows.length === 0;
+  const noMatches =
+    !homeVisible && activeRows.length === 0 && settledRows.length === 0;
+
+  // Avatar loading is scoped to the rows actually on screen. It used to fetch
+  // 3 UI-state keys for EVERY known project on every open — 50+ IPC round
+  // trips on a long-lived install, most of them for rows behind the collapsed
+  // settled tail. Now the collapsed list costs a handful, and expanding or
+  // searching pays only for what it newly reveals.
+  const visibleAvatarPaths = useMemo(
+    () => [...activeRows, ...visibleSettled].map((g) => g.projectPath),
+    [activeRows, visibleSettled],
+  );
+  // Bumped on each open so appearance edits made elsewhere in the session are
+  // picked up, matching `useProjectAppearance`'s refresh-on-mount contract.
+  const avatarFetchGen = useRef(0);
+  const fetchedAvatarPaths = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (!open) return;
+    avatarFetchGen.current += 1;
+    fetchedAvatarPaths.current = new Set();
+  }, [open]);
+  useEffect(() => {
+    if (!open) return;
+    const pending = visibleAvatarPaths.filter(
+      (path) => !fetchedAvatarPaths.current.has(path),
+    );
+    if (pending.length === 0) return;
+    for (const path of pending) fetchedAvatarPaths.current.add(path);
+    const gen = avatarFetchGen.current;
+    void (async () => {
+      const entries = await Promise.all(
+        pending.map(async (path) => {
+          const [color, image, imageVersion] = await Promise.all([
+            dbGetUiState(`project.color:${path}`).catch(() => null),
+            dbGetUiState(`project.image:${path}`).catch(() => null),
+            dbGetUiState(`project.image.v:${path}`).catch(() => null),
+          ]);
+          return [
+            path,
+            {
+              color: color || null,
+              image: image || null,
+              imageVersion: imageVersion || null,
+            },
+          ] as const;
+        }),
+      );
+      // Deliberately NOT cancelled when the visible set changes mid-flight —
+      // that would drop a batch and leave those rows on default avatars. Only
+      // a reopen (new generation) invalidates the result.
+      if (avatarFetchGen.current !== gen) return;
+      setProjectAvatars((prev) => ({ ...prev, ...Object.fromEntries(entries) }));
+    })();
+  }, [open, visibleAvatarPaths]);
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
     // Every open starts from the full list — a stale query from last
-    // time would silently hide projects.
-    if (!next) setQuery("");
+    // time would silently hide projects, and a stale expansion would
+    // pre-spend the "Show N more" affordance.
+    if (!next) {
+      setQuery("");
+      setSettledExpanded(false);
+    }
   };
 
   const handleSelectHome = () => {
@@ -343,6 +443,34 @@ function LocationControl({
       ? basename(activeProjectPath)
       : "Project";
 
+  const renderProjectItem = (g: ProjectGroup) => {
+    const active = g.projectPath === activeProjectPath;
+    const avatar = projectAvatars[g.projectPath] ?? EMPTY_AVATAR;
+    return (
+      <CommandItem
+        key={g.projectPath}
+        value={g.projectPath}
+        onSelect={() => handleSelectProject(g.projectPath)}
+        className={cn(PICKER_ITEM, CHECKED_ACCENT)}
+        data-checked={active ? "true" : undefined}
+        // Stable hook for tests/automation: the row's visible text is the
+        // display name, which collides across same-basename projects and is
+        // prefixed by the avatar's initial glyph.
+        data-project-path={g.projectPath}
+      >
+        <ProjectAvatar
+          name={g.projectName}
+          color={avatar.color}
+          imageUrl={avatar.image}
+          cacheBust={avatar.imageVersion}
+          size="md"
+          shape="square"
+        />
+        <span className="min-w-0 flex-1 truncate">{g.projectName}</span>
+      </CommandItem>
+    );
+  };
+
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
@@ -356,16 +484,20 @@ function LocationControl({
           <ChevronDown className="size-2.5 opacity-45" />
         </button>
       </PopoverTrigger>
-      {/* No `onOpenAutoFocus` override here (unlike the sibling
-          controls): this popover owns a `CommandInput`, so Radix's
-          default auto-focus lands on the input — which is exactly
-          what we want, since it both takes the query and forwards
-          arrow/Enter to cmdk. */}
-      <PopoverContent className="w-[250px] p-0" align="start" side="top">
+      <PopoverContent
+        // Bounded by the space Radix actually has above the trigger, so the
+        // taller sectioned popover can't clip off the top of a short window —
+        // `CommandList` is the flex child that gives way.
+        className="flex max-h-[var(--radix-popover-content-available-height)] w-[260px] flex-col p-0"
+        align="start"
+        side="top"
+        collisionPadding={10}
+        onOpenAutoFocus={focusCmdkOnOpen}
+      >
         {/* `shouldFilter={false}`: cmdk's built-in scorer ranks by its
-            own rules; we filter with `fuzzyFilter` so a project's
-            path is a (penalized) second haystack and initials-style
-            queries win. cmdk still owns highlight + Enter. */}
+            own rules; we filter each section with `fuzzyFilter` so
+            initials-style queries win and the Active/Settled split
+            survives a search. cmdk still owns highlight + Enter. */}
         <Command shouldFilter={false} loop>
           <div className="px-2.5 pb-1 pt-2 font-mono text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground">
             Run in
@@ -377,7 +509,7 @@ function LocationControl({
             className="text-xs"
           />
           <CommandList
-            className="max-h-[280px] overflow-y-auto p-1.5 pb-0 [scrollbar-width:thin]"
+            className="max-h-[280px] min-h-0 flex-1 overflow-y-auto p-1.5 pb-0 [scrollbar-width:thin]"
             onWheel={(e) => e.stopPropagation()}
           >
             {noMatches && (
@@ -389,7 +521,8 @@ function LocationControl({
               <CommandItem
                 value="home-directory"
                 onSelect={handleSelectHome}
-                className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-xs font-medium text-foreground"
+                className={cn(PICKER_ITEM, CHECKED_ACCENT)}
+                data-checked={isHome ? "true" : undefined}
               >
                 <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
                   <Home className="size-3" />
@@ -397,41 +530,44 @@ function LocationControl({
                 <span className="min-w-0 flex-1 truncate">
                   Home directory (~)
                 </span>
-                {isHome && (
-                  <Check className="size-3.5 shrink-0 text-accent-ember" />
-                )}
               </CommandItem>
             )}
-            {projectRows.map((g) => {
-              const active = g.projectPath === activeProjectPath;
-              const avatar = projectAvatars[g.projectPath] ?? EMPTY_AVATAR;
-              return (
-                <CommandItem
-                  key={g.projectPath}
-                  value={g.projectPath}
-                  onSelect={() => handleSelectProject(g.projectPath)}
-                  className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-left text-xs font-medium text-foreground"
-                >
-                  <ProjectAvatar
-                    name={g.projectName}
-                    color={avatar.color}
-                    imageUrl={avatar.image}
-                    cacheBust={avatar.imageVersion}
-                    size="md"
-                    shape="square"
-                  />
-                  <span className="min-w-0 flex-1 truncate">
-                    {g.projectName}
+            {activeRows.length > 0 && (
+              <CommandGroup
+                heading={showSectionHeadings ? "Active" : undefined}
+              >
+                {activeRows.map(renderProjectItem)}
+              </CommandGroup>
+            )}
+            {visibleSettled.length > 0 && (
+              <CommandGroup
+                heading={
+                  // Spells out the thing the section title alone implies but
+                  // doesn't say: settling parks a workspace, it never closes
+                  // it, so these are still perfectly valid places to run.
+                  <span>
+                    Settled{" "}
+                    <span className="font-normal opacity-60">· still open</span>
                   </span>
-                  {active && (
-                    <Check className="size-3.5 shrink-0 text-accent-ember" />
-                  )}
-                </CommandItem>
-              );
-            })}
+                }
+              >
+                {visibleSettled.map(renderProjectItem)}
+                {hiddenSettledCount > 0 && (
+                  <CommandItem
+                    value="show-all-settled-projects"
+                    onSelect={() => setSettledExpanded(true)}
+                    className="gap-2 rounded-lg px-2 py-1.5 text-[11.5px] text-muted-foreground"
+                  >
+                    <ChevronDown className="size-3.5 shrink-0" />
+                    Show {hiddenSettledCount} more
+                  </CommandItem>
+                )}
+              </CommandGroup>
+            )}
           </CommandList>
           {/* Outside the list, and never filtered: the escape hatch has
-              to stay reachable precisely when nothing matched. */}
+              to stay reachable precisely when nothing matched — and it
+              must never scroll away behind a long project list. */}
           <div className="mt-1.5 border-t border-border p-1.5">
             <button
               type="button"
@@ -490,7 +626,7 @@ function CheckoutControl({
         className="w-[320px] p-1.5"
         align="start"
         side="top"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         <div className="px-2 pb-1 pt-1 font-mono text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground">
           Where should the agent work?
@@ -685,7 +821,7 @@ function BranchControl({
         className="w-[340px] p-0"
         align="end"
         side="top"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         <Command>
           <CommandInput placeholder="Search branches…" className="h-8" />

--- a/src/components/chat/pickers/focus-cmdk-root.ts
+++ b/src/components/chat/pickers/focus-cmdk-root.ts
@@ -1,24 +1,36 @@
 /**
- * `PopoverContent.onOpenAutoFocus` handler that puts focus on the
- * cmdk root div when a popover opens.
+ * `PopoverContent.onOpenAutoFocus` handler that routes focus to the
+ * right cmdk element when a popover opens.
  *
  * Why: cmdk's arrow-key / Enter / Escape handlers live on the Command
  * root element (a div with `tabIndex={-1}` and `[cmdk-root]` attribute).
  * Keydown events must originate on that element (or a descendant) for
- * cmdk to process them. When we ship pickers without a `CommandInput`,
- * nothing in the popover is naturally focusable, so Radix's default
- * auto-focus lands on the `PopoverContent` wrapper — which sits
- * *outside* cmdk's keydown scope. Arrow keys do nothing.
+ * cmdk to process them. Radix's default auto-focus lands on the first
+ * tabbable element inside the popover — which is the `PopoverContent`
+ * wrapper when nothing inside is focusable (arrow keys do nothing), or
+ * whatever control happens to precede the search field in the DOM (a
+ * filter rail, a tab strip — typing goes nowhere).
  *
- * This handler intercepts Radix's auto-focus, finds the cmdk root
- * inside the popover content, and focuses it explicitly. Safe on
- * popovers that still have a `CommandInput` too — the input's own
- * `autoFocus` already handles that case, and we'd just be redundantly
- * focusing the root.
+ * So this handler intercepts Radix's auto-focus and picks the element
+ * cmdk actually wants:
+ *
+ *  - the `CommandInput` (`[cmdk-input]`), when the popover has one — the
+ *    search field must own focus so typing filters immediately, and it
+ *    is a descendant of the root, so arrow keys still reach cmdk;
+ *  - the `[cmdk-root]` div otherwise, which restores arrow-key
+ *    navigation on input-less pickers.
+ *
+ * The input MUST win when present: neither shadcn's `CommandInput` nor
+ * cmdk's `Command.Input` sets `autoFocus`, and cmdk's root keydown only
+ * handles navigation keys — focusing the root on an input-bearing
+ * popover leaves printable keystrokes with nowhere to go until the user
+ * clicks the search box.
  */
-export function focusCmdkRootOnOpen(event: Event): void {
+export function focusCmdkOnOpen(event: Event): void {
   event.preventDefault();
   const content = event.currentTarget as HTMLElement | null;
-  const root = content?.querySelector<HTMLElement>("[cmdk-root]");
-  root?.focus();
+  const target =
+    content?.querySelector<HTMLElement>("[cmdk-input]") ??
+    content?.querySelector<HTMLElement>("[cmdk-root]");
+  target?.focus();
 }

--- a/src/components/chat/pickers/project-scope-list.test.ts
+++ b/src/components/chat/pickers/project-scope-list.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProjectGroup } from "@/stores/app-store";
+import type { SettledEntry, SnoozeEntry } from "@/stores/sidebar-inbox-store";
+import type { WorkspaceSnapshot } from "@/tauri/types";
+
+import {
+  partitionProjectScopes,
+  visibleSettledProjects,
+  SETTLED_COLLAPSED_COUNT,
+} from "./project-scope-list";
+
+function ws(id: string): WorkspaceSnapshot {
+  return { workspace_id: id } as WorkspaceSnapshot;
+}
+
+function group(path: string, workspaceIds: string[]): ProjectGroup {
+  return {
+    projectName: path.split("/").pop() ?? path,
+    projectPath: path,
+    workspaces: workspaceIds.map(ws),
+  } as ProjectGroup;
+}
+
+function settledEntry(id: string, at: number): SettledEntry {
+  return { id, at };
+}
+
+function snoozeEntry(id: string, at: number): SnoozeEntry {
+  return { id, at, until: at + 60_000 };
+}
+
+const paths = (groups: ProjectGroup[]) => groups.map((g) => g.projectPath);
+
+describe("partitionProjectScopes", () => {
+  it("puts every project in Active when nothing is settled", () => {
+    const groups = [group("/p/a", ["a1"]), group("/p/b", ["b1"])];
+    const { active, settled } = partitionProjectScopes(groups, [], [], {});
+    expect(paths(active)).toEqual(["/p/a", "/p/b"]);
+    expect(settled).toEqual([]);
+  });
+
+  it("moves a project to Settled only when ALL of its workspaces are settled", () => {
+    const groups = [
+      // Two worktrees, only one settled → still drawing a sidebar card.
+      group("/p/partly", ["p1", "p2"]),
+      group("/p/fully", ["f1", "f2"]),
+    ];
+    const { active, settled } = partitionProjectScopes(
+      groups,
+      [
+        settledEntry("p1", 1_000),
+        settledEntry("f1", 1_000),
+        settledEntry("f2", 2_000),
+      ],
+      [],
+      {},
+    );
+    expect(paths(active)).toEqual(["/p/partly"]);
+    expect(paths(settled)).toEqual(["/p/fully"]);
+  });
+
+  it("orders Active by most-recent activity stamp", () => {
+    const groups = [
+      group("/p/stale", ["s1"]),
+      group("/p/fresh", ["f1"]),
+      group("/p/mid", ["m1"]),
+    ];
+    const { active } = partitionProjectScopes(groups, [], [], {
+      s1: 1_000,
+      f1: 9_000,
+      m1: 5_000,
+    });
+    expect(paths(active)).toEqual(["/p/fresh", "/p/mid", "/p/stale"]);
+  });
+
+  it("ranks a multi-worktree project by its most recently active workspace", () => {
+    const groups = [group("/p/multi", ["m1", "m2"]), group("/p/solo", ["s1"])];
+    const { active } = partitionProjectScopes(groups, [], [], {
+      m1: 1_000,
+      m2: 9_000,
+      s1: 5_000,
+    });
+    expect(paths(active)).toEqual(["/p/multi", "/p/solo"]);
+  });
+
+  it("sorts unstamped Active projects last, preserving app-state order", () => {
+    const groups = [
+      group("/p/none1", ["n1"]),
+      group("/p/stamped", ["s1"]),
+      group("/p/none2", ["n2"]),
+    ];
+    const { active } = partitionProjectScopes(groups, [], [], { s1: 5_000 });
+    expect(paths(active)).toEqual(["/p/stamped", "/p/none1", "/p/none2"]);
+  });
+
+  it("orders Settled most-recently-settled first", () => {
+    const groups = [
+      group("/p/old", ["o1"]),
+      group("/p/new", ["n1"]),
+      group("/p/mid", ["m1"]),
+    ];
+    const { settled } = partitionProjectScopes(
+      groups,
+      [
+        settledEntry("o1", 1_000),
+        settledEntry("n1", 9_000),
+        settledEntry("m1", 5_000),
+      ],
+      [],
+      {},
+    );
+    expect(paths(settled)).toEqual(["/p/new", "/p/mid", "/p/old"]);
+  });
+
+  it("keeps a workspace-less group Active rather than treating it as settled", () => {
+    const groups = [group("/p/empty", [])];
+    const { active, settled } = partitionProjectScopes(groups, [], [], {});
+    expect(paths(active)).toEqual(["/p/empty"]);
+    expect(settled).toEqual([]);
+  });
+
+  it("ignores settled entries for workspaces that no longer exist", () => {
+    const groups = [group("/p/a", ["a1"])];
+    const { active, settled } = partitionProjectScopes(
+      groups,
+      [settledEntry("ghost", 1_000)],
+      [],
+      {},
+    );
+    expect(paths(active)).toEqual(["/p/a"]);
+    expect(settled).toEqual([]);
+  });
+
+  // Snooze is the sidebar's second parked lifecycle: a snoozed card leaves
+  // the active list just like a settled one, so the partition must fold it
+  // in — otherwise a fully-snoozed project would read as Active here.
+  describe("snoozed workspaces fold into the parked partition", () => {
+    it("moves a project whose every workspace is snoozed out of Active", () => {
+      const groups = [group("/p/napping", ["n1", "n2"]), group("/p/live", ["l1"])];
+      const { active, settled } = partitionProjectScopes(
+        groups,
+        [],
+        [snoozeEntry("n1", 1_000), snoozeEntry("n2", 2_000)],
+        {},
+      );
+      expect(paths(active)).toEqual(["/p/live"]);
+      expect(paths(settled)).toEqual(["/p/napping"]);
+    });
+
+    it("keeps a project Active while any workspace is neither settled nor snoozed", () => {
+      const groups = [group("/p/mixed", ["m1", "m2"])];
+      const { active, settled } = partitionProjectScopes(
+        groups,
+        [],
+        [snoozeEntry("m1", 1_000)],
+        {},
+      );
+      expect(paths(active)).toEqual(["/p/mixed"]);
+      expect(settled).toEqual([]);
+    });
+
+    it("parks a project whose workspaces are split between settled and snoozed", () => {
+      const groups = [group("/p/parked", ["p1", "p2"])];
+      const { active, settled } = partitionProjectScopes(
+        groups,
+        [settledEntry("p1", 1_000)],
+        [snoozeEntry("p2", 2_000)],
+        {},
+      );
+      expect(active).toEqual([]);
+      expect(paths(settled)).toEqual(["/p/parked"]);
+    });
+
+    it("ranks snooze-parked projects by their park time alongside settled ones", () => {
+      const groups = [
+        group("/p/settled-old", ["so1"]),
+        group("/p/snoozed-new", ["sn1"]),
+      ];
+      const { settled } = partitionProjectScopes(
+        groups,
+        [settledEntry("so1", 1_000)],
+        [snoozeEntry("sn1", 9_000)],
+        {},
+      );
+      expect(paths(settled)).toEqual(["/p/snoozed-new", "/p/settled-old"]);
+    });
+
+    it("ignores snooze entries for workspaces that no longer exist", () => {
+      const groups = [group("/p/a", ["a1"])];
+      const { active, settled } = partitionProjectScopes(
+        groups,
+        [],
+        [snoozeEntry("ghost", 1_000)],
+        {},
+      );
+      expect(paths(active)).toEqual(["/p/a"]);
+      expect(settled).toEqual([]);
+    });
+  });
+});
+
+describe("visibleSettledProjects", () => {
+  const many = Array.from({ length: 9 }, (_, i) => group(`/p/s${i}`, [`s${i}`]));
+
+  it("collapses to the cap by default", () => {
+    const visible = visibleSettledProjects(many, {
+      expanded: false,
+      searching: false,
+      activeProjectPath: null,
+    });
+    expect(visible).toHaveLength(SETTLED_COLLAPSED_COUNT);
+    expect(paths(visible)).toEqual(paths(many.slice(0, SETTLED_COLLAPSED_COUNT)));
+  });
+
+  it("reveals everything once expanded", () => {
+    const visible = visibleSettledProjects(many, {
+      expanded: true,
+      searching: false,
+      activeProjectPath: null,
+    });
+    expect(visible).toHaveLength(many.length);
+  });
+
+  it("reveals everything while searching, so the tail stays reachable", () => {
+    const visible = visibleSettledProjects(many, {
+      expanded: false,
+      searching: true,
+      activeProjectPath: null,
+    });
+    expect(visible).toHaveLength(many.length);
+  });
+
+  it("always includes the targeted project even from the hidden tail", () => {
+    const visible = visibleSettledProjects(many, {
+      expanded: false,
+      searching: false,
+      activeProjectPath: "/p/s8",
+    });
+    expect(paths(visible)).toContain("/p/s8");
+    expect(visible).toHaveLength(SETTLED_COLLAPSED_COUNT + 1);
+  });
+
+  it("does not duplicate the targeted project when it is already in the head", () => {
+    const visible = visibleSettledProjects(many, {
+      expanded: false,
+      searching: false,
+      activeProjectPath: "/p/s0",
+    });
+    expect(visible).toHaveLength(SETTLED_COLLAPSED_COUNT);
+    expect(paths(visible).filter((p) => p === "/p/s0")).toHaveLength(1);
+  });
+
+  it("tolerates a targeted project that is not settled at all", () => {
+    const visible = visibleSettledProjects(many, {
+      expanded: false,
+      searching: false,
+      activeProjectPath: "/p/not-settled",
+    });
+    expect(visible).toHaveLength(SETTLED_COLLAPSED_COUNT);
+  });
+});

--- a/src/components/chat/pickers/project-scope-list.ts
+++ b/src/components/chat/pickers/project-scope-list.ts
@@ -1,0 +1,145 @@
+import type { ProjectGroup } from "@/stores/app-store";
+import type { SettledEntry, SnoozeEntry } from "@/stores/sidebar-inbox-store";
+
+/**
+ * Ordering + sectioning for the Thread Scope location picker ("Run in").
+ *
+ * The picker lists every project that has a live workspace, which is the
+ * same set the sidebar draws from — but the sidebar splits that set into
+ * "active" and parked tiers (settled and snoozed — see
+ * `docs/features/sidebar.md`), and the picker used to render it as one
+ * flat, unsorted, uncapped list. On a machine with a dozen-plus adopted
+ * projects that reads as a wall of equals: the project you touched a
+ * minute ago sits below one you settled months ago, because the only
+ * ordering was workspace creation order.
+ *
+ * So the picker mirrors the sidebar's own vocabulary:
+ *
+ *  - **Active** — at least one workspace is neither settled nor snoozed,
+ *    i.e. it still has a card in the sidebar's active list. Ordered
+ *    most-recently-active first.
+ *  - **Settled** — every workspace is parked (settled or snoozed). Still
+ *    fully open (neither state closes anything), just parked, so it
+ *    belongs below the fold rather than hidden. Ordered
+ *    most-recently-parked first, matching the sidebar's settled section.
+ *
+ * All signals come from the sidebar inbox store, so the picker's order
+ * can never disagree with what the sidebar shows.
+ */
+
+/** How many settled projects render before the "Show N more" tail. Keeps a
+ *  long-parked backlog from burying the "Open another project…" action. */
+export const SETTLED_COLLAPSED_COUNT = 4;
+
+export interface ScopeProjectSections {
+  /** Projects with at least one unparked workspace, most-recently-active first. */
+  active: ProjectGroup[];
+  /** Projects whose every workspace is parked (settled or snoozed),
+   *  most-recently-parked first. */
+  settled: ProjectGroup[];
+}
+
+/**
+ * Split grouped projects into the picker's Active / Settled sections and
+ * order each by recency.
+ *
+ * `activity` is the inbox store's client-side last-activity stamp map
+ * (workspace id → ms epoch). It is only stamped while the sidebar inbox is
+ * mounted, so a workspace can legitimately have no stamp; those rank last
+ * and keep their app-state order, because `Array.prototype.sort` is stable.
+ * That makes the ordering strictly better than insertion order rather than
+ * dependent on a signal we can't guarantee.
+ *
+ * "Parked" folds BOTH of the sidebar's parked lifecycles — settled and
+ * snoozed — because either one removes the workspace's card from the
+ * active list: a project whose workspaces are all snoozed must not read
+ * as Active here any more than a fully-settled one. If another parked
+ * state ever ships, it MUST be folded into this partition the same way —
+ * otherwise a project whose workspaces are all parked in the new state
+ * would read as Active.
+ */
+export function partitionProjectScopes(
+  groups: ProjectGroup[],
+  settled: SettledEntry[],
+  snoozed: SnoozeEntry[],
+  activity: Record<string, number>,
+): ScopeProjectSections {
+  // Workspace id → when it was parked. A snooze records when the deferral
+  // was made (`at`), which is the moment the card left the active list —
+  // the parked-recency analogue of a settle sweep's `at`.
+  const parkedAt = new Map<string, number>();
+  for (const entry of settled) parkedAt.set(entry.id, entry.at);
+  for (const entry of snoozed) {
+    // Settled supersedes snoozed in the store (mutually exclusive shelves),
+    // but a stale blob could carry both — keep the settle stamp.
+    if (!parkedAt.has(entry.id)) parkedAt.set(entry.id, entry.at);
+  }
+
+  const activeRanked: Array<{ group: ProjectGroup; rank: number }> = [];
+  const settledRanked: Array<{ group: ProjectGroup; rank: number }> = [];
+
+  for (const group of groups) {
+    const workspaces = group.workspaces;
+    // A project leaves the sidebar's active list only when EVERY one of its
+    // workspaces is parked — one unparked worktree still draws a card, so
+    // the project is still active work. A group with no workspaces has
+    // nothing to park and stays active.
+    const allParked =
+      workspaces.length > 0 &&
+      workspaces.every((ws) => parkedAt.has(ws.workspace_id));
+
+    if (allParked) {
+      const rank = Math.max(
+        ...workspaces.map((ws) => parkedAt.get(ws.workspace_id) ?? 0),
+      );
+      settledRanked.push({ group, rank });
+    } else {
+      // Seeded with 0 so an empty group (or one with no stamps) is still a
+      // finite rank rather than -Infinity.
+      const rank = Math.max(
+        0,
+        ...workspaces.map((ws) => activity[ws.workspace_id] ?? 0),
+      );
+      activeRanked.push({ group, rank });
+    }
+  }
+
+  const byRecencyDesc = (
+    a: { rank: number },
+    b: { rank: number },
+  ): number => b.rank - a.rank;
+
+  return {
+    active: activeRanked.sort(byRecencyDesc).map((entry) => entry.group),
+    settled: settledRanked.sort(byRecencyDesc).map((entry) => entry.group),
+  };
+}
+
+/**
+ * The slice of the settled section to render.
+ *
+ * Collapsed to {@link SETTLED_COLLAPSED_COUNT} by default; a search or an
+ * explicit expand reveals the rest. The currently-targeted project is always
+ * included even when it falls in the hidden tail — a checkmark the user
+ * cannot see reads as "my selection was lost".
+ */
+export function visibleSettledProjects(
+  settled: ProjectGroup[],
+  opts: {
+    expanded: boolean;
+    searching: boolean;
+    activeProjectPath: string | null;
+  },
+): ProjectGroup[] {
+  if (opts.expanded || opts.searching) return settled;
+
+  const head = settled.slice(0, SETTLED_COLLAPSED_COUNT);
+  const { activeProjectPath } = opts;
+  if (!activeProjectPath) return head;
+  if (head.some((group) => group.projectPath === activeProjectPath)) return head;
+
+  const current = settled.find(
+    (group) => group.projectPath === activeProjectPath,
+  );
+  return current ? [...head, current] : head;
+}

--- a/src/components/overlays/launch-model-picker.test.tsx
+++ b/src/components/overlays/launch-model-picker.test.tsx
@@ -126,4 +126,20 @@ describe("LaunchModelPicker — adaptive search", () => {
     await userEvent.click(trigger);
     expect(document.querySelector('[cmdk-input=""]')).toBeInTheDocument();
   });
+
+  it("focuses the search box on open so typing filters without a click", async () => {
+    const { trigger } = renderPicker({
+      providerKind: "opencode",
+      models: manyModels(24),
+    });
+    await userEvent.click(trigger);
+    const input = document.querySelector('[cmdk-input=""]') as HTMLElement;
+    expect(input).toHaveFocus();
+    // Deliberately NO click on the input — keystrokes must land in it
+    // straight from the popover's open-autofocus.
+    await userEvent.keyboard("Model 3");
+    expect(input).toHaveValue("Model 3");
+    expect(screen.getByText("Model 3")).toBeInTheDocument();
+    expect(screen.queryByText("Model 1")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/overlays/launch-model-picker.tsx
+++ b/src/components/overlays/launch-model-picker.tsx
@@ -14,7 +14,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { focusCmdkRootOnOpen } from "@/components/chat/pickers/focus-cmdk-root";
+import { focusCmdkOnOpen } from "@/components/chat/pickers/focus-cmdk-root";
 import { cn } from "@/lib/utils";
 import {
   MODEL_SEARCH_THRESHOLD,
@@ -267,7 +267,7 @@ export function LaunchModelPicker({
       <PopoverContent
         className="w-[300px] p-0"
         align="start"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         <Command shouldFilter={false}>
           {showSearch ? (

--- a/src/components/overlays/launch-reasoning-picker.tsx
+++ b/src/components/overlays/launch-reasoning-picker.tsx
@@ -13,7 +13,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { focusCmdkRootOnOpen } from "@/components/chat/pickers/focus-cmdk-root";
+import { focusCmdkOnOpen } from "@/components/chat/pickers/focus-cmdk-root";
 import { cn } from "@/lib/utils";
 import type { ReasoningOption } from "@/lib/launch-models";
 
@@ -147,7 +147,7 @@ export function LaunchReasoningPicker({
       <PopoverContent
         className="w-[260px] p-0"
         align="start"
-        onOpenAutoFocus={focusCmdkRootOnOpen}
+        onOpenAutoFocus={focusCmdkOnOpen}
       >
         <Command shouldFilter={false}>
           {/* This popover is portaled outside the enclosing modal Dialog, so


### PR DESCRIPTION
## Problem

The Thread Scope location picker lists every project that has a live workspace — the same set the sidebar draws from. Since the inbox landed, **settling a workspace parks its sidebar card without closing anything**, so that set only ever grows.

The picker and the sidebar had drifted into two different models of the same data. The sidebar means *"what I'm working on"*; the picker meant *"everything I've ever opened and not explicitly closed."* Auto-settle actively widens that gap, since settling is now the cheap, encouraged gesture and each one leaves a permanent picker entry that appears nowhere in the sidebar.

At a dozen-plus adopted projects that reads as a wall of equals: flat, unsorted, uncapped, running off the top of the viewport, with the project you touched a minute ago sitting below one you settled months ago.


## Approach

Rather than hiding settled projects (loses a real use case — starting a thread in a settled project is how you resurrect parked work) or switching to the `recent_projects` table (makes picker and sidebar disagree in a *new* way), the picker now **speaks the sidebar's own vocabulary**, reading the same store so the two can't disagree.

- **Active** — at least one unsettled workspace. Most-recently-active first via the inbox `activity` stamps.
- **Settled · still open** — every workspace settled. Deprioritized, never hidden. Newest-settled first (matching the sidebar's settled section), collapsed to 4 behind "Show N more". The currently-targeted project always shows, even from the hidden tail — a checkmark you can't see reads as a lost selection.
- Section headings appear **only** when something is settled; a small install keeps the flat list it always had.
- Search appears only past 6 project rows and reveals the full settled tail, so list length stops mattering.
- The list is capped and scrollable, bounded by `--radix-popover-content-available-height` so the taller popover can't clip off the top of a short window. `Open another project…` moved outside the scroll area — the escape hatch must never scroll away.

## Notes for review

**The picker never writes the inbox store.** Selecting a settled project deliberately does *not* un-settle it — the inbox already resurfaces a settled workspace the moment its agent goes `working`, which is exactly what first send does. Un-settling on mere selection would also fire while only browsing locations.

**Ordering degrades honestly.** `WorkspaceSnapshot` carries no last-activity timestamp, and the inbox `activity` map is only stamped while the expanded sidebar is mounted. Rather than invent a parallel recency store, unstamped projects rank last and keep their app-state order — strictly better than insertion order, never dependent on a signal we can't guarantee. Hard recency would need backend stamping; that's a separate change.

**Avatar loading is now scoped to visible rows.** It used to fetch 3 UI-state keys for every known project on every open (~57 IPC round trips at 18 projects), most for rows behind the collapsed tail. The effect deliberately does *not* cancel when the visible set changes mid-flight — that drops a batch and strands rows on default avatars; only a reopen invalidates a result.

## Testing

- 32 new tests: 18 unit tests on the partition/collapse logic (`project-scope-list.test.ts`), 14 component tests covering sectioning, ordering, collapse, search, laziness, and the no-un-settle contract.
- Full suite green: **3076 tests / 210 files**. `tsc --noEmit` and `vite build` clean.
- Verified live in the browser at 18 projects and at 4 — sections, expansion, search-to-1, and the flat small-install fallback.

⚠️ `npm run verify` can't complete in a fresh worktree: `cargo check` needs the gitignored `src-tauri/binaries/agent-browser-*` sidecar. This change touches zero Rust, so the frontend gates were run individually.
