### PR TITLE
Give every workspace creation path a real name

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -2034,7 +2034,14 @@ Both surfaces now name it from the first message via the shared
   straight through to the unmodified `handleSubmit`, so the send path is
   byte-for-byte what it was. The interception is gated on
   `messages.length === 0`, a non-home workspace, and a resolvable project
-  root; everything else stays on `handleSubmit`.
+  root; everything else stays on `handleSubmit`. It re-checks
+  `handleSubmit`'s own bail-outs (`sendInFlightRef`, `threadId`, empty
+  text) BEFORE naming, in the same order: `messages.length` only flips
+  once the optimistic bubble lands, so two Enter presses in one tick both
+  reach this handler and only the in-flight ref rules the second one out —
+  without it they would race two `claude --print` calls into two renames,
+  the second landing before the first's title reached the store, where the
+  apply-time guard below could no longer see it.
 
 **Same namer as worktrees, on purpose.** Naming routes through
 `generateBranchName` — the exact call `createDeferredWorktree` and the

--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -1981,7 +1981,9 @@ layout. Only ONE surface routes it (the pane arm was removed — see
   backstop prime so children can't double-spawn).
 - **Pane empty state** — no longer participates. Every submit on a
   workspace-bound pane goes through the unmodified `handleSubmit` and
-  stays in that pane's own workspace.
+  stays in that pane's own workspace. (Its empty-thread first send is
+  wrapped only to TITLE that workspace — see "Current-checkout
+  auto-naming" below — never to create one.)
 
 **CWD-resolution invariant.** A freshly-created worktree
 workspace only reaches the Zustand app-store via the async
@@ -2009,8 +2011,67 @@ the session at the parent/project-root cwd — on timeout,
 `materializeAndSend` fails the send via `markSendFailed` (draft text
 preserved) rather than proceeding.
 
-`checkoutMode === "current"` (the draft surface's default) is unchanged
-from before the redesign — no worktree, no new Tauri calls.
+**Current-checkout auto-naming.** `checkoutMode === "current"` (the
+default) still creates no worktree and no branch, but it is no longer
+naming-inert. A worktree first-send gets a human-readable workspace name
+for free — `createDeferredWorktree` resolves an AI branch name and the
+backend's `set_workspace_worktree` (`state_impl.rs`) overwrites the
+workspace title with that branch — whereas the current-checkout path
+creates no branch and so used to keep the backend default
+(`format!("Workspace {workspace_index}")`, i.e. `Workspace 58`) forever.
+That was the last asymmetry: Home already derived a title, worktrees
+inherited one, and only "run on the current checkout" stayed numbered.
+Both surfaces now name it from the first message via the shared
+`autoNameWorkspace` (`materialize.ts`):
+
+- **Draft surface** — a `project` target routes through
+  `createProjectWorkspace`, which is `createEmptyWorkspace` + a fired-off
+  `autoNameWorkspace`. Same treatment in `materializeWithPreset`.
+- **Pane empty state** — the pane has no checkout mode to choose; it
+  always sends into the checkout its workspace is already on, so its
+  first send is a current-checkout send by construction.
+  `handleCurrentCheckoutFirstSubmit` fires `autoNameWorkspace` and falls
+  straight through to the unmodified `handleSubmit`, so the send path is
+  byte-for-byte what it was. The interception is gated on
+  `messages.length === 0`, a non-home workspace, and a resolvable project
+  root; everything else stays on `handleSubmit`.
+
+**Same namer as worktrees, on purpose.** Naming routes through
+`generateBranchName` — the exact call `createDeferredWorktree` and the
+CLI use — rather than the cheap `deriveTitleFromFirstMessage`. These
+titles sit side by side in the sidebar; deriving from message text would
+put `take a look at this image, when i make a…` directly above
+`sidebar-workspace-ordering` and the list would read as two different
+products. One namer means every workspace title has the same shape.
+`deriveTitleFromFirstMessage` survives as the fallback when the namer's
+IPC itself rejects (truncated message text still beats `Workspace 58`)
+and as the Home path's naming, which stays message-derived — a
+home-rooted workspace is not a project checkout, so there is no repo for
+`generateBranchName` to name a branch against or deconflict within.
+
+**Fire-and-forget, guarded at apply time.** `generateBranchName` shells
+out to `claude --print` (5-9s warm, 30s timeout), so awaiting it would
+put that on the critical path of a send that otherwise makes no extra
+backend calls. The send proceeds immediately and the sidebar card
+re-titles itself seconds later — the "conversation names itself shortly
+after you send" behavior chat UIs use. Renaming twice (instant
+truncation, then upgrading to the slug) was rejected: two visible title
+changes per workspace is churn and the intermediate value is the ugly
+one. Because the rename lands seconds late, the
+`isDefaultWorkspaceTitle` guard (`derive-title.ts`) is re-read AFTER the
+namer resolves, not at call time — on the pane path the workspace may
+have existed for days, and a user can rename it mid-flight; either way a
+user-chosen or branch-derived name is never clobbered. The guard takes
+the workspace's directory alongside its title, because a
+backend-assigned title can BE the directory name: it accepts the
+directory-name default (`~/projects/codemux` → `codemux`), the legacy
+`Workspace {n}` shape, and an absent title (nothing there to protect).
+See `docs/features/workspace-creation.md` § Workspace Titles for where
+each default comes from. A workspace absent from the store is one just
+created whose `app-state-changed` hasn't landed, so absence is not
+evidence of a user-chosen name and naming proceeds. Naming never rejects
+into the send path (it is cosmetic), and an empty/whitespace-only message
+skips it entirely rather than blanking the title.
 
 **Backend adopt-don't-duplicate guard.** `git_create_worktree` can
 return an EXISTING worktree path without creating anything (the

--- a/docs/features/workspace-creation.md
+++ b/docs/features/workspace-creation.md
@@ -33,7 +33,60 @@ Creation dispatches one of:
 
 **Orphan worktree reclamation**: a worktree's conventional path is `~/.codemux/worktrees/<repo>/<branch>`. When a previous worktree for the same branch was removed from git's registry but its directory was left on disk (e.g. spinning up a workspace from an already-worked, often closed, issue branch whose `feature/<n>-<slug>` name is auto-suggested), `git worktree add` would otherwise die with `fatal: '<path>' already exists`. Creation now detects a **safe orphan** — a path git no longer tracks as a worktree, with no `.git` entry, holding nothing but Codemux's own `.codemux/` metadata (or empty) — and removes it before adding. Anything resembling user data, or a real path collision against a different registered branch, is left untouched so git still fails loudly. Both the desktop and headless daemon paths share this policy (`is_reclaimable_orphan_worktree`).
 
+**Optional workspace name**: the dialog's "Workspace name (optional)" input
+is applied via `renameWorkspace` once the workspace exists
+(`applyTypedWorkspaceName`), on every create path including the
+current-checkout ones. It has to be applied explicitly because each path
+lands on a backend-assigned title first (see "Workspace titles" below). A
+typed name is the strongest signal available, so it wins over the
+branch-derived title too; the rename is best-effort and never fails a
+workspace that already exists. (Before this the input only fed the
+optimistic pending-row label and was silently discarded the moment the
+real workspace landed.) The one exclusion is the backend's adopt path
+(`WorkspaceCreated.adopted`, see "Backend adopt-don't-duplicate guard" in
+`docs/features/agent-chat.md`): nothing was created, and the workspace
+that got focused belongs to a session already in use, so its title is not
+this dialog's to overwrite.
+
+**Current checkout vs. worktree in the branch picker**: selecting the
+repo's currently-checked-out branch, when it has no worktree or workspace
+yet, attaches a workspace to the existing checkout
+(`handlePrimaryAction` → `onCreateOnCurrent`) instead of cutting a
+worktree. That row is labelled **"Open here"** and carries a `checked out`
+badge. Both exist because the behaviour was previously undiscoverable:
+the row read `Open` like every other, and when the checked-out branch was
+also the default it read `Fork` — claiming the opposite of what the click
+did, since the `currentBranch` test in `handlePrimaryAction` runs before
+the `isDefault` one.
+
 After creation: preset applied, issue linked, project marked as recent, workspace activated.
+
+### Workspace Titles
+
+Every creation path lands on a backend default from
+`state_impl.rs::default_workspace_title`, which some paths then overwrite:
+
+| Path | Title |
+|---|---|
+| Worktree creation | branch name (`set_workspace_worktree` overwrites) |
+| Dialog with a typed name | that name (`applyTypedWorkspaceName`) |
+| Chat first-send on a current checkout | AI name from the first prompt (`autoNameWorkspace`, async — see `docs/features/agent-chat.md`) |
+| Open project / Clone / New project | the backend default, permanently |
+
+The backend default is **the directory's own name** (`~/projects/codemux`
+→ `codemux`), falling back to `Workspace {n}` only when the path has no
+usable final component (filesystem root, empty path). It used to be
+`Workspace {n}` unconditionally, which was fine for the paths that
+overwrite it but left the last row of that table — the paths with no
+branch and no prompt — showing a bare ordinal forever.
+
+Existing workspaces keep whatever title they were created with; there is
+no migration. The frontend's `isDefaultWorkspaceTitle`
+(`src/lib/agent-chat/derive-title.ts`) therefore recognises **both**
+shapes plus an absent title, so a legacy `Workspace 58` is still
+upgradeable by a first prompt. It needs the workspace's directory to do
+this, since the current default *is* the directory name — call it with
+the cwd/project root, not just the title.
 
 ### Cloning a Repository
 

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -1025,6 +1025,33 @@ impl AppStateStore {
         self.create_workspace_with_layout(cwd_path, WorkspacePresetLayout::Single)
     }
 
+    /// Title a freshly-created workspace that has nothing better to go on.
+    ///
+    /// Prefers the directory's own name (`~/projects/codemux` → `codemux`),
+    /// falling back to `Workspace {n}` only when the path has no usable
+    /// final component (filesystem root, empty path).
+    ///
+    /// Why not always `Workspace {n}`: several creation paths never get a
+    /// second chance at a name. Worktree creation overwrites the title with
+    /// its branch (`set_workspace_worktree`) and the chat surfaces rename
+    /// from the first prompt, but "Open project", "Clone", and "New project"
+    /// have no branch and no prompt — so their workspaces kept a bare
+    /// ordinal forever. The directory name is what the user picked and what
+    /// every other tool shows for the same thing.
+    ///
+    /// Callers that DO have a better name still overwrite this afterwards;
+    /// the frontend's `isDefaultWorkspaceTitle` recognises both this shape
+    /// and the legacy `Workspace {n}` so auto-naming can still upgrade it.
+    fn default_workspace_title(cwd_path: &Path, workspace_index: usize) -> String {
+        cwd_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.trim())
+            .filter(|n| !n.is_empty())
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| format!("Workspace {workspace_index}"))
+    }
+
     /// Create a workspace with no tabs, surfaces, or terminal sessions.
     /// Used by "Add repository" so the empty workspace state shows.
     pub fn create_empty_workspace_at_path(&self, cwd_path: PathBuf) -> WorkspaceId {
@@ -1046,7 +1073,7 @@ impl AppStateStore {
         snapshot.workspaces.push(WorkspaceSnapshot {
             workspace_id: workspace_id.clone(),
             is_git: true,
-            title: format!("Workspace {workspace_index}"),
+            title: Self::default_workspace_title(&cwd_path, workspace_index),
             workspace_type: WorkspaceType::Standard,
             cwd,
             git_branch: None,
@@ -1447,7 +1474,7 @@ impl AppStateStore {
         snapshot.workspaces.push(WorkspaceSnapshot {
             workspace_id: workspace_id.clone(),
             is_git: true,
-            title: format!("Workspace {workspace_index}"),
+            title: Self::default_workspace_title(&cwd_path, workspace_index),
             workspace_type: WorkspaceType::Standard,
             cwd,
             git_branch: None,
@@ -5592,6 +5619,54 @@ fn collect_numeric_ids_from_node(root: &PaneNodeSnapshot) -> Vec<Option<u64>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Default workspace titles ────────────────────────────────────
+    //
+    // "Open project" / "Clone" / "New project" have no branch and no
+    // first prompt, so whatever these produce is what the user lives
+    // with permanently.
+
+    #[test]
+    fn default_title_uses_the_directory_name() {
+        assert_eq!(
+            AppStateStore::default_workspace_title(Path::new("/home/u/projects/codemux"), 58),
+            "codemux"
+        );
+    }
+
+    #[test]
+    fn default_title_ignores_a_trailing_slash() {
+        assert_eq!(
+            AppStateStore::default_workspace_title(Path::new("/home/u/projects/codemux/"), 58),
+            "codemux"
+        );
+    }
+
+    #[test]
+    fn default_title_falls_back_to_the_ordinal_without_a_usable_name() {
+        // Filesystem root and empty paths have no final component.
+        assert_eq!(
+            AppStateStore::default_workspace_title(Path::new("/"), 58),
+            "Workspace 58"
+        );
+        assert_eq!(
+            AppStateStore::default_workspace_title(Path::new(""), 7),
+            "Workspace 7"
+        );
+    }
+
+    #[test]
+    fn created_workspace_is_titled_after_its_directory() {
+        let store = AppStateStore::default();
+        let id = store.create_empty_workspace_at_path(PathBuf::from("/home/u/projects/codemux"));
+        let snapshot = store.snapshot();
+        let ws = snapshot
+            .workspaces
+            .iter()
+            .find(|w| w.workspace_id == id)
+            .expect("workspace exists");
+        assert_eq!(ws.title, "codemux");
+    }
 
     fn sample_split_tree() -> PaneNodeSnapshot {
         PaneNodeSnapshot::Split {

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -1231,6 +1231,35 @@ describe("AgentChatPane Thread Scope — the pane's scope is fixed, not chosen",
     });
   });
 
+  it("names once when two Enter presses land in the same tick", async () => {
+    // `messages.length === 0` (the gate that selects the naming handler)
+    // only flips once the optimistic bubble lands, so both presses see an
+    // empty thread. Only the send-in-flight ref rules the second one out,
+    // and it has to do so BEFORE the namer runs — two `claude --print`
+    // calls would otherwise race two different titles into the workspace,
+    // the second landing before the first reached the store.
+    const projectPane = seedProjectWorkspace({ title: "Workspace 58" });
+    currentSliceOverrides = {
+      "thread-x": { inputDraft: "fix the login bug" },
+    };
+    const { agentChatSendTurn, generateBranchName } = await import(
+      "@/tauri/commands"
+    );
+    vi.mocked(generateBranchName).mockClear();
+    vi.mocked(agentChatSendTurn).mockClear().mockResolvedValue({
+      turn_id: "turn-1",
+      queued_id: null,
+    } as never);
+    const { container } = render(<AgentChatPane pane={projectPane} />);
+    const submit = container.querySelector('[data-testid="composer-submit"]')!;
+    fireEvent.click(submit);
+    fireEvent.click(submit);
+    await waitFor(() => {
+      expect(vi.mocked(agentChatSendTurn)).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(generateBranchName)).toHaveBeenCalledTimes(1);
+  });
+
   it("does not clobber a title the user already chose", async () => {
     const projectPane = seedProjectWorkspace({ title: "Payments rewrite" });
     currentSliceOverrides = {

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
-import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 
 let currentMessages: unknown[] = [];
 // Overridable per-test: thread -> messages map so the new race-fix
@@ -1184,9 +1184,104 @@ describe("AgentChatPane Thread Scope — the pane's scope is fixed, not chosen",
     });
     const [, sendInput] = vi.mocked(agentChatSendTurn).mock.calls[0];
     expect(sendInput.thread_id).toBe("thread-x");
+    // The invariant is "no worktree, no second workspace, no relocation".
+    // `generateBranchName` NOT being called used to stand in for that, but
+    // it no longer can: the first send legitimately runs the namer to
+    // TITLE this workspace (see the auto-naming test below), it just never
+    // cuts a branch off it.
     expect(vi.mocked(createWorktreeWorkspaceResult)).not.toHaveBeenCalled();
-    expect(vi.mocked(generateBranchName)).not.toHaveBeenCalled();
     expect(vi.mocked(activateWorkspace)).not.toHaveBeenCalled();
+  });
+
+  it("names the workspace off the first message, without blocking the send", async () => {
+    // The reported asymmetry: a worktree first send got a real name for
+    // free (the backend overwrites the title with the new branch), while
+    // a pane sending into its own checkout cuts no branch and so kept the
+    // backend default forever.
+    const projectPane = seedProjectWorkspace({ title: "Workspace 58" });
+    currentSliceOverrides = {
+      "thread-x": { inputDraft: "fix the login bug" },
+    };
+    const { agentChatSendTurn, generateBranchName, renameWorkspace } =
+      await import("@/tauri/commands");
+    vi.mocked(generateBranchName).mockClear();
+    vi.mocked(renameWorkspace).mockClear();
+    vi.mocked(agentChatSendTurn).mockClear().mockResolvedValue({
+      turn_id: "turn-1",
+      queued_id: null,
+    } as never);
+    const { container } = render(<AgentChatPane pane={projectPane} />);
+    fireEvent.click(
+      container.querySelector('[data-testid="composer-submit"]')!,
+    );
+    // The send lands first — naming is fire-and-forget behind it, so a
+    // slow `claude --print` can never delay the turn.
+    await waitFor(() => {
+      expect(vi.mocked(agentChatSendTurn)).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(generateBranchName)).toHaveBeenCalledWith(
+      "fix the login bug",
+      "/projects/foo",
+    );
+    await waitFor(() => {
+      expect(vi.mocked(renameWorkspace)).toHaveBeenCalledWith(
+        "ws-foo",
+        "ai-named-branch",
+      );
+    });
+  });
+
+  it("does not clobber a title the user already chose", async () => {
+    const projectPane = seedProjectWorkspace({ title: "Payments rewrite" });
+    currentSliceOverrides = {
+      "thread-x": { inputDraft: "fix the login bug" },
+    };
+    const { agentChatSendTurn, renameWorkspace } = await import(
+      "@/tauri/commands"
+    );
+    vi.mocked(renameWorkspace).mockClear();
+    vi.mocked(agentChatSendTurn).mockClear().mockResolvedValue({
+      turn_id: "turn-1",
+      queued_id: null,
+    } as never);
+    const { container } = render(<AgentChatPane pane={projectPane} />);
+    fireEvent.click(
+      container.querySelector('[data-testid="composer-submit"]')!,
+    );
+    await waitFor(() => {
+      expect(vi.mocked(agentChatSendTurn)).toHaveBeenCalledTimes(1);
+    });
+    // The guard is re-read AFTER the namer resolves, so drain the
+    // fire-and-forget chain before asserting it declined to rename.
+    await act(async () => {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+    expect(vi.mocked(renameWorkspace)).not.toHaveBeenCalled();
+  });
+
+  it("does not name a home-rooted pane from its first message", async () => {
+    // Home workspaces are not project checkouts — `generateBranchName`
+    // has no repo to name a branch against or deconflict within.
+    currentSliceOverrides = {
+      "thread-x": { inputDraft: "fix the login bug" },
+    };
+    const { agentChatSendTurn, generateBranchName } = await import(
+      "@/tauri/commands"
+    );
+    vi.mocked(generateBranchName).mockClear();
+    vi.mocked(agentChatSendTurn).mockClear().mockResolvedValue({
+      turn_id: "turn-1",
+      queued_id: null,
+    } as never);
+    const homePane = { ...pane, pane_id: "pane-home", thread_id: "thread-x" };
+    const { container } = render(<AgentChatPane pane={homePane} />);
+    fireEvent.click(
+      container.querySelector('[data-testid="composer-submit"]')!,
+    );
+    await waitFor(() => {
+      expect(vi.mocked(agentChatSendTurn)).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(generateBranchName)).not.toHaveBeenCalled();
   });
 
   it("renders no strip at all when appState is null (early-boot fallback)", () => {

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -2609,17 +2609,28 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   // send path is byte-for-byte what it was.
   const handleCurrentCheckoutFirstSubmit = useCallback(
     (textOverride?: string, options?: { continueRun?: boolean }) => {
-      // Mirror `handleSubmit`'s text resolution so the name is derived
+      // Mirror `handleSubmit`'s bail-outs BEFORE naming, in the same
+      // order, so the namer fires exactly when a turn does. The
+      // `sendInFlightRef` check matters most: `messages.length === 0`
+      // (which selects this handler) only flips once the optimistic
+      // bubble lands, so two Enter presses in one tick would otherwise
+      // both reach here and race two `claude --print` calls into two
+      // renames — the second landing before the first's title reached
+      // the store, so the late guard couldn't stop it either.
+      if (sendInFlightRef.current) return;
+      if (!threadId) return;
+      // Same text resolution as `handleSubmit`, so the name is derived
       // from the message actually sent.
       const rawText = (
         typeof textOverride === "string" ? textOverride : draft
       ).trim();
-      if (rawText && paneWorkspaceId && workspaceProjectRoot) {
+      if (!rawText) return;
+      if (paneWorkspaceId && workspaceProjectRoot) {
         autoNameWorkspace(paneWorkspaceId, workspaceProjectRoot, rawText);
       }
       handleSubmit(textOverride, options);
     },
-    [draft, paneWorkspaceId, workspaceProjectRoot, handleSubmit],
+    [draft, threadId, paneWorkspaceId, workspaceProjectRoot, handleSubmit],
   );
 
   // Intercept ONLY the empty-thread first send; everything else stays on

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -89,6 +89,7 @@ import {
   type AgentChatSessionRecord,
 } from "@/tauri/commands";
 import { replayPayloads } from "@/lib/agent-chat/hydrate";
+import { autoNameWorkspace } from "@/lib/agent-chat/materialize";
 import { capabilityDefaults } from "@/lib/agent-chat/capability-defaults";
 import type { AgentChatEventPayload, ApprovalDecision } from "@/tauri/events";
 import type {
@@ -371,6 +372,15 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   });
   const isHomeWorkspace =
     homeDir !== null && workspaceProjectRoot === homeDir;
+  // Identity of the pane's workspace, for the current-checkout
+  // first-send rename (see `handleCurrentCheckoutFirstSubmit`). A plain
+  // scalar, so this selector doesn't re-render on unrelated snapshot
+  // churn. The workspace's CURRENT title is deliberately not read here —
+  // `autoNameWorkspace` re-reads it after its AI call resolves, which is
+  // the only moment the guard is meaningful.
+  const paneWorkspaceId = useAppStore(
+    (s) => workspaceIdForPane ?? s.appState?.active_workspace_id ?? null,
+  );
   // The pane workspace's actual checked-out branch (from the workspace
   // snapshot's git watcher). Thread Scope prefers this over the branch
   // picker's main/master heuristic for the "current checkout" display,
@@ -2587,6 +2597,41 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     </div>
   ) : undefined;
 
+  // A worktree first-send gets a human-readable workspace name for free
+  // (the backend overwrites the title with the new branch name). A
+  // workspace-bound pane never cuts a branch — it always sends into the
+  // checkout it is already on — so without this the workspace keeps the
+  // backend default title forever.
+  //
+  // `autoNameWorkspace` is fire-and-forget and re-checks the
+  // still-default-title guard itself, so this wrapper only resolves the
+  // text and hands straight off to the unmodified `handleSubmit` — the
+  // send path is byte-for-byte what it was.
+  const handleCurrentCheckoutFirstSubmit = useCallback(
+    (textOverride?: string, options?: { continueRun?: boolean }) => {
+      // Mirror `handleSubmit`'s text resolution so the name is derived
+      // from the message actually sent.
+      const rawText = (
+        typeof textOverride === "string" ? textOverride : draft
+      ).trim();
+      if (rawText && paneWorkspaceId && workspaceProjectRoot) {
+        autoNameWorkspace(paneWorkspaceId, workspaceProjectRoot, rawText);
+      }
+      handleSubmit(textOverride, options);
+    },
+    [draft, paneWorkspaceId, workspaceProjectRoot, handleSubmit],
+  );
+
+  // Intercept ONLY the empty-thread first send; everything else stays on
+  // the unmodified `handleSubmit` path. This pane always sends into its
+  // own checkout (the per-thread "New worktree" control was removed —
+  // see the Thread Scope note above), so the first send just names the
+  // workspace it is already in.
+  const composerOnSubmit =
+    messages.length === 0 && !isHomeWorkspace && workspaceProjectRoot !== null
+      ? handleCurrentCheckoutFirstSubmit
+      : handleSubmit;
+
   // AskUserQuestion prompts render as a composer-attached panel
   // (one-question-per-card pattern, similar to Claude.ai) rather
   // than inline in the transcript. Only the first pending
@@ -2696,7 +2741,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         if (!threadId) return;
         setInputDraft(threadId, next);
       }}
-      onSubmit={handleSubmit}
+      onSubmit={composerOnSubmit}
       onStop={handleStop}
       onProviderModelChange={handleProviderModelChange}
       onModelChange={handleModelChange}

--- a/src/components/overlays/branch-picker.tsx
+++ b/src/components/overlays/branch-picker.tsx
@@ -306,8 +306,20 @@ export function BranchPicker({
 
                       // Determine action labels based on branch state
                       const hasAnyWorktree = hasOpenWorkspace || hasWorktree;
+                      // This row is the repo's currently-checked-out
+                      // branch and has nothing attached yet, so
+                      // `handlePrimaryAction` takes the
+                      // `onCreateOnCurrent` path: it works IN the
+                      // existing checkout instead of cutting a worktree.
+                      // The label has to say so — it previously read
+                      // "Open" (or, when the current branch was also the
+                      // default, "Fork", which claimed the opposite of
+                      // what the click did).
+                      const isCurrentCheckout =
+                        !baseOnly && !hasAnyWorktree && branch.name === currentBranch;
                       const primaryLabel = baseOnly ? "Select"
                         : hasOpenWorkspace ? "Focus"
+                        : isCurrentCheckout ? "Open here"
                         : (isDefault && !hasAnyWorktree) ? "Fork"
                         : "Open";
                       const secondaryLabel = (!hasAnyWorktree && isDefault) ? "Open" : "Fork";
@@ -335,6 +347,18 @@ export function BranchPicker({
                           </span>
 
                           {/* Badges */}
+                          {branch.name === currentBranch && (
+                            // Nothing else in this list identified the
+                            // checked-out branch, so the row whose
+                            // primary action behaves differently looked
+                            // identical to every other row.
+                            <Badge
+                              variant="secondary"
+                              className="text-[9px] px-1 py-0 shrink-0"
+                            >
+                              checked out
+                            </Badge>
+                          )}
                           {isDefault && (
                             <Badge
                               variant="secondary"

--- a/src/components/overlays/new-workspace-dialog.test.tsx
+++ b/src/components/overlays/new-workspace-dialog.test.tsx
@@ -42,6 +42,7 @@ vi.mock("@/tauri/commands", () => ({
     .mockResolvedValue({ workspaceId: "ws-new", cwd: null, adopted: false }),
   importWorktreeWorkspace: vi.fn().mockResolvedValue("ws-new"),
   activateWorkspace: vi.fn().mockResolvedValue(undefined),
+  renameWorkspace: vi.fn().mockResolvedValue(undefined),
   applyPreset: vi.fn().mockResolvedValue(undefined),
   dbAddRecentProject: vi.fn().mockResolvedValue(undefined),
   dbGetRecentProjects: vi.fn().mockResolvedValue([]),
@@ -101,6 +102,7 @@ import {
   getGitBranchInfo,
   createWorktreeWorkspaceResult,
   activateWorkspace,
+  renameWorkspace,
   generateBranchName,
   generateRandomBranchName,
   pasteClipboardImageToFile,
@@ -358,6 +360,49 @@ describe("Submit flow", () => {
     });
   });
 
+  it("applies the typed workspace name to the created workspace", async () => {
+    // Regression: the "Workspace name (optional)" input used to feed
+    // only the optimistic pending row, so the name was silently dropped
+    // the moment the real workspace landed and it kept the
+    // backend-assigned title.
+    setAppState("/path/to/project");
+    renderDialog(true);
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(
+      within(dialog).getByPlaceholderText("Workspace name (optional)"),
+      { target: { value: "  Payments rewrite  " } },
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: /Create/i }));
+
+    await waitFor(() => {
+      // Trimmed, and applied to whatever workspace the create path made.
+      expect(renameWorkspace).toHaveBeenCalledWith(
+        "ws-new",
+        "Payments rewrite",
+      );
+    });
+  });
+
+  it("leaves the backend title alone when no workspace name is typed", async () => {
+    setAppState("/path/to/project");
+    renderDialog(true);
+
+    const dialog = await screen.findByRole("dialog");
+    const textarea = within(dialog).getByPlaceholderText(
+      "What do you want to do?",
+    );
+    fireEvent.change(textarea, { target: { value: "Fix the login bug" } });
+    fireEvent.click(within(dialog).getByRole("button", { name: /Create/i }));
+
+    await waitFor(() => {
+      expect(createWorktreeWorkspaceResult).toHaveBeenCalled();
+    });
+    // Worktree paths are titled from the branch by the backend; an
+    // untouched name input must not overwrite that with anything.
+    expect(renameWorkspace).not.toHaveBeenCalled();
+  });
+
   it("uses explicit branch name when provided", async () => {
     setAppState("/path/to/project");
     renderDialog(true);
@@ -543,6 +588,32 @@ describe("Submit flow", () => {
     expect(toast.info).toHaveBeenCalledWith(
       expect.stringContaining("prompt wasn't sent"),
     );
+  });
+
+  it("does not rename an adopted workspace to the typed name", async () => {
+    // An adopted workspace belongs to a session someone is already using.
+    // The typed name is meant for the workspace this dialog CREATES — the
+    // dialog never creates one here, so retitling the adoptee would rename
+    // another workspace out from under its owner.
+    (createWorktreeWorkspaceResult as Mock).mockResolvedValueOnce({
+      workspaceId: "ws-existing",
+      cwd: "/path/to/wt",
+      adopted: true,
+    });
+    setAppState("/path/to/project");
+    renderDialog(true);
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.change(
+      within(dialog).getByPlaceholderText("Workspace name (optional)"),
+      { target: { value: "Payments rewrite" } },
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: /Create/i }));
+
+    await waitFor(() => {
+      expect(activateWorkspace).toHaveBeenCalledWith("ws-existing");
+    });
+    expect(renameWorkspace).not.toHaveBeenCalled();
   });
 
   it("does not show the adoption notice for a freshly created workspace", async () => {

--- a/src/components/overlays/new-workspace-dialog.tsx
+++ b/src/components/overlays/new-workspace-dialog.tsx
@@ -120,12 +120,13 @@ export function buildPromptWithIssueContext(
 /** Apply the dialog's optional "Workspace name" to the workspace that was
  *  just created.
  *
- *  Every create path here lands on a backend-assigned title — `Workspace
- *  N` for the repo-root paths (`create_workspace`), the branch name for
- *  the worktree paths (`set_workspace_worktree`) — so a name the user
- *  typed has to be applied explicitly afterwards. Without this the input
- *  only ever labelled the optimistic pending row and was silently
- *  discarded the moment the real workspace landed.
+ *  Every create path here lands on a backend-assigned title —
+ *  `default_workspace_title` (the directory's own name) for the repo-root
+ *  paths, the branch name for the worktree paths
+ *  (`set_workspace_worktree`) — so a name the user typed has to be
+ *  applied explicitly afterwards. Without this the input only ever
+ *  labelled the optimistic pending row and was silently discarded the
+ *  moment the real workspace landed.
  *
  *  A typed name is the strongest available signal, so it wins over the
  *  branch-derived title too. Best-effort: a rename failure leaves the
@@ -1450,8 +1451,10 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
                 createWorkspace(projectDir)
                   .then(async (wsId) => {
                     // Same contract as the main create paths: honour a
-                    // typed name before the workspace becomes visible,
-                    // otherwise it lands as `Workspace N`.
+                    // typed name before the workspace becomes visible.
+                    // Nothing else ever names this one — it cuts no
+                    // branch — so without this it keeps the backend
+                    // default (the directory's name) forever.
                     await applyTypedWorkspaceName(wsId, workspaceName);
                     await activateWorkspace(wsId);
                   })

--- a/src/components/overlays/new-workspace-dialog.tsx
+++ b/src/components/overlays/new-workspace-dialog.tsx
@@ -65,6 +65,7 @@ import {
   linkWorkspaceIssue,
   getGithubIssueByPath,
   applyPreset,
+  renameWorkspace,
 } from "@/tauri/commands";
 import { pickFiles } from "@/lib/file-dialog";
 import type { TerminalPreset, WorktreeInfo, BranchDetail, PullRequestInfo, GitHubIssue, LinkedIssue, ModelSelection } from "@/tauri/types";
@@ -114,6 +115,38 @@ export function buildPromptWithIssueContext(
   lines.push("", "---", "");
 
   return lines.join("\n") + userPrompt;
+}
+
+/** Apply the dialog's optional "Workspace name" to the workspace that was
+ *  just created.
+ *
+ *  Every create path here lands on a backend-assigned title — `Workspace
+ *  N` for the repo-root paths (`create_workspace`), the branch name for
+ *  the worktree paths (`set_workspace_worktree`) — so a name the user
+ *  typed has to be applied explicitly afterwards. Without this the input
+ *  only ever labelled the optimistic pending row and was silently
+ *  discarded the moment the real workspace landed.
+ *
+ *  A typed name is the strongest available signal, so it wins over the
+ *  branch-derived title too. Best-effort: a rename failure leaves the
+ *  backend title rather than failing a workspace that already exists.
+ *
+ *  Callers must skip this when the backend ADOPTED a pre-existing live
+ *  workspace instead of creating one (`WorkspaceCreated.adopted`) — that
+ *  workspace belongs to someone else's session and its title is not ours
+ *  to overwrite. */
+async function applyTypedWorkspaceName(
+  workspaceId: string,
+  typedName: string,
+): Promise<void> {
+  const name = typedName.trim();
+  if (!name) return;
+  await renameWorkspace(workspaceId, name).catch((err) => {
+    console.warn(
+      "[new-workspace-dialog] workspace rename failed (non-fatal):",
+      err,
+    );
+  });
 }
 
 interface Props {
@@ -742,6 +775,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
 
         let wsId: string;
         let agentHandled = false;
+        let adoptedExisting = false;
         // A real orphan is a worktree on disk whose branch we want, that isn't the
         // main repo itself and isn't already owned by an existing Codemux workspace.
         // Both filters are required: the first excludes the primary repo (which appears
@@ -783,12 +817,17 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
           // here would read as "nothing happened" and quietly lose the
           // typed message, so say so.
           if (created.adopted) {
+            adoptedExisting = true;
             toast.info(
               fullPrompt
                 ? `"${openExistingBranch}" already has a live workspace — switched to it. Your prompt wasn't sent.`
                 : `"${openExistingBranch}" already has a live workspace — switched to it.`,
             );
           }
+        }
+
+        if (!adoptedExisting) {
+          await applyTypedWorkspaceName(wsId, workspaceName);
         }
 
         // Launch agent for paths that don't handle it internally
@@ -862,6 +901,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
 
       let wsId: string;
       let agentHandled = false;
+      let adoptedExisting = false;
 
       // Existing default branch (main/master): always attach to the real repo
       // root regardless of what the main repo currently has checked out. The
@@ -909,6 +949,7 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
           // typing into its in-flight session. Surface that — otherwise the
           // user's prompt disappears silently.
           if (created.adopted) {
+            adoptedExisting = true;
             toast.info(
               fullPrompt
                 ? `"${resolvedBranch}" already has a live workspace — switched to it. Your prompt wasn't sent.`
@@ -916,6 +957,10 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
             );
           }
         }
+      }
+
+      if (!adoptedExisting) {
+        await applyTypedWorkspaceName(wsId, workspaceName);
       }
 
       // Launch agent for paths that don't handle it internally
@@ -1403,7 +1448,13 @@ export function NewWorkspaceDialog({ open, onOpenChange }: Props) {
               onCreateOnCurrent={() => {
                 onOpenChange(false);
                 createWorkspace(projectDir)
-                  .then((wsId) => activateWorkspace(wsId))
+                  .then(async (wsId) => {
+                    // Same contract as the main create paths: honour a
+                    // typed name before the workspace becomes visible,
+                    // otherwise it lands as `Workspace N`.
+                    await applyTypedWorkspaceName(wsId, workspaceName);
+                    await activateWorkspace(wsId);
+                  })
                   .catch(console.error);
               }}
               onOpenExisting={handleOpenExisting}

--- a/src/lib/agent-chat/derive-title.test.ts
+++ b/src/lib/agent-chat/derive-title.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { deriveTitleFromFirstMessage } from "./derive-title";
+import {
+  deriveTitleFromFirstMessage,
+  isDefaultWorkspaceTitle,
+} from "./derive-title";
 
 describe("deriveTitleFromFirstMessage", () => {
   it("returns null for an empty string", () => {
@@ -66,5 +69,53 @@ describe("deriveTitleFromFirstMessage", () => {
     const text = "word1 word2 word3                       suffix-far-away";
     const result = deriveTitleFromFirstMessage(text);
     expect(result!.endsWith(" ")).toBe(false);
+  });
+});
+
+describe("isDefaultWorkspaceTitle", () => {
+  it("matches the backend's `Workspace <n>` default", () => {
+    // Mirrors state_impl.rs: format!("Workspace {workspace_index}").
+    expect(isDefaultWorkspaceTitle("Workspace 1")).toBe(true);
+    expect(isDefaultWorkspaceTitle("Workspace 58")).toBe(true);
+    expect(isDefaultWorkspaceTitle("  Workspace 58  ")).toBe(true);
+  });
+
+  it("treats an absent title as nameable — there is nothing to protect", () => {
+    expect(isDefaultWorkspaceTitle(null)).toBe(true);
+    expect(isDefaultWorkspaceTitle(undefined)).toBe(true);
+    expect(isDefaultWorkspaceTitle("")).toBe(true);
+    expect(isDefaultWorkspaceTitle("   ")).toBe(true);
+  });
+
+  it("matches the directory-name default", () => {
+    // The current backend default (`default_workspace_title`): a
+    // workspace opened at ~/projects/codemux is titled `codemux`.
+    expect(isDefaultWorkspaceTitle("codemux", "/home/u/projects/codemux")).toBe(
+      true,
+    );
+    expect(isDefaultWorkspaceTitle("codemux", "/home/u/projects/codemux/")).toBe(
+      true,
+    );
+    // A different name at the same path is the user's.
+    expect(
+      isDefaultWorkspaceTitle("payments rewrite", "/home/u/projects/codemux"),
+    ).toBe(false);
+    // Without a path to compare against, only the legacy shape matches —
+    // the safe direction is declining to rename.
+    expect(isDefaultWorkspaceTitle("codemux")).toBe(false);
+  });
+
+  it("never claims a user-chosen or branch-derived name as default", () => {
+    // These are the names auto-renaming must never clobber.
+    expect(isDefaultWorkspaceTitle("sidebar-workspace-ordering")).toBe(false);
+    expect(isDefaultWorkspaceTitle("Workspace")).toBe(false);
+    expect(isDefaultWorkspaceTitle("Workspace 58 (mine)")).toBe(false);
+    expect(isDefaultWorkspaceTitle("My Workspace 58")).toBe(false);
+    expect(isDefaultWorkspaceTitle("workspace 58")).toBe(false);
+    expect(isDefaultWorkspaceTitle("Workspace 58b")).toBe(false);
+    // A branch-named worktree workspace, whose dirPath is the repo root.
+    expect(
+      isDefaultWorkspaceTitle("fix-login-bug", "/home/u/projects/codemux"),
+    ).toBe(false);
   });
 });

--- a/src/lib/agent-chat/derive-title.ts
+++ b/src/lib/agent-chat/derive-title.ts
@@ -16,6 +16,8 @@
  *    truncated.
  */
 
+import { basename } from "@/lib/path";
+
 const MAX_TITLE = 40;
 const WORD_BOUNDARY_LOOKBACK = 15;
 
@@ -35,4 +37,41 @@ export function deriveTitleFromFirstMessage(text: string): string | null {
 
   // No good word boundary — hard truncate with ellipsis.
   return hardCut.trimEnd() + "…";
+}
+
+/** Whether a workspace is still wearing a title the BACKEND assigned,
+ *  rather than one a human (or a branch) chose.
+ *
+ *  Used to decide whether an already-existing workspace may be
+ *  auto-renamed from its first chat message. A user-chosen name — or one
+ *  inherited from a worktree branch — must never be silently
+ *  overwritten, so anything not recognised here is left alone.
+ *
+ *  Two shapes count as default, both from `state_impl.rs`'s
+ *  `default_workspace_title`:
+ *   - the directory's own name (`~/projects/codemux` → `codemux`), the
+ *     current default; and
+ *   - `Workspace {n}`, the legacy default, still worn by every workspace
+ *     created before that change — they must stay upgradeable.
+ *
+ *  `dirPath` is the workspace's cwd/project root. Omit it and only the
+ *  legacy shape is recognised, which is the safe direction: the worst
+ *  case is declining to rename.
+ *
+ *  Note the deliberate consequence: if a user manually renames a
+ *  workspace to exactly its directory name, a first prompt will still
+ *  rename it. That collision is indistinguishable from the default by
+ *  construction, and re-titling a workspace the user never really named
+ *  is the cheaper error. */
+export function isDefaultWorkspaceTitle(
+  title: string | null | undefined,
+  dirPath?: string | null,
+): boolean {
+  // No title at all is the clearest case of "not user-chosen" — there is
+  // nothing here to protect, so it is always safe to name.
+  const trimmed = title?.trim();
+  if (!trimmed) return true;
+  if (/^Workspace \d+$/.test(trimmed)) return true;
+  if (!dirPath) return false;
+  return trimmed === basename(dirPath);
 }

--- a/src/lib/agent-chat/materialize.test.ts
+++ b/src/lib/agent-chat/materialize.test.ts
@@ -43,6 +43,7 @@ vi.mock("@/tauri/commands", () => ({
 }));
 
 import {
+  autoNameWorkspace,
   materializeAndSend,
   materializeWithPreset,
   type MaterializeActions,
@@ -83,6 +84,15 @@ function makeActions(): SpyActions {
     setFastMode: vi.fn(),
     setMode: vi.fn(),
   };
+}
+
+/** Workspace auto-naming is fire-and-forget by design (it must not add
+ *  `claude --print` latency to a send), so it settles AFTER
+ *  `materializeAndSend` resolves. Yield to the macrotask queue to let
+ *  its promise chain — generateBranchName → title re-check → rename —
+ *  run to completion before asserting on it. */
+function flushAutoName(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function makeDraft(overrides: Partial<ChatDraft> = {}): ChatDraft {
@@ -167,7 +177,7 @@ describe("materializeAndSend", () => {
       expect(activateWorkspace).toHaveBeenCalledWith("ws-home");
     });
 
-    it("uses createEmptyWorkspace without skipSetup for a project target, and does not rename", async () => {
+    it("uses createEmptyWorkspace without skipSetup for a project target, and auto-names it via the AI namer", async () => {
       const actions = makeActions();
       const draft = makeDraft({
         target: { kind: "project", projectPath: "/projects/foo" },
@@ -182,13 +192,61 @@ describe("materializeAndSend", () => {
 
       expect(result.success).toBe(true);
       expect(createEmptyWorkspace).toHaveBeenCalledWith("/projects/foo");
-      // Project paths are named after the basename by default; no rename.
-      expect(renameWorkspace).not.toHaveBeenCalled();
       expect(agentChatCreatePane).toHaveBeenCalledWith(
         "ws-project",
         "claude",
         "/projects/foo",
       );
+      // A current-checkout workspace creates no branch, so nothing else
+      // would ever name it — without this it keeps the backend default
+      // (`Workspace 58`) forever, unlike the worktree path which
+      // inherits its branch name. It routes through the SAME namer the
+      // worktree path uses, so titles share one shape.
+      await flushAutoName();
+      expect(generateBranchName).toHaveBeenCalledWith("hello", "/projects/foo");
+      expect(renameWorkspace).toHaveBeenCalledWith(
+        "ws-project",
+        "ai-named-branch",
+      );
+    });
+
+    it("auto-naming does not block the send", async () => {
+      // The namer shells out to `claude --print` (5-9s warm). If the send
+      // awaited it, first-send latency on the most common flow would
+      // regress by seconds — so a namer that never settles must still
+      // let the whole send complete.
+      const actions = makeActions();
+      vi.mocked(generateBranchName).mockReturnValueOnce(
+        new Promise(() => {}) as Promise<string>,
+      );
+      const draft = makeDraft({
+        target: { kind: "project", projectPath: "/projects/foo" },
+      });
+
+      const result = await materializeAndSend(
+        draft,
+        "hello",
+        "/projects/foo",
+        actions,
+      );
+
+      expect(result.success).toBe(true);
+      expect(agentChatSendTurn).toHaveBeenCalled();
+      expect(renameWorkspace).not.toHaveBeenCalled();
+    });
+
+    it("empty composer text leaves a project workspace with its default title", async () => {
+      const actions = makeActions();
+      const draft = makeDraft({
+        target: { kind: "project", projectPath: "/projects/foo" },
+      });
+
+      await materializeAndSend(draft, "   ", "/projects/foo", actions);
+
+      await flushAutoName();
+      expect(createEmptyWorkspace).toHaveBeenCalledWith("/projects/foo");
+      expect(generateBranchName).not.toHaveBeenCalled();
+      expect(renameWorkspace).not.toHaveBeenCalled();
     });
 
     it("skips workspace creation entirely for an existing_workspace target", async () => {
@@ -829,10 +887,14 @@ describe("materializeAndSend", () => {
 
       expect(result.success).toBe(true);
       expect(createWorktreeWorkspaceResult).not.toHaveBeenCalled();
-      expect(generateBranchName).not.toHaveBeenCalled();
       expect(generateRandomBranchName).not.toHaveBeenCalled();
       // Falls through to the ordinary project-target path.
       expect(createEmptyWorkspace).toHaveBeenCalledWith("/projects/foo");
+      // `generateBranchName` IS called here now — but only to title the
+      // workspace, never to cut a branch. The no-worktree assertion above
+      // is the invariant; the namer is no longer a proxy for it.
+      await flushAutoName();
+      expect(createWorktreeWorkspaceResult).not.toHaveBeenCalled();
     });
 
     it("checkoutMode 'worktree' without a worktreeProjectPath (e.g. a home target) falls through unchanged", async () => {
@@ -1513,5 +1575,132 @@ describe("materializeWithPreset", () => {
       expect(agentChatCreatePane).toHaveBeenCalled();
       warnSpy.mockRestore();
     });
+  });
+});
+
+describe("autoNameWorkspace", () => {
+  /** Seed the store with one workspace wearing `title`, so the
+   *  apply-time guard has something real to read. `dirPath` matters
+   *  because the backend's default title IS the directory name. */
+  function seedWorkspace(
+    workspaceId: string,
+    title: string,
+    dirPath = "/projects/foo",
+  ) {
+    useAppStore.setState({
+      appState: {
+        schema_version: 1,
+        active_workspace_id: workspaceId,
+        workspaces: [
+          {
+            workspace_id: workspaceId,
+            title,
+            project_root: dirPath,
+            cwd: dirPath,
+          },
+        ],
+      } as never,
+    });
+  }
+
+  beforeEach(() => {
+    vi.mocked(renameWorkspace).mockClear().mockResolvedValue(undefined);
+    vi.mocked(generateBranchName)
+      .mockClear()
+      .mockResolvedValue("ai-named-branch");
+    useAppStore.setState({ appState: null });
+  });
+
+  it("renames a workspace still carrying the backend default title", async () => {
+    seedWorkspace("ws-58", "Workspace 58");
+    autoNameWorkspace("ws-58", "/projects/foo", "fix the sidebar");
+    await flushAutoName();
+    expect(renameWorkspace).toHaveBeenCalledWith("ws-58", "ai-named-branch");
+  });
+
+  it("renames a workspace still wearing the directory-name default", async () => {
+    // The current backend default. "Open project" / "Clone" workspaces
+    // land here, so a first prompt must still be able to upgrade them.
+    seedWorkspace("ws-58", "foo", "/projects/foo");
+    autoNameWorkspace("ws-58", "/projects/foo", "fix the sidebar");
+    await flushAutoName();
+    expect(renameWorkspace).toHaveBeenCalledWith("ws-58", "ai-named-branch");
+  });
+
+  it("never clobbers a user-chosen or branch-derived title", async () => {
+    // The pane path runs against workspaces that may have existed for
+    // days — a name the user (or a worktree branch) already set is the
+    // one signal we must not destroy.
+    seedWorkspace("ws-58", "my important work");
+    autoNameWorkspace("ws-58", "/projects/foo", "hello");
+    await flushAutoName();
+    expect(renameWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("re-checks the title AFTER the AI call, not before", async () => {
+    // The namer takes seconds; a user can rename the workspace during
+    // that window. Reading the guard at call time would race and
+    // overwrite them.
+    seedWorkspace("ws-58", "Workspace 58");
+    let release!: (name: string) => void;
+    vi.mocked(generateBranchName).mockReturnValueOnce(
+      new Promise<string>((r) => {
+        release = r;
+      }),
+    );
+
+    autoNameWorkspace("ws-58", "/projects/foo", "hello");
+    await flushAutoName();
+    // User renames mid-flight.
+    seedWorkspace("ws-58", "my important work");
+    release("ai-named-branch");
+    await flushAutoName();
+
+    expect(renameWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("names a workspace the store hasn't hydrated yet", async () => {
+    // A just-created workspace reaches the store via the async
+    // `app-state-changed` event. Absence is not evidence of a
+    // user-chosen name, so naming must still proceed.
+    autoNameWorkspace("ws-brand-new", "/projects/foo", "hello");
+    await flushAutoName();
+    expect(renameWorkspace).toHaveBeenCalledWith(
+      "ws-brand-new",
+      "ai-named-branch",
+    );
+  });
+
+  it("falls back to the message text when the namer IPC rejects", async () => {
+    vi.mocked(generateBranchName).mockRejectedValueOnce(new Error("no ipc"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    seedWorkspace("ws-58", "Workspace 58");
+
+    autoNameWorkspace("ws-58", "/projects/foo", "fix the sidebar");
+    await flushAutoName();
+
+    // Truncated message text still beats leaving `Workspace 58`.
+    expect(renameWorkspace).toHaveBeenCalledWith("ws-58", "fix the sidebar");
+    warnSpy.mockRestore();
+  });
+
+  it("skips an empty first message rather than blanking the title", async () => {
+    seedWorkspace("ws-58", "Workspace 58");
+    autoNameWorkspace("ws-58", "/projects/foo", "   ");
+    await flushAutoName();
+    expect(generateBranchName).not.toHaveBeenCalled();
+    expect(renameWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("swallows a rejecting rename instead of surfacing an unhandled rejection", async () => {
+    vi.mocked(renameWorkspace).mockRejectedValueOnce(new Error("boom"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    seedWorkspace("ws-58", "Workspace 58");
+
+    // Returns void — a naming failure must never reach the send path.
+    expect(autoNameWorkspace("ws-58", "/projects/foo", "hello")).toBeUndefined();
+    await flushAutoName();
+
+    warnSpy.mockRestore();
   });
 });

--- a/src/lib/agent-chat/materialize.ts
+++ b/src/lib/agent-chat/materialize.ts
@@ -17,7 +17,10 @@ import { useAppStore } from "@/stores/app-store";
 import type { ChatDraft, DraftId } from "@/stores/chat-draft-store";
 import type { TerminalPreset } from "@/tauri/types";
 
-import { deriveTitleFromFirstMessage } from "./derive-title";
+import {
+  deriveTitleFromFirstMessage,
+  isDefaultWorkspaceTitle,
+} from "./derive-title";
 import { defaultPermissionModeForProvider } from "./capability-defaults";
 import { applyAllPrefixes } from "./mode-prefix";
 import type { UserMessageImage } from "./types";
@@ -250,7 +253,10 @@ export async function materializeAndSend(
           break;
         }
         case "project":
-          workspaceId = await createEmptyWorkspace(draft.target.projectPath);
+          workspaceId = await createProjectWorkspace(
+            draft.target.projectPath,
+            text,
+          );
           break;
         case "existing_workspace":
           workspaceId = draft.target.workspaceId;
@@ -413,7 +419,10 @@ export async function materializeWithPreset(
         break;
       }
       case "project":
-        workspaceId = await createEmptyWorkspace(draft.target.projectPath);
+        workspaceId = await createProjectWorkspace(
+          draft.target.projectPath,
+          initialPrompt,
+        );
         break;
       case "existing_workspace":
         workspaceId = draft.target.workspaceId;
@@ -632,16 +641,151 @@ async function createHomeRootedWorkspace(firstMessage: string): Promise<string> 
     throw new Error("Home directory not loaded yet");
   }
   const workspaceId = await createEmptyWorkspace(homeDir, { skipSetup: true });
-  const title = deriveTitleFromFirstMessage(firstMessage);
-  if (title) {
-    await renameWorkspace(workspaceId, title).catch((err) => {
+  await applyFirstMessageTitle(workspaceId, firstMessage);
+  return workspaceId;
+}
+
+/** Create a workspace on a project's EXISTING checkout (the default
+ *  `checkoutMode === "current"`) and kick off its auto-naming.
+ *
+ *  Naming is fire-and-forget (see `autoNameWorkspace`) so workspace
+ *  creation — and therefore the whole first send — is not blocked on it. */
+async function createProjectWorkspace(
+  projectPath: string,
+  firstMessage: string,
+): Promise<string> {
+  const workspaceId = await createEmptyWorkspace(projectPath);
+  autoNameWorkspace(workspaceId, projectPath, firstMessage);
+  return workspaceId;
+}
+
+/** Name a `checkoutMode === "current"` workspace after its first message,
+ *  in the background.
+ *
+ *  **Why this exists.** The `"worktree"` path gets a human-readable name
+ *  for free: `createDeferredWorktree` resolves an AI branch name and the
+ *  backend's `set_workspace_worktree` overwrites the workspace title with
+ *  that branch. The current-checkout path creates no branch, so nothing
+ *  ever named it and it kept the backend default
+ *  (`format!("Workspace {workspace_index}")` → `Workspace 58`) forever.
+ *
+ *  **Why the AI name and not the cheap truncated message.** These titles
+ *  sit side by side in the sidebar. Deriving from message text would
+ *  produce `take a look at this image, when i make a…` directly above
+ *  `sidebar-workspace-ordering`, so the list would read as two different
+ *  products. Routing through `generateBranchName` — the exact call the
+ *  worktree path and the CLI use — means the app has ONE naming pipeline
+ *  and every workspace title has the same shape.
+ *
+ *  **Why fire-and-forget.** `generateBranchName` shells out to
+ *  `claude --print` (5-9s warm, 30s timeout). Awaiting it would put that
+ *  on the critical path of a send that otherwise makes no extra backend
+ *  calls. Instead the send proceeds immediately and the sidebar card
+ *  re-titles itself a few seconds later — the same "the conversation
+ *  names itself shortly after you send" behavior chat UIs use. The
+ *  alternative of renaming twice (instant truncation, then upgrade to the
+ *  slug) was rejected: two visible title changes per workspace is churn,
+ *  and the intermediate value is the ugly one.
+ *
+ *  Never rejects — naming is cosmetic and must not surface as a send
+ *  failure. */
+export function autoNameWorkspace(
+  workspaceId: string,
+  projectPath: string,
+  firstMessage: string,
+): void {
+  void resolveAndApplyWorkspaceName(workspaceId, projectPath, firstMessage)
+    .catch((err) => {
       console.warn(
-        "[materialize] title rename failed (non-fatal):",
+        "[materialize] workspace auto-name failed (non-fatal):",
         errorMessage(err),
       );
     });
+}
+
+async function resolveAndApplyWorkspaceName(
+  workspaceId: string,
+  projectPath: string,
+  firstMessage: string,
+): Promise<void> {
+  // An empty / whitespace-only message has nothing to name from — leave
+  // the default title rather than blanking it.
+  const fallback = deriveTitleFromFirstMessage(firstMessage);
+  if (!fallback) return;
+
+  // `generate_ai_name` degrades internally (bad output / timeout / no
+  // CLI → `generate_random_name`), so a resolved value is always usable
+  // and this catch only covers the IPC itself failing. In that case the
+  // truncated message still beats leaving `Workspace 58`.
+  let title: string;
+  try {
+    title = (await generateBranchName(firstMessage, projectPath)).trim() || fallback;
+  } catch (err) {
+    console.warn(
+      "[materialize] generateBranchName failed, naming from message text:",
+      errorMessage(err),
+    );
+    title = fallback;
   }
-  return workspaceId;
+
+  // Re-read the title HERE, not at call time: we just spent seconds in
+  // the AI call, and on the pane path the workspace may have existed for
+  // days. Only a workspace still wearing a backend-assigned title gets
+  // renamed — a name the user chose (or one a worktree branch supplied)
+  // is never clobbered. A workspace missing from the store is one we
+  // just created whose `app-state-changed` hasn't landed yet, so absence
+  // is not evidence of a user-chosen name and naming proceeds.
+  const current = currentWorkspace(workspaceId);
+  if (current && !isDefaultWorkspaceTitle(current.title, current.dirPath)) {
+    return;
+  }
+
+  await renameWorkspace(workspaceId, title).catch((err) => {
+    console.warn(
+      "[materialize] title rename failed (non-fatal):",
+      errorMessage(err),
+    );
+  });
+}
+
+/** Current title + directory of `workspaceId` per the app store, or
+ *  `null` when the store has no such workspace (not yet hydrated, or
+ *  already closed). Both are needed because a backend-assigned title can
+ *  BE the directory name — see `isDefaultWorkspaceTitle`. */
+function currentWorkspace(
+  workspaceId: string,
+): { title: string; dirPath: string | null } | null {
+  const appState = useAppStore.getState().appState;
+  if (!appState) return null;
+  const ws = appState.workspaces.find((w) => w.workspace_id === workspaceId);
+  if (!ws) return null;
+  return { title: ws.title, dirPath: ws.project_root ?? ws.cwd ?? null };
+}
+
+/** Best-effort "label this workspace with the first message" rename.
+ *
+ *  The Home path's naming, kept separate from `autoNameWorkspace`: a
+ *  home-rooted workspace is not a project checkout, so there is no repo
+ *  to name a branch against and `generateBranchName`'s deconfliction
+ *  would have nothing to deconflict. Home titles stay message-derived.
+ *
+ *  Never throws: a rename failure leaves the workspace with its
+ *  backend-default title rather than aborting a send that has already
+ *  created real resources. Matches the locked "no rollback on
+ *  post-create failure" policy. An empty/whitespace-only message
+ *  derives `null` and is skipped entirely. */
+async function applyFirstMessageTitle(
+  workspaceId: string,
+  firstMessage: string,
+): Promise<void> {
+  const title = deriveTitleFromFirstMessage(firstMessage);
+  if (!title) return;
+  await renameWorkspace(workspaceId, title).catch((err) => {
+    console.warn(
+      "[materialize] title rename failed (non-fatal):",
+      errorMessage(err),
+    );
+  });
 }
 
 /** Thread Scope redesign — create the sibling worktree a `"worktree"`

--- a/src/lib/agent-chat/materialize.ts
+++ b/src/lib/agent-chat/materialize.ts
@@ -667,7 +667,8 @@ async function createProjectWorkspace(
  *  backend's `set_workspace_worktree` overwrites the workspace title with
  *  that branch. The current-checkout path creates no branch, so nothing
  *  ever named it and it kept the backend default
- *  (`format!("Workspace {workspace_index}")` → `Workspace 58`) forever.
+ *  (`state_impl.rs::default_workspace_title` — the directory's own name,
+ *  or `Workspace {n}` for anything created before that) forever.
  *
  *  **Why the AI name and not the cheap truncated message.** These titles
  *  sit side by side in the sidebar. Deriving from message text would
@@ -716,7 +717,7 @@ async function resolveAndApplyWorkspaceName(
   // `generate_ai_name` degrades internally (bad output / timeout / no
   // CLI → `generate_random_name`), so a resolved value is always usable
   // and this catch only covers the IPC itself failing. In that case the
-  // truncated message still beats leaving `Workspace 58`.
+  // truncated message still beats leaving the backend default.
   let title: string;
   try {
     title = (await generateBranchName(firstMessage, projectPath)).trim() || fallback;


### PR DESCRIPTION
## Problem

Creating a workspace with **new worktree** named it automatically from the first prompt. Creating one with **current worktree** left it as `Workspace 58` forever.

That asymmetry wasn't a missing feature — it was a side effect. The worktree path turns the first prompt into a *branch* name, and `set_workspace_worktree` overwrites the workspace title with that branch. Current-checkout cuts no branch, so nothing ever named it.

Auditing the rest of the creation surface turned up two more places where names went missing.

## Changes

### Current checkout — the reported case

`autoNameWorkspace` names the workspace from the first prompt via `generateBranchName`, the same namer the worktree path and the CLI use, so titles share one shape. Deriving from raw message text instead would have put `take a look at this image, when i make a…` directly above `sidebar-workspace-ordering` in the sidebar.

It's fire-and-forget. The namer shells out to `claude --print` (5-9s warm) and this send path otherwise makes no extra backend calls, so awaiting it would regress first-send latency on the most common flow. The send goes immediately; the card re-titles itself a few seconds later. Renaming twice (instant truncation, then upgrading to the slug) was rejected — two visible title changes per workspace, and the intermediate value is the ugly one.

Because the rename lands late, the still-default-title guard is re-read **after** the namer resolves rather than at call time: the workspace may have existed for days, and the user can rename it mid-flight. A user-chosen or branch-derived name is never clobbered.

### New Workspace dialog — typed names were discarded

The "Workspace name (optional)" input only fed the optimistic pending row. `renameWorkspace` was never called, so whatever you typed vanished the moment the real workspace landed. Now applied on every create path, including the dialog's own current-checkout path.

### Open project / Clone / New project — never nameable

No branch, no prompt, so nothing could ever name them. `default_workspace_title` now returns the directory's own name (`~/projects/codemux` → `codemux`), falling back to `Workspace {n}` only when a path has no usable final component. Done in Rust so the CLI, MCP, and remote creation paths inherit it.

No migration — existing titles stand, and `isDefaultWorkspaceTitle` accepts both shapes so a legacy `Workspace 58` is still upgradeable by a first prompt.

### Branch picker — a mislabelled action

Selecting the checked-out branch attaches to the existing checkout, but the row read `Open` like every other. Worse, when that branch was also the default it read **`Fork`** — the opposite of what clicking did, since `handlePrimaryAction` tests `currentBranch` before `isDefault`. Now labelled `Open here` with a `checked out` badge, which is also the only thing in that list identifying the current branch.

## Result

| Path | Before | After |
|---|---|---|
| New worktree | branch name | unchanged |
| Chat first send, current checkout | `Workspace 58` forever | AI name from first prompt |
| Dialog with typed name | name silently discarded | the typed name |
| Dialog "keep current worktree" | `Workspace 58` forever | typed name, else directory name |
| Open project / Clone / New project | `Workspace 58` forever | directory name |

## Testing

- `tsc --noEmit` clean
- Frontend: 3285 tests / 219 files pass
- Rust: 2141 pass, 0 fail (excluding `agent_provider::opencode` live-binary tests, which are flaky independent of this change — the unmodified baseline gives 3 → 1 → 0 failures across three identical runs)

Two existing tests asserted `generateBranchName` was never called on the current-checkout path, using that as a proxy for "no worktree created". That proxy is now wrong — the namer legitimately runs, it just doesn't cut a branch — so both were rewritten to assert the actual invariant.

## Note

Since titles now default to the directory name, two workspaces on the same project both read `codemux` until one gets named, distinguished only by the branch line beneath. If that's too ambiguous, appending the branch is a one-line change in `default_workspace_title`.