### PR TITLE
fix(agent-chat): expire stale provider requests after restart

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -332,12 +332,31 @@ The chat pane stack:
     Claude/Codex session merely to answer an old request. It persists
     `request_response_failed { reason: "stale_provider_callback" }` instead;
     reducer replay terminalizes the request and explains that the user should
-    Continue so the agent can repeat it. Hydration applies the same terminal
-    state to an unresolved persisted request whenever the backend confirms no
-    turn is live, while preserving requests across an ordinary workspace
-    switch when their original turn is still running. OpenCode is the
-    exception: its permission state lives in the external HTTP server, so its
-    adapter explicitly opts into request resume.
+    Continue so the agent can repeat it. Hydration (`replayPayloads` in
+    `src/lib/agent-chat/hydrate.ts`) applies the same terminal state to an
+    unresolved persisted request, but only when BOTH guards say the callback
+    is gone:
+    - `opts.runLive` — the backend's `agent_chat_turn_active` probe. A live
+      turn means an ordinary workspace-switch remount, so its requests stay
+      actionable.
+    - `opts.provider` — OpenCode is the exception: its permission state lives
+      in the external HTTP server, so its adapter opts into request resume
+      (`pending_requests_survive_session_restart`) and
+      `agent_chat_respond_to_request` re-adopts the session to deliver the
+      answer. Hydration mirrors that opt-in through the pure frontend table
+      `providerRequestsSurviveSessionRestart` (in
+      `src/lib/agent-chat/capability-defaults.ts`, no extra IPC) and leaves
+      OpenCode requests `pending`. Expiring them would be unrecoverable: the
+      reducer's `request_opened` early-returns on a known request id, so no
+      re-broadcast can resurrect a request the UI already terminalized.
+    Terminalizing is one-way but not destructive of a real answer: the
+    reducer's `request_response_failed` arm skips a request already in the
+    `resolved` state. Providers cannot distinguish "unknown request" from
+    "already answered" (Codex drops the pending entry on the first reply), so
+    a duplicate respond — the same thread answered from two windows — reports
+    a failure for a request that actually succeeded; without the guard that
+    persisted event would durably flip an answered approval to "expired" on
+    every replay.
   - **NULL `permission_mode` heal**: rows created before the
     `permission_mode` column existed read back NULL. The frontend seeds its
     permission picker to the provider default ("Full access" =

--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -308,7 +308,7 @@ The chat pane stack:
   empty on every launch (no startup rehydration), so the backend
   `ensure_live_session` choke point in `commands/agent_chat.rs` rebuilds a
   dead session from its `agent_chat_sessions` row on the next
-  `agent_chat_send_turn` / `agent_chat_respond_to_request` — reusing the
+  `agent_chat_send_turn` — reusing the
   SAME `thread_id` (keeping the attached Channel, pane snapshot, and store
   slice valid) and passing `resume_cursor: {"resume": sdk_session_id}`
   when the row carries one (falling back to a fresh session, whose
@@ -325,6 +325,19 @@ The chat pane stack:
   pickers + resume cursor from the row, falling back to the provider
   default model only when no row (or no persisted model) exists —
   fixing the post-restart "reset to Opus" regression.
+  - **Pending requests are not conversation history.** Claude/Codex keep
+    approval and `AskUserQuestion` callbacks only in the live
+    sidecar/app-server process. Resuming the transcript cannot reconstruct
+    those callbacks, so `agent_chat_respond_to_request` never starts a new
+    Claude/Codex session merely to answer an old request. It persists
+    `request_response_failed { reason: "stale_provider_callback" }` instead;
+    reducer replay terminalizes the request and explains that the user should
+    Continue so the agent can repeat it. Hydration applies the same terminal
+    state to an unresolved persisted request whenever the backend confirms no
+    turn is live, while preserving requests across an ordinary workspace
+    switch when their original turn is still running. OpenCode is the
+    exception: its permission state lives in the external HTTP server, so its
+    adapter explicitly opts into request resume.
   - **NULL `permission_mode` heal**: rows created before the
     `permission_mode` column existed read back NULL. The frontend seeds its
     permission picker to the provider default ("Full access" =
@@ -2052,7 +2065,7 @@ surfacing a `feature_disabled` string.
 | `agent_chat_send_turn` | Queue a user turn on a thread. Auto-resumes a dead session (rebuilt from its persisted row) before the turn, so a pane reopened after an app restart never sees `session_not_found`. |
 | `agent_chat_interrupt_turn` | Halt the currently-running turn. On a live session the turn ends as `TurnCompleted(interrupted)` and the session stays `Ready` (the sidecar keeps the thread alive and the next `send_turn` rebuilds a resumed query). A `SessionNotFound` (nothing to interrupt on an already-dead session) is swallowed into `Ok`; unlike `send_turn` it does NOT auto-resume a dead session just to interrupt it. |
 | `agent_chat_turn_active` | Cheap in-memory liveness probe: `true` iff a live (non-dead) session is bound to the thread and its `active_turn` is set (Running or WaitingApproval). Never touches the subprocess and never auto-resumes. Used by the remount hydrate path to suppress the false "Run interrupted" divider on a healthy mid-flight run (see "Live-run guard on hydrate"). |
-| `agent_chat_respond_to_request` | Resolve a pending approval / input request. Auto-resumes a dead session first (same choke point as `send_turn`). |
+| `agent_chat_respond_to_request` | Resolve a pending approval / input request. Claude/Codex only respond on the original live session; if its process-local callback is gone, a durable `request_response_failed` event expires the control instead of starting a replacement session that cannot know the request. OpenCode may resume its server-backed pending permission first. |
 | `agent_chat_set_model` | Swap a thread's model. Persist-always, apply-if-live: writes the model to the session row unconditionally, then applies to the live session if one exists; a `SessionNotFound` from the apply is swallowed into `Ok` (the value takes effect on the next auto-resume). |
 | `agent_chat_set_permission_mode` | Swap a thread's permission mode. Same persist-always, apply-if-live contract as `agent_chat_set_model`. |
 | `agent_chat_stop_session` | Gracefully close a session. Idempotent. |

--- a/sidecar/claude-agent/src/methods/index.ts
+++ b/sidecar/claude-agent/src/methods/index.ts
@@ -300,7 +300,18 @@ const respondToRequest: MethodHandler = async (params) => {
       `decision.behavior must be "allow" or "deny", got ${behavior}`,
     );
   }
-  await session.respondToRequest(requestId, decision);
+  try {
+    await session.respondToRequest(requestId, decision);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (
+      message.includes("not found or already resolved") ||
+      message.toLowerCase().includes("unknown pending")
+    ) {
+      throw new InvalidParamsError(message);
+    }
+    throw err;
+  }
   return {};
 };
 

--- a/sidecar/claude-agent/test/permissions.test.ts
+++ b/sidecar/claude-agent/test/permissions.test.ts
@@ -3,6 +3,7 @@
 // a full session.
 
 import { describe, expect, test } from "bun:test";
+import type { PermissionUpdate } from "@anthropic-ai/claude-agent-sdk";
 
 import type { EventEmitter } from "../src/session.ts";
 import {
@@ -218,7 +219,7 @@ test("allow with updatedPermissions surfaces the array on PermissionResult", asy
       behavior: "allow",
       destination: "localSettings",
     },
-  ];
+  ] satisfies PermissionUpdate[];
   pending.get(requestId)?.({
     behavior: "allow",
     updatedPermissions: ruleArray,

--- a/src-tauri/src/agent_provider/claude/session.rs
+++ b/src-tauri/src/agent_provider/claude/session.rs
@@ -812,14 +812,9 @@ impl ClaudeSession {
                 Ok(())
             }
             Err(crate::json_rpc_child::RpcChildError::RpcError(err))
-                if err.code == -32602 =>
+                if is_request_not_pending_rpc(&err) =>
             {
-                Err(ProviderError::ValidationError {
-                    message: format!(
-                        "request {} not found or already resolved",
-                        request_id.0
-                    ),
-                })
+                Err(ProviderError::RequestNotPending { request_id })
             }
             Err(e) => Err(ProviderError::RpcError {
                 message: format!("respond-to-request RPC failed: {e}"),
@@ -920,6 +915,21 @@ impl ClaudeSession {
             state.pending_approvals.clear();
         }
     }
+}
+
+/// The sidecar now reports a missing callback as InvalidParams (`-32602`),
+/// but older bundled sidecars threw a plain `Error`, which the dispatcher
+/// surfaced as InternalError (`-32603`). Match both only when the message is
+/// the known missing-request diagnostic so unrelated invalid params/internal
+/// failures retain their real classification.
+fn is_request_not_pending_rpc(err: &crate::json_rpc_child::RpcError) -> bool {
+    if err.code != -32602 && err.code != -32603 {
+        return false;
+    }
+    let message = err.message.to_ascii_lowercase();
+    message.contains("not found or already resolved")
+        || message.contains("unknown pending")
+        || message.contains("no pending approval")
 }
 
 /// Replace an empty [`TurnId`] on an event with the session's
@@ -1492,6 +1502,33 @@ mod tests {
             "alreadyClosed": true
         })));
         assert!(!stop_response_indicates_already_closed(&json!({})));
+    }
+
+    #[test]
+    fn missing_request_rpc_classifier_accepts_old_and_new_sidecar_codes_only() {
+        for code in [-32602, -32603] {
+            assert!(is_request_not_pending_rpc(
+                &crate::json_rpc_child::RpcError {
+                    code,
+                    message: "request req-1 not found or already resolved".into(),
+                    data: None,
+                }
+            ));
+        }
+        assert!(!is_request_not_pending_rpc(
+            &crate::json_rpc_child::RpcError {
+                code: -32603,
+                message: "database exploded".into(),
+                data: None,
+            }
+        ));
+        assert!(!is_request_not_pending_rpc(
+            &crate::json_rpc_child::RpcError {
+                code: -32000,
+                message: "request req-1 not found or already resolved".into(),
+                data: None,
+            }
+        ));
     }
 
     /// Build a bare `QueuedTurn` with a given id for reorder tests. The

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -772,8 +772,8 @@ impl CodexSession {
             state
                 .pending_approvals
                 .remove(&request_id)
-                .ok_or_else(|| ProviderError::ValidationError {
-                    message: format!("no pending approval for request {}", request_id.0),
+                .ok_or_else(|| ProviderError::RequestNotPending {
+                    request_id: request_id.clone(),
                 })?
         };
         let payload = serde_json::to_value(&response).unwrap();

--- a/src-tauri/src/agent_provider/errors.rs
+++ b/src-tauri/src/agent_provider/errors.rs
@@ -10,7 +10,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use super::types::{ProviderKind, ThreadId};
+use super::types::{ProviderKind, RequestId, ThreadId};
 
 /// All ways an [`AgentProvider`](super::AgentProvider) call can fail.
 #[derive(Debug)]
@@ -30,6 +30,11 @@ pub enum ProviderError {
     SessionNotFound { thread_id: ThreadId },
     /// The session existed but has already been closed.
     SessionClosed { thread_id: ThreadId },
+    /// The provider no longer has a live callback for a request that the
+    /// persisted transcript still considers open. Pending approval/input
+    /// callbacks are generally process-local and cannot be reconstructed by
+    /// resuming conversation history after an app or provider restart.
+    RequestNotPending { request_id: RequestId },
     /// Inputs failed adapter-level validation (missing required fields,
     /// unsupported mode, etc.).
     ValidationError { message: String },
@@ -59,6 +64,9 @@ impl fmt::Display for ProviderError {
             }
             Self::SessionClosed { thread_id } => {
                 write!(f, "session for thread {:?} is closed", thread_id.0)
+            }
+            Self::RequestNotPending { request_id } => {
+                write!(f, "request {:?} is not pending", request_id.0)
             }
             Self::ValidationError { message } => write!(f, "validation error: {message}"),
             Self::ProcessError { message, source } => match source {
@@ -99,6 +107,9 @@ pub enum SerializableProviderError {
     SessionClosed {
         thread_id: ThreadId,
     },
+    RequestNotPending {
+        request_id: RequestId,
+    },
     ValidationError {
         message: String,
     },
@@ -136,6 +147,11 @@ impl ProviderError {
             Self::SessionClosed { thread_id } => SerializableProviderError::SessionClosed {
                 thread_id: thread_id.clone(),
             },
+            Self::RequestNotPending { request_id } => {
+                SerializableProviderError::RequestNotPending {
+                    request_id: request_id.clone(),
+                }
+            }
             Self::ValidationError { message } => SerializableProviderError::ValidationError {
                 message: message.clone(),
             },
@@ -171,6 +187,9 @@ impl From<SerializableProviderError> for ProviderError {
             }
             SerializableProviderError::SessionClosed { thread_id } => {
                 Self::SessionClosed { thread_id }
+            }
+            SerializableProviderError::RequestNotPending { request_id } => {
+                Self::RequestNotPending { request_id }
             }
             SerializableProviderError::ValidationError { message } => {
                 Self::ValidationError { message }

--- a/src-tauri/src/agent_provider/events.rs
+++ b/src-tauri/src/agent_provider/events.rs
@@ -36,6 +36,19 @@ pub enum SubagentStatus {
     Stopped,
 }
 
+/// Why a response to a provider request could not be delivered.
+///
+/// Kept separate from [`ApprovalDecision`]: a failed response is not a
+/// denial/cancellation by the user, and must never be rendered as though the
+/// provider received their decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequestResponseFailureReason {
+    /// Conversation history was resumed, but the provider's process-local
+    /// callback for this request no longer exists.
+    StaleProviderCallback,
+}
+
 /// A merge-able state snapshot for one subagent.
 ///
 /// Providers dribble a subagent's identity out across many events (its
@@ -307,6 +320,15 @@ pub enum ProviderRuntimeEvent {
         thread_id: ThreadId,
         request_id: RequestId,
         decision: ApprovalDecision,
+    },
+    /// A response could not be delivered and the request is terminal from
+    /// Codemux's perspective. Persisting this event prevents transcript
+    /// hydration from resurrecting an orphaned approval/question forever.
+    RequestResponseFailed {
+        thread_id: ThreadId,
+        request_id: RequestId,
+        reason: RequestResponseFailureReason,
+        message: String,
     },
     /// The session lifecycle phase changed (starting → ready → running …).
     SessionStateChanged {

--- a/src-tauri/src/agent_provider/mod.rs
+++ b/src-tauri/src/agent_provider/mod.rs
@@ -17,9 +17,9 @@ pub mod types;
 
 pub use errors::{ProviderError, SerializableProviderError};
 pub use events::{
-    child_exit_events, CompletedItem, ContentDelta, ProviderRuntimeEvent, SubagentSnapshot,
-    SubagentStatus, TurnStatus, TurnUsage, WorkflowPhaseSnapshot, WorkflowSnapshot,
-    CHILD_EXITED_SUBTYPE,
+    child_exit_events, CompletedItem, ContentDelta, ProviderRuntimeEvent,
+    RequestResponseFailureReason, SubagentSnapshot, SubagentStatus, TurnStatus, TurnUsage,
+    WorkflowPhaseSnapshot, WorkflowSnapshot, CHILD_EXITED_SUBTYPE,
 };
 pub use instance::ProviderInstanceId;
 pub use provider::{AgentProvider, ProviderEventStream};

--- a/src-tauri/src/agent_provider/opencode/agent.rs
+++ b/src-tauri/src/agent_provider/opencode/agent.rs
@@ -260,6 +260,14 @@ impl AgentProvider for OpenCodeAgentProvider {
         session.respond_to_request(request_id, decision).await
     }
 
+    fn pending_requests_survive_session_restart(&self) -> bool {
+        // OpenCode stores permission requests in its HTTP server and accepts
+        // replies by session/request id. Re-adopting the server-side session
+        // can therefore preserve an outstanding request across a Codemux
+        // process restart, unlike Claude/Codex's in-process callbacks.
+        true
+    }
+
     async fn set_model(&self, thread_id: ThreadId, model: String) -> Result<(), ProviderError> {
         let session = self.lookup(&thread_id).await?;
         session.set_model(model).await;

--- a/src-tauri/src/agent_provider/opencode/session.rs
+++ b/src-tauri/src/agent_provider/opencode/session.rs
@@ -382,6 +382,14 @@ impl OpenCodeSession {
             })?;
         let status = response.status();
         if !status.is_success() {
+            if matches!(
+                status,
+                reqwest::StatusCode::NOT_FOUND
+                    | reqwest::StatusCode::CONFLICT
+                    | reqwest::StatusCode::GONE
+            ) {
+                return Err(ProviderError::RequestNotPending { request_id });
+            }
             return Err(ProviderError::RpcError {
                 message: format!("permission_http_status_{}", status.as_u16()),
             });

--- a/src-tauri/src/agent_provider/provider.rs
+++ b/src-tauri/src/agent_provider/provider.rs
@@ -95,6 +95,16 @@ pub trait AgentProvider: Send + Sync {
         decision: ApprovalDecision,
     ) -> Result<(), ProviderError>;
 
+    /// Whether an outstanding provider request can still be answered after
+    /// Codemux rebuilds a missing live session from its resume cursor.
+    ///
+    /// Claude and Codex callbacks are tied to the sidecar/app-server process,
+    /// so the safe default is `false`. Providers whose request state lives in
+    /// a durable external service can opt in.
+    fn pending_requests_survive_session_restart(&self) -> bool {
+        false
+    }
+
     /// Swap the session's model at runtime. Providers that do not support
     /// this return
     /// [`ProviderError::ValidationError`](super::errors::ProviderError::ValidationError).

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -24,8 +24,8 @@ use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 
 use crate::agent_provider::{
     AgentProvider, ApprovalDecision, ProviderChatCapabilities, ProviderError, ProviderKind,
-    ProviderRuntimeEvent, RequestId, SendTurnInput, SerializableProviderError,
-    StartSessionInput, ThreadId, TurnId,
+    ProviderRuntimeEvent, RequestId, RequestResponseFailureReason, SendTurnInput,
+    SerializableProviderError, StartSessionInput, ThreadId, TurnId,
 };
 use crate::database::{
     AgentChatCheckpointRecord, AgentChatSessionConfig, AgentChatSessionRecord, DatabaseStore,
@@ -2099,16 +2099,59 @@ pub async fn agent_chat_respond_to_request<R: Runtime>(
 ) -> Result<(), String> {
     let observability: State<'_, ObservabilityStore> = app.state();
     feature_flag_on(&observability)?;
-    // Auto-resume before responding: a pending approval a user acts on
-    // after a restart must land on a live session, not a
-    // `session_not_found`. No-op when a session is already live.
-    ensure_live_session(&app, provider, &thread_id).await?;
     let registry: State<'_, ProviderRegistry> = app.state();
     let impl_ = lookup_provider(&registry, provider).await?;
-    impl_
-        .respond_to_request(thread_id, request_id, decision)
+
+    // Conversation history is resumable; provider callbacks usually are
+    // not. Rebuilding a Claude/Codex session here creates a healthy process
+    // with an empty pending-request map, then guarantees the confusing
+    // "request not found or already resolved" failure. Terminalize the
+    // orphan instead. OpenCode opts into resume because its permission
+    // request lives in the external HTTP server rather than this process.
+    if !impl_.has_session(&thread_id).await {
+        if !impl_.pending_requests_survive_session_restart() {
+            emit_stale_request_failure(&app, thread_id, request_id);
+            return Ok(());
+        }
+        ensure_live_session(&app, provider, &thread_id).await?;
+    }
+
+    match impl_
+        .respond_to_request(thread_id.clone(), request_id.clone(), decision)
         .await
-        .map_err(provider_err)
+    {
+        Ok(()) => Ok(()),
+        // A provider can lose the callback between the liveness check and
+        // the response, or a recovered external session may no longer know
+        // the request. Persist one terminal failure so remount/hydration
+        // cannot make the same dead control actionable again.
+        Err(ProviderError::RequestNotPending { .. })
+        | Err(ProviderError::SessionNotFound { .. })
+        | Err(ProviderError::SessionClosed { .. }) => {
+            emit_stale_request_failure(&app, thread_id, request_id);
+            Ok(())
+        }
+        Err(err) => Err(provider_err(err)),
+    }
+}
+
+const STALE_REQUEST_MESSAGE: &str =
+    "This request expired when the provider session restarted. Continue to have the agent repeat it.";
+
+fn emit_stale_request_failure<R: Runtime>(
+    app: &AppHandle<R>,
+    thread_id: ThreadId,
+    request_id: RequestId,
+) {
+    forward_event(
+        app,
+        ProviderRuntimeEvent::RequestResponseFailed {
+            thread_id,
+            request_id,
+            reason: RequestResponseFailureReason::StaleProviderCallback,
+            message: STALE_REQUEST_MESSAGE.to_string(),
+        },
+    );
 }
 
 /// Swap a session's active model. `model == None` is a validation
@@ -2839,6 +2882,7 @@ fn map_event_to_pane_status(
         | ProviderRuntimeEvent::ItemCompleted { .. }
         | ProviderRuntimeEvent::RequestResolved { .. } => Some(PaneStatus::Working),
         ProviderRuntimeEvent::RequestOpened { .. } => Some(PaneStatus::Permission),
+        ProviderRuntimeEvent::RequestResponseFailed { .. } => Some(PaneStatus::Review),
         ProviderRuntimeEvent::SubagentUpdated { subagent, .. } => match subagent.status {
             SubagentStatus::Pending | SubagentStatus::Running => {
                 if !subagent.subagent_id.is_empty() {
@@ -3092,6 +3136,7 @@ fn activity_update(
         } => mid_turn(true),
         // Turn/session settled — the thread is no longer mid-turn.
         ProviderRuntimeEvent::TurnCompleted { .. }
+        | ProviderRuntimeEvent::RequestResponseFailed { .. }
         | ProviderRuntimeEvent::SessionStateChanged {
             status: SessionStatus::Ready
                 | SessionStatus::Closed
@@ -3236,6 +3281,7 @@ pub fn should_persist_event(event: &ProviderRuntimeEvent) -> bool {
             | ProviderRuntimeEvent::TurnCompleted { .. }
             | ProviderRuntimeEvent::RequestOpened { .. }
             | ProviderRuntimeEvent::RequestResolved { .. }
+            | ProviderRuntimeEvent::RequestResponseFailed { .. }
             // Subagent snapshots persist so the orchestration card and
             // child transcripts survive restart: DB hydrate replays them
             // through the same reducer with zero schema migration.
@@ -3373,6 +3419,7 @@ pub fn thread_id_for_event(event: &ProviderRuntimeEvent) -> Option<ThreadId> {
         | ProviderRuntimeEvent::TurnCompleted { thread_id, .. }
         | ProviderRuntimeEvent::RequestOpened { thread_id, .. }
         | ProviderRuntimeEvent::RequestResolved { thread_id, .. }
+        | ProviderRuntimeEvent::RequestResponseFailed { thread_id, .. }
         | ProviderRuntimeEvent::SessionStateChanged { thread_id, .. }
         | ProviderRuntimeEvent::SubagentUpdated { thread_id, .. }
         | ProviderRuntimeEvent::WorkflowUpdated { thread_id, .. }

--- a/src-tauri/tests/agent_chat_commands.rs
+++ b/src-tauri/tests/agent_chat_commands.rs
@@ -34,9 +34,9 @@ use codemux_lib::agent_provider::{
     SendTurnInput, StartSessionInput, ThreadId, TurnId,
 };
 use codemux_lib::commands::agent_chat::{
-    feature_flag_on, forward_event, thread_id_for_event, AgentChatChannelRegistry,
-    AgentChatEventPayload, ProviderRegistry, RunActivityTracker, SubagentTracker,
-    AGENT_CHAT_EVENT, FEATURE_DISABLED_ERROR,
+    agent_chat_respond_to_request, feature_flag_on, forward_event, thread_id_for_event,
+    AgentChatChannelRegistry, AgentChatEventPayload, ProviderRegistry, RunActivityTracker,
+    SubagentTracker, AGENT_CHAT_EVENT, FEATURE_DISABLED_ERROR,
 };
 use codemux_lib::database::DatabaseStore;
 use codemux_lib::observability::{FeatureFlags, ObservabilityStore};
@@ -285,6 +285,71 @@ async fn respond_to_request_forwards_to_provider() {
             RequestId("req-1".into()),
         )]
     );
+}
+
+#[tokio::test]
+async fn response_on_dead_nonresumable_session_persists_terminal_stale_event() {
+    let app = tauri::test::mock_app();
+    let handle = app.handle().clone();
+    let db = DatabaseStore::new_in_memory();
+    db.upsert_agent_chat_session(
+        "thread-stale",
+        "workspace-stale",
+        Some("/tmp/codemux-test"),
+        "claude",
+    )
+    .unwrap();
+    app.manage(db);
+    app.manage(test_observability(true));
+    app.manage(AppStateStore::default());
+    app.manage(ProviderRegistry::new());
+    app.manage(AgentChatChannelRegistry::default());
+    app.manage(SubagentTracker::default());
+    app.manage(RunActivityTracker::default());
+
+    let claude_mock = Arc::new(MockAgentProvider::new(ProviderKind::Claude));
+    {
+        let registry: State<'_, ProviderRegistry> = handle.state();
+        registry.set_claude(claude_mock.clone() as _).await;
+    }
+
+    agent_chat_respond_to_request(
+        handle.clone(),
+        ProviderKind::Claude,
+        ThreadId("thread-stale".into()),
+        RequestId("req-stale".into()),
+        ApprovalDecision::Allow {
+            updated_input: Some(serde_json::json!({ "answers": {} })),
+            updated_permissions: None,
+        },
+    )
+    .await
+    .expect("stale response is handled as a durable terminal outcome");
+
+    assert!(
+        claude_mock.calls.snapshot().is_empty(),
+        "a dead callback must not spawn/resume a session or attempt a response"
+    );
+    let db: State<'_, DatabaseStore> = handle.state();
+    let payloads = db.list_agent_chat_messages("thread-stale");
+    assert_eq!(payloads.len(), 1);
+    let event: ProviderRuntimeEvent = serde_json::from_str(&payloads[0]).unwrap();
+    match event {
+        ProviderRuntimeEvent::RequestResponseFailed {
+            request_id,
+            reason,
+            message,
+            ..
+        } => {
+            assert_eq!(request_id.0, "req-stale");
+            assert_eq!(
+                reason,
+                codemux_lib::agent_provider::RequestResponseFailureReason::StaleProviderCallback
+            );
+            assert!(message.contains("expired"));
+        }
+        other => panic!("expected terminal request failure, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/src-tauri/tests/claude_adapter.rs
+++ b/src-tauri/tests/claude_adapter.rs
@@ -1697,9 +1697,11 @@ async fn session_error_emits_session_state_changed_plus_warning() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn respond_to_unknown_request_id_returns_validation_error() {
-    // The fake sidecar rejects requestId=="unknown-request" with
-    // -32602; the adapter maps that to ValidationError.
+async fn respond_to_unknown_request_id_returns_request_not_pending() {
+    // The fake sidecar rejects requestId=="unknown-request" with -32602
+    // ("not found or already resolved"); the adapter classifies that as
+    // RequestNotPending so the command layer can expire the control
+    // instead of surfacing a generic validation failure.
     let provider = provider_with_fake().await;
     provider.start_session(start_input("t-unkr")).await.unwrap();
     let err = provider
@@ -1710,7 +1712,10 @@ async fn respond_to_unknown_request_id_returns_validation_error() {
         )
         .await
         .unwrap_err();
-    assert!(matches!(err, ProviderError::ValidationError { .. }));
+    assert!(
+        matches!(err, ProviderError::RequestNotPending { .. }),
+        "expected RequestNotPending, got {err:?}"
+    );
     provider.stop_session(ThreadId("t-unkr".into())).await.ok();
 }
 

--- a/src-tauri/tests/sidecar_sdk.rs
+++ b/src-tauri/tests/sidecar_sdk.rs
@@ -282,17 +282,10 @@ async fn respond_to_request_with_unknown_request_id_returns_invalid_params() {
         .unwrap_err();
     match err {
         RpcChildError::RpcError(e) => {
-            // -32603 (internal) or -32602 (invalid params) are both
-            // acceptable since respondToRequest throws a plain Error
-            // inside the session, which the dispatcher surfaces as
-            // internal. The important thing is that the sidecar
-            // stays alive and the error is structured.
-            assert!(
-                e.code == -32602 || e.code == -32603,
-                "unexpected error code {}: {}",
-                e.code,
-                e.message,
-            );
+            // Missing callbacks are a caller-visible stale request, not an
+            // internal sidecar crash. Keep this code stable so the Rust
+            // adapter can classify it without relying on prose alone.
+            assert_eq!(e.code, -32602, "unexpected error: {}", e.message);
             assert!(
                 e.message.contains("does-not-exist")
                     || e.message.contains("not found")

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -756,7 +756,7 @@ describe("AgentChatPane hydrate-on-mount (workspace swap recovery)", () => {
       expect(hydrateThreadMock).toHaveBeenCalledWith(
         "thread-x",
         [userPayload, assistantPayload],
-        { runLive: false },
+        { runLive: false, provider: "claude" },
       );
     });
   });
@@ -789,7 +789,7 @@ describe("AgentChatPane hydrate-on-mount (workspace swap recovery)", () => {
       expect(hydrateThreadMock).toHaveBeenCalledWith(
         "thread-x",
         [userPayload, assistantPayload],
-        { runLive: true },
+        { runLive: true, provider: "claude" },
       );
     });
   });
@@ -821,7 +821,7 @@ describe("AgentChatPane hydrate-on-mount (workspace swap recovery)", () => {
       expect(hydrateThreadMock).toHaveBeenCalledWith(
         "thread-x",
         [userPayload, assistantPayload],
-        { runLive: false },
+        { runLive: false, provider: "claude" },
       );
     });
   });

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -918,7 +918,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         const payloads = await agentChatListMessages(threadId);
         if (cancelled) return;
         if (payloads.length === 0) return;
-        const replayed = replayPayloads(payloads);
+        const replayed = replayPayloads(payloads, { provider });
         const slice = useAgentChatStore.getState().threads[threadId];
         const localCount = slice?.messages.length ?? 0;
         // Guard against clobbering live state: only hydrate when disk
@@ -940,7 +940,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         if (cancelled) return;
         useAgentChatStore
           .getState()
-          .hydrateThread(threadId, payloads, { runLive });
+          .hydrateThread(threadId, payloads, { runLive, provider });
       } catch (err) {
         // Soft-fail: if hydrate fails, the user still sees whatever
         // the live stream brings in. Log so it's debuggable.

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -444,6 +444,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   const markRequestResponding = useAgentChatStore(
     (s) => s.markRequestResponding,
   );
+  const markRequestPending = useAgentChatStore((s) => s.markRequestPending);
   const markRequestResolved = useAgentChatStore(
     (s) => s.markRequestResolved,
   );
@@ -1923,16 +1924,31 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   );
 
   const handleRespond = useCallback(
-    (requestId: string, decision: ApprovalDecision) => {
-      if (!threadId) return;
+    (
+      requestId: string,
+      decision: ApprovalDecision,
+      propagateFailure = false,
+    ) => {
+      if (!threadId) return Promise.resolve();
+      const tid = threadId;
       markRequestResponding(threadId, requestId, decision);
-      agentChatRespondToRequest(provider, threadId, requestId, decision).catch(
-        (err) => {
-          toast.error(`Failed to send decision: ${err}`);
-        },
-      );
+      return agentChatRespondToRequest(
+        provider,
+        threadId,
+        requestId,
+        decision,
+      ).catch((err) => {
+        markRequestPending(tid, requestId);
+        toast.error(`Failed to send decision: ${err}`);
+        if (propagateFailure) throw err;
+      });
     },
-    [threadId, provider, markRequestResponding],
+    [
+      threadId,
+      provider,
+      markRequestResponding,
+      markRequestPending,
+    ],
   );
 
   /**
@@ -2689,12 +2705,16 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   const handleSubmitUserInput = useCallback(
     (output: AskUserQuestionOutput) => {
       if (!pendingUserInput || pendingUserInput.kind !== "permission_request") {
-        return;
+        return Promise.resolve();
       }
-      handleRespond(pendingUserInput.request_id, {
-        decision: "allow",
-        updated_input: output,
-      });
+      return handleRespond(
+        pendingUserInput.request_id,
+        {
+          decision: "allow",
+          updated_input: output,
+        },
+        true,
+      );
     },
     [pendingUserInput, handleRespond],
   );

--- a/src/components/chat/ComposerPendingInputPanel.tsx
+++ b/src/components/chat/ComposerPendingInputPanel.tsx
@@ -69,6 +69,7 @@ export function ComposerPendingInputPanel({ item, onSubmit }: Props) {
   });
   const [otherText, setOtherText] = useState<Record<number, string>>({});
   const [submitted, setSubmitted] = useState(false);
+  const submittedRef = useRef(false);
 
   // ------- Selection + answer helpers ---------------------------------
 
@@ -165,11 +166,13 @@ export function ComposerPendingInputPanel({ item, onSubmit }: Props) {
   }, [questions.length]);
 
   const handleSubmit = useCallback(async () => {
-    if (submitted || !allAnswered) return;
+    if (submittedRef.current || submitted || !allAnswered) return;
+    submittedRef.current = true;
     setSubmitted(true);
     try {
       await onSubmit(collectAnswers());
     } catch {
+      submittedRef.current = false;
       setSubmitted(false);
     }
   }, [submitted, allAnswered, collectAnswers, onSubmit]);

--- a/src/components/chat/MessageList.test.tsx
+++ b/src/components/chat/MessageList.test.tsx
@@ -199,6 +199,22 @@ describe("MessageList dispatch", () => {
     expect(screen.getByText(/Submitting answers/)).toBeInTheDocument();
   });
 
+  it("shows the durable expiry explanation for a stale user-input request", () => {
+    renderList([
+      askReq({
+        resolution: {
+          state: "failed",
+          reason: "stale_provider_callback",
+          message: "This question expired after restart.",
+        },
+      }),
+    ]);
+    expect(
+      screen.getByText("This question expired after restart."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/answer above the composer/)).toBeNull();
+  });
+
   it("echoes the user's answer as a reply once a user-input request resolves", () => {
     renderList([
       askReq({

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -709,6 +709,13 @@ function renderAssistantBody(
               </div>
             );
           }
+          if (item.resolution.state === "failed") {
+            return (
+              <div className="py-0.5 text-xs text-muted-foreground">
+                {item.resolution.message}
+              </div>
+            );
+          }
           // Resolved: echo the user's selection as a reply bubble so the
           // transcript actually shows that they answered.
           return <UserInputAnswer item={item} />;

--- a/src/components/chat/PermissionRequestBlock.tsx
+++ b/src/components/chat/PermissionRequestBlock.tsx
@@ -38,6 +38,14 @@ export const PermissionRequestBlock = memo(function PermissionRequestBlock({
     );
   }
 
+  if (item.resolution.state === "failed") {
+    return (
+      <div className="py-0.5 text-xs text-muted-foreground">
+        {item.resolution.message}
+      </div>
+    );
+  }
+
   const toolName = readToolName(item.payload);
   const toolInput = readToolInput(item.payload);
   const inputText =

--- a/src/components/chat/PlanProposalBlock.tsx
+++ b/src/components/chat/PlanProposalBlock.tsx
@@ -50,7 +50,9 @@ export const PlanProposalBlock = memo(function PlanProposalBlock({
     // after the user has acted.
     return (
       <div className="py-0.5 text-xs text-muted-foreground">
-        {resolvedLabel(item.resolution.state)}
+        {item.resolution.state === "failed"
+          ? item.resolution.message
+          : resolvedLabel(item.resolution.state)}
       </div>
     );
   }

--- a/src/components/chat/SubagentView.tsx
+++ b/src/components/chat/SubagentView.tsx
@@ -131,7 +131,11 @@ function SubItem({ item }: { item: ChatViewItem }) {
     case "permission_request":
       return (
         <div className="rounded-[9px] border border-border/60 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-          Approval requested — respond in the orchestrator.
+          {item.resolution.state === "failed"
+            ? item.resolution.message
+            : item.resolution.state === "pending"
+              ? "Approval requested — respond in the orchestrator."
+              : "Approval handled in the orchestrator."}
         </div>
       );
     default:

--- a/src/components/chat/ToolCallCard.tsx
+++ b/src/components/chat/ToolCallCard.tsx
@@ -54,6 +54,7 @@ interface Props {
  *
  *   pending_approval  approval=pending           → header + expanded input + Allow/Deny
  *   responding        approval=responding        → header + "Submitting decision…"
+ *   expired           approval=failed            → error header + expiry explanation
  *   denied            approval=resolved & deny   → header with strike-through + one-liner
  *   executing         no approval & status=running → header + spinner, body collapsed
  *   success           status=done                → header + check, body collapsed, expandable
@@ -67,9 +68,15 @@ export const ToolCallCard = memo(function ToolCallCard({
   const resolution = approval?.resolution;
   const isPendingApproval = resolution?.state === "pending";
   const isResponding = resolution?.state === "responding";
+  const isRequestFailed = resolution?.state === "failed";
   const isDenied =
     resolution?.state === "resolved" && resolution.decision.decision !== "allow";
-  const isExecuting = !isPendingApproval && !isResponding && !isDenied && item.status === "running";
+  const isExecuting =
+    !isPendingApproval &&
+    !isResponding &&
+    !isRequestFailed &&
+    !isDenied &&
+    item.status === "running";
   const isSuccess = item.status === "done";
   const isError = item.status === "error";
 
@@ -181,6 +188,12 @@ export const ToolCallCard = memo(function ToolCallCard({
       {isResponding && (
         <div className="border-t border-border/60 px-3 py-2 text-xs text-muted-foreground/70">
           Submitting decision…
+        </div>
+      )}
+
+      {isRequestFailed && resolution?.state === "failed" && (
+        <div className="border-t border-border/60 px-3 py-2 text-xs text-muted-foreground">
+          {resolution.message}
         </div>
       )}
 

--- a/src/dev/workflow-fixture.test.ts
+++ b/src/dev/workflow-fixture.test.ts
@@ -19,8 +19,11 @@ import {
  * shapes the design calls for.
  */
 describe("workflow demo fixtures", () => {
-  function replay(envelopes: unknown[]): ReturnType<typeof replayPayloads> {
-    return replayPayloads(envelopes.map((e) => JSON.stringify(e)));
+  function replay(
+    envelopes: unknown[],
+    runLive = false,
+  ): ReturnType<typeof replayPayloads> {
+    return replayPayloads(envelopes.map((e) => JSON.stringify(e)), { runLive });
   }
 
   function soleWorkflow(state: ReturnType<typeof replayPayloads>): WorkflowRunItem {
@@ -36,7 +39,7 @@ describe("workflow demo fixtures", () => {
   }
 
   it("approval thread: pending_approval with planned phases, script, and a linked open request", () => {
-    const state = replay(workflowApprovalEnvelopes("t-approval"));
+    const state = replay(workflowApprovalEnvelopes("t-approval"), true);
     const wf = soleWorkflow(state);
 
     expect(wf.status).toBe("pending_approval");

--- a/src/hooks/use-agent-chat-session-actions.ts
+++ b/src/hooks/use-agent-chat-session-actions.ts
@@ -98,7 +98,7 @@ export function useAgentChatSessionActions(
           if (payloads.length > 0) {
             useAgentChatStore
               .getState()
-              .hydrateThread(newLocalThreadId, payloads);
+              .hydrateThread(newLocalThreadId, payloads, { provider });
           }
         } catch (err) {
           // Hydration failure is non-fatal — the SDK still has the

--- a/src/lib/agent-chat/capability-defaults.ts
+++ b/src/lib/agent-chat/capability-defaults.ts
@@ -47,6 +47,41 @@ const FALLBACK_DEFAULT_PERMISSION_MODE_BY_PROVIDER: Record<
   opencode: null,
 };
 
+/**
+ * Whether a provider's outstanding approval / input requests can still be
+ * answered after the live Codemux session is gone (app restart, pane
+ * teardown, session adoption).
+ *
+ * Mirrors `AgentProvider::pending_requests_survive_session_restart` in
+ * `src-tauri/src/agent_provider/provider.rs`. Claude and Codex keep their
+ * callbacks inside the sidecar / app-server process, so a rebuilt session
+ * can never deliver an old answer. OpenCode holds permissions in its
+ * external HTTP server and its adapter opts in, so `respond_to_request`
+ * re-adopts the server session and delivers the reply.
+ *
+ * This is a protocol fact, not a harvested capability — it is a static
+ * table rather than a `provider-capabilities-store` read so the pure
+ * hydrate path can consult it without an extra IPC round-trip.
+ */
+const REQUESTS_SURVIVE_SESSION_RESTART_BY_PROVIDER: Record<
+  AgentChatProviderKind,
+  boolean
+> = {
+  claude: false,
+  codex: false,
+  opencode: true,
+};
+
+/** Predicate form of {@link REQUESTS_SURVIVE_SESSION_RESTART_BY_PROVIDER}.
+ *  An unknown / absent provider is treated as NOT surviving, matching the
+ *  backend trait default. */
+export function providerRequestsSurviveSessionRestart(
+  provider: AgentChatProviderKind | null | undefined,
+): boolean {
+  if (!provider) return false;
+  return REQUESTS_SURVIVE_SESSION_RESTART_BY_PROVIDER[provider] ?? false;
+}
+
 /** Synchronous accessor for the provider's default model id.
  *
  * Reads `provider-capabilities-store.getState()` (safe outside React —

--- a/src/lib/agent-chat/hydrate.test.ts
+++ b/src/lib/agent-chat/hydrate.test.ts
@@ -4,7 +4,7 @@ import type { ProviderRuntimeEvent } from "@/tauri/events";
 
 import { lastTurnUnsettled, replayPayloads } from "./hydrate";
 import { findSubagentView, runningSubagentEntries } from "./subagents";
-import type { WorkflowRunItem } from "./types";
+import type { PermissionRequestItem, WorkflowRunItem } from "./types";
 
 function user(text: string): string {
   return JSON.stringify({ type: "user_message", thread_id: "t", text });
@@ -193,7 +193,7 @@ describe("replayPayloads", () => {
     expect(state.pendingRequestIds).toEqual([]);
   });
 
-  it("clears streaming and pendingRequestIds even if the source ended mid-turn", () => {
+  it("expires the rendered request, not only its pending id, when the source ended mid-turn", () => {
     // A truncated history (process killed mid-stream) ends up with a
     // streaming assistant_message and an unresolved request. Replay
     // must not leave the resumed slice in those states or the UI
@@ -218,6 +218,35 @@ describe("replayPayloads", () => {
     ]);
     expect(state.streaming).toBe(false);
     expect(state.pendingRequestIds).toEqual([]);
+    const request = state.messages.find(
+      (m): m is PermissionRequestItem => m.kind === "permission_request",
+    );
+    expect(request?.resolution).toMatchObject({
+      state: "failed",
+      reason: "stale_provider_callback",
+    });
+  });
+
+  it("preserves an open request when the backend confirms its turn is still live", () => {
+    const state = replayPayloads(
+      [
+        event({
+          type: "request_opened",
+          thread_id: "t",
+          turn_id: "turn-live",
+          request_id: "req-live",
+          request_kind: "user-input",
+          payload: { questions: [] },
+          tool_use_id: null,
+        }),
+      ],
+      { runLive: true },
+    );
+    const request = state.messages.find(
+      (m): m is PermissionRequestItem => m.kind === "permission_request",
+    );
+    expect(request?.resolution.state).toBe("pending");
+    expect(state.pendingRequestIds).toEqual(["req-live"]);
   });
 
   it("skips malformed JSON without affecting the rest of the replay", () => {
@@ -485,29 +514,32 @@ describe("replayPayloads", () => {
     expect(wf?.status).toBe("stopped");
   });
 
-  it("preserves a pending_approval workflow on hydrate (a resting state, not a spinner)", () => {
-    const state = replayPayloads([
-      user("/workflow audit"),
-      event({
-        type: "workflow_updated",
-        thread_id: "t",
-        workflow: {
-          workflow_id: "wf",
-          status: "pending_approval",
-          name: "Audit",
-          phases: [{ title: "Run", detail: null }],
-        },
-      } as ProviderRuntimeEvent),
-      event({
-        type: "request_opened",
-        thread_id: "t",
-        turn_id: "turn-1",
-        request_id: "req-1",
-        request_kind: "other",
-        payload: {},
-        tool_use_id: "wf",
-      }),
-    ]);
+  it("preserves a pending_approval workflow only while its provider turn is live", () => {
+    const state = replayPayloads(
+      [
+        user("/workflow audit"),
+        event({
+          type: "workflow_updated",
+          thread_id: "t",
+          workflow: {
+            workflow_id: "wf",
+            status: "pending_approval",
+            name: "Audit",
+            phases: [{ title: "Run", detail: null }],
+          },
+        } as ProviderRuntimeEvent),
+        event({
+          type: "request_opened",
+          thread_id: "t",
+          turn_id: "turn-1",
+          request_id: "req-1",
+          request_kind: "other",
+          payload: {},
+          tool_use_id: "wf",
+        }),
+      ],
+      { runLive: true },
+    );
     const wf = state.messages.find(
       (m): m is WorkflowRunItem => m.kind === "workflow_run",
     );

--- a/src/lib/agent-chat/hydrate.test.ts
+++ b/src/lib/agent-chat/hydrate.test.ts
@@ -249,6 +249,94 @@ describe("replayPayloads", () => {
     expect(state.pendingRequestIds).toEqual(["req-live"]);
   });
 
+  describe("provider-aware orphan expiry", () => {
+    function openRequest(): string[] {
+      return [
+        user("run the thing"),
+        event({
+          type: "request_opened",
+          thread_id: "t",
+          turn_id: "turn-1",
+          request_id: "req-orphan",
+          request_kind: "tool",
+          payload: {},
+          tool_use_id: null,
+        }),
+      ];
+    }
+
+    function soleRequest(
+      state: ReturnType<typeof replayPayloads>,
+    ): PermissionRequestItem | undefined {
+      return state.messages.find(
+        (m): m is PermissionRequestItem => m.kind === "permission_request",
+      );
+    }
+
+    it("keeps an OpenCode request actionable with no live turn", () => {
+      // OpenCode's permissions live in its own HTTP server, and the
+      // backend's `pending_requests_survive_session_restart` opt-in lets
+      // `agent_chat_respond_to_request` re-adopt that session to answer
+      // them. Expiring the control here would strand a request the user
+      // can still resolve — and `request_opened`'s early-return on a known
+      // id means no re-broadcast could resurrect it.
+      const state = replayPayloads(openRequest(), { provider: "opencode" });
+      expect(soleRequest(state)?.resolution.state).toBe("pending");
+      expect(state.pendingRequestIds).toEqual(["req-orphan"]);
+    });
+
+    it.each(["claude", "codex"] as const)(
+      "expires a %s request with no live turn (process-local callback)",
+      (provider) => {
+        const state = replayPayloads(openRequest(), { provider });
+        expect(soleRequest(state)?.resolution).toMatchObject({
+          state: "failed",
+          reason: "stale_provider_callback",
+        });
+        expect(state.pendingRequestIds).toEqual([]);
+      },
+    );
+
+    it("expires when the provider is unknown (matches the backend default)", () => {
+      const state = replayPayloads(openRequest());
+      expect(soleRequest(state)?.resolution.state).toBe("failed");
+      expect(state.pendingRequestIds).toEqual([]);
+    });
+
+    it("preserves a pending_approval OpenCode workflow with no live turn", () => {
+      const state = replayPayloads(
+        [
+          user("/workflow audit"),
+          event({
+            type: "workflow_updated",
+            thread_id: "t",
+            workflow: {
+              workflow_id: "wf",
+              status: "pending_approval",
+              name: "Audit",
+              phases: [{ title: "Run", detail: null }],
+            },
+          } as ProviderRuntimeEvent),
+          event({
+            type: "request_opened",
+            thread_id: "t",
+            turn_id: "turn-1",
+            request_id: "req-wf",
+            request_kind: "other",
+            payload: {},
+            tool_use_id: "wf",
+          }),
+        ],
+        { provider: "opencode" },
+      );
+      const wf = state.messages.find(
+        (m): m is WorkflowRunItem => m.kind === "workflow_run",
+      );
+      expect(wf?.status).toBe("pending_approval");
+      expect(soleRequest(state)?.resolution.state).toBe("pending");
+    });
+  });
+
   it("skips malformed JSON without affecting the rest of the replay", () => {
     const state = replayPayloads([
       user("first"),

--- a/src/lib/agent-chat/hydrate.ts
+++ b/src/lib/agent-chat/hydrate.ts
@@ -1,5 +1,7 @@
 import type { ProviderRuntimeEvent } from "@/tauri/events";
+import type { AgentChatProviderKind } from "@/tauri/types";
 
+import { providerRequestsSurviveSessionRestart } from "./capability-defaults";
 import {
   applyEvent,
   appendUserMessage,
@@ -33,6 +35,18 @@ type ReplayPayload = UserMessageEnvelope | ProviderRuntimeEvent;
 const STALE_REQUEST_MESSAGE =
   "This request expired when the provider session restarted. Continue to have the agent repeat it.";
 
+/** Options accepted by {@link replayPayloads} (and forwarded verbatim by
+ *  `agent-chat-store.hydrateThread`). */
+export interface ReplayOptions {
+  /** The backend authoritatively confirmed a turn is in flight. */
+  runLive?: boolean;
+  /** Provider that owns the thread. Decides whether an unresolved
+   *  persisted request is still answerable once no turn is live — see
+   *  `providerRequestsSurviveSessionRestart`. Omitted means "assume
+   *  process-local callbacks", i.e. today's expire-on-hydrate behavior. */
+  provider?: AgentChatProviderKind | null;
+}
+
 /**
  * Rebuild a thread state by replaying persisted payloads through the
  * same pure reducer that handles live events.
@@ -63,12 +77,24 @@ const STALE_REQUEST_MESSAGE =
  * instead of the divider. The next live event keeps or clears that flag
  * through the reducer as usual. With `opts` absent (or `runLive` falsy)
  * behavior is identical to the resume path.
+ *
+ * `opts.provider` gates the synthetic expiry of unresolved requests: a
+ * provider whose request state lives outside the Codemux process (OpenCode)
+ * keeps its pending requests actionable even with no live turn.
  */
 export function replayPayloads(
   payloads: string[],
-  opts?: { runLive?: boolean },
+  opts?: ReplayOptions,
 ): ChatThreadState {
   const runLive = opts?.runLive ?? false;
+  // Only providers with process-local callbacks lose their requests when the
+  // session dies. OpenCode's permissions live in its HTTP server, and
+  // `agent_chat_respond_to_request` re-adopts that session to deliver the
+  // answer, so expiring them here would render a still-answerable request
+  // dead — and the reducer's `request_opened` early-return means no
+  // re-broadcast could ever bring it back.
+  const requestsSurvive = providerRequestsSurviveSessionRestart(opts?.provider);
+  const expireOrphanRequests = !runLive && !requestsSurvive;
   let state = createEmptyThreadState();
   for (const raw of payloads) {
     const parsed = parsePayload(raw);
@@ -96,7 +122,7 @@ export function replayPayloads(
   // A workspace-switch remount can happen while the original provider turn
   // is still alive. `runLive` is the backend's authoritative guard for that
   // case, so those callbacks remain actionable.
-  if (!runLive) {
+  if (expireOrphanRequests) {
     for (const requestId of [...state.pendingRequestIds]) {
       state = applyEvent(state, {
         type: "request_response_failed",
@@ -135,9 +161,11 @@ export function replayPayloads(
   // the reducer derived from), that terminal state already won during
   // replay and is left untouched here.
   //
-  // A live `pending_approval` workflow is deliberately preserved. A replayed
-  // orphan was already stopped above by `request_response_failed`; resuming
-  // conversation history cannot recreate its provider callback.
+  // A `pending_approval` workflow whose request is still answerable (live
+  // turn, or a provider whose requests survive the session) is deliberately
+  // preserved. A genuinely-orphaned one was already stopped above by
+  // `request_response_failed`, since resuming conversation history cannot
+  // recreate a process-local provider callback.
   messages = interruptRunningSubagents(messages);
   messages = messages.map((m) =>
     m.kind === "workflow_run" && m.status === "running"
@@ -152,7 +180,7 @@ export function replayPayloads(
     // turn is in flight we mark the thread streaming so the streaming
     // marker shows instead of the Run-interrupted divider.
     streaming: runLive,
-    pendingRequestIds: runLive ? state.pendingRequestIds : [],
+    pendingRequestIds: expireOrphanRequests ? [] : state.pendingRequestIds,
     // Interrupted when EITHER the replay itself observed a `child_exited`
     // terminal turn (the watchdog persisted a `turn_completed` error) OR
     // the raw history ends with an unsettled user turn (the app died before

--- a/src/lib/agent-chat/hydrate.ts
+++ b/src/lib/agent-chat/hydrate.ts
@@ -30,6 +30,9 @@ export interface UserMessageEnvelope {
 
 type ReplayPayload = UserMessageEnvelope | ProviderRuntimeEvent;
 
+const STALE_REQUEST_MESSAGE =
+  "This request expired when the provider session restarted. Continue to have the agent repeat it.";
+
 /**
  * Rebuild a thread state by replaying persisted payloads through the
  * same pure reducer that handles live events.
@@ -82,6 +85,28 @@ export function replayPayloads(
       state = applyEvent(state, parsed);
     }
   }
+
+  // Provider request callbacks are ephemeral even though the transcript is
+  // durable. When no live turn owns the replayed requests, settle every
+  // orphan through the same reducer event used by a failed live response.
+  // This is the part the old `pendingRequestIds: []` cleanup missed: the
+  // rendered PermissionRequestItem itself stayed `pending`, so the composer
+  // resurrected the questionnaire despite the supposedly-empty pending set.
+  //
+  // A workspace-switch remount can happen while the original provider turn
+  // is still alive. `runLive` is the backend's authoritative guard for that
+  // case, so those callbacks remain actionable.
+  if (!runLive) {
+    for (const requestId of [...state.pendingRequestIds]) {
+      state = applyEvent(state, {
+        type: "request_response_failed",
+        thread_id: "",
+        request_id: requestId,
+        reason: "stale_provider_callback",
+        message: STALE_REQUEST_MESSAGE,
+      });
+    }
+  }
   // Guarantee post-replay state matches a quiescent thread. The
   // reducer's turn_completed handler already clears `streaming`, but
   // not every transcript ends with one (interrupted resume, partial
@@ -110,11 +135,9 @@ export function replayPayloads(
   // the reducer derived from), that terminal state already won during
   // replay and is left untouched here.
   //
-  // A `pending_approval` workflow is deliberately PRESERVED — it is a
-  // legitimate persisted resting state awaiting the user's decision (the
-  // "Run as a workflow?" card), not a runaway spinner, and the backend
-  // auto-resume re-establishes the session so the approval can still be
-  // answered after a restart.
+  // A live `pending_approval` workflow is deliberately preserved. A replayed
+  // orphan was already stopped above by `request_response_failed`; resuming
+  // conversation history cannot recreate its provider callback.
   messages = interruptRunningSubagents(messages);
   messages = messages.map((m) =>
     m.kind === "workflow_run" && m.status === "running"
@@ -129,7 +152,7 @@ export function replayPayloads(
     // turn is in flight we mark the thread streaming so the streaming
     // marker shows instead of the Run-interrupted divider.
     streaming: runLive,
-    pendingRequestIds: [],
+    pendingRequestIds: runLive ? state.pendingRequestIds : [],
     // Interrupted when EITHER the replay itself observed a `child_exited`
     // terminal turn (the watchdog persisted a `turn_completed` error) OR
     // the raw history ends with an unsettled user turn (the app died before

--- a/src/lib/agent-chat/reducer.test.ts
+++ b/src/lib/agent-chat/reducer.test.ts
@@ -406,6 +406,66 @@ describe("agent-chat reducer", () => {
     expect(state.pendingRequestIds).toEqual([]);
   });
 
+  it("keeps a resolved request resolved when a duplicate respond fails", () => {
+    // Two windows on the same thread: the second respond loses the race and
+    // the provider answers "not found" — which it cannot distinguish from
+    // "already resolved" (Codex drops the pending entry on the first answer).
+    // The persisted failure event must not flip an answered approval into
+    // the expired state, live or on replay.
+    let state = runEvents([
+      {
+        type: "item_completed",
+        thread_id: "t1",
+        turn_id: "turn-1",
+        item: {
+          kind: "tool_use",
+          tool_name: "Bash",
+          input: { command: "pwd" },
+          tool_use_id: "tool-dup",
+        },
+      },
+      {
+        type: "request_opened",
+        thread_id: "t1",
+        turn_id: "turn-1",
+        request_id: "req-dup",
+        request_kind: "tool-permission",
+        payload: { tool_name: "Bash" },
+        tool_use_id: "tool-dup",
+      },
+      {
+        type: "request_resolved",
+        thread_id: "t1",
+        request_id: "req-dup",
+        decision: { decision: "allow" },
+      },
+    ]);
+
+    state = applyEvent(state, {
+      type: "request_response_failed",
+      thread_id: "t1",
+      request_id: "req-dup",
+      reason: "stale_provider_callback",
+      message: "Question expired.",
+    });
+
+    const request = state.messages.find(
+      (m): m is PermissionRequestItem =>
+        m.kind === "permission_request" && m.request_id === "req-dup",
+    );
+    expect(request?.resolution).toEqual({
+      state: "resolved",
+      decision: { decision: "allow" },
+    });
+    // The allowed tool keeps running — the failure belongs to a duplicate
+    // reply, not to the tool call the user approved.
+    const tool = state.messages.find(
+      (m) => m.kind === "tool_call" && m.tool_use_id === "tool-dup",
+    );
+    expect(tool?.kind === "tool_call" && tool.status).toBe("running");
+    expect(state.pendingRequestIds).toEqual([]);
+  });
+
   it("terminalizes a stale request response and settles its linked tool", () => {
     let state = runEvents([
       {

--- a/src/lib/agent-chat/reducer.test.ts
+++ b/src/lib/agent-chat/reducer.test.ts
@@ -406,6 +406,54 @@ describe("agent-chat reducer", () => {
     expect(state.pendingRequestIds).toEqual([]);
   });
 
+  it("terminalizes a stale request response and settles its linked tool", () => {
+    let state = runEvents([
+      {
+        type: "item_completed",
+        thread_id: "t1",
+        turn_id: "turn-1",
+        item: {
+          kind: "tool_use",
+          tool_name: "Bash",
+          input: { command: "pwd" },
+          tool_use_id: "tool-1",
+        },
+      },
+      {
+        type: "request_opened",
+        thread_id: "t1",
+        turn_id: "turn-1",
+        request_id: "req-stale",
+        request_kind: "tool-permission",
+        payload: { tool_name: "Bash" },
+        tool_use_id: "tool-1",
+      },
+    ]);
+
+    state = applyEvent(state, {
+      type: "request_response_failed",
+      thread_id: "t1",
+      request_id: "req-stale",
+      reason: "stale_provider_callback",
+      message: "Question expired.",
+    });
+
+    const request = state.messages.find(
+      (m): m is PermissionRequestItem =>
+        m.kind === "permission_request" && m.request_id === "req-stale",
+    );
+    expect(request?.resolution).toEqual({
+      state: "failed",
+      reason: "stale_provider_callback",
+      message: "Question expired.",
+    });
+    const tool = state.messages.find(
+      (m) => m.kind === "tool_call" && m.tool_use_id === "tool-1",
+    );
+    expect(tool?.kind === "tool_call" && tool.status).toBe("error");
+    expect(state.pendingRequestIds).toEqual([]);
+  });
+
   it("passes through unknown event variants and warns once", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const base = createEmptyThreadState();

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -1035,6 +1035,24 @@ export function markRequestResponding(
   };
 }
 
+/** Restore a locally-responding request after a retryable IPC/provider
+ * failure. Terminal `resolved`/`failed` requests are intentionally left
+ * untouched so a late promise rejection can never resurrect them. */
+export function markRequestPending(
+  state: ChatThreadState,
+  requestId: string,
+): ChatThreadState {
+  const found = findPermissionRequest(state.messages, requestId);
+  if (!found || found.item.resolution.state !== "responding") return state;
+  return {
+    ...state,
+    messages: replaceItem(state.messages, found.index, {
+      ...found.item,
+      resolution: { state: "pending" },
+    }),
+  };
+}
+
 /**
  * Local-only action: mark a permission request as resolved. Used for
  * synthetic decisions where there is no round-trip through the sidecar
@@ -1378,6 +1396,62 @@ function applyEventInner(
         messages = replaceItem(messages, wfMatch.index, patchedWf);
       }
       if (!found && !wfMatch) return state;
+      return {
+        ...state,
+        messages,
+        pendingRequestIds: state.pendingRequestIds.filter(
+          (id) => id !== event.request_id,
+        ),
+      };
+    }
+
+    case "request_response_failed": {
+      const found = findPermissionRequest(state.messages, event.request_id);
+      if (!found) {
+        return {
+          ...state,
+          pendingRequestIds: state.pendingRequestIds.filter(
+            (id) => id !== event.request_id,
+          ),
+        };
+      }
+
+      let messages = replaceItem(state.messages, found.index, {
+        ...found.item,
+        resolution: {
+          state: "failed",
+          reason: event.reason,
+          message: event.message,
+        },
+      });
+
+      // A request-linked tool/workflow cannot receive a later result once
+      // its provider callback is gone. Settle those visual owners too so a
+      // stale approval never leaves a spinner or pending workflow card.
+      if (found.item.tool_use_id) {
+        const toolMatch = findToolCallByUseId(
+          messages,
+          found.item.tool_use_id,
+        );
+        if (toolMatch && toolMatch.item.status === "running") {
+          messages = replaceItem(messages, toolMatch.index, {
+            ...toolMatch.item,
+            status: "error",
+            completed_at: now(),
+          });
+        }
+      }
+      const wfMatch = findWorkflowByApprovalRequestId(
+        messages,
+        event.request_id,
+      );
+      if (wfMatch) {
+        messages = replaceItem(messages, wfMatch.index, {
+          ...wfMatch.item,
+          status: "stopped",
+        });
+      }
+
       return {
         ...state,
         messages,

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -1407,14 +1407,24 @@ function applyEventInner(
 
     case "request_response_failed": {
       const found = findPermissionRequest(state.messages, event.request_id);
-      if (!found) {
-        return {
-          ...state,
-          pendingRequestIds: state.pendingRequestIds.filter(
-            (id) => id !== event.request_id,
-          ),
-        };
-      }
+      const settled: ChatThreadState = {
+        ...state,
+        pendingRequestIds: state.pendingRequestIds.filter(
+          (id) => id !== event.request_id,
+        ),
+      };
+      if (!found) return settled;
+
+      // A request that already reached the terminal `resolved` state keeps
+      // it. Providers conflate "unknown request" with "already answered"
+      // (Codex drops the pending entry the moment it is answered), so a
+      // duplicate respond — same thread open in two windows, or a retry
+      // after a slow first call — reports a failure for a request the user
+      // successfully answered. Overwriting would durably (this event is
+      // persisted and replayed) flip an answered approval to "expired", and
+      // would un-resume a workflow that `request_resolved` already set
+      // running. Same reasoning as `markRequestPending`.
+      if (found.item.resolution.state === "resolved") return settled;
 
       let messages = replaceItem(state.messages, found.index, {
         ...found.item,

--- a/src/lib/agent-chat/types.ts
+++ b/src/lib/agent-chat/types.ts
@@ -164,7 +164,12 @@ export interface PermissionRequestItem {
   resolution:
     | { state: "pending" }
     | { state: "responding"; decision: ApprovalDecision }
-    | { state: "resolved"; decision: ApprovalDecision };
+    | { state: "resolved"; decision: ApprovalDecision }
+    | {
+        state: "failed";
+        reason: "stale_provider_callback";
+        message: string;
+      };
 }
 
 export interface TurnEndedItem {

--- a/src/stores/agent-chat-store.ts
+++ b/src/stores/agent-chat-store.ts
@@ -5,6 +5,7 @@ import {
   applyEvent,
   appendUserMessage,
   createEmptyThreadState,
+  markRequestPending,
   markRequestResolved,
   markRequestResponding,
   removeUserMessageByNonce,
@@ -202,6 +203,8 @@ interface AgentChatStore {
     requestId: string,
     decision: ApprovalDecision,
   ) => void;
+  /** Restore an in-flight request after a retryable response failure. */
+  markRequestPending: (threadId: string, requestId: string) => void;
   /** Locally mark a permission request resolved (no sidecar round-trip).
    *  Used for plan accept/reject — the sidecar denied+interrupted the
    *  ExitPlanMode tool, so no `request-resolved` notification will fire. */
@@ -375,6 +378,14 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
       updateSlice(state, threadId, (slice) => ({
         ...slice,
         ...markRequestResponding(slice, requestId, decision),
+      })),
+    ),
+
+  markRequestPending: (threadId, requestId) =>
+    set((state) =>
+      updateSlice(state, threadId, (slice) => ({
+        ...slice,
+        ...markRequestPending(slice, requestId),
       })),
     ),
 

--- a/src/stores/agent-chat-store.ts
+++ b/src/stores/agent-chat-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import { replayPayloads } from "@/lib/agent-chat/hydrate";
+import type { ReplayOptions } from "@/lib/agent-chat/hydrate";
 import {
   applyEvent,
   appendUserMessage,
@@ -238,11 +239,16 @@ interface AgentChatStore {
    *  `opts.runLive` is forwarded to `replayPayloads`: when the caller
    *  has confirmed the thread's turn is in flight (remount of a live
    *  run) it suppresses the Run-interrupted heuristic and marks the
-   *  slice streaming. Omit for the plain resume path. */
+   *  slice streaming. Omit for the plain resume path.
+   *
+   *  `opts.provider` is likewise forwarded: it decides whether an
+   *  unresolved persisted request is expired on hydrate (Claude/Codex,
+   *  whose callbacks die with the process) or kept actionable (OpenCode,
+   *  whose permissions live in its own server). */
   hydrateThread: (
     threadId: string,
     payloads: string[],
-    opts?: { runLive?: boolean },
+    opts?: ReplayOptions,
   ) => void;
   /** Clear a thread entirely (e.g. on session stop). */
   resetThread: (threadId: string) => void;

--- a/src/tauri/events.ts
+++ b/src/tauri/events.ts
@@ -343,6 +343,13 @@ export type ProviderRuntimeEvent =
       decision: ApprovalDecision;
     }
   | {
+      type: "request_response_failed";
+      thread_id: string;
+      request_id: string;
+      reason: "stale_provider_callback";
+      message: string;
+    }
+  | {
       type: "session_state_changed";
       thread_id: string;
       status: SessionStatus;


### PR DESCRIPTION
## Summary

- distinguish durable conversation history from process-local approval and AskUserQuestion callbacks
- expire stale Claude/Codex requests with a persisted terminal event instead of auto-resuming into an unknown request
- preserve OpenCode server-backed requests across session adoption and classify provider-side stale races consistently
- reconcile orphaned requests during hydration, restore retryable UI submissions, prevent duplicate questionnaire submits, and render a clear expiry state
- document the pending-request lifecycle contract

## Root cause

Claude and Codex keep request callbacks only in their live sidecar/app-server process. Codemux persisted `request_opened`, but after a restart it rebuilt the conversation session and attempted to answer the old request against a fresh, empty callback map. Hydration also cleared only `pendingRequestIds`, leaving the rendered request itself pending and actionable.

## Verification

- `cargo check --manifest-path src-tauri/Cargo.toml`
- command regression: dead Claude session persists `request_response_failed` without resuming
- Claude sidecar protocol regression: unknown request returns JSON-RPC `-32602`
- Claude adapter classifier unit test
- 191 focused frontend hydration/reducer/composer/rendering tests
- Claude sidecar: 91 tests + ToS boundary check
- sidecar and application TypeScript checks
- broad Rust suite: 2,220 tests passed; 77 Git tests affected by the suite-wide PATH race passed serially (196 Git-related tests total)
- broad frontend suite: all 3,324 tests passed under the Node 25 web-storage compatibility flag; one unrelated Radix hover-card teardown timer remains, and its 11-test file passes in isolation
- Codemux browser-pane smoke check against the Vite dev mock