### PR TITLE
fix(chat): hide unusable provider commands, collapse duplicate skills

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -269,7 +269,23 @@ The chat pane stack:
     `ModelPicker` / `MultiProviderModelPicker`; the composer skips its
     usual textarea refocus for this pick so the popover isn't
     dismissed by focus-outside). Built in `buildModelCommand`.
-  - **SKILLS** — dynamic, from the skills registry (unchanged).
+  - **SKILLS** — dynamic, from the skills registry. Same-named skills
+    collapse to one row via `dedupeSkillsByName`
+    (`src/lib/agent-chat/skill-groups.ts`, first-wins over the
+    backend's provider → scope → name order). A skill is addressed in
+    the draft by name alone, so every copy of `/omarchy` would insert
+    byte-identical text; one source symlinked into `~/.claude/skills`,
+    `~/.codex/skills`, and `~/.agents/skills` (plus a real directory
+    under `~/.codemux/skills`) previously produced one row per root,
+    and copies reached through symlinks share a skill id — the id is a
+    hash of the *canonical* SKILL.md path — so the popup emitted
+    duplicate React keys and colliding menu values. The send-time
+    resolver `parseSkillTokens` (`skill-tokens.ts`) applies the same
+    first-wins rule, so the row the menu offers is guaranteed to be the
+    body that gets injected; its lookup used to be last-wins, which
+    silently resolved a picked skill to the *lowest*-priority copy.
+    Settings deliberately keeps every copy visible — `detectConflicts`
+    exists to surface exactly these clashes.
   - **COMMANDS** — **provider-native slash commands, discovered live**
     (never hardcoded). The claude-agent sidecar's `list-commands`
     JSON-RPC method opens a transient SDK `query()` (same lifecycle as
@@ -281,6 +297,17 @@ The chat pane stack:
     (`ClaudeSlashCommandCache`, per-cwd, app-lifetime, errors not
     cached) behind the `list_chat_slash_commands` Tauri command
     (Codex/OpenCode resolve to an empty list — no discovery surface).
+    `dedupe_commands` also drops commands the CLI marks `isHidden` but
+    the SDK reports anyway (`is_internal_command`): any `__`-prefixed
+    name, plus an exact-match denylist of `heapdump`,
+    `workflow-launch-exec`, `design-consent`, `design-revoke`,
+    `extra-usage`, `pro-trial-expired`, `rate-limit-options`. Each is
+    unusable from a Codemux thread — a debug affordance, a renamed
+    alias, or gated on a session kind Codemux never creates (the
+    workflow entries describe their own gate: "server-launched
+    sessions only"). Against the deployed CLI this trims 54 discovered
+    commands to 48. The filter is menu-only: a hand-typed name is still
+    forwarded verbatim.
     Frontend: `provider-commands-store.ts` (lazy load on first popup
     open, 60s TTL, keyed `(provider, cwd)`), `buildProviderCommands`
     (case-preserving map + reserved-name filter: collisions with
@@ -289,6 +316,23 @@ The chat pane stack:
     literal `/name ` text (same mechanics as skills/`/workflow`); the
     text is forwarded verbatim and the provider interprets the leading
     slash itself — Codemux never executes provider commands locally.
+
+    **Why the CLI's interactive commands are absent, and should stay
+    absent.** The CLI registers commands as `local`, `local-jsx`, or
+    `prompt`. The `local-jsx` ones render an ink/TUI surface and exist
+    only in an interactive terminal — `/remote-control` (alias `/rc`),
+    `/login`, `/resume`, `/rewind`, `/terminal-setup`, `/theme`,
+    `/statusline`, … The Agent SDK does not report them, and forwarding
+    one anyway returns `"<name> isn't available in this environment."`
+    Listing them would only offer rows that cannot work. Verified two
+    ways: `initializationResult().commands` and `supportedCommands()`
+    return the *identical* 54-command list (diffed, zero difference),
+    so switching probe APIs would change nothing. Remote control does
+    surface in the init result, but as session capability flags
+    (`remote_control_auto_enable`, `remote_control_auto_on_by_default`,
+    `ide_rc_auto_enable_gate`) rather than a command — deliberately not
+    consumed, since Codemux ships its own web remote access
+    (`docs/features/web-remote-access.md`).
 - **Cross-provider skill system**: watcher, conflicts, disable, refined
   compat. Server-side sync (see `docs/features/skills-sync.md`).
 - **MCP host runtime** (Step 9): Codemux discovers user-installed MCP

--- a/src-tauri/src/agent_provider/claude/slash_commands.rs
+++ b/src-tauri/src/agent_provider/claude/slash_commands.rs
@@ -91,16 +91,67 @@ impl ClaudeSlashCommandCache {
     }
 }
 
+/// Commands the CLI itself marks `isHidden` but which the SDK's
+/// command list reports anyway. They are unusable from a Codemux chat
+/// thread — each is either a debug affordance or gated on a session
+/// kind Codemux never creates — so offering them is pure menu noise.
+///
+/// Verified against the deployed CLI's command registry: every name
+/// here carries `isHidden` upstream, and the two `*workflow*` entries
+/// describe their own gate ("server-launched sessions only",
+/// "workflow_launch event sessions only").
+///
+/// This is deliberately a small, evidence-backed denylist rather than
+/// a broad heuristic: a custom user command is never dropped by it.
+const HIDDEN_COMMAND_NAMES: &[&str] = &[
+    // Debug-only: writes a heap snapshot to the user's Desktop.
+    "heapdump",
+    // Gated on server-launched / workflow-handoff sessions.
+    "workflow-launch-exec",
+    // Consent flows that require the CLI's interactive UI.
+    "design-consent",
+    "design-revoke",
+    // Renamed upstream to `usage-credits`, kept only as a hidden alias.
+    "extra-usage",
+    // Transient upsell states, surfaced by the CLI on its own terms.
+    "pro-trial-expired",
+    "rate-limit-options",
+];
+
+/// Whether a discovered command should be withheld from the menu.
+///
+/// Two rules, both evidence-backed:
+/// 1. A `__` prefix is the CLI's internal-command convention
+///    (e.g. `__remote-workflow`).
+/// 2. An explicit denylist for hidden commands the SDK leaks anyway.
+///
+/// Note this filters only the *menu*. A user who types the name by
+/// hand still has it forwarded verbatim — Codemux does not block
+/// commands, it just declines to advertise unusable ones.
+fn is_internal_command(name: &str) -> bool {
+    if name.starts_with("__") {
+        return true;
+    }
+    let lower = name.to_ascii_lowercase();
+    HIDDEN_COMMAND_NAMES.contains(&lower.as_str())
+}
+
 /// Case-insensitive dedupe by name, first occurrence wins. The SDK
 /// can report a user-level and a project-level custom command with
 /// the same name; the CLI resolves to one of them, so the menu should
 /// list it once.
+///
+/// Internal / CLI-hidden commands are dropped here too, so every
+/// consumer of the cache sees the same filtered vocabulary.
 fn dedupe_commands(commands: Vec<SdkSlashCommand>) -> Vec<ProviderSlashCommand> {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut out = Vec::with_capacity(commands.len());
     for c in commands {
         let name = c.name.trim().trim_start_matches('/').to_string();
         if name.is_empty() {
+            continue;
+        }
+        if is_internal_command(&name) {
             continue;
         }
         if !seen.insert(name.to_ascii_lowercase()) {
@@ -192,6 +243,54 @@ mod tests {
         ]);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].name, "init");
+    }
+
+    #[test]
+    fn drops_double_underscore_internal_commands() {
+        let out = dedupe_commands(vec![
+            sdk("compact", "Compact the conversation", ""),
+            sdk(
+                "__remote-workflow",
+                "Run the workflow script delivered in this session environment",
+                "",
+            ),
+        ]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "compact");
+    }
+
+    #[test]
+    fn drops_cli_hidden_commands_the_sdk_still_reports() {
+        // Every name here is `isHidden` in the deployed CLI registry
+        // but comes back from the SDK's command list regardless.
+        let out = dedupe_commands(vec![
+            sdk("heapdump", "Dump the JS heap to ~/Desktop", ""),
+            sdk("workflow-launch-exec", "Execute a handoff", ""),
+            sdk("design-consent", "Grant access", ""),
+            sdk("design-revoke", "Revoke access", ""),
+            sdk("extra-usage", "Renamed to /usage-credits", ""),
+            sdk("usage-credits", "Configure usage credits", ""),
+        ]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "usage-credits");
+    }
+
+    #[test]
+    fn hidden_filter_is_case_insensitive_and_slash_tolerant() {
+        let out = dedupe_commands(vec![sdk("/HeapDump", "shouting", "")]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn keeps_user_commands_that_merely_resemble_hidden_ones() {
+        // The denylist is exact-match: a custom command must never be
+        // swallowed by a prefix/substring heuristic.
+        let out = dedupe_commands(vec![
+            sdk("design", "Real user command", ""),
+            sdk("heapdump-report", "Custom command", ""),
+            sdk("my__internal", "Underscores not at the start", ""),
+        ]);
+        assert_eq!(out.len(), 3);
     }
 
     #[test]

--- a/src/lib/agent-chat/skill-commands.ts
+++ b/src/lib/agent-chat/skill-commands.ts
@@ -2,6 +2,7 @@ import { BookOpen } from "lucide-react";
 
 import type { Skill } from "@/tauri/commands";
 
+import { dedupeSkillsByName } from "./skill-groups";
 import type { SlashCommandItem } from "./slash-commands";
 
 interface BuildSkillCommandsArgs {
@@ -20,12 +21,17 @@ interface BuildSkillCommandsArgs {
  * Items are returned in the order the backend produced them
  * (provider → scope → name) so the popup mirrors the order the user
  * sees in Settings.
+ *
+ * Same-named skills collapse to one row via `dedupeSkillsByName` —
+ * every copy would insert the same `/name` text, and the send-time
+ * resolver in `skill-tokens.ts` applies the identical first-wins rule,
+ * so the row shown is guaranteed to be the body that gets injected.
  */
 export function buildSkillCommands({
   skills,
   onInvoke,
 }: BuildSkillCommandsArgs): SlashCommandItem[] {
-  return skills.map((skill) => ({
+  return dedupeSkillsByName(skills).map((skill) => ({
     id: `skill:${skill.id}`,
     label: skill.name,
     description: formatSkillDescription(skill),

--- a/src/lib/agent-chat/skill-groups.test.ts
+++ b/src/lib/agent-chat/skill-groups.test.ts
@@ -4,6 +4,7 @@ import type { Skill, SkillProvider, SkillScope } from "@/tauri/commands";
 
 import {
   GROUP_ORDER,
+  dedupeSkillsByName,
   detectConflicts,
   groupHeadingFor,
   groupSkillsByScope,
@@ -144,6 +145,60 @@ describe("groupSkillsByScope", () => {
       makeSkill("solo", "claude", "user"),
     ]);
     expect(conflicts.size).toBe(0);
+  });
+
+  it("dedupeSkillsByName keeps the first copy of a name, dropping the rest", () => {
+    // The real-world shape: one source symlinked into several provider
+    // roots, so the same name arrives once per root.
+    const out = dedupeSkillsByName([
+      makeSkill("omarchy", "claude", "user"),
+      makeSkill("omarchy", "codex", "user"),
+      makeSkill("omarchy", "codemux", "user"),
+      makeSkill("solo", "claude", "user"),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].provider).toBe("claude");
+    expect(out[1].name).toBe("solo");
+  });
+
+  it("dedupeSkillsByName keeps names that differ only in case", () => {
+    // `parseSkillTokens` resolves case-sensitively, so these are two
+    // separately addressable skills. Folding them would hide one from
+    // the menu while leaving it reachable by typing.
+    const out = dedupeSkillsByName([
+      makeSkill("Deploy", "claude", "user"),
+      makeSkill("deploy", "codex", "user"),
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it("dedupeSkillsByName leaves distinct names untouched and preserves order", () => {
+    const out = dedupeSkillsByName([
+      makeSkill("b", "claude", "user"),
+      makeSkill("a", "codex", "user"),
+    ]);
+    expect(out.map((s) => s.name)).toEqual(["b", "a"]);
+  });
+
+  it("dedupeSkillsByName does not mutate its input", () => {
+    const input = [
+      makeSkill("dup", "claude", "user"),
+      makeSkill("dup", "codex", "user"),
+    ];
+    dedupeSkillsByName(input);
+    expect(input).toHaveLength(2);
+  });
+
+  it("detectConflicts still reports duplicates that the popup collapses", () => {
+    // Settings must keep showing every install location even though
+    // the composer only ever offers one — the two behaviours are
+    // intentionally different views of the same data.
+    const skills = [
+      makeSkill("omarchy", "claude", "user"),
+      makeSkill("omarchy", "codex", "user"),
+    ];
+    expect(dedupeSkillsByName(skills)).toHaveLength(1);
+    expect(detectConflicts(skills).get("omarchy")).toHaveLength(2);
   });
 
   it("produces independent arrays per group (mutating one doesn't bleed)", () => {

--- a/src/lib/agent-chat/skill-groups.ts
+++ b/src/lib/agent-chat/skill-groups.ts
@@ -76,6 +76,48 @@ export function detectConflicts(skills: Skill[]): Map<string, Skill[]> {
 }
 
 /**
+ * Collapse same-named skills down to the one the composer will
+ * actually use, preserving input order.
+ *
+ * A skill is addressed in the draft purely by name — typing
+ * `/omarchy` cannot express "the Codex copy". So when the same name
+ * is reachable through several roots (very common: `~/.claude/skills`,
+ * `~/.codex/skills`, and `~/.agents/skills` are frequently symlinks to
+ * one source, and a real directory may exist under `~/.codemux/skills`
+ * as well) every copy inserts byte-identical text. Listing them all
+ * offers a choice that does not exist, and — because rows are keyed by
+ * skill id — copies reached through symlinks share an id, producing
+ * duplicate React keys and colliding menu values.
+ *
+ * First-wins. The backend sorts provider → scope → name, so the
+ * winner is the highest-priority provider at the narrowest scope,
+ * which is the copy a user would expect to take precedence.
+ *
+ * Matching is case-SENSITIVE, deliberately. `parseSkillTokens` resolves
+ * `/name` case-sensitively so that `/Plan` never silently expands to a
+ * skill called `plan`, which makes names differing only in case two
+ * genuinely distinct, separately addressable skills. Folding case here
+ * would hide one of them from the menu while leaving it reachable by
+ * typing — the exact popup/send-time drift this helper exists to
+ * prevent. Real duplicates come from one source reached through
+ * several roots, so their names match exactly anyway.
+ *
+ * This is deliberately NOT applied to the Settings list: seeing every
+ * install location is the point there, and `detectConflicts` above
+ * surfaces exactly these clashes so they stay discoverable.
+ */
+export function dedupeSkillsByName(skills: Skill[]): Skill[] {
+  const seen = new Set<string>();
+  const out: Skill[] = [];
+  for (const skill of skills) {
+    if (seen.has(skill.name)) continue;
+    seen.add(skill.name);
+    out.push(skill);
+  }
+  return out;
+}
+
+/**
  * Bucket skills by their group heading, returning groups in
  * `GROUP_ORDER`. Within each group skills are sorted alphabetically
  * by name (case-insensitive). Empty groups are dropped.

--- a/src/lib/agent-chat/skill-tokens.test.ts
+++ b/src/lib/agent-chat/skill-tokens.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { Skill } from "@/tauri/commands";
 
+import { buildSkillCommands } from "./skill-commands";
 import {
   parseSkillTokens,
   resolveSkillBodies,
@@ -133,6 +134,69 @@ describe("resolveSkillBodies", () => {
   it("skips skills with empty / whitespace-only body", () => {
     const empty = makeSkill("blank", "   \n  ");
     expect(resolveSkillBodies("/blank", [empty])).toBeNull();
+  });
+
+  it("resolves a duplicated name to the FIRST copy, matching the popup", () => {
+    // Regression: the name lookup used to be last-wins while the popup
+    // was first-wins, so picking the top `/omarchy` row injected the
+    // last copy's body.
+    const duplicated = [
+      makeSkill("omarchy", "CLAUDE COPY"),
+      { ...makeSkill("omarchy", "CODEX COPY"), id: "id-omarchy-codex" },
+    ];
+    expect(resolveSkillBodies("/omarchy", duplicated)).toBe("CLAUDE COPY");
+  });
+});
+
+describe("popup / send-time agreement", () => {
+  it("injects the body of exactly the skill the popup offered", () => {
+    // The two surfaces must not drift: whatever single row the menu
+    // shows for a duplicated name is the body the model receives.
+    const duplicated = [
+      makeSkill("omarchy", "CLAUDE COPY"),
+      { ...makeSkill("omarchy", "CODEX COPY"), id: "id-omarchy-codex" },
+      { ...makeSkill("omarchy", "CODEMUX COPY"), id: "id-omarchy-codemux" },
+    ];
+
+    const rows = buildSkillCommands({
+      skills: duplicated,
+      onInvoke: () => {},
+    });
+    const omarchyRows = rows.filter((r) => r.command === "/omarchy");
+    expect(omarchyRows).toHaveLength(1);
+
+    const offeredId = omarchyRows[0].id.replace(/^skill:/, "");
+    const [resolved] = parseSkillTokens("/omarchy", duplicated);
+    expect(resolved.skill.id).toBe(offeredId);
+    expect(resolveSkillBodies("/omarchy", duplicated)).toBe("CLAUDE COPY");
+  });
+
+  it("keeps case-variant names reachable from both surfaces", () => {
+    // The dedupe must not fold case, because the resolver does not.
+    const variants = [
+      { ...makeSkill("Deploy", "UPPER BODY"), id: "id-Deploy" },
+      { ...makeSkill("deploy", "lower body"), id: "id-deploy" },
+    ];
+    const rows = buildSkillCommands({ skills: variants, onInvoke: () => {} });
+    expect(rows).toHaveLength(2);
+    expect(resolveSkillBodies("/Deploy", variants)).toBe("UPPER BODY");
+    expect(resolveSkillBodies("/deploy", variants)).toBe("lower body");
+  });
+
+  it("gives every popup row a unique id so menu keys cannot collide", () => {
+    // Symlinked copies share a canonical path, hence the same skill id
+    // — duplicate React keys / menu values before the dedupe.
+    const symlinked = [
+      makeSkill("omarchy", "BODY"),
+      makeSkill("omarchy", "BODY"),
+    ];
+    expect(symlinked[0].id).toBe(symlinked[1].id);
+
+    const ids = buildSkillCommands({
+      skills: symlinked,
+      onInvoke: () => {},
+    }).map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 });
 

--- a/src/lib/agent-chat/skill-tokens.ts
+++ b/src/lib/agent-chat/skill-tokens.ts
@@ -42,8 +42,15 @@ export function parseSkillTokens(text: string, skills: Skill[]): SkillTokenMatch
 
   // Build a fast lookup once per call. Skill lists are small (≤50 in
   // practice) so a Map is sufficient — no need to memoize across calls.
+  //
+  // FIRST-wins, matching the popup's `dedupeSkillsByName`. A plain
+  // `set` loop would be last-wins, which silently disagreed with the
+  // menu: picking the top `/omarchy` row inserted text that resolved
+  // to the *lowest*-priority copy's body at send time.
   const byName = new Map<string, Skill>();
-  for (const s of skills) byName.set(s.name, s);
+  for (const s of skills) {
+    if (!byName.has(s.name)) byName.set(s.name, s);
+  }
 
   const matches: SkillTokenMatch[] = [];
   // Reset stateful regex's lastIndex per call — `g` flag mutates the


### PR DESCRIPTION
Three defects in the Agent Chat composer's slash popup, all visible when typing `/` in a thread.

## 1. Internal commands leaked into COMMANDS

The Agent SDK reports commands the CLI itself marks `isHidden`, so typing `/remote` offered `__remote-workflow` — which self-describes as *"server-launched sessions only"* and cannot run in a Codemux thread.

`dedupe_commands` now drops `__`-prefixed names plus an exact-match denylist (`heapdump`, `workflow-launch-exec`, `design-consent`, `design-revoke`, `extra-usage`, `pro-trial-expired`, `rate-limit-options`).

Validated against the deployed CLI's live output — trims 54 discovered commands to 48, dropping exactly those six and nothing else. Typing `/remote` now returns no rows.

The filter is menu-only: a hand-typed name is still forwarded verbatim, and the exact-match rule never swallows a custom user command (covered by a test).

## 2. Same-named skills produced one row each

A single source symlinked into `~/.claude/skills`, `~/.codex/skills` and `~/.agents/skills` (plus a real directory under `~/.codemux/skills`) rendered six identical `/omarchy` rows that all insert byte-identical text.

Copies reached through symlinks also share a skill id — it hashes the *canonical* `SKILL.md` path — so the popup emitted duplicate React keys and colliding cmdk values.

`buildSkillCommands` now collapses them via a shared `dedupeSkillsByName` helper.

## 3. The popup and send-time resolution disagreed

The one you can't see in a screenshot, and the worst of the three.

`parseSkillTokens` built its name lookup **last-wins** while the popup was **first-wins**. Picking the top `/omarchy` row inserted text that resolved to the *lowest*-priority copy's body at send time — silent wrong-skill injection.

Both surfaces now share one first-wins rule, with a test asserting the row offered *is* the body injected.

## Note on case sensitivity

Dedupe is case-**sensitive** on purpose. `parseSkillTokens` resolves names case-sensitively so `/Plan` never expands to `plan`, which makes case-variant names separately addressable. Folding case would hide one from the menu while leaving it reachable by typing — recreating the exact drift this helper exists to prevent.

Settings deliberately keeps every copy visible; `detectConflicts` exists to surface these clashes.

## Why `/remote-control` is still absent

This PR started from a report that `/remote-control` was "missing" from the GUI. It isn't a discovery gap, and the docs now record why so it isn't re-litigated:

- The CLI registers it as `local-jsx` — it renders an interactive TUI and has no terminal in an SDK session. Forwarding it returns `"isn't available in this environment."` (verified with `/status`).
- `initializationResult().commands` and `supportedCommands()` were diffed and return the **identical** 54-command list, so switching probe APIs would change nothing.
- Remote control does appear in the init result, but as session capability flags (`remote_control_auto_enable`, `ide_rc_auto_enable_gate`) rather than a command — deliberately not consumed, since Codemux ships its own web remote access and the real interactive CLI already runs in terminal panes.

## Verification

- `cargo test … slash_commands` — 7 passed (4 new)
- `tsc --noEmit` — clean
- `vitest` — 3330 passed, 221 files
- Command filter validated against the live SDK output, not just fixtures

Rebased onto `main`; no conflicts.

## Not addressed (out of scope)

- `src/dev/tauri-mock.ts` seeds `pr-comments` and `todos` as Claude commands; neither exists in CLI 2.1.220. Pre-existing mock drift.
- Codex/OpenCode still resolve to an empty COMMANDS group (`ProviderKind::Codex | ProviderKind::OpenCode => Ok(Vec::new())`) — their custom-command conventions are never surfaced.