### PR TITLE
Syntax-highlight chat code blocks from the terminal palette

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -82,6 +82,59 @@ The chat pane stack:
   Assistant markdown renders through **Streamdown**
   (`parseIncompleteMarkdown` keeps mid-stream fences/emphasis clean).
 
+### Code blocks in chat
+
+`ChatMarkdown.tsx` is the single place chat markdown is configured.
+
+- **Syntax highlighting** is Streamdown's Shiki `code` plugin
+  (`@streamdown/code`), enabled via `plugins={{ code }}`. Token colors come
+  from a theme built out of the **terminal ANSI palette**
+  (`src/lib/shiki-chat-theme.ts`), whose scope map mirrors the Lezer tag map
+  in `src/lib/codemirror-theme.ts` — so a keyword is the same color in chat,
+  the file editor, and the terminal. Keep the two maps in sync.
+- The plugin is supplied by `useChatCodePlugin()`
+  (`src/hooks/use-chat-code-plugin.ts`), a **module-level store** rather than
+  a per-component hook: a transcript mounts one `ChatMarkdown` per assistant
+  message, so a per-hook fetch would fire one `get_current_theme` IPC call and
+  one `theme-changed` listener per message. The plugin instance is memoized on
+  palette identity because Shiki's highlighter and token caches live inside it.
+- Shiki's highlighter cache in `@streamdown/code` is keyed by theme **name**,
+  not content, so `buildChatCodeThemes` hashes the palette into the name. A
+  fixed name would serve stale colors after a terminal-theme switch.
+- **Streamdown owns the card.** It renders its own container, header,
+  copy/download pill, and body whether or not the `code` plugin is installed —
+  fenced blocks are *not* a bare `<pre>`. The `prose-pre:*` / `prose-code:*`
+  chain in `ChatMarkdown.tsx` therefore only *neutralizes* the typography
+  plugin's defaults; the card is styled by `.chat-markdown` rules in
+  `globals.css`. Styling `pre` there again stacks a third border/background
+  inside the card.
+- **Line numbers are off** (`lineNumbers={false}`) — chat snippets are quotes,
+  not files. Streamdown only gives each line span `display: block` as part of
+  its line-number class, so `globals.css` restores the line box explicitly;
+  without that rule every line collapses onto one.
+- **Word wrap** is the `chat.code_wrap` setting (default off), applied as
+  `data-code-wrap` on the markdown root. Off keeps lines intact behind a
+  horizontal scroll.
+- Streamdown's fence meta only supports `startLine=` and `noLineNumbers`;
+  there is no filename/title slot, so the header shows the language only.
+
+Card styling (all in `globals.css`, all on design tokens):
+
+- A fence with **no language** (plain command output) still renders a header
+  element with an empty label, which otherwise reserves an empty strip at the
+  top of the block. It's hidden via `[data-language=""]`, and the body takes
+  over the block's top padding in that case.
+- The copy/download pill is **revealed on hover/focus** — a transcript can hold
+  dozens of blocks and always-lit icons are a lot of standing chrome. A
+  `@media (hover: none)` fallback keeps it visible where hover doesn't exist.
+- Streamdown positions that pill by pulling a sticky spacer row up over the
+  header (`-mt-10`), hard-coupling it to the header's height — so hiding the
+  header would fling the pill outside the card. The spacer (the only child div
+  with no `data-streamdown` attribute) is collapsed and the pill is anchored to
+  the card instead.
+- The language caption is a small uppercase tracked label with no divider rule;
+  the fill change against surrounding prose is enough separation.
+
 ## What Works Today
 
 - **Three end-to-end providers** behind one unified picker:

--- a/docs/reference/DESIGN-SYSTEM.md
+++ b/docs/reference/DESIGN-SYSTEM.md
@@ -97,3 +97,10 @@ overview):
 - Streamdown's compiled utility classes are registered as a Tailwind scan
   source (`@source "../node_modules/streamdown/dist/*.js"`) so the streaming
   markdown renderer's classes survive the Tailwind v4 tree-shake.
+- Chat code blocks are syntax-highlighted by Shiki, which inlines concrete
+  colors into `style` attributes and so cannot consume CSS variables. Their
+  token colors are derived from the terminal ANSI palette
+  (`src/lib/shiki-chat-theme.ts`) — the same documented ANSI exception that
+  covers `TerminalPane` and the CodeMirror editor theme. Structural chrome
+  (container, header, borders, inline-code pill) stays on design tokens under
+  `.chat-markdown` in `globals.css`.

--- a/src/components/chat/ChatMarkdown.tsx
+++ b/src/components/chat/ChatMarkdown.tsx
@@ -1,7 +1,10 @@
+import { useMemo } from "react";
 import remarkGfm from "remark-gfm";
 import { Streamdown } from "streamdown";
 
+import { useChatCodePlugin } from "@/hooks/use-chat-code-plugin";
 import { cn } from "@/lib/utils";
+import { selectChatCodeWrap, useSettingsStore } from "@/stores/settings-store";
 
 /**
  * Shared markdown renderer for chat surfaces (assistant messages,
@@ -12,9 +15,19 @@ import { cn } from "@/lib/utils";
  * closes unterminated fences / emphasis / lists mid-stream so a
  * half-arrived token never flashes broken markup. We keep the same
  * `remarkGfm`-only plugin set the previous react-markdown renderer used
- * (no math/KaTeX) and skip streamdown's shiki `code` plugin, so fenced
- * blocks render as plain `<pre>` styled by the prose chain below — no
- * async highlighter, identical DOM semantics.
+ * (no math/KaTeX).
+ *
+ * Fenced code blocks are syntax-highlighted by streamdown's shiki `code`
+ * plugin, themed from the terminal ANSI palette via `useChatCodePlugin`
+ * so chat code matches the file editor and terminal panes.
+ *
+ * Note that streamdown renders its own code-block card (container, header,
+ * copy/download pill, optional line numbers) whether or not the `code`
+ * plugin is installed — it is not a bare `<pre>`. The prose chain below
+ * therefore *neutralizes* the typography plugin's `pre`/`code` defaults
+ * instead of styling them; the card itself is styled by design tokens in
+ * `globals.css` under `.chat-markdown`. Styling `pre` here again would
+ * stack a third border/background/padding inside that card.
  *
  * Built on `@tailwindcss/typography` (registered as a `@plugin` in
  * `globals.css`). The `prose` class provides a typography stack;
@@ -60,13 +73,15 @@ const proseClasses = [
   // and muted-foreground tones them down.
   "prose-ul:pl-6 prose-ol:pl-6",
   "marker:text-muted-foreground",
-  // Inline code — typography plugin wraps inline code in backticks
-  // by default (ugh). Override to subtle muted pill, strip the
-  // quotes via the ::before/::after reset.
-  "prose-code:font-mono prose-code:text-[0.85em] prose-code:bg-muted prose-code:text-foreground prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:border prose-code:border-border/60 prose-code:before:content-none prose-code:after:content-none",
-  // Fenced code blocks — bordered card, muted fill, tight line
-  // height so ASCII diagrams stay visually continuous.
-  "prose-pre:my-3 prose-pre:rounded-md prose-pre:border prose-pre:border-border prose-pre:bg-muted prose-pre:text-foreground prose-pre:p-3 prose-pre:text-[0.8em] prose-pre:leading-snug prose-pre:overflow-x-auto",
+  // Inline code — the typography plugin wraps inline code in literal
+  // backticks and bolds it; strip both. The pill itself (muted fill,
+  // border, padding) is streamdown's `inline-code` element, styled in
+  // `globals.css` — don't restate it here or the two stack.
+  "prose-code:before:content-none prose-code:after:content-none prose-code:font-normal",
+  // Fenced code blocks — neutralize the typography plugin's `pre`
+  // defaults (dark slab, padding, radius). Streamdown's card provides
+  // the real surface; see `.chat-markdown` in `globals.css`.
+  "prose-pre:m-0 prose-pre:p-0 prose-pre:bg-transparent prose-pre:text-inherit prose-pre:rounded-none prose-pre:border-0 prose-pre:leading-snug",
   // Tables — plugin-default spacing is loose; pull in for chat.
   "prose-table:my-3 prose-table:text-[0.9em]",
   "prose-th:px-3 prose-th:py-1.5 prose-th:bg-muted/60 prose-th:font-semibold prose-th:text-foreground prose-th:border prose-th:border-border/70",
@@ -77,13 +92,28 @@ const proseClasses = [
   "[&_*]:break-words",
 ].join(" ");
 
+// Line numbers are an editor affordance; chat snippets are quotes, not
+// files, and the gutter competes with the prose column. Tables keep their
+// full control set — only the code block's chrome is trimmed.
+const controls = {
+  code: { copy: true, download: true },
+  table: { copy: true, download: true, fullscreen: true },
+} as const;
+
 export function ChatMarkdown({ children }: { children: string }) {
+  const code = useChatCodePlugin();
+  const plugins = useMemo(() => ({ code }), [code]);
+  const wrap = useSettingsStore(selectChatCodeWrap);
+
   return (
-    <div className={cn(proseClasses)}>
+    <div className={cn("chat-markdown", proseClasses)} data-code-wrap={wrap}>
       <Streamdown
         parseIncompleteMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[]}
+        plugins={plugins}
+        controls={controls}
+        lineNumbers={false}
       >
         {children}
       </Streamdown>

--- a/src/components/settings/SettingsPanel.test.tsx
+++ b/src/components/settings/SettingsPanel.test.tsx
@@ -57,6 +57,7 @@ vi.mock("@/stores/settings-store", () => {
     "sidebar.auto_settle_days": "3",
     "sidebar.working_indicator": "braille",
     "sidebar.working_indicator_color": "status-working",
+    "chat.code_wrap": "false",
   };
   return {
     SETTINGS_DEFAULTS: defaults,
@@ -70,6 +71,7 @@ vi.mock("@/stores/settings-store", () => {
     selectPalette: () => "cool",
     selectDensity: () => "comfortable",
     selectSidebarShowGitStats: () => true,
+    selectChatCodeWrap: () => false,
     selectSidebarAutoSettleDays: () => 3,
     selectWorkingIndicator: () => "braille",
     selectWorkingIndicatorColor: () => "status-working",

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -67,6 +67,7 @@ import {
   selectTerminalColorTheme,
   selectPalette,
   selectDensity,
+  selectChatCodeWrap,
   selectSidebarShowGitStats,
   selectWorkingIndicator,
   selectWorkingIndicatorColor,
@@ -1396,6 +1397,7 @@ export function SettingsView() {
   const palette = useSettingsStore(selectPalette);
   const density = useSettingsStore(selectDensity);
   const showGitStats = useSettingsStore(selectSidebarShowGitStats);
+  const chatCodeWrap = useSettingsStore(selectChatCodeWrap);
   const autoSettleDays = useSettingsStore(
     (s) =>
       (s.settings["sidebar.auto_settle_days"] ??
@@ -1767,6 +1769,17 @@ export function SettingsView() {
                       { value: "comfortable", label: "Comfortable" },
                       { value: "compact", label: "Compact" },
                     ]}
+                  />
+                </SettingRow>
+                <SettingRow
+                  label="Wrap code in chat"
+                  description="Soft-wrap long lines in agent chat code blocks. Off keeps each line intact behind a horizontal scroll, which is easier to read for diffs and command output."
+                >
+                  <Switch
+                    checked={chatCodeWrap}
+                    onCheckedChange={(checked) =>
+                      storeSet("chat.code_wrap", checked ? "true" : "false")
+                    }
                   />
                 </SettingRow>
               </div>

--- a/src/globals.css
+++ b/src/globals.css
@@ -393,6 +393,166 @@ body.pane-resizing iframe {
   accent-color: var(--accent-ember);
 }
 
+/* ── Chat markdown (Streamdown) ──────────────────────────────────────
+ *
+ * Streamdown renders its own code-block card: an outer container *and* an
+ * inner bordered body. Left alone that reads as a box inside a box, so the
+ * body is flattened here and the outer container carries the single border.
+ *
+ * Only structure/chrome is styled here, all from design tokens. Syntax token
+ * colors are inlined by Shiki from the terminal ANSI palette — see
+ * `src/lib/shiki-chat-theme.ts` and the ANSI exception in
+ * `docs/reference/DESIGN-SYSTEM.md`.
+ *
+ * These selectors are `.chat-markdown [data-streamdown=...]` (two units of
+ * specificity) so they win over streamdown's inline Tailwind utilities
+ * without `!important`.
+ */
+.chat-markdown [data-streamdown="code-block"] {
+  position: relative;
+  margin: 0.6rem 0;
+  gap: 0;
+  border-radius: 8px;
+  border-color: color-mix(in srgb, var(--border) 80%, transparent);
+  background: var(--muted);
+  padding: 0;
+}
+
+/* The language caption. Small, tracked, and quiet — it labels the block
+ * without competing with the code. No divider rule: the fill change against
+ * the surrounding prose is already enough separation, and a second line here
+ * is what made the card read as boxy. */
+.chat-markdown [data-streamdown="code-block-header"] {
+  height: auto;
+  padding: 0.4rem 0.7rem 0;
+  border-bottom: none;
+  color: color-mix(in srgb, var(--muted-foreground) 85%, transparent);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+/* A fence with no language (plain command output) still gets a header
+ * element with an empty label. Left alone it reserves a full empty strip at
+ * the top of the block, which is why those blocks looked top-heavy. */
+.chat-markdown [data-streamdown="code-block-header"][data-language=""] {
+  display: none;
+}
+
+.chat-markdown [data-streamdown="code-block-body"] {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.3rem 0.7rem 0.55rem;
+}
+
+/* Long lines scroll sideways (wrap is opt-in via `chat.code_wrap`), so the
+ * scrollbar is a permanent fixture on wide blocks — keep it thin and quiet
+ * instead of the platform default slab. */
+.chat-markdown [data-streamdown="code-block-body"] {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--border) 90%, transparent) transparent;
+}
+
+.chat-markdown [data-streamdown="code-block-body"]::-webkit-scrollbar {
+  height: 7px;
+}
+
+.chat-markdown [data-streamdown="code-block-body"]::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat-markdown [data-streamdown="code-block-body"]::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--border) 90%, transparent);
+}
+
+.chat-markdown [data-streamdown="code-block-body"]::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--muted-foreground) 60%, transparent);
+}
+
+/* Without the caption above it, the body owns the block's top padding. */
+.chat-markdown
+  [data-streamdown="code-block"][data-language=""]
+  [data-streamdown="code-block-body"] {
+  padding-top: 0.55rem;
+}
+
+/* Copy/download pill.
+ *
+ * Streamdown positions it by pulling a sticky spacer row up over the header
+ * (`-mt-10`), which hard-couples it to the header's height — so hiding the
+ * header for plain fences would fling the pill outside the card. Collapsing
+ * that spacer and anchoring the pill to the card instead decouples the two.
+ * The spacer is the only child div with no `data-streamdown` attribute. */
+.chat-markdown [data-streamdown="code-block"] > div:not([data-streamdown]) {
+  position: static;
+  height: 0;
+  margin: 0;
+}
+
+/* Reveal on hover/focus: a transcript can hold dozens of blocks, and two
+ * always-lit icons per block is a lot of standing chrome. */
+.chat-markdown [data-streamdown="code-block-actions"] {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  z-index: 10;
+  border-color: transparent;
+  background: color-mix(in srgb, var(--muted) 92%, var(--foreground));
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.chat-markdown [data-streamdown="code-block"]:hover [data-streamdown="code-block-actions"],
+.chat-markdown [data-streamdown="code-block-actions"]:focus-within {
+  opacity: 1;
+}
+
+/* Keyboard users never trigger :hover, so never hide it from them. */
+@media (hover: none) {
+  .chat-markdown [data-streamdown="code-block-actions"] {
+    opacity: 1;
+  }
+}
+
+.chat-markdown [data-streamdown="code-block-body"] pre,
+.chat-markdown [data-streamdown="code-block-body"] code {
+  font-family: 'JetBrains Mono Variable', monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  background: transparent;
+}
+
+/* Streamdown wraps each source line in a bare `<span>` and only gives it
+ * `display: block` as part of the *line-number* class. With line numbers off
+ * those spans stay inline and every line collapses onto one, so the line box
+ * has to be restored here. */
+.chat-markdown [data-streamdown="code-block-body"] pre > code > span {
+  display: block;
+  min-height: 1.55em;
+}
+
+/* Word wrap is a per-surface toggle driven by the `codeWrap` setting; the
+ * default (off) keeps long lines on one line behind a horizontal scroll. */
+.chat-markdown[data-code-wrap="true"] [data-streamdown="code-block-body"] pre,
+.chat-markdown[data-code-wrap="true"] [data-streamdown="code-block-body"] code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Inline code — streamdown emits its own pill; the prose chain in
+ * `ChatMarkdown.tsx` only strips the typography plugin's backticks. */
+.chat-markdown [data-streamdown="inline-code"] {
+  font-family: 'JetBrains Mono Variable', monospace;
+  font-size: 0.82em;
+  background: var(--muted);
+  color: var(--foreground);
+  border: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
+  border-radius: 4px;
+  padding: 0.1rem 0.35rem;
+}
+
 /* Workspaces overview "pulse a row to draw attention" effect.
  *
  * Triggered when:

--- a/src/hooks/use-chat-code-plugin.ts
+++ b/src/hooks/use-chat-code-plugin.ts
@@ -1,0 +1,87 @@
+import { useMemo, useSyncExternalStore } from "react";
+import { createCodePlugin, type CodeHighlighterPlugin } from "@streamdown/code";
+
+import { buildChatCodeThemes } from "@/lib/shiki-chat-theme";
+import { getCurrentTheme } from "@/tauri/commands";
+import { onThemeChanged } from "@/tauri/events";
+import type { ThemeColors } from "@/tauri/types";
+import { fallbackTheme } from "./use-theme-colors";
+
+/**
+ * Supplies the Shiki code-highlighting plugin for chat markdown, colored by
+ * the active terminal palette.
+ *
+ * Deliberately a module-level store rather than `useThemeColors()`: a
+ * transcript mounts one `ChatMarkdown` per assistant message, and a per-hook
+ * implementation would fire one `get_current_theme` IPC call and register one
+ * `theme-changed` listener *per message*. Here every consumer shares a single
+ * fetch, a single listener, and a single plugin instance.
+ *
+ * The plugin is memoized on palette identity because `@streamdown/code` keeps
+ * its Shiki highlighter and token caches inside the plugin instance — rebuilding
+ * it on unrelated renders would throw those caches away on every keystroke.
+ */
+
+let currentTheme: ThemeColors = fallbackTheme;
+const subscribers = new Set<() => void>();
+let unlisten: (() => void) | null = null;
+let started = false;
+
+function setTheme(next: ThemeColors) {
+  currentTheme = next;
+  for (const notify of subscribers) notify();
+}
+
+function start() {
+  if (started) return;
+  started = true;
+  // Both are best-effort: outside Tauri (or before the backend is ready) the
+  // fallback palette renders fine, it just isn't the user's terminal theme.
+  getCurrentTheme()
+    .then(setTheme)
+    .catch(() => {});
+  onThemeChanged(setTheme)
+    .then((fn) => {
+      unlisten = fn;
+    })
+    .catch(() => {});
+}
+
+function subscribe(onStoreChange: () => void) {
+  subscribers.add(onStoreChange);
+  start();
+  return () => {
+    subscribers.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): ThemeColors {
+  return currentTheme;
+}
+
+/** Test-only: drops the listener and resets the palette to the fallback. */
+export function resetChatCodePluginStore() {
+  unlisten?.();
+  unlisten = null;
+  started = false;
+  currentTheme = fallbackTheme;
+  cachedPlugin = null;
+  subscribers.clear();
+}
+
+let cachedPlugin: { key: string; plugin: CodeHighlighterPlugin } | null = null;
+
+export function useChatCodePlugin(): CodeHighlighterPlugin {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  return useMemo(() => {
+    const themes = buildChatCodeThemes(theme);
+    // Theme names embed a hash of the palette, so this key changes exactly
+    // when the colors change.
+    const key = String(themes[0].name);
+    if (cachedPlugin?.key === key) return cachedPlugin.plugin;
+    const plugin = createCodePlugin({ themes });
+    cachedPlugin = { key, plugin };
+    return plugin;
+  }, [theme]);
+}

--- a/src/hooks/use-chat-code-plugin.ts
+++ b/src/hooks/use-chat-code-plugin.ts
@@ -17,9 +17,11 @@ import { fallbackTheme } from "./use-theme-colors";
  * `theme-changed` listener *per message*. Here every consumer shares a single
  * fetch, a single listener, and a single plugin instance.
  *
- * The plugin is memoized on palette identity because `@streamdown/code` keeps
- * its Shiki highlighter and token caches inside the plugin instance — rebuilding
- * it on unrelated renders would throw those caches away on every keystroke.
+ * The plugin is memoized on palette identity so a streaming transcript hands
+ * every `ChatMarkdown` the same plugin object across renders. (`@streamdown/code`
+ * keeps its highlighter and token caches in module-level maps, so those survive
+ * a rebuild — what the memo avoids is the churn of a new plugin identity
+ * propagating through the markdown tree on every keystroke.)
  */
 
 let currentTheme: ThemeColors = fallbackTheme;

--- a/src/lib/shiki-chat-theme.test.ts
+++ b/src/lib/shiki-chat-theme.test.ts
@@ -82,6 +82,26 @@ describe("buildChatCodeThemes", () => {
     expect(a.name).not.toBe(b.name);
   });
 
+  // `color9` only feeds the `invalid` scope, so it is the easiest color to
+  // drop out of the identity hash. Every color the token map reads has to be
+  // in it, or two palettes collide on name and the cache serves stale colors.
+  it.each([
+    ["color1", "#101010"],
+    ["color2", "#202020"],
+    ["color3", "#303030"],
+    ["color4", "#404040"],
+    ["color5", "#505050"],
+    ["color6", "#606060"],
+    ["color8", "#808080"],
+    ["color9", "#909090"],
+    ["color11", "#b0b0b0"],
+    ["foreground", "#fefefe"],
+  ] as const)("changes the theme name when %s alone changes", (key, value) => {
+    const [a] = buildChatCodeThemes(palette);
+    const [b] = buildChatCodeThemes({ ...palette, [key]: value });
+    expect(b.name).not.toBe(a.name);
+  });
+
   it("is stable for an unchanged palette", () => {
     const [a] = buildChatCodeThemes(palette);
     const [b] = buildChatCodeThemes({ ...palette });

--- a/src/lib/shiki-chat-theme.test.ts
+++ b/src/lib/shiki-chat-theme.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { buildChatCodeThemes } from "./shiki-chat-theme";
+import type { ThemeColors } from "@/tauri/types";
+
+const palette: ThemeColors = {
+  accent: "#7aa2f7",
+  cursor: "#c0caf5",
+  foreground: "#c0caf5",
+  background: "#1a1b26",
+  selection_foreground: "#c0caf5",
+  selection_background: "#283457",
+  color0: "#15161e",
+  color1: "#f7768e",
+  color2: "#9ece6a",
+  color3: "#e0af68",
+  color4: "#7aa2f7",
+  color5: "#bb9af7",
+  color6: "#7dcfff",
+  color7: "#a9b1d6",
+  color8: "#414868",
+  color9: "#ff0000",
+  color10: "#9ece6a",
+  color11: "#e0af68",
+  color12: "#7aa2f7",
+  color13: "#bb9af7",
+  color14: "#7dcfff",
+  color15: "#c0caf5",
+};
+
+/** Flattens the token map to `scope -> foreground` for easy assertions. */
+function foregroundFor(theme: ReturnType<typeof buildChatCodeThemes>[number], scope: string) {
+  const entry = (
+    theme as unknown as {
+      tokenColors: { scope: string[]; settings: { foreground?: string } }[];
+    }
+  ).tokenColors.find((t) => t.scope.includes(scope));
+  return entry?.settings.foreground;
+}
+
+describe("buildChatCodeThemes", () => {
+  it("returns a light/dark pair with distinct names", () => {
+    const [light, dark] = buildChatCodeThemes(palette);
+    expect(light.type).toBe("light");
+    expect(dark.type).toBe("dark");
+    expect(light.name).not.toBe(dark.name);
+  });
+
+  it("maps token scopes to the ANSI palette, matching the editor theme", () => {
+    const [theme] = buildChatCodeThemes(palette);
+    // Mirrors src/lib/codemirror-theme.ts so chat and the editor agree.
+    expect(foregroundFor(theme, "keyword")).toBe(palette.color5);
+    expect(foregroundFor(theme, "comment")).toBe(palette.color8);
+    expect(foregroundFor(theme, "string")).toBe(palette.color2);
+    expect(foregroundFor(theme, "constant.numeric")).toBe(palette.color3);
+    expect(foregroundFor(theme, "entity.name.function")).toBe(palette.color4);
+    expect(foregroundFor(theme, "entity.name.type")).toBe(palette.color6);
+  });
+
+  it("keeps the background transparent so the card surface shows through", () => {
+    for (const theme of buildChatCodeThemes(palette)) {
+      expect(theme.bg).toBe("transparent");
+      expect(theme.fg).toBe(palette.foreground);
+    }
+  });
+
+  it("italicizes comments", () => {
+    const [theme] = buildChatCodeThemes(palette);
+    const comment = (
+      theme as unknown as {
+        tokenColors: { scope: string[]; settings: { fontStyle?: string } }[];
+      }
+    ).tokenColors.find((t) => t.scope.includes("comment"));
+    expect(comment?.settings.fontStyle).toBe("italic");
+  });
+
+  // The highlighter cache in `@streamdown/code` is keyed by theme *name*, so a
+  // palette change must produce a new name or the old colors are served back.
+  it("changes the theme name when the palette changes", () => {
+    const [a] = buildChatCodeThemes(palette);
+    const [b] = buildChatCodeThemes({ ...palette, color5: "#123456" });
+    expect(a.name).not.toBe(b.name);
+  });
+
+  it("is stable for an unchanged palette", () => {
+    const [a] = buildChatCodeThemes(palette);
+    const [b] = buildChatCodeThemes({ ...palette });
+    expect(a.name).toBe(b.name);
+  });
+});

--- a/src/lib/shiki-chat-theme.ts
+++ b/src/lib/shiki-chat-theme.ts
@@ -28,28 +28,6 @@ function fnv1a32(input: string): number {
   return hash >>> 0;
 }
 
-/**
- * Shiki's highlighter cache inside `@streamdown/code` is keyed by theme
- * *name*, not by theme content. A fixed name would serve stale colors after
- * the user switches terminal theme, so the palette is hashed into the name:
- * a new palette is a new theme identity and misses the cache correctly.
- */
-function paletteId(theme: ThemeColors): string {
-  const palette = [
-    theme.foreground,
-    theme.background,
-    theme.color1,
-    theme.color2,
-    theme.color3,
-    theme.color4,
-    theme.color5,
-    theme.color6,
-    theme.color8,
-    theme.color11,
-  ].join("|");
-  return fnv1a32(palette).toString(36);
-}
-
 function buildTokenColors(theme: ThemeColors) {
   return [
     {
@@ -146,6 +124,27 @@ function buildTokenColors(theme: ThemeColors) {
   ];
 }
 
+type ChatCodeThemeBase = {
+  bg: string;
+  fg: string;
+  tokenColors: ReturnType<typeof buildTokenColors>;
+};
+
+/**
+ * Shiki's highlighter cache inside `@streamdown/code` is keyed by theme
+ * *name*, not by theme content. A fixed name would serve stale colors after
+ * the user switches terminal theme, so the theme is hashed into the name: a
+ * new palette is a new theme identity and misses the cache correctly.
+ *
+ * The hash covers the *built* theme rather than a hand-picked list of
+ * `ThemeColors` fields, so every color the token map actually consumes is
+ * part of the identity by construction — repointing a scope or adding one
+ * can't silently leave a color out of the hash.
+ */
+function themeId(base: ChatCodeThemeBase): string {
+  return fnv1a32(JSON.stringify(base)).toString(36);
+}
+
 /**
  * Streamdown always renders a light/dark theme pair, and Shiki emits both a
  * `color` and a `--shiki-dark` value per token. The app shell is dark-only
@@ -161,14 +160,12 @@ function buildTokenColors(theme: ThemeColors) {
 export function buildChatCodeThemes(
   theme: ThemeColors,
 ): [ThemeRegistrationAny, ThemeRegistrationAny] {
-  const id = paletteId(theme);
-  const tokenColors = buildTokenColors(theme);
-
-  const base = {
+  const base: ChatCodeThemeBase = {
     bg: "transparent",
     fg: theme.foreground,
-    tokenColors,
-  } as const;
+    tokenColors: buildTokenColors(theme),
+  };
+  const id = themeId(base);
 
   return [
     { ...base, name: `codemux-ansi-${id}-light`, type: "light" },

--- a/src/lib/shiki-chat-theme.ts
+++ b/src/lib/shiki-chat-theme.ts
@@ -1,0 +1,177 @@
+import type { ThemeRegistrationAny } from "shiki";
+import type { ThemeColors } from "@/tauri/types";
+
+/**
+ * Builds a Shiki theme from the active terminal ANSI palette so fenced
+ * code blocks in chat are colored by the same source as the file editor
+ * (`src/lib/codemirror-theme.ts`) and the terminal panes.
+ *
+ * This is the documented ANSI-palette exception to the no-hardcoded-colors
+ * rule (see `docs/reference/DESIGN-SYSTEM.md`): Shiki emits concrete colors
+ * into inline `style` attributes, so it needs real values rather than CSS
+ * variables. Structural chrome (container, header, borders) stays on design
+ * tokens — only the token colors come from `ThemeColors`.
+ *
+ * The scope map below mirrors the Lezer tag map in `codemirror-theme.ts`
+ * so a given construct is the same color in chat and in the editor. Keep
+ * the two in sync when either changes.
+ */
+
+/** FNV-1a (32-bit), matching the hashing style used elsewhere for cache keys. */
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    // 32-bit FNV prime multiply via shifts, kept in uint32 range.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Shiki's highlighter cache inside `@streamdown/code` is keyed by theme
+ * *name*, not by theme content. A fixed name would serve stale colors after
+ * the user switches terminal theme, so the palette is hashed into the name:
+ * a new palette is a new theme identity and misses the cache correctly.
+ */
+function paletteId(theme: ThemeColors): string {
+  const palette = [
+    theme.foreground,
+    theme.background,
+    theme.color1,
+    theme.color2,
+    theme.color3,
+    theme.color4,
+    theme.color5,
+    theme.color6,
+    theme.color8,
+    theme.color11,
+  ].join("|");
+  return fnv1a32(palette).toString(36);
+}
+
+function buildTokenColors(theme: ThemeColors) {
+  return [
+    {
+      scope: ["keyword", "storage", "storage.type", "storage.modifier", "keyword.control"],
+      settings: { foreground: theme.color5 },
+    },
+    {
+      scope: ["comment", "punctuation.definition.comment", "string.comment"],
+      settings: { foreground: theme.color8, fontStyle: "italic" },
+    },
+    {
+      scope: ["string", "string.quoted", "string.template", "constant.other.symbol"],
+      settings: { foreground: theme.color2 },
+    },
+    {
+      scope: ["constant.numeric", "constant.numeric.integer", "constant.numeric.float"],
+      settings: { foreground: theme.color3 },
+    },
+    {
+      scope: [
+        "entity.name.function",
+        "support.function",
+        "meta.function-call",
+        "variable.function",
+      ],
+      settings: { foreground: theme.color4 },
+    },
+    {
+      scope: [
+        "entity.name.type",
+        "entity.name.class",
+        "entity.name.namespace",
+        "support.type",
+        "support.class",
+      ],
+      settings: { foreground: theme.color6 },
+    },
+    {
+      scope: ["keyword.operator", "punctuation", "meta.brace"],
+      settings: { foreground: theme.color1 },
+    },
+    {
+      scope: ["constant.language", "constant.language.boolean", "constant.language.null"],
+      settings: { foreground: theme.color3 },
+    },
+    {
+      scope: [
+        "variable.other.property",
+        "support.variable.property",
+        "meta.object-literal.key",
+      ],
+      settings: { foreground: theme.color4 },
+    },
+    {
+      scope: ["variable", "variable.other", "meta.definition.variable.name"],
+      settings: { foreground: theme.foreground },
+    },
+    {
+      scope: ["meta.annotation", "entity.name.decorator", "meta.decorator"],
+      settings: { foreground: theme.color11 },
+    },
+    {
+      scope: ["entity.name.tag", "punctuation.definition.tag"],
+      settings: { foreground: theme.color1 },
+    },
+    {
+      scope: ["entity.other.attribute-name"],
+      settings: { foreground: theme.color3 },
+    },
+    {
+      scope: ["markup.heading", "entity.name.section"],
+      settings: { foreground: theme.color4, fontStyle: "bold" },
+    },
+    {
+      scope: ["markup.underline.link", "markup.link", "string.other.link"],
+      settings: { foreground: theme.color6, fontStyle: "underline" },
+    },
+    {
+      scope: ["markup.inserted", "meta.diff.header.to-file"],
+      settings: { foreground: theme.color2 },
+    },
+    {
+      scope: ["markup.deleted", "meta.diff.header.from-file"],
+      settings: { foreground: theme.color1 },
+    },
+    {
+      scope: ["markup.changed", "meta.diff.range"],
+      settings: { foreground: theme.color3 },
+    },
+    {
+      scope: ["invalid", "invalid.illegal"],
+      settings: { foreground: theme.color9 },
+    },
+  ];
+}
+
+/**
+ * Streamdown always renders a light/dark theme pair, and Shiki emits both a
+ * `color` and a `--shiki-dark` value per token. The app shell is dark-only
+ * (`main.tsx` pins `.dark` on the root) and the terminal ANSI palette is a
+ * single palette — the CodeMirror editor theme likewise hardcodes
+ * `{ dark: true }` — so both slots are filled with the same colors under
+ * distinct names. Distinct names matter because Shiki registers themes by
+ * name and the pair must not collide.
+ *
+ * The background is transparent so the code-block container's own token-based
+ * surface shows through.
+ */
+export function buildChatCodeThemes(
+  theme: ThemeColors,
+): [ThemeRegistrationAny, ThemeRegistrationAny] {
+  const id = paletteId(theme);
+  const tokenColors = buildTokenColors(theme);
+
+  const base = {
+    bg: "transparent",
+    fg: theme.foreground,
+    tokenColors,
+  } as const;
+
+  return [
+    { ...base, name: `codemux-ansi-${id}-light`, type: "light" },
+    { ...base, name: `codemux-ansi-${id}-dark`, type: "dark" },
+  ];
+}

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -34,6 +34,11 @@ export const SETTINGS_DEFAULTS: Record<string, string> = {
   // idle sweep (merged/closed-PR cards still auto-settle once idle). See
   // sidebar-inbox.tsx.
   "sidebar.auto_settle_days": "3",
+  // Whether fenced code blocks in chat soft-wrap long lines. Off keeps each
+  // line intact behind a horizontal scroll (better for diffs and tables of
+  // output); on trades that for no sideways scrolling. Applied as a
+  // `data-code-wrap` attr on the chat markdown root — see globals.css.
+  "chat.code_wrap": "false",
 };
 
 /** Color palette variant. */
@@ -163,6 +168,10 @@ export const selectSidebarAutoSettleDays = (s: SettingsStore): number | null => 
   const days = Number(raw);
   return Number.isFinite(days) && days > 0 ? days : null;
 };
+
+export const selectChatCodeWrap = (s: SettingsStore): boolean =>
+  (s.settings["chat.code_wrap"] ?? SETTINGS_DEFAULTS["chat.code_wrap"]!) ===
+  "true";
 
 export const selectWorkingIndicator = (
   s: SettingsStore,


### PR DESCRIPTION
## Problem

Fenced code blocks in agent chat rendered as flat grey text: no syntax colors, a line-number gutter nobody asked for, and a visible box-in-a-box border.

Two root causes:

- `shiki` and `@streamdown/code` were **declared and locked in `package.json` but never installed** — the feature had been started and abandoned, not merely disabled.
- A stale comment in `ChatMarkdown.tsx` claimed fenced blocks render as a plain `<pre>` "with identical DOM semantics". That was true under react-markdown but is false under Streamdown v2.5, which injects its own container, header, action pill, and line-numbered body regardless of whether the code plugin is installed. So we got all of its chrome, none of its color, and our `prose-pre:*` chain stacked a third border, background, and padding inside its card.

## What this does

Enables Streamdown's Shiki `code` plugin, themed from the **terminal ANSI palette** via a scope map that mirrors the Lezer tag map in `codemirror-theme.ts`. A keyword is now the same color in chat, the file editor, and the terminal, and switching terminal theme recolors chat live.

Also: line numbers off, the nested borders flattened, an empty-language header strip hidden, the copy/download pill revealed on hover, and a `chat.code_wrap` setting (default off) with an Appearance toggle.

## Non-obvious decisions

- **The plugin is a module-level store, not a hook.** A transcript mounts one `ChatMarkdown` per assistant message, so a per-hook implementation would fire one `get_current_theme` IPC call and register one `theme-changed` listener *per message*.
- **The palette is hashed into the theme name.** Shiki's highlighter cache inside `@streamdown/code` is keyed by theme *name*, not content — a fixed name would serve stale colors forever after a terminal-theme switch. Pinned by a test.
- **The prose chain now neutralizes rather than styles.** Removing the `prose-pre:*` rules outright would let the typography plugin's dark-slab defaults back in, so they're explicitly zeroed instead.

## Two bugs caught by visual verification, not typechecking

1. **Disabling line numbers collapsed every block onto one line.** Streamdown gives each line span `display: block` only as part of its line-number CSS class, and Shiki emits no `\n` between lines — so a 20-line block became one long horizontally-scrolling line. The line box is restored explicitly in CSS.
2. **Hiding the empty header would have flung the action pill out of the card.** Streamdown anchors that pill by pulling a sticky spacer row *up over* the header with `-mt-10`, hard-coupling the two. The spacer is collapsed and the pill anchored to the card instead.

## Result

Block heights on a representative sample (python fence / bare output fence / long TS line): **86 → 73**, **141 → 113**, **138 → 125** px.

## Scope notes

- The header shows the language only. Streamdown's fence meta supports just `startLine=` and `noLineNumbers` — there is no filename/title slot, and adding one means forking its `code` component. Documented rather than hacked.
- The action pill's hover-reveal has a `@media (hover: none)` fallback and `:focus-within`, so touch and keyboard users never lose it.
- Structural chrome stays on design tokens. Only Shiki token colors are concrete, under the ANSI-palette exception already documented for `TerminalPane` and the CodeMirror theme.

## Verification

- `npm run check` clean.
- `npm run test` — **210 files / 3057 tests pass**, including 6 new ones for the theme builder.
- Visually verified in the running app.

⚠️ `npm run verify` does not currently pass end-to-end on this machine: `cargo check` fails on a missing sidecar (`src-tauri/binaries/agent-browser-x86_64-unknown-linux-gnu`; the directory doesn't exist). Pre-existing and unrelated — this branch touches no Rust — but since `verify` is an `&&` chain that failure masks the frontend gates, so those were run directly.