### PR TITLE
fix(sidebar): right-align the workspace card PR chip

### DIFF
--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -131,9 +131,21 @@ visual only — nothing is archived, closed, or deleted.
 - **Workspace cards** (`sidebar-inbox-card.tsx`): each active workspace is a
   card — repo avatar + name eyebrow; work title (linked-issue title while an
   agent is live, worktree name when idle) + issue chip; a red blocker line
-  (needs-you only); and a mono meta line (branch · `↑ahead` · `+/−` diff · PR
-  chip (`PR #n` green / `merged` violet, opens the PR) · provider logos ·
-  remote cloud icon · notification badge). The blocker line is a fixed string
+  (needs-you only); and a mono meta line. The meta line is **two columns, not
+  one flow**: the git-local facts (branch · `↑ahead` · `+/−` diff) flow from the
+  left, then a `flex-1` spacer pins the rest to the right — PR chip (`PR #n`
+  green / `merged` violet, opens the PR) · provider logos · remote cloud icon ·
+  notification badge. The spacer sits *before* the PR chip deliberately: with it
+  after, the chip began wherever the branch name happened to end, so chips landed
+  at a different x on every card and the column read as ragged. Right-aligning
+  also makes the chip's own variable width (`merged` vs `PR #1234`) harmless. The
+  trailing indicator cluster owns the far-right column and reserves a
+  `min-w-[15px]` slot — sized to the *widest* single indicator (the notification
+  pill, not the 13px provider logo) so neither a bare card nor a card showing a
+  different indicator can shift the chip. The invariant is guarded by the
+  "meta line alignment" tests in `sidebar-inbox-card.test.tsx`, which assert DOM
+  order around the spacer (jsdom does not lay out, so pixels cannot be asserted).
+  The blocker line is a fixed string
   (`permissionBlockerText()` always returns "Waiting for your input" — it does
   not surface the agent's actual question). The right side of the eyebrow shows
   the agent state — Working (configurable `WorkingIndicator`, amber text) /

--- a/src/components/layout/sidebar-inbox-card.test.tsx
+++ b/src/components/layout/sidebar-inbox-card.test.tsx
@@ -302,3 +302,91 @@ describe("SidebarInboxCard — multi-select", () => {
     expect(card?.className).toContain("ring-accent-ember/55");
   });
 });
+
+describe("SidebarInboxCard — meta line alignment", () => {
+  function metaLine(container: HTMLElement) {
+    return container.querySelector("[data-meta-line]") as HTMLElement;
+  }
+
+  // jsdom does not lay out, so these assert the DOM contract that *produces*
+  // the alignment rather than the pixels: the git-local facts flow from the
+  // left, a flex spacer absorbs the slack, and everything after it is pinned
+  // right. Before this, the PR chip sat directly after the branch name, so it
+  // landed at a different x on every card depending on how long that branch
+  // happened to be.
+  it("puts the flex spacer before the PR chip so the chip right-aligns", () => {
+    const { container } = renderCard({
+      workspace: makeWorkspace({
+        git_branch: "a-very-long-worktree-branch-name",
+        pr_number: 219,
+        pr_state: "open",
+        pr_url: "https://example.test/pr/219",
+      }),
+    });
+    const children = [...metaLine(container).children];
+    const spacer = children.findIndex((c) => c.className.includes("flex-1"));
+    const chip = children.findIndex(
+      (c) => c.getAttribute("aria-label") === "Pull request #219 — open",
+    );
+
+    expect(spacer).toBeGreaterThanOrEqual(0);
+    expect(chip).toBeGreaterThan(spacer);
+    // Branch text stays on the left of the spacer, where its length can only
+    // push its own truncation — never the chip's position.
+    expect(children[0]).toHaveTextContent("a-very-long-worktree-branch-name");
+    expect(children.indexOf(children[0])).toBeLessThan(spacer);
+  });
+
+  it("keeps the git-local facts left of the spacer for every PR state", () => {
+    for (const state of ["open", "closed", "draft", "merged"] as const) {
+      const { container } = renderCard({
+        workspace: makeWorkspace({
+          git_branch: "feat/x",
+          git_ahead: 2,
+          git_additions: 484,
+          git_deletions: 26,
+          pr_number: 7,
+          pr_state: state,
+          pr_url: "https://example.test/pr/7",
+        }),
+      });
+      const children = [...metaLine(container).children];
+      const spacer = children.findIndex((c) => c.className.includes("flex-1"));
+      const chip = children.findIndex((c) =>
+        c.getAttribute("aria-label")?.startsWith("Pull request #7"),
+      );
+
+      // ahead + diff stats are git-local facts: they belong with the branch on
+      // the left, so growing them shifts nothing in the right-hand column.
+      expect(children.slice(0, spacer).map((c) => c.textContent).join(" ")).toContain("↑2");
+      expect(children.slice(0, spacer).map((c) => c.textContent).join(" ")).toContain("+484");
+      expect(chip).toBeGreaterThan(spacer);
+      cleanup();
+    }
+  });
+
+  it("reserves the trailing indicator column so a bare card still aligns", () => {
+    // The reserved width is sized to the widest single indicator (the 15px
+    // notification pill), not the 13px provider logo — otherwise which
+    // indicator a card happens to show would shift its PR chip by 2px.
+    const { container } = renderCard({
+      workspace: makeWorkspace({ pr_number: 1, pr_state: "open" }),
+    });
+    const children = [...metaLine(container).children];
+    const trailing = children[children.length - 1];
+
+    expect(trailing.className).toContain("min-w-[15px]");
+    expect(trailing.className).toContain("justify-end");
+    // Last child, so it — not the PR chip — owns the far-right column.
+    expect(trailing.nextElementSibling).toBeNull();
+  });
+
+  it("still renders the trailing indicators it owns", () => {
+    const { container } = renderCard({
+      workspace: makeWorkspace({ notification_count: 3 }),
+    });
+    const children = [...metaLine(container).children];
+    const trailing = children[children.length - 1];
+    expect(trailing).toHaveTextContent("3");
+  });
+});

--- a/src/components/layout/sidebar-inbox-card.tsx
+++ b/src/components/layout/sidebar-inbox-card.tsx
@@ -74,7 +74,8 @@ interface Props {
 
 /** One active-workspace card in the flat sidebar inbox: repo eyebrow, work
  *  title + issue chip, optional blocker line (needs-you only), and a mono
- *  meta line (branch · ↑ahead · +/− · PR chip · remote / notifications).
+ *  meta line, left-to-right: branch · ↑ahead · +/− — then, right-aligned,
+ *  PR chip · provider marks / remote / notifications.
  *  The right side of the eyebrow shows the agent state, swapping to a
  *  "✓ Settle" button on hover/focus. */
 export function SidebarInboxCard({
@@ -510,8 +511,18 @@ export function SidebarInboxCard({
                 </div>
               )}
 
-              {/* Mono meta line: branch · ↑ahead · +/− · PR chip · remote/notifs */}
-              <div className="mt-[5px] flex min-w-0 items-center gap-2 font-mono text-[10.5px] leading-tight text-muted-foreground/60">
+              {/* Mono meta line, two columns: the git-local facts (branch ·
+                  ↑ahead · +/−) flow from the left, then a flex spacer pins the
+                  PR chip and the trailing indicator cluster to the right.
+                  The spacer sits *before* the PR chip on purpose: with it after,
+                  the chip started wherever the branch name happened to end, so
+                  chips landed at a different x on every card and the column read
+                  as ragged noise down a scrolling list. Right-aligning also makes
+                  the chip's own variable width ("merged" vs "PR #1234") harmless. */}
+              <div
+                data-meta-line
+                className="mt-[5px] flex min-w-0 items-center gap-2 font-mono text-[10.5px] leading-tight text-muted-foreground/60"
+              >
                 {workspace.git_branch && (
                   <span className="min-w-0 truncate">{workspace.git_branch}</span>
                 )}
@@ -534,6 +545,7 @@ export function SidebarInboxCard({
                     )}
                   </span>
                 )}
+                <span className="flex-1" />
                 {prState && (
                   <button
                     type="button"
@@ -554,25 +566,33 @@ export function SidebarInboxCard({
                     {prMerged ? "merged" : `PR #${workspace.pr_number ?? ""}`}
                   </button>
                 )}
-                <span className="flex-1" />
-                {providers.map((p) => (
-                  <ProviderLogo
-                    key={p}
-                    provider={p}
-                    className="h-[13px] w-[13px] opacity-80"
-                  />
-                ))}
-                {isRemote && (
-                  <Cloud
-                    aria-label="Runs on a remote host"
-                    className="h-[13px] w-[13px] shrink-0 text-status-remote"
-                  />
-                )}
-                {workspace.notification_count > 0 && (
-                  <span className="flex h-[15px] min-w-[15px] shrink-0 items-center justify-center rounded-full bg-foreground/10 px-1 text-[9.5px] font-bold text-muted-foreground">
-                    {workspace.notification_count}
-                  </span>
-                )}
+                {/* Trailing indicators keep the far-right column. The reserved
+                    min-width is what stops a card with no provider mark from
+                    pulling its PR chip out past its neighbours' — the icon
+                    cluster is the anchor the chip aligns against. It is sized to
+                    the *widest* single indicator (the 15px notification pill, not
+                    the 13px logos) so which indicator a card happens to show
+                    cannot shift the chip either. */}
+                <span className="flex min-w-[15px] shrink-0 items-center justify-end gap-2">
+                  {providers.map((p) => (
+                    <ProviderLogo
+                      key={p}
+                      provider={p}
+                      className="h-[13px] w-[13px] opacity-80"
+                    />
+                  ))}
+                  {isRemote && (
+                    <Cloud
+                      aria-label="Runs on a remote host"
+                      className="h-[13px] w-[13px] shrink-0 text-status-remote"
+                    />
+                  )}
+                  {workspace.notification_count > 0 && (
+                    <span className="flex h-[15px] min-w-[15px] shrink-0 items-center justify-center rounded-full bg-foreground/10 px-1 text-[9.5px] font-bold text-muted-foreground">
+                      {workspace.notification_count}
+                    </span>
+                  )}
+                </span>
               </div>
             </div>
         </WorkspaceHoverCard>


### PR DESCRIPTION
## Problem

The inbox card's meta line was a single left-to-right flow with the `flex-1` spacer placed **after** the PR chip:

```
[branch][↑ahead][+/−][PR chip]  ←spacer→  [logos][cloud][badge]
```

So the chip began wherever the branch name happened to end. Measured in the running app, chip right edges spread across **90px** (167→257) — the column read as ragged noise down a scrolling list.

## Fix

Move the spacer **before** the chip and group the trailing indicators, making the line two columns:

```
[branch][↑ahead][+/−]  ←spacer→  [PR chip][logos·cloud·badge]
```

Two details that mattered:

- **Ahead/diff stay on the left** with the branch — they're git-local facts, so growing them can no longer shift the right-hand column. This is the piece a naive right-align would have broken.
- **The indicator group reserves `min-w-[15px]`**, sized to the *widest* single indicator (the notification pill), not the 13px provider logo. Without it, a card with no provider mark pulled its chip past its neighbours'; sizing it to 13px first left a 2px residual on notification-badge cards.

Right-aligning also makes the chip's own variable width (`merged` vs `PR #1234`) harmless, which the old layout couldn't do.

## No functionality removed

Provider logos, remote cloud icon, notification badge, and every PR state (open / closed / draft / merged) render and behave exactly as before — same elements, same handlers, same tones. Only their grouping changed.

## Results

Measured live via the dev mock runtime:

| | before | after |
|---|---|---|
| PR chip right-edge spread (8 cards) | 90px | **0px** |
| Trailing icon column (18 cards) | aligned | aligned (single edge) |
| Meta line overflow | 0 | 0 |
| Branches truncating | 3 | 3 |

## Tests

Added four `SidebarInboxCard — meta line alignment` tests. jsdom doesn't lay out, so they assert the DOM contract that *produces* the alignment (ordering around the spacer, the reserved trailing slot, the indicators still rendering) rather than pixels. Confirmed they **fail** against the old ordering rather than passing vacuously.

- `npm run check` — clean
- `npm run test` — 3325 passed, no regressions

> Note: `npm run verify` can't complete in this worktree — `cargo check` fails on a missing sidecar (`binaries/agent-browser-x86_64-unknown-linux-gnu`). Verified this fails identically on a stashed clean tree, so it's pre-existing environment setup, not this change. The diff is TSX + markdown only.

## Docs

Updated `docs/features/sidebar.md`, which documented the old meta-line ordering.
