### PR TITLE
fix: persist done-review checkmarks across app restarts

### DIFF
--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -183,6 +183,13 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
   select-without-expand, and the shared footer destinations.
 - Per-workspace agent status covers both terminal and Agent Chat (Beta) agents
   (chat sessions publish into the same `pane_statuses` snapshot).
+- The done-review checkmark **survives an app restart**. `save_persisted_state`
+  keeps `PaneStatus::Review` entries in `layout.json` and drops
+  `Working`/`Permission` (dead processes after a quit) plus entries whose pane
+  no longer exists — see `retain_persistable_pane_statuses` in
+  `src-tauri/src/state/state_impl.rs`. Previously the whole map was cleared on
+  every save, so finished workspaces came back looking already-reviewed. The
+  badge still clears the normal way, on activating the workspace/tab.
 
 ## Current Constraints
 

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -4480,6 +4480,37 @@ fn persisted_layout_path() -> Option<PathBuf> {
     Some(base.join(crate::APP_DIR_NAME).join("layout.json"))
 }
 
+/// Drop the pane statuses that mean nothing after a restart, keeping the ones
+/// that do.
+///
+/// `Working` and `Permission` describe a live process. The agent is dead once
+/// the app exits, so restoring a spinner or a permission badge would show the
+/// user a state that no process backs — the reason this whole map used to be
+/// cleared wholesale.
+///
+/// `Review` is a different kind of fact: it means "this agent finished and you
+/// have not looked at the result yet", which is just as true after a restart as
+/// it was before. Persisting it is what keeps the sidebar's done-checkmark
+/// alive across a quit; clearing it made every finished workspace come back
+/// looking like the user had already reviewed it.
+///
+/// Entries whose pane no longer exists are dropped too. Nothing removes a
+/// status when its pane goes away (`close_pane` leaves the key behind, and the
+/// openflow/browser strips above delete panes wholesale), so without this the
+/// map would grow forever now that it survives restarts.
+fn retain_persistable_pane_statuses(snapshot: &mut AppStateSnapshot) {
+    let live_panes: std::collections::HashSet<String> = snapshot
+        .workspaces
+        .iter()
+        .flat_map(|workspace| workspace.surfaces.iter())
+        .flat_map(|surface| collect_pane_ids_from_node(&surface.root))
+        .collect();
+
+    snapshot
+        .pane_statuses
+        .retain(|pane_id, status| *status == PaneStatus::Review && live_panes.contains(pane_id));
+}
+
 fn save_persisted_state(snapshot: &AppStateSnapshot) -> Result<(), String> {
     let Some(path) = persisted_layout_path() else {
         return Ok(());
@@ -4497,8 +4528,8 @@ fn save_persisted_state(snapshot: &AppStateSnapshot) -> Result<(), String> {
     snapshot = strip_browser_panes_from_snapshot(snapshot);
     // Detected ports are runtime-only state — never persist them.
     snapshot.detected_ports.clear();
-    // Pane statuses are runtime-only — agents are dead after restart.
-    snapshot.pane_statuses.clear();
+    // Keep only the review checkmarks; working/permission are runtime-only.
+    retain_persistable_pane_statuses(&mut snapshot);
     // Agent browser sessions are runtime-only — pane_id/browser_id/user_dismissed
     // become stale after restart and block auto-creation.
     snapshot.agent_browser_sessions.clear();
@@ -7202,6 +7233,65 @@ mod tests {
 
         // Unknown thread never resolves.
         assert!(!store.set_pane_status_by_thread("does-not-exist", PaneStatus::Working));
+    }
+
+    /// The sidebar's "Done · review" checkmark is `PaneStatus::Review`, and it
+    /// has to still be there tomorrow morning. Persisting it is the whole point
+    /// of the filter — the map used to be cleared wholesale, so every finished
+    /// workspace came back from a restart looking already-reviewed.
+    #[test]
+    fn review_status_survives_persistence_but_live_process_statuses_do_not() {
+        let store = AppStateStore::default();
+        let ws_id = store.snapshot().active_workspace_id.clone();
+        let reviewed = store
+            .create_agent_chat_pane(&ws_id.0, None, None, None)
+            .unwrap();
+        let working = store
+            .create_agent_chat_pane(&ws_id.0, None, None, None)
+            .unwrap();
+        let prompting = store
+            .create_agent_chat_pane(&ws_id.0, None, None, None)
+            .unwrap();
+
+        store.set_pane_status(&reviewed.0, PaneStatus::Review);
+        store.set_pane_status(&working.0, PaneStatus::Working);
+        store.set_pane_status(&prompting.0, PaneStatus::Permission);
+
+        let mut snapshot = store.snapshot();
+        retain_persistable_pane_statuses(&mut snapshot);
+
+        assert_eq!(
+            snapshot.pane_statuses.get(&reviewed.0),
+            Some(&PaneStatus::Review),
+            "a finished agent's review checkmark must survive a restart",
+        );
+        // Working/Permission describe a process that is dead after the quit —
+        // restoring them would render a spinner nothing is driving.
+        assert_eq!(snapshot.pane_statuses.get(&working.0), None);
+        assert_eq!(snapshot.pane_statuses.get(&prompting.0), None);
+    }
+
+    /// Nothing removes a status when its pane goes away, so the filter has to
+    /// drop orphans itself — otherwise the map grows without bound now that it
+    /// is written to disk instead of cleared.
+    #[test]
+    fn persisted_pane_statuses_drop_entries_whose_pane_is_gone() {
+        let store = AppStateStore::default();
+        let ws_id = store.snapshot().active_workspace_id.clone();
+        let pane = store
+            .create_agent_chat_pane(&ws_id.0, None, None, None)
+            .unwrap();
+        store.set_pane_status(&pane.0, PaneStatus::Review);
+        store.set_pane_status("pane-that-never-existed", PaneStatus::Review);
+
+        let mut snapshot = store.snapshot();
+        retain_persistable_pane_statuses(&mut snapshot);
+
+        assert_eq!(
+            snapshot.pane_statuses.get(&pane.0),
+            Some(&PaneStatus::Review)
+        );
+        assert_eq!(snapshot.pane_statuses.get("pane-that-never-existed"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The sidebar's "Done · review" checkmark did not survive a restart. Every finished workspace came back looking already-reviewed, which makes the inbox much less useful — the whole point is to show what you have not looked at yet.

`save_persisted_state` cleared the entire `pane_statuses` map before every write:

```rust
snapshot.pane_statuses.clear();
```

So `layout.json` always hit disk with `pane_statuses: {}`, and boot (`lib.rs:439-455`) just deserializes that file — there is no re-derivation. Every workspace initialized to idle.

This is not a regression from the sidebar rework. The `clear()` predates it: it came in with `70e97f98` (March) and is the only commit that ever touched that line. The rework commits (`6cf275ef`, `a9d61bb8`, `8fe9ec00`, `d06dfa89`) are all later and never went near status persistence.

## Fix

Replace the wholesale clear with `retain_persistable_pane_statuses`, which keeps `Review` and drops the rest:

```rust
snapshot.pane_statuses.retain(|pane_id, status| {
    *status == PaneStatus::Review && live_panes.contains(pane_id)
});
```

Three notes on the shape:

- **`Working`/`Permission` are still cleared.** The original comment was correct about those — the agent is dead after a quit, so restoring them would render a spinner or permission badge that no process backs. `Review` is a durable fact, not live process state.
- **Orphan pruning is load-bearing, not defensive.** Nothing removes a status when its pane disappears (`close_pane` leaves the key behind; the openflow/browser strips delete panes wholesale). That was harmless while the map was wiped every save, but would grow without bound now that it persists. The filter runs *after* those strips, so stale entries are cleaned up on the next write.
- **Nothing wipes the restored badge at boot.** All seven `set_pane_status` call sites are event-driven (`agent_chat.rs:360` is the close-pane handler, not a boot path), and `clear_transient_pane_status_by_session` already spares `Review` deliberately. Badges clear the usual way, via `activate_workspace`.

## Tests

Two regression tests in `state_impl.rs`:

- `review_status_survives_persistence_but_live_process_statuses_do_not`
- `persisted_pane_statuses_drop_entries_whose_pane_is_gone`

## Verification

`cargo check`, `tsc --noEmit`, and `npm run test` (209 files / 3051 tests) all clean; both new tests pass.

Two unrelated things surfaced while running the Rust suite, neither caused by this change:

- 10 `terminal::tests::process_kill` failures appeared only when the suite was run concurrently with `npm test` — those tests call `openpty` and were losing the race for resources. Run serially, all 13 pass.
- 2 `agent_provider::opencode` *live-binary* tests fail; reproduced on a clean tree with this change stashed, where a different one of them failed. They shell out to a real `opencode` binary and are environment-dependent and flaky.

## Docs

`docs/features/sidebar.md` updated — the checkmark's restart behavior is now documented under "What Works Today".