### PR TITLE
fix(skills): discover project-scope Codex skills under .agents/skills

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -269,7 +269,12 @@ The chat pane stack:
     `ModelPicker` / `MultiProviderModelPicker`; the composer skips its
     usual textarea refocus for this pick so the popover isn't
     dismissed by focus-outside). Built in `buildModelCommand`.
-  - **SKILLS** — dynamic, from the skills registry (unchanged).
+  - **SKILLS** — dynamic, from the skills registry. Every discovered
+    skill is offered to every provider: the list is **not** filtered by
+    the active pane's provider, which is the whole point of the
+    cross-provider design (a Codex skill is invocable from a Claude
+    pane and vice versa). Provider appears only as a label in the row
+    description and as grouping/sort order.
   - **COMMANDS** — **provider-native slash commands, discovered live**
     (never hardcoded). The claude-agent sidecar's `list-commands`
     JSON-RPC method opens a transient SDK `query()` (same lifecycle as
@@ -291,6 +296,30 @@ The chat pane stack:
     slash itself — Codemux never executes provider commands locally.
 - **Cross-provider skill system**: watcher, conflicts, disable, refined
   compat. Server-side sync (see `docs/features/skills-sync.md`).
+  - **Scan roots** (`skills::paths::enumerate_scan_paths` — the single
+    source of truth; scanner, watcher, conflict detection and the
+    Settings grouping all derive from it, so adding a provider root is
+    a one-line change there):
+    - *User*: `~/.claude/skills`, `~/.codex/skills`, `~/.agents/skills`,
+      `~/.opencode/skills`, `~/.config/opencode/skills`,
+      `~/.codemux/skills`
+    - *Project*: `<root>/.claude/skills`, `<root>/.codex/skills`,
+      `<root>/.agents/skills`, `<root>/.opencode/skills`,
+      `<root>/.codemux/skills`
+    - *Plugin* (only when `include_plugins`):
+      `~/.claude/plugins/marketplaces/*/plugins/*/skills`,
+      `~/.claude/plugins/external_plugins/*/skills`
+  - Codex reads **both** `.codex/skills` and `.agents/skills` at each
+    scope; `.agents` is the newer convention and is frequently a
+    symlink to the older one.
+  - `~/.codex/skills/.system/` is excluded (Codex built-ins, not user
+    content) — see `is_codex_system_dir`.
+  - **Roots are deduped by canonical path** before scanning. Several of
+    these roots are commonly symlinked to each other, and walking both
+    sides of an alias would surface every skill twice — which the
+    name-based `detectConflicts` would then report as a conflict. The
+    first root to claim a directory wins, so enumeration order encodes
+    precedence (user before project; canonical location before alias).
 - **MCP host runtime** (Step 9): Codemux discovers user-installed MCP
   servers across Codemux / Claude / Cursor paths, spawns each child once,
   exposes tools to the Claude SDK via an in-process facade with dynamic

--- a/docs/features/skills-sync.md
+++ b/docs/features/skills-sync.md
@@ -49,7 +49,8 @@ The Better Auth account is still cross-product compatible with Vexis (email+pass
 
 ### Provider scope rules
 
-- **Synced (`scope=user`):** `~/.codemux/skills/`, `~/.claude/skills/`, `~/.codex/skills/`, `~/.opencode/skills/`. The origin provider tag is preserved through the wire format and restored on the receiving device's mapping.
+- **Synced (`scope=user`):** `~/.codemux/skills/`, `~/.claude/skills/`, `~/.codex/skills/`, `~/.agents/skills/` (Codex's newer root), `~/.opencode/skills/`, `~/.config/opencode/skills/`. The origin provider tag is preserved through the wire format and restored on the receiving device's mapping.
+- **Lockstep invariant:** this list is `path_detection::USER_SCOPE_PROVIDERS`, and it must cover every user root that `skills::paths::enumerate_scan_paths` returns. The push pipeline walks the scanner's enumeration and classifies each hit through `detect_skill_path`; a root the scanner knows but the table doesn't classifies as `None` and is dropped from sync with no diagnostic. `user_scope_table_covers_every_scan_root` / `project_scope_table_covers_every_scan_root` fail the build if the two drift.
 - **NOT synced (`is_syncable=false`):** project-scope skills under `<project>/.codemux/skills/`, etc. Reserved for Step 10.5.
 - **NOT synced (`None`):** plugin skills, marketplace skills, anything outside the recognized layouts.
 - **Sync target invariant:** the receiving device always writes to `~/.codemux/skills/<name>/SKILL.md` regardless of origin provider.

--- a/src-tauri/src/skills/paths.rs
+++ b/src-tauri/src/skills/paths.rs
@@ -38,51 +38,142 @@ pub fn enumerate_scan_paths_with_home(
     let mut project_paths: Vec<(PathBuf, SkillProvider)> = Vec::new();
     let mut plugin_paths: Vec<(PathBuf, String)> = Vec::new();
 
+    // One canonical-path ledger for the whole enumeration. Several of the
+    // roots below are commonly symlinked to one another (`~/.agents/skills`
+    // → `~/.codex/skills`, `~/.config/opencode/skills` →
+    // `~/.opencode/skills`, a project root that *is* `$HOME`). Walking both
+    // sides of such an alias would surface every skill twice, which reads
+    // as a name conflict in Settings even though it is one file on disk.
+    // Deduping here — at the single source of truth for scan paths — keeps
+    // every downstream consumer (scanner, watcher, conflict detection)
+    // honest without any of them needing to know about symlinks.
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+
     if let Some(home) = home {
         // Claude user-wide.
-        user_paths.push((home.join(".claude").join("skills"), SkillProvider::Claude));
+        push_unique(
+            &mut user_paths,
+            &mut seen,
+            home.join(".claude").join("skills"),
+            SkillProvider::Claude,
+        );
 
         // Codex: legacy `~/.codex/skills/` plus OpenAI's newer
         // `$HOME/.agents/skills/`. The scanner is responsible for
         // excluding the `.system/` subdirectory of `~/.codex/skills/`
         // (built-in skills, not user content).
-        user_paths.push((home.join(".codex").join("skills"), SkillProvider::Codex));
-        user_paths.push((home.join(".agents").join("skills"), SkillProvider::Codex));
+        push_unique(
+            &mut user_paths,
+            &mut seen,
+            home.join(".codex").join("skills"),
+            SkillProvider::Codex,
+        );
+        push_unique(
+            &mut user_paths,
+            &mut seen,
+            home.join(".agents").join("skills"),
+            SkillProvider::Codex,
+        );
 
-        // OpenCode: dedupe the two known conventions if they resolve to
-        // the same directory (e.g., one is a symlink to the other).
-        let oc_a = home.join(".opencode").join("skills");
-        let oc_b = home.join(".config").join("opencode").join("skills");
-        let mut opencode_seen: HashSet<PathBuf> = HashSet::new();
-        for path in [oc_a, oc_b] {
-            let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
-            if opencode_seen.insert(canonical) {
-                user_paths.push((path, SkillProvider::Opencode));
-            }
-        }
+        // OpenCode publishes two conventions for the same directory.
+        push_unique(
+            &mut user_paths,
+            &mut seen,
+            home.join(".opencode").join("skills"),
+            SkillProvider::Opencode,
+        );
+        push_unique(
+            &mut user_paths,
+            &mut seen,
+            home.join(".config").join("opencode").join("skills"),
+            SkillProvider::Opencode,
+        );
 
         // Codemux's neutral location.
-        user_paths.push((home.join(".codemux").join("skills"), SkillProvider::Codemux));
+        push_unique(
+            &mut user_paths,
+            &mut seen,
+            home.join(".codemux").join("skills"),
+            SkillProvider::Codemux,
+        );
 
         // Plugin-bundled Claude skills. The locked path globs are
         // `~/.claude/plugins/marketplaces/*/plugins/*/skills`
         // and `~/.claude/plugins/external_plugins/*/skills`.
         if include_plugins {
-            plugin_paths.extend(enumerate_claude_plugin_paths(home));
+            for (path, slug) in enumerate_claude_plugin_paths(home) {
+                if seen.insert(canonical_key(&path)) {
+                    plugin_paths.push((path, slug));
+                }
+            }
         }
     }
 
     if let Some(root) = project_root {
-        project_paths.push((root.join(".claude").join("skills"), SkillProvider::Claude));
-        project_paths.push((root.join(".codex").join("skills"), SkillProvider::Codex));
-        project_paths.push((root.join(".opencode").join("skills"), SkillProvider::Opencode));
-        project_paths.push((root.join(".codemux").join("skills"), SkillProvider::Codemux));
+        push_unique(
+            &mut project_paths,
+            &mut seen,
+            root.join(".claude").join("skills"),
+            SkillProvider::Claude,
+        );
+        // Codex reads BOTH `<root>/.codex/skills/` and the newer
+        // `<root>/.agents/skills/` at project scope, mirroring the two
+        // user-scope Codex roots above. Omitting `.agents/skills` here
+        // meant project-local Codex skills showed up in the Codex CLI but
+        // never in the Codemux slash popup.
+        push_unique(
+            &mut project_paths,
+            &mut seen,
+            root.join(".codex").join("skills"),
+            SkillProvider::Codex,
+        );
+        push_unique(
+            &mut project_paths,
+            &mut seen,
+            root.join(".agents").join("skills"),
+            SkillProvider::Codex,
+        );
+        push_unique(
+            &mut project_paths,
+            &mut seen,
+            root.join(".opencode").join("skills"),
+            SkillProvider::Opencode,
+        );
+        push_unique(
+            &mut project_paths,
+            &mut seen,
+            root.join(".codemux").join("skills"),
+            SkillProvider::Codemux,
+        );
     }
 
     ScanPaths {
         user_paths,
         project_paths,
         plugin_paths,
+    }
+}
+
+/// Identity used for alias detection. Resolves symlinks when the
+/// directory exists; falls back to the literal path when it doesn't.
+/// The fallback is deliberate — a missing directory can't alias anything,
+/// and the scanner skips it silently anyway.
+fn canonical_key(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Append `path` unless some earlier root already resolved to the same
+/// directory. The *first* root to claim a directory wins, so enumeration
+/// order encodes precedence: user scope before project scope, and within
+/// a provider the canonical location before the alias.
+fn push_unique(
+    out: &mut Vec<(PathBuf, SkillProvider)>,
+    seen: &mut HashSet<PathBuf>,
+    path: PathBuf,
+    provider: SkillProvider,
+) {
+    if seen.insert(canonical_key(&path)) {
+        out.push((path, provider));
     }
 }
 
@@ -211,7 +302,24 @@ mod tests {
 
         let project_dir = TempDir::new().unwrap();
         let with_project = enumerate_scan_paths_with_home(Some(project_dir.path()), false, Some(home.path()));
-        assert_eq!(with_project.project_paths.len(), 4);
+        assert_eq!(with_project.project_paths.len(), 5);
+    }
+
+    #[test]
+    fn project_scope_includes_both_codex_roots() {
+        let home = fake_home();
+        let project_dir = TempDir::new().unwrap();
+        let paths =
+            enumerate_scan_paths_with_home(Some(project_dir.path()), false, Some(home.path()));
+        let codex: Vec<_> = paths
+            .project_paths
+            .iter()
+            .filter(|(_, p)| matches!(p, SkillProvider::Codex))
+            .map(|(p, _)| p.clone())
+            .collect();
+        assert_eq!(codex.len(), 2);
+        assert!(codex.iter().any(|p| p.ends_with(".codex/skills")));
+        assert!(codex.iter().any(|p| p.ends_with(".agents/skills")));
     }
 
     #[test]
@@ -299,5 +407,82 @@ mod tests {
             .collect();
         // Symlink resolves to the same target — only one entry survives.
         assert_eq!(opencode.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_dedupes_when_agents_symlinks_to_codex() {
+        use std::os::unix::fs::symlink;
+
+        // `~/.agents/skills -> ~/.codex/skills` is a common way to serve
+        // both Codex conventions from one directory. Scanning both would
+        // double every Codex skill and read as a name conflict.
+        let home = fake_home();
+        let real = home.path().join(".codex").join("skills");
+        fs::create_dir_all(&real).unwrap();
+        fs::create_dir_all(home.path().join(".agents")).unwrap();
+        symlink(&real, home.path().join(".agents").join("skills")).unwrap();
+
+        let paths = enumerate_scan_paths_with_home(None, false, Some(home.path()));
+        let codex: Vec<_> = paths
+            .user_paths
+            .iter()
+            .filter(|(_, p)| matches!(p, SkillProvider::Codex))
+            .map(|(p, _)| p.clone())
+            .collect();
+        assert_eq!(codex.len(), 1);
+        // The canonical root wins because it is enumerated first.
+        assert!(codex[0].ends_with(".codex/skills"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_root_aliasing_home_does_not_duplicate_user_paths() {
+        use std::os::unix::fs::symlink;
+
+        // A project whose `.claude/skills` symlinks at the user-wide one
+        // must not yield the same directory under both scopes.
+        let home = fake_home();
+        let user_skills = home.path().join(".claude").join("skills");
+        fs::create_dir_all(&user_skills).unwrap();
+
+        let project = TempDir::new().unwrap();
+        fs::create_dir_all(project.path().join(".claude")).unwrap();
+        symlink(&user_skills, project.path().join(".claude").join("skills")).unwrap();
+
+        let paths =
+            enumerate_scan_paths_with_home(Some(project.path()), false, Some(home.path()));
+        // User scope claimed it first; the project alias is dropped.
+        assert!(paths
+            .project_paths
+            .iter()
+            .all(|(p, _)| !p.ends_with(".claude/skills")));
+        assert_eq!(
+            paths
+                .user_paths
+                .iter()
+                .filter(|(p, _)| p.ends_with(".claude/skills"))
+                .count(),
+            1
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn plugin_paths_dedupe_against_user_roots() {
+        use std::os::unix::fs::symlink;
+
+        let home = fake_home();
+        let user_skills = home.path().join(".claude").join("skills");
+        fs::create_dir_all(&user_skills).unwrap();
+
+        let plugin_parent = home
+            .path()
+            .join(".claude/plugins/external_plugins/aliased");
+        fs::create_dir_all(&plugin_parent).unwrap();
+        symlink(&user_skills, plugin_parent.join("skills")).unwrap();
+
+        let paths = enumerate_scan_paths_with_home(None, true, Some(home.path()));
+        assert!(paths.plugin_paths.is_empty());
     }
 }

--- a/src-tauri/src/skills_sync/path_detection.rs
+++ b/src-tauri/src/skills_sync/path_detection.rs
@@ -114,11 +114,19 @@ pub fn destination_path_after_pull(name: &str, home: &Path) -> PathBuf {
 
 /// User-scope skill roots. Order matters only for diagnostic
 /// messages — paths are mutually disjoint by construction.
+///
+/// Must stay in lockstep with `crate::skills::paths::enumerate_scan_paths`
+/// — the push pipeline walks that enumeration and classifies each hit
+/// here, so a root present there but missing here is silently dropped
+/// from sync. `skills_sync::tests::user_scope_table_covers_every_scan_root`
+/// pins the two lists together.
 const USER_SCOPE_PROVIDERS: &[(&str, &str)] = &[
     (".codemux/skills", "codemux"),
     (".claude/skills", "claude"),
     (".codex/skills", "codex"),
+    (".agents/skills", "codex"),
     (".opencode/skills", "opencode"),
+    (".config/opencode/skills", "opencode"),
 ];
 
 /// Subdirectories searched relative to a project root. Each one
@@ -129,6 +137,7 @@ const PROJECT_SCOPE_SUBDIRS: &[&str] = &[
     ".codemux/skills",
     ".claude/skills",
     ".codex/skills",
+    ".agents/skills",
     ".opencode/skills",
 ];
 
@@ -136,7 +145,7 @@ fn provider_from_project_subdir(subdir: &str) -> &'static str {
     match subdir {
         ".codemux/skills" => "codemux",
         ".claude/skills" => "claude",
-        ".codex/skills" => "codex",
+        ".codex/skills" | ".agents/skills" => "codex",
         ".opencode/skills" => "opencode",
         _ => "unknown",
     }
@@ -171,6 +180,17 @@ mod tests {
         PathBuf::from("/home/zeus")
     }
 
+    /// `SkillPathInfo::provider` is documented to mirror
+    /// `SkillProvider`'s serde output, so compare through serde rather
+    /// than hand-maintaining a second mapping in the test.
+    fn provider_str(p: &crate::skills::SkillProvider) -> String {
+        serde_json::to_value(p)
+            .unwrap()
+            .as_str()
+            .expect("SkillProvider serializes to a string")
+            .to_string()
+    }
+
     // ── User-scope detection ───────────────────────────────────
 
     #[test]
@@ -199,6 +219,75 @@ mod tests {
         let info = detect_skill_path(&p, &home).unwrap();
         assert_eq!(info.provider, "codex");
         assert!(info.is_syncable);
+    }
+
+    #[test]
+    fn codex_agents_root_user_path_is_syncable() {
+        let home = fake_home();
+        let p = home.join(".agents/skills/bar/SKILL.md");
+        let info = detect_skill_path(&p, &home).unwrap();
+        assert_eq!(info.provider, "codex");
+        assert!(info.is_syncable);
+    }
+
+    /// The push pipeline walks `skills::paths::enumerate_scan_paths` and
+    /// classifies each hit through `detect_skill_path`. A root that the
+    /// scanner knows but this table doesn't is classified `None` and
+    /// dropped from sync without a diagnostic — which is how
+    /// `~/.agents/skills` and `~/.config/opencode/skills` went missing.
+    /// Fail loudly here instead of silently there.
+    #[test]
+    fn user_scope_table_covers_every_scan_root() {
+        let home = fake_home();
+        let scan = crate::skills::paths::enumerate_scan_paths_with_home(None, false, Some(&home));
+
+        for (root, provider) in &scan.user_paths {
+            let probe = root.join("probe/SKILL.md");
+            let info = detect_skill_path(&probe, &home).unwrap_or_else(|| {
+                panic!(
+                    "scan root {} is not classified by path_detection — it would be \
+                     silently dropped from sync",
+                    root.display()
+                )
+            });
+            assert_eq!(info.scope, "user", "root {}", root.display());
+            assert_eq!(
+                info.provider,
+                provider_str(provider),
+                "provider mismatch for {}",
+                root.display()
+            );
+        }
+    }
+
+    #[test]
+    fn project_scope_table_covers_every_scan_root() {
+        let home = fake_home();
+        let project = PathBuf::from("/repo/myproj");
+        let scan = crate::skills::paths::enumerate_scan_paths_with_home(
+            Some(&project),
+            false,
+            Some(&home),
+        );
+
+        for (root, provider) in &scan.project_paths {
+            let probe = root.join("probe/SKILL.md");
+            let info = detect_with_project_root(&probe, &home, Some(&project)).unwrap_or_else(
+                || {
+                    panic!(
+                        "project scan root {} is not classified by path_detection",
+                        root.display()
+                    )
+                },
+            );
+            assert_eq!(info.scope, "project", "root {}", root.display());
+            assert_eq!(
+                info.provider,
+                provider_str(provider),
+                "provider mismatch for {}",
+                root.display()
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/tests/skills_command.rs
+++ b/src-tauri/tests/skills_command.rs
@@ -140,6 +140,95 @@ fn discovers_skills_across_all_provider_directories() {
     );
 }
 
+/// Regression: a Codex skill in a project's `.agents/skills/` is listed
+/// by the Codex CLI but was invisible in the Codemux slash popup, because
+/// project-scope enumeration only covered `.codex/skills`. The user-scope
+/// enumeration had both Codex roots; project scope had one.
+#[test]
+fn discovers_project_scoped_codex_skill_under_agents_root() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    let agents_project = project.path().join(".agents").join("skills");
+    fs::create_dir_all(&agents_project).unwrap();
+    write_skill(
+        &agents_project,
+        "update-personal-desktop",
+        "---\nname: update-personal-desktop\ndescription: Update the fork and rebuild\n---\nBody.",
+    );
+
+    let skills = collect_skills(home.path(), Some(project.path()), false);
+
+    let found = skills
+        .iter()
+        .find(|s| s.name == "update-personal-desktop")
+        .expect("project-scope .agents/skills skill not discovered");
+    assert_eq!(found.provider, SkillProvider::Codex);
+    assert_eq!(found.scope, SkillScope::Project);
+}
+
+/// Both Codex project roots are scanned, and a skill in each shows up
+/// exactly once — no accidental double-listing when a repo populates
+/// both conventions with different skills.
+#[test]
+fn both_codex_project_roots_are_scanned_independently() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    let codex_project = project.path().join(".codex").join("skills");
+    fs::create_dir_all(&codex_project).unwrap();
+    write_skill(
+        &codex_project,
+        "legacy-root",
+        "---\nname: legacy-root\ndescription: x\n---\nBody.",
+    );
+
+    let agents_project = project.path().join(".agents").join("skills");
+    fs::create_dir_all(&agents_project).unwrap();
+    write_skill(
+        &agents_project,
+        "new-root",
+        "---\nname: new-root\ndescription: x\n---\nBody.",
+    );
+
+    let skills = collect_skills(home.path(), Some(project.path()), false);
+    let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+
+    assert_eq!(names.iter().filter(|n| **n == "legacy-root").count(), 1);
+    assert_eq!(names.iter().filter(|n| **n == "new-root").count(), 1);
+}
+
+/// When a repo symlinks `.agents/skills` at `.codex/skills` to serve both
+/// conventions from one directory, the skill must be listed once. Listing
+/// it twice would trip the name-based conflict detector in Settings for
+/// what is a single file on disk.
+#[cfg(unix)]
+#[test]
+fn aliased_codex_project_roots_yield_one_listing() {
+    use std::os::unix::fs::symlink;
+
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+
+    let codex_project = project.path().join(".codex").join("skills");
+    fs::create_dir_all(&codex_project).unwrap();
+    write_skill(
+        &codex_project,
+        "shared",
+        "---\nname: shared\ndescription: x\n---\nBody.",
+    );
+    fs::create_dir_all(project.path().join(".agents")).unwrap();
+    symlink(&codex_project, project.path().join(".agents").join("skills")).unwrap();
+
+    let skills = collect_skills(home.path(), Some(project.path()), false);
+    assert_eq!(
+        skills.iter().filter(|s| s.name == "shared").count(),
+        1,
+        "aliased roots should not double-list: {:?}",
+        skills.iter().map(|s| &s.name).collect::<Vec<_>>()
+    );
+}
+
 #[test]
 fn include_plugins_false_hides_plugin_pool() {
     let home = TempDir::new().unwrap();


### PR DESCRIPTION
## Problem

A Codex skill at `<project>/.agents/skills/<name>/SKILL.md` is listed by the Codex CLI but never appears in the Codemux agent-chat slash popup.

The cross-provider design itself is fine — the skill list is **not** filtered by the active pane's provider, so any provider's skills are offered to every agent, as intended. The bug was narrower: `enumerate_scan_paths` knew both Codex roots (`.codex/skills` and the newer `.agents/skills`) at **user** scope, but only `.codex/skills` at **project** scope. That one combination fell through.

Verified against a real checkout before/after:

```
<project>/.claude/skills   (Claude)   -> 0
<project>/.codex/skills    (Codex)    -> 0
<project>/.agents/skills   (Codex)    -> 1     <- was 0, never scanned
   - /update-personal-desktop
<project>/.opencode/skills (Opencode) -> 0
<project>/.codemux/skills  (Codemux)  -> 0
```

## Changes

**1. Scan-path fix.** Added the project-scope `.agents/skills` root. Because `enumerate_scan_paths` is the single source of truth, the scanner, watcher, conflict detection and Settings grouping all pick it up with no further plumbing — `GROUP_ORDER` already had a `Project · Codex` bucket.

**2. Generalized root deduplication.** The existing `opencode_seen` HashSet covered only OpenCode's two conventions, while the Codex pair is the one most likely to be symlinked together (`.agents/skills` → `.codex/skills` is a common way to serve both). It is now a `push_unique` / `canonical_key` pair backed by one ledger spanning user, project and plugin roots. Walking both sides of an alias would list every skill twice, which the name-based `detectConflicts` then reports as a clash for what is a single file on disk. First root to claim a directory wins, so enumeration order encodes precedence: user before project, canonical location before alias.

**3. Sync path table drift.** `skills_sync::path_detection` keeps its own path table; the push pipeline walks the scanner's enumeration and classifies each hit through it, so a root the scanner knows and the table doesn't returns `None` and is dropped from sync with no diagnostic. Two roots had already drifted out — `~/.agents/skills` and `~/.config/opencode/skills`. Both added, plus a guard test that drives the real enumeration through the classifier and fails with the offending path when the lists disagree.

## Testing

- `npm run verify` — 221 files / 3321 frontend tests, exit 0
- `cargo test` — 2303 lib tests + all integration suites
- Both commits verified independently green (bisectable)

Every new test was verified **non-vacuous** by reverting the corresponding fix:

| Removed | Failing test |
|---|---|
| project `.agents/skills` root | `discovers_project_scoped_codex_skill_under_agents_root`, `both_codex_project_roots_are_scanned_independently` |
| root dedup | `aliased_codex_project_roots_yield_one_listing`, `codex_dedupes_when_agents_symlinks_to_codex`, `project_root_aliasing_home_does_not_duplicate_user_paths`, `opencode_dedupes_via_symlink` |
| `.agents/skills` from sync table | `user_scope_table_covers_every_scan_root` — *"scan root /home/…/.agents/skills is not classified by path_detection — it would be silently dropped from sync"* |

## Docs

Scan roots are now documented in `docs/features/agent-chat.md` (they existed only as code comments), along with the deliberate no-provider-filtering rule. The syncable-roots table in `docs/features/skills-sync.md` is updated with the lockstep invariant.

## Known issue, deliberately not fixed here

`skill_id_for_path` hashes the **canonical** path, so one physical `SKILL.md` reached through several roots yields several records sharing one id. On a real machine `omarchy` is symlinked into `.claude/skills`, `.codex/skills` and `.agents/skills`, producing three records with id `eb37c92835eb215d`.

Root dedup does not address this — those are three distinct directories that each happen to contain a symlink to the same target, not aliased roots. Consequences: duplicate React keys (`skills-section.tsx:302,387`), one `disabledIds` entry driving three toggles that look independent, and `detectConflicts` reporting a 3-way clash for a single file. Fixing it means collapsing by canonical `file_path` in `list_skills` and carrying the other origins as aliases — a `Skill` schema change, best done separately.
