### PR TITLE
Refine typography rendering and readability

### DIFF
--- a/docs/reference/DESIGN-SYSTEM.md
+++ b/docs/reference/DESIGN-SYSTEM.md
@@ -89,6 +89,16 @@ overview):
   aliases it — headings are sans, not mono).
 - `--font-mono` — **JetBrains Mono Variable**, reserved for code-like
   metadata only (branch names, counters, ids).
+- UI font sizes use whole CSS pixels. Keep the compact scale on
+  `10px` / `11px` / `12px` / `13px` / `14px`; half-pixel font sizes make
+  glyphs noticeably softer in the Linux WebKitGTK desktop renderer.
+- Primary chat prose and composer input use `text-sm leading-relaxed`
+  (14px with a 1.625 line height). Supporting labels may be smaller, but
+  should not compress the main reading surface.
+- Font rasterization is platform-native. Do not apply global
+  `-webkit-font-smoothing`, `-moz-osx-font-smoothing`, or `text-rendering`
+  overrides: they thin DM Sans in WebKitGTK and render differently from the
+  Chromium dev mock.
 
 ## Notes
 

--- a/src/components/automations/automations-section.tsx
+++ b/src/components/automations/automations-section.tsx
@@ -406,7 +406,7 @@ export function AutomationsSection() {
             <h3 className="text-[15px] font-semibold tracking-tight text-foreground">
               No automations yet
             </h3>
-            <p className="text-[12.5px] leading-relaxed text-muted-foreground/80">
+            <p className="text-[13px] leading-relaxed text-muted-foreground/80">
               Run an agent on a schedule — triage issues each morning,
               sweep stale branches nightly, post a weekly summary. It runs
               on the host you choose, even with your laptop closed.
@@ -416,7 +416,7 @@ export function AutomationsSection() {
             type="button"
             variant="secondary"
             size="sm"
-            className="h-8 gap-1.5 text-[12.5px]"
+            className="h-8 gap-1.5 text-[13px]"
             onClick={startCreate}
           >
             <Plus className="size-3.5" />
@@ -638,7 +638,7 @@ function AutomationDetail({
         <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
           Prompt
         </p>
-        <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-[12.5px] text-foreground/90 leading-relaxed whitespace-pre-wrap max-h-40 overflow-y-auto">
+        <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-[13px] text-foreground/90 leading-relaxed whitespace-pre-wrap max-h-40 overflow-y-auto">
           {automation.prompt}
         </div>
       </div>
@@ -701,7 +701,7 @@ function FactCard({ label, value }: { label: string; value: string }) {
       <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
         {label}
       </p>
-      <p className="mt-1 text-[12.5px] text-foreground/90 tabular-nums">{value}</p>
+      <p className="mt-1 text-[13px] text-foreground/90 tabular-nums">{value}</p>
     </div>
   );
 }
@@ -772,7 +772,7 @@ function RunHistory({ automationId }: { automationId: number }) {
               title={run.error ?? undefined}
               className="flex items-center gap-2.5 px-3 py-2"
             >
-              <span className="shrink-0 font-mono text-[11.5px] tabular-nums text-muted-foreground/80">
+              <span className="shrink-0 font-mono text-[12px] tabular-nums text-muted-foreground/80">
                 {formatStamp(run.scheduled_for)}
               </span>
               {run.pr_url ? (
@@ -784,7 +784,7 @@ function RunHistory({ automationId }: { automationId: number }) {
                   Pull request ↗
                 </button>
               ) : run.branch ? (
-                <span className="min-w-0 truncate font-mono text-[10.5px] text-muted-foreground/55">
+                <span className="min-w-0 truncate font-mono text-[11px] text-muted-foreground/55">
                   {run.branch}
                 </span>
               ) : null}
@@ -1044,7 +1044,7 @@ function ScheduleField({
             className="h-9 w-28 text-[13px] tabular-nums"
           />
           {draft.builder.frequency === "HOURLY" && (
-            <span className="text-[11.5px] text-muted-foreground/70">
+            <span className="text-[12px] text-muted-foreground/70">
               past each hour
             </span>
           )}
@@ -1173,7 +1173,7 @@ function RepoAccessRow({
   if (hostId === null) return null;
 
   return (
-    <div className="flex items-start gap-2 text-[11.5px] leading-relaxed">
+    <div className="flex items-start gap-2 text-[12px] leading-relaxed">
       {checking ? (
         <>
           <Loader2 className="mt-0.5 size-3 shrink-0 animate-spin text-muted-foreground/60" />

--- a/src/components/chat/ActivityBlock.tsx
+++ b/src/components/chat/ActivityBlock.tsx
@@ -103,7 +103,7 @@ function WorkingHeader({
         strokeWidth={1.9}
         aria-hidden
       />
-      <span className="shrink-0 text-[12.5px] font-bold text-foreground">
+      <span className="shrink-0 text-[13px] font-bold text-foreground">
         Working
       </span>
       <span className="min-w-0 flex-1 truncate">
@@ -111,7 +111,7 @@ function WorkingHeader({
           {deriveLiveAction(steps)}
         </span>
       </span>
-      <span className="shrink-0 font-mono text-[10.5px] text-muted-foreground">
+      <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
         {deriveWorkingCounter(steps)}
       </span>
       <ChevronDown
@@ -148,17 +148,17 @@ function SettledHeader({
         strokeWidth={1.8}
         aria-hidden
       />
-      <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-muted-foreground">
+      <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-muted-foreground">
         {deriveActivitySummary(steps)}
       </span>
-      <span className="shrink-0 font-mono text-[10.5px] text-muted-foreground">
+      <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
         {total} step{total === 1 ? "" : "s"}
         {durationMs != null ? ` · ${formatActivityDuration(durationMs)}` : ""}
         {failed > 0 ? (
           <span className="text-status-attention"> · {failed} failed</span>
         ) : null}
       </span>
-      <span className="flex shrink-0 items-center gap-1.5 text-[11.5px] font-semibold text-muted-foreground/70">
+      <span className="flex shrink-0 items-center gap-1.5 text-[12px] font-semibold text-muted-foreground/70">
         {open ? "Hide" : "Details"}
         <ChevronDown
           className={cn("h-3 w-3 transition-transform", open && "rotate-180")}
@@ -221,7 +221,7 @@ function StepRow({
 function StepDetail({ step }: { step: ActivityStep }) {
   if (step.kind === "reasoning") {
     return (
-      <p className="whitespace-pre-wrap break-words text-[12.5px] italic leading-[1.6] text-muted-foreground">
+      <p className="whitespace-pre-wrap break-words text-[13px] italic leading-[1.6] text-muted-foreground">
         {step.text}
       </p>
     );

--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -8,7 +8,7 @@ import { StreamingIndicator } from "./streaming-indicator";
 /**
  * Assistant prose (design D4). No bubble, no avatar (the avatar lives in
  * the turn gutter, drawn once by MessageList) — just the streaming
- * markdown at 13.5px / 1.62 line-height. All element styling lives in
+ * markdown at 14px / 1.625 line-height. All element styling lives in
  * `ChatMarkdown` so the plan renderer and reasoning body share one prose
  * treatment. The pulsing caret trails a streaming row.
  */
@@ -20,7 +20,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   const showIndicator = item.streaming && item.text.length === 0;
 
   return (
-    <div className="text-[13.5px] leading-[1.62] text-foreground break-words">
+    <div className="text-sm leading-relaxed text-foreground break-words">
       <ChatMarkdown>{item.text}</ChatMarkdown>
       {item.streaming && !showIndicator && (
         <StreamingIndicator className="ml-0.5" />

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -2219,7 +2219,7 @@ export function Composer({
               className={cn(
                 "pointer-events-none absolute inset-0 px-3 py-2.5",
                 "whitespace-pre-wrap break-words",
-                "text-sm text-foreground",
+                "text-sm leading-relaxed text-foreground",
                 // `overflow-y-auto` (rather than `overflow-hidden`) is
                 // required so we can imperatively assign `scrollTop` —
                 // setting `scrollTop` on a clipped element is a no-op in
@@ -2384,7 +2384,7 @@ export function Composer({
                 "relative block w-full resize-none bg-transparent px-3 py-2.5",
                 // Transparent text — the colored mirror behind shows
                 // through. Caret stays visible via `caret-foreground`.
-                "text-sm text-transparent caret-foreground",
+                "text-sm leading-relaxed text-transparent caret-foreground",
                 "placeholder:text-muted-foreground/60",
                 "outline-none",
               )}

--- a/src/components/chat/ComposerCommandMenu.tsx
+++ b/src/components/chat/ComposerCommandMenu.tsx
@@ -134,7 +134,7 @@ export function ComposerCommandMenu({
             placeholder={placeholder}
             data-testid="composer-command-search"
             className={cn(
-              "flex-1 bg-transparent text-[12.5px] text-foreground",
+              "flex-1 bg-transparent text-[13px] text-foreground",
               "outline-none placeholder:text-muted-foreground",
             )}
           />
@@ -153,7 +153,7 @@ export function ComposerCommandMenu({
                   "**:[[cmdk-group-heading]]:px-2",
                   "**:[[cmdk-group-heading]]:pt-2 **:[[cmdk-group-heading]]:pb-1",
                   "**:[[cmdk-group-heading]]:font-mono",
-                  "**:[[cmdk-group-heading]]:text-[9.5px]",
+                  "**:[[cmdk-group-heading]]:text-[10px]",
                   "**:[[cmdk-group-heading]]:font-semibold",
                   "**:[[cmdk-group-heading]]:uppercase",
                   "**:[[cmdk-group-heading]]:tracking-[0.09em]",
@@ -207,7 +207,7 @@ export function ComposerCommandMenu({
                         )}
                       </span>
                       <span className="flex min-w-0 flex-1 flex-col gap-px">
-                        <span className="text-[12.5px] font-semibold leading-tight text-foreground">
+                        <span className="text-[13px] font-semibold leading-tight text-foreground">
                           {item.label}
                         </span>
                         {item.description && (
@@ -228,7 +228,7 @@ export function ComposerCommandMenu({
                           {item.rightAdornment}
                         </span>
                       ) : item.command ? (
-                        <span className="ml-auto shrink-0 rounded-[5px] bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[10.5px] text-muted-foreground">
+                        <span className="ml-auto shrink-0 rounded-[5px] bg-foreground/[0.06] px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
                           {item.command}
                         </span>
                       ) : null}

--- a/src/components/chat/ComposerPendingInputPanel.tsx
+++ b/src/components/chat/ComposerPendingInputPanel.tsx
@@ -489,7 +489,7 @@ function OptionRow({
         <p className="mb-1 text-[10px] uppercase tracking-[0.08em] text-muted-foreground/70">
           Preview
         </p>
-        <pre className="whitespace-pre-wrap break-words font-mono text-[11.5px] leading-5 text-foreground">
+        <pre className="whitespace-pre-wrap break-words font-mono text-[12px] leading-5 text-foreground">
           {preview}
         </pre>
       </HoverCardContent>

--- a/src/components/chat/DiffView.tsx
+++ b/src/components/chat/DiffView.tsx
@@ -31,7 +31,7 @@ export function DiffView({
   return (
     <div className="overflow-hidden rounded-[11px] border border-border/60 bg-muted/40">
       <div className="flex items-center justify-between gap-3 border-b border-border/60 px-[13px] py-[9px]">
-        <span className="flex min-w-0 items-center gap-2 font-mono text-[11.5px] text-muted-foreground">
+        <span className="flex min-w-0 items-center gap-2 font-mono text-[12px] text-muted-foreground">
           <FileText
             className="h-3 w-3 shrink-0 text-muted-foreground/70"
             strokeWidth={1.4}
@@ -47,7 +47,7 @@ export function DiffView({
           <CopyButton text={copyText} />
         </span>
       </div>
-      <div className="overflow-x-auto py-[9px] font-mono text-[11.5px] leading-[1.75]">
+      <div className="overflow-x-auto py-[9px] font-mono text-[12px] leading-[1.75]">
         {rows.map((row, i) => {
           if (row.type === "context" || row.type === "add") lineNo += 1;
           const gutter =

--- a/src/components/chat/DraftChatSurface.tsx
+++ b/src/components/chat/DraftChatSurface.tsx
@@ -1082,7 +1082,7 @@ function DraftPendingConversation({
                 aria-hidden
               />
             </span>
-            <span className="shimmer text-[12.5px] font-semibold">
+            <span className="shimmer text-[13px] font-semibold">
               {PHASE_LABEL[pending.phase]}
             </span>
           </div>

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -354,7 +354,7 @@ export function MessageList({
           behavior="auto"
           variant="secondary"
           size="sm"
-          className="bottom-4 h-8 w-auto gap-1.5 rounded-full border border-border bg-card px-3.5 text-[11.5px] font-semibold text-muted-foreground shadow-lg hover:bg-card hover:text-foreground"
+          className="bottom-4 h-8 w-auto gap-1.5 rounded-full border border-border bg-card px-3.5 text-[12px] font-semibold text-muted-foreground shadow-lg hover:bg-card hover:text-foreground"
         >
           Jump to latest
           <ArrowDown className="h-3.5 w-3.5" aria-hidden />
@@ -447,7 +447,7 @@ function RunInterruptedDivider() {
       className="flex items-center gap-3 text-warning"
     >
       <span className="h-px flex-1 bg-warning/40" />
-      <span className="font-mono text-[10.5px] font-medium tracking-wide">
+      <span className="font-mono text-[11px] font-medium tracking-wide">
         Run interrupted
       </span>
       <span className="h-px flex-1 bg-warning/40" />
@@ -459,7 +459,7 @@ function SessionStartMarker({ startedAt }: { startedAt?: number }) {
   return (
     <div className="flex items-center gap-3 text-muted-foreground/70">
       <span className="h-px flex-1 bg-border/60" />
-      <span className="font-mono text-[10.5px] font-medium tracking-wide">
+      <span className="font-mono text-[11px] font-medium tracking-wide">
         {formatSessionStart(startedAt)}
       </span>
       <span className="h-px flex-1 bg-border/60" />
@@ -724,7 +724,7 @@ function renderAssistantBody(
           return (
             <div className="space-y-1">
               {handlers.subagentName && (
-                <div className="font-mono text-[10.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <div className="font-mono text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
                   From subagent {handlers.subagentName}
                 </div>
               )}

--- a/src/components/chat/ReasoningBlock.tsx
+++ b/src/components/chat/ReasoningBlock.tsx
@@ -55,7 +55,7 @@ export const ReasoningBlock = memo(function ReasoningBlock({
         />
         <span
           className={cn(
-            "text-[12.5px] font-semibold text-muted-foreground",
+            "text-[13px] font-semibold text-muted-foreground",
             item.streaming && "shimmer",
           )}
         >
@@ -70,7 +70,7 @@ export const ReasoningBlock = memo(function ReasoningBlock({
         />
       </button>
       {open && item.text.length > 0 && (
-        <div className="whitespace-pre-wrap break-words border-t border-border/60 py-[11px] pl-[33px] pr-3.5 text-[12.5px] italic leading-[1.65] text-muted-foreground">
+        <div className="whitespace-pre-wrap break-words border-t border-border/60 py-[11px] pl-[33px] pr-3.5 text-[13px] italic leading-[1.65] text-muted-foreground">
           {item.text}
         </div>
       )}

--- a/src/components/chat/StreamingMarker.tsx
+++ b/src/components/chat/StreamingMarker.tsx
@@ -47,7 +47,7 @@ export function StreamingMarker({ messages }: { messages: ChatViewItem[] }) {
         />
       </span>
       <span className="flex min-w-0 items-baseline gap-1.5">
-        <span className="shimmer text-[12.5px] font-semibold">{label}</span>
+        <span className="shimmer text-[13px] font-semibold">{label}</span>
         {startedAt != null && (
           // Populated imperatively by the effect; render nothing when no
           // turn start is derivable (e.g. hydrated old transcripts) so the

--- a/src/components/chat/SubagentActivityBar.tsx
+++ b/src/components/chat/SubagentActivityBar.tsx
@@ -133,10 +133,10 @@ export const SubagentActivityBar = memo(function SubagentActivityBar({
               aria-hidden
             />
           </span>
-          <span className="shrink-0 whitespace-nowrap text-[12.5px] font-bold text-foreground">
+          <span className="shrink-0 whitespace-nowrap text-[13px] font-bold text-foreground">
             Subagents finished
           </span>
-          <span className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-muted-foreground">
+          <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-muted-foreground">
             all tasks complete · results are in the thread
           </span>
         </div>
@@ -178,7 +178,7 @@ export const SubagentActivityBar = memo(function SubagentActivityBar({
           className="rise-in mb-2 overflow-hidden rounded-xl border border-border bg-popover shadow-lg"
         >
           <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2.5">
-            <span className="whitespace-nowrap text-[11.5px] font-bold text-foreground">
+            <span className="whitespace-nowrap text-[12px] font-bold text-foreground">
               {count} subagents running
             </span>
             <span className="text-[11px] text-muted-foreground">
@@ -224,17 +224,17 @@ export const SubagentActivityBar = memo(function SubagentActivityBar({
             aria-hidden
           />
         </span>
-        <span className="shrink-0 whitespace-nowrap text-[12.5px] font-bold text-foreground">
+        <span className="shrink-0 whitespace-nowrap text-[13px] font-bold text-foreground">
           {count} subagent{count === 1 ? "" : "s"} running
         </span>
         <span
           className="h-[3px] w-[3px] shrink-0 rounded-full bg-muted-foreground"
           aria-hidden
         />
-        <span className="shimmer min-w-0 flex-1 truncate font-mono text-[11.5px]">
+        <span className="shimmer min-w-0 flex-1 truncate font-mono text-[12px]">
           {primaryName} · {primaryActivity}
         </span>
-        <span className="shrink-0 whitespace-nowrap font-mono text-[10.5px] text-muted-foreground">
+        <span className="shrink-0 whitespace-nowrap font-mono text-[11px] text-muted-foreground">
           {primaryElapsedMs != null ? formatElapsed(primaryElapsedMs) : ""}
         </span>
         <span className="flex h-[30px] shrink-0 items-center gap-1.5 rounded-lg bg-foreground/[0.08] px-2.5 text-[11px] font-semibold text-muted-foreground">

--- a/src/components/chat/SubagentBreadcrumb.tsx
+++ b/src/components/chat/SubagentBreadcrumb.tsx
@@ -44,7 +44,7 @@ export function SubagentBreadcrumb({
         strokeWidth={1.5}
         aria-hidden
       />
-      <span className="flex items-center gap-2 text-[12.5px] font-semibold text-foreground">
+      <span className="flex items-center gap-2 text-[13px] font-semibold text-foreground">
         <span
           className={cn(
             "flex h-[19px] w-[19px] items-center justify-center rounded-md font-mono text-[10px]",
@@ -56,7 +56,7 @@ export function SubagentBreadcrumb({
         <span className="truncate">{name}</span>
       </span>
       {subagent.model && (
-        <span className="rounded-[5px] bg-foreground/[0.07] px-1.5 py-0.5 font-mono text-[10.5px] text-muted-foreground">
+        <span className="rounded-[5px] bg-foreground/[0.07] px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
           {subagent.model}
         </span>
       )}

--- a/src/components/chat/SubagentView.tsx
+++ b/src/components/chat/SubagentView.tsx
@@ -61,7 +61,7 @@ export function SubagentView({
       {/* Read-only banner */}
       <div
         className={cn(
-          "mb-4 flex items-center gap-2.5 rounded-[9px] border px-3 py-2.5 text-[11.5px] text-muted-foreground",
+          "mb-4 flex items-center gap-2.5 rounded-[9px] border px-3 py-2.5 text-[12px] text-muted-foreground",
           tone.softBg,
           tone.border,
         )}

--- a/src/components/chat/SubagentsCard.tsx
+++ b/src/components/chat/SubagentsCard.tsx
@@ -88,7 +88,7 @@ export const SubagentsCard = memo(function SubagentsCard({
           )}
         </span>
         <span className="text-[13px] font-bold text-foreground">Subagents</span>
-        <span className="text-[11.5px] text-muted-foreground">
+        <span className="text-[12px] text-muted-foreground">
           {subs.length} {subs.length === 1 ? "task" : "tasks"}
           {anyRunning ? " · running in parallel" : " · complete"}
         </span>
@@ -187,7 +187,7 @@ function SubagentRow({
 
         {/* Name + model column */}
         <div className="flex w-[150px] shrink-0 flex-col gap-0.5">
-          <span className="truncate text-[12.5px] font-bold text-foreground">
+          <span className="truncate text-[13px] font-bold text-foreground">
             {sub.name ?? sub.agentType ?? "Subagent"}
           </span>
           {sub.model && (
@@ -200,7 +200,7 @@ function SubagentRow({
         {/* Live activity / result line */}
         <div className="min-w-0 flex-1 overflow-hidden">
           {running ? (
-            <span className="shimmer block truncate font-mono text-[11.5px]">
+            <span className="shimmer block truncate font-mono text-[12px]">
               {activity}
             </span>
           ) : (
@@ -211,7 +211,7 @@ function SubagentRow({
         </div>
 
         {/* Meta */}
-        <span className="shrink-0 font-mono text-[10.5px] text-muted-foreground">
+        <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
           {meta}
         </span>
 
@@ -278,7 +278,7 @@ function SubagentRow({
               e.stopPropagation();
               onEnter();
             }}
-            className="mt-2 flex h-7 items-center gap-1.5 self-start rounded-lg bg-foreground/[0.09] px-3 text-[11.5px] font-semibold text-foreground hover:bg-foreground/[0.14]"
+            className="mt-2 flex h-7 items-center gap-1.5 self-start rounded-lg bg-foreground/[0.09] px-3 text-[12px] font-semibold text-foreground hover:bg-foreground/[0.14]"
           >
             Enter subagent
             <ChevronRight className="h-3 w-3" strokeWidth={1.7} aria-hidden />

--- a/src/components/chat/TaskSummaryCard.tsx
+++ b/src/components/chat/TaskSummaryCard.tsx
@@ -32,7 +32,7 @@ export const TaskSummaryCard = memo(function TaskSummaryCard({
           return (
             <div
               key={i}
-              className="flex items-start gap-[9px] text-[12.5px] leading-[1.5] text-foreground"
+              className="flex items-start gap-[9px] text-[13px] leading-[1.5] text-foreground"
             >
               {complete ? (
                 <CircleCheck

--- a/src/components/chat/ToolCallBlock.tsx
+++ b/src/components/chat/ToolCallBlock.tsx
@@ -33,7 +33,7 @@ export function ToolCallBlock({ content, error, text }: Props) {
   return (
     <div
       className={cn(
-        "rounded-md bg-muted/40 font-mono text-[11.5px] leading-5",
+        "rounded-md bg-muted/40 font-mono text-[12px] leading-5",
         "text-foreground whitespace-pre-wrap break-words",
         error && "text-foreground",
       )}

--- a/src/components/chat/ToolCallBodies.tsx
+++ b/src/components/chat/ToolCallBodies.tsx
@@ -80,7 +80,7 @@ export function BashToolBody({ item, input }: BodyProps) {
   return (
     <div className="space-y-2">
       {command && (
-        <div className="rounded-md bg-muted/40 px-3 py-2 font-mono text-[11.5px] leading-5 text-foreground whitespace-pre-wrap break-words">
+        <div className="rounded-md bg-muted/40 px-3 py-2 font-mono text-[12px] leading-5 text-foreground whitespace-pre-wrap break-words">
           <span className="text-muted-foreground/70">$ </span>
           {command}
           {description && (
@@ -92,7 +92,7 @@ export function BashToolBody({ item, input }: BodyProps) {
       )}
       {result && (
         <div className="rounded-md bg-muted/40">
-          <pre className="whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11.5px] leading-5 text-foreground">
+          <pre className="whitespace-pre-wrap break-words px-3 py-2 font-mono text-[12px] leading-5 text-foreground">
             {tail}
           </pre>
           {tailHidden > 0 && (
@@ -110,7 +110,7 @@ export function BashToolBody({ item, input }: BodyProps) {
         // not a status billboard.
         <span
           aria-label={`Exit code ${exitCode}`}
-          className="font-mono text-[10.5px] text-destructive/80"
+          className="font-mono text-[11px] text-destructive/80"
         >
           exit {exitCode}
         </span>
@@ -132,7 +132,7 @@ export function ReadToolBody({ item, input }: BodyProps) {
   return (
     <div className="space-y-2">
       {path && (
-        <div className="font-mono text-[11.5px] text-foreground">
+        <div className="font-mono text-[12px] text-foreground">
           {path}
           {(offset != null || limit != null) && (
             <span className="ml-2 text-muted-foreground/70">
@@ -143,7 +143,7 @@ export function ReadToolBody({ item, input }: BodyProps) {
       )}
       {preview && (
         <div className="rounded-md bg-muted/40">
-          <pre className="whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11.5px] leading-5 text-foreground">
+          <pre className="whitespace-pre-wrap break-words px-3 py-2 font-mono text-[12px] leading-5 text-foreground">
             {preview}
           </pre>
           {totalLines > READ_PREVIEW_LINES && (
@@ -168,7 +168,7 @@ export function GrepToolBody({ item, input }: BodyProps) {
   return (
     <div className="space-y-2">
       {(pattern || path) && (
-        <div className="font-mono text-[11.5px] text-foreground">
+        <div className="font-mono text-[12px] text-foreground">
           {pattern && <span>{pattern}</span>}
           {path && (
             <span className="ml-2 text-muted-foreground/70">in {path}</span>
@@ -184,7 +184,7 @@ export function GrepToolBody({ item, input }: BodyProps) {
             {visible.map((m, i) => (
               <li
                 key={i}
-                className="font-mono text-[11.5px] leading-5 text-foreground break-words"
+                className="font-mono text-[12px] leading-5 text-foreground break-words"
               >
                 <span className="text-muted-foreground/70">{m.location}</span>
                 {m.text && <span className="ml-2">{m.text}</span>}
@@ -218,7 +218,7 @@ export function WebFetchToolBody({ item, input }: BodyProps) {
             href={url}
             target="_blank"
             rel="noopener noreferrer"
-            className="block break-all font-mono text-[11.5px] text-foreground underline-offset-4 hover:underline"
+            className="block break-all font-mono text-[12px] text-foreground underline-offset-4 hover:underline"
           >
             {url}
           </a>
@@ -226,16 +226,16 @@ export function WebFetchToolBody({ item, input }: BodyProps) {
           // Refuse to render non-http(s) URLs as links — `javascript:`,
           // `data:`, `file:`, etc. from a buggy or malicious tool result
           // are XSS vectors otherwise.
-          <span className="block break-all font-mono text-[11.5px] text-muted-foreground">
+          <span className="block break-all font-mono text-[12px] text-muted-foreground">
             {url}
           </span>
         )
       )}
       {title && (
-        <p className="text-[11.5px] text-muted-foreground">{title}</p>
+        <p className="text-[12px] text-muted-foreground">{title}</p>
       )}
       {prompt && (
-        <p className="rounded-md bg-muted/40 px-3 py-2 text-[11.5px] text-foreground">
+        <p className="rounded-md bg-muted/40 px-3 py-2 text-[12px] text-foreground">
           {prompt}
         </p>
       )}
@@ -281,7 +281,7 @@ export function EditToolBody({ item, input }: BodyProps) {
   return (
     <div className="space-y-1">
       {path && (
-        <div className="font-mono text-[11.5px] text-foreground">{path}</div>
+        <div className="font-mono text-[12px] text-foreground">{path}</div>
       )}
       {result && <ToolCallBlock content={result} />}
     </div>

--- a/src/components/chat/ToolCallStatus.tsx
+++ b/src/components/chat/ToolCallStatus.tsx
@@ -9,7 +9,7 @@ export function ToolCallStatus({ item }: { item: ToolCallItem }) {
   const { verb, target, argument } = describeToolCall(item);
 
   return (
-    <div className="font-mono text-[11.5px] leading-5 text-muted-foreground break-words">
+    <div className="font-mono text-[12px] leading-5 text-muted-foreground break-words">
       <span>{verb}</span>
       {target && (
         <>

--- a/src/components/chat/UserInputAnswer.tsx
+++ b/src/components/chat/UserInputAnswer.tsx
@@ -42,11 +42,11 @@ export const UserInputAnswer = memo(function UserInputAnswer({
   return (
     <div className="flex justify-end">
       <div className="flex max-w-[82%] flex-col items-end gap-1">
-        <div className="flex flex-col gap-2 rounded-[14px_14px_5px_14px] border border-border/60 bg-card px-[15px] py-[11px] text-[13.5px] leading-[1.55] text-foreground">
+        <div className="flex flex-col gap-2 rounded-[14px_14px_5px_14px] border border-border/60 bg-card px-[15px] py-[11px] text-sm leading-relaxed text-foreground">
           {lines.map((line, i) => (
             <div key={i} className="flex flex-col gap-0.5">
               {showHeaders && line.header ? (
-                <div className="text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
                   {line.header}
                 </div>
               ) : null}

--- a/src/components/chat/UserMessage.tsx
+++ b/src/components/chat/UserMessage.tsx
@@ -116,7 +116,7 @@ export const UserMessage = memo(function UserMessage({
       <div className="flex max-w-[82%] flex-col items-end gap-1">
         <div
           className={cn(
-            "flex flex-col gap-2 rounded-[14px_14px_5px_14px] border px-[15px] py-[11px] text-[13.5px] leading-[1.55]",
+            "flex flex-col gap-2 rounded-[14px_14px_5px_14px] border px-[15px] py-[11px] text-sm leading-relaxed",
             queued
               ? "border-dashed border-border/50 bg-muted/40 text-muted-foreground opacity-70"
               : "border-border/60 bg-card text-foreground",

--- a/src/components/chat/WorkflowRunCard.tsx
+++ b/src/components/chat/WorkflowRunCard.tsx
@@ -128,7 +128,7 @@ function WorkflowApprovalCard({
           <div className="text-[13px] font-bold text-foreground">
             Run as a workflow?
           </div>
-          <div className="text-[11.5px] text-muted-foreground">
+          <div className="text-[12px] text-muted-foreground">
             Claude wrote a script to orchestrate this — you can read it before
             running.
           </div>
@@ -149,7 +149,7 @@ function WorkflowApprovalCard({
                 {phase.title}
               </span>
               {phase.detail && (
-                <span className="font-mono text-[10.5px] text-muted-foreground">
+                <span className="font-mono text-[11px] text-muted-foreground">
                   {phase.detail}
                 </span>
               )}
@@ -226,7 +226,7 @@ function WorkflowApprovalCard({
                 "The script Claude wrote to orchestrate this workflow."}
             </DialogDescription>
           </DialogHeader>
-          <pre className="max-h-[60vh] overflow-auto rounded-md bg-muted/40 p-3 font-mono text-[11.5px] leading-5 text-foreground whitespace-pre-wrap break-words">
+          <pre className="max-h-[60vh] overflow-auto rounded-md bg-muted/40 p-3 font-mono text-[12px] leading-5 text-foreground whitespace-pre-wrap break-words">
             {item.script ?? "No script available."}
           </pre>
         </DialogContent>
@@ -297,7 +297,7 @@ function WorkflowRunningRow({
           strokeWidth={1.9}
           aria-hidden
         />
-        <span className="shrink-0 text-[12.5px] font-bold text-foreground">
+        <span className="shrink-0 text-[13px] font-bold text-foreground">
           Workflow running
         </span>
         <span className="min-w-0 flex-1 overflow-hidden">
@@ -376,11 +376,11 @@ function WorkflowSummaryRow({
       className="flex cursor-pointer items-center gap-2.5 rounded-[12px] border border-border/60 bg-muted/30 px-3.5 py-2.5 hover:border-muted-foreground/60"
     >
       <Icon className={cn("h-4 w-4 shrink-0", iconClass)} strokeWidth={1.8} aria-hidden />
-      <span className="flex-1 text-[12.5px] font-semibold text-muted-foreground">
+      <span className="flex-1 text-[13px] font-semibold text-muted-foreground">
         {label} · {agents} agent{agents === 1 ? "" : "s"} · {phases} phase
         {phases === 1 ? "" : "s"} · {elapsed}
       </span>
-      <span className="font-mono text-[10.5px] text-muted-foreground">
+      <span className="font-mono text-[11px] text-muted-foreground">
         View run
       </span>
     </div>

--- a/src/components/chat/WorkspaceStatusCluster.tsx
+++ b/src/components/chat/WorkspaceStatusCluster.tsx
@@ -231,7 +231,7 @@ export function WorkspaceStatusCluster() {
                 aria-label="Workspace details"
                 title="Workspace details"
                 className={cn(
-                  "inline-flex h-[26px] shrink-0 items-center gap-1 rounded-md px-2 text-[11.5px] font-semibold text-foreground/80 outline-none transition-colors hover:bg-foreground/[0.09]",
+                  "inline-flex h-[26px] shrink-0 items-center gap-1 rounded-md px-2 text-[12px] font-semibold text-foreground/80 outline-none transition-colors hover:bg-foreground/[0.09]",
                   open && "bg-foreground/[0.09]",
                 )}
               >
@@ -246,10 +246,10 @@ export function WorkspaceStatusCluster() {
               className="w-[290px] p-0"
             >
               <div className="border-b px-3.5 py-2.5">
-                <div className="truncate text-[12.5px] font-bold text-foreground">
+                <div className="truncate text-[13px] font-bold text-foreground">
                   {workspace.title}
                 </div>
-                <div className="mt-0.5 truncate font-mono text-[10.5px] text-muted-foreground">
+                <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
                   {projectName} · {deviceLabel}
                 </div>
               </div>
@@ -304,7 +304,7 @@ export function WorkspaceStatusCluster() {
                     <button
                       type="button"
                       onClick={handlePrClick}
-                      className="h-[30px] flex-1 rounded-md border bg-background text-[11.5px] font-semibold text-foreground transition-colors hover:bg-foreground/[0.06]"
+                      className="h-[30px] flex-1 rounded-md border bg-background text-[12px] font-semibold text-foreground transition-colors hover:bg-foreground/[0.06]"
                     >
                       View PR #{workspace.pr_number}
                     </button>
@@ -314,7 +314,7 @@ export function WorkspaceStatusCluster() {
                       type="button"
                       onClick={handleSync}
                       disabled={pulling}
-                      className="h-[30px] flex-1 rounded-md border bg-background text-[11.5px] font-semibold text-foreground transition-colors hover:bg-foreground/[0.06] disabled:cursor-not-allowed disabled:opacity-60"
+                      className="h-[30px] flex-1 rounded-md border bg-background text-[12px] font-semibold text-foreground transition-colors hover:bg-foreground/[0.06] disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       {pulling ? "Syncing…" : `Sync ↓${workspace.git_behind}`}
                     </button>
@@ -348,7 +348,7 @@ function DetailRow({
 }) {
   return (
     <div className="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-foreground/[0.05]">
-      <span className="min-w-0 flex-1 truncate text-[11.5px] text-muted-foreground">
+      <span className="min-w-0 flex-1 truncate text-[12px] text-muted-foreground">
         {label}
       </span>
       <span

--- a/src/components/chat/pickers/ThreadScopeRow.tsx
+++ b/src/components/chat/pickers/ThreadScopeRow.tsx
@@ -499,7 +499,7 @@ function LocationControl({
             initials-style queries win and the Active/Settled split
             survives a search. cmdk still owns highlight + Enter. */}
         <Command shouldFilter={false} loop>
-          <div className="px-2.5 pb-1 pt-2 font-mono text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+          <div className="px-2.5 pb-1 pt-2 font-mono text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             Run in
           </div>
           <CommandInput
@@ -513,7 +513,7 @@ function LocationControl({
             onWheel={(e) => e.stopPropagation()}
           >
             {noMatches && (
-              <div className="px-2 py-3 text-center text-[11.5px] text-muted-foreground">
+              <div className="px-2 py-3 text-center text-[12px] text-muted-foreground">
                 No projects match “{query.trim()}”
               </div>
             )}
@@ -556,7 +556,7 @@ function LocationControl({
                   <CommandItem
                     value="show-all-settled-projects"
                     onSelect={() => setSettledExpanded(true)}
-                    className="gap-2 rounded-lg px-2 py-1.5 text-[11.5px] text-muted-foreground"
+                    className="gap-2 rounded-lg px-2 py-1.5 text-[12px] text-muted-foreground"
                   >
                     <ChevronDown className="size-3.5 shrink-0" />
                     Show {hiddenSettledCount} more
@@ -578,7 +578,7 @@ function LocationControl({
                   handleSelectProject(result.path);
                 }
               }}
-              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[11.5px] text-muted-foreground transition-colors hover:bg-foreground/[0.08] hover:text-foreground"
+              className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-[12px] text-muted-foreground transition-colors hover:bg-foreground/[0.08] hover:text-foreground"
             >
               <FolderPlus className="size-3.5" />
               Open another project…
@@ -628,7 +628,7 @@ function CheckoutControl({
         side="top"
         onOpenAutoFocus={focusCmdkOnOpen}
       >
-        <div className="px-2 pb-1 pt-1 font-mono text-[9.5px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <div className="px-2 pb-1 pt-1 font-mono text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
           Where should the agent work?
         </div>
         <button
@@ -684,10 +684,10 @@ function CheckoutControl({
                 onKeyDown={(e) => e.stopPropagation()}
                 placeholder="name — leave empty to auto-name"
                 aria-label="Worktree name"
-                className="flex-1 min-w-0 bg-transparent font-mono text-[11.5px] text-foreground outline-none placeholder:text-muted-foreground/60"
+                className="flex-1 min-w-0 bg-transparent font-mono text-[12px] text-foreground outline-none placeholder:text-muted-foreground/60"
               />
             </div>
-            <div className="mt-1.5 flex items-start gap-1.5 px-0.5 text-[10.5px] leading-snug text-muted-foreground">
+            <div className="mt-1.5 flex items-start gap-1.5 px-0.5 text-[11px] leading-snug text-muted-foreground">
               <Sparkle className="mt-px size-3 shrink-0 text-status-remote" />
               <span>
                 Empty → CodeMux names it from your first message, like the
@@ -889,7 +889,7 @@ function BranchControl({
                           WORKTREE
                         </span>
                       )}
-                      <span className="shrink-0 font-mono text-[10.5px] text-muted-foreground/70">
+                      <span className="shrink-0 font-mono text-[11px] text-muted-foreground/70">
                         {formatRelativeTime(branch.last_commit_unix)}
                       </span>
                     </CommandItem>

--- a/src/components/layout/agent-launcher.tsx
+++ b/src/components/layout/agent-launcher.tsx
@@ -214,7 +214,7 @@ export function AgentLauncher({ workspace }: AgentLauncherProps) {
                     <PresetIcon icon={preset.icon} className="h-4 w-4" />
                     <span className="flex-1 truncate">{preset.name}</span>
                     {preset.pinned && (
-                      <span className="text-[9.5px] font-bold tracking-wide text-muted-foreground">
+                      <span className="text-[10px] font-bold tracking-wide text-muted-foreground">
                         PINNED
                       </span>
                     )}

--- a/src/components/layout/run-button.tsx
+++ b/src/components/layout/run-button.tsx
@@ -107,7 +107,7 @@ export function RunButton({ workspaceId, variant = "legacy" }: RunButtonProps) {
               type="button"
               onClick={isConfigured ? handleRun : handleConfigure}
               className={cn(
-                "flex h-full items-center gap-1.5 px-[9px] text-[11.5px] font-semibold text-foreground",
+                "flex h-full items-center gap-1.5 px-[9px] text-[12px] font-semibold text-foreground",
                 "transition-colors duration-150 hover:bg-secondary",
                 !isConfigured && "text-muted-foreground",
               )}

--- a/src/components/layout/sidebar-action-row.tsx
+++ b/src/components/layout/sidebar-action-row.tsx
@@ -106,7 +106,7 @@ export function SidebarActionRow() {
           <SearchIcon className="h-3.5 w-3.5 shrink-0" />
           <span className="flex-1 text-left text-xs">Search</span>
           {paletteKeys && (
-            <kbd className="rounded border border-border/60 px-1 py-px font-mono text-[9.5px]">
+            <kbd className="rounded border border-border/60 px-1 py-px font-mono text-[10px]">
               {paletteKeys}
             </kbd>
           )}

--- a/src/components/layout/sidebar-footer-bar.tsx
+++ b/src/components/layout/sidebar-footer-bar.tsx
@@ -190,7 +190,7 @@ export function SidebarFooterBar() {
         className="flex h-7 flex-1 items-center justify-center gap-1.5 rounded-[7px] bg-transparent text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
       >
         <CalendarClock className="size-[13px]" />
-        <span className="text-[11.5px] font-medium">Automations</span>
+        <span className="text-[12px] font-medium">Automations</span>
       </button>
       <button
         type="button"
@@ -199,7 +199,7 @@ export function SidebarFooterBar() {
         className="flex h-7 flex-1 items-center justify-center gap-1.5 rounded-[7px] bg-transparent text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
       >
         <LayoutGrid className="size-[13px]" />
-        <span className="text-[11.5px] font-medium">Workspaces</span>
+        <span className="text-[12px] font-medium">Workspaces</span>
       </button>
       <SidebarPortsPopover />
       <AppMenu />

--- a/src/components/layout/sidebar-inbox-card.tsx
+++ b/src/components/layout/sidebar-inbox-card.tsx
@@ -214,7 +214,7 @@ export function SidebarInboxCard({
    *  pair rather than two buttons that happen to sit together. */
   const eyebrowActionClass = cn(
     "h-5 shrink-0 items-center gap-1 rounded-md border border-border bg-muted px-2",
-    "text-[10.5px] font-semibold text-muted-foreground transition-colors duration-150",
+    "text-[11px] font-semibold text-muted-foreground transition-colors duration-150",
     "hover:border-muted-foreground/50 hover:text-foreground",
     actionsPinned
       ? "inline-flex"
@@ -396,7 +396,7 @@ export function SidebarInboxCard({
                     className={cn(
                       "flex shrink-0 items-center gap-0.5 rounded-full px-1.5",
                       "border border-status-open/25 bg-status-open/10",
-                      "text-[9.5px] font-semibold leading-[15px] text-status-open",
+                      "text-[10px] font-semibold leading-[15px] text-status-open",
                     )}
                   >
                     <AlarmClock className="h-2.5 w-2.5" strokeWidth={2.5} />
@@ -521,7 +521,7 @@ export function SidebarInboxCard({
                   the chip's own variable width ("merged" vs "PR #1234") harmless. */}
               <div
                 data-meta-line
-                className="mt-[5px] flex min-w-0 items-center gap-2 font-mono text-[10.5px] leading-tight text-muted-foreground/60"
+                className="mt-[5px] flex min-w-0 items-center gap-2 font-mono text-[11px] leading-tight text-muted-foreground/60"
               >
                 {workspace.git_branch && (
                   <span className="min-w-0 truncate">{workspace.git_branch}</span>
@@ -557,7 +557,7 @@ export function SidebarInboxCard({
                         : `Pull request — ${prState}`
                     }
                     className={cn(
-                      "shrink-0 rounded-[5px] border px-[5px] py-px font-mono text-[9.5px] font-medium",
+                      "shrink-0 rounded-[5px] border px-[5px] py-px font-mono text-[10px] font-medium",
                       "transition-colors duration-150",
                       PR_CHIP_TONE[prState],
                       !workspace.pr_url && "pointer-events-none",
@@ -588,7 +588,7 @@ export function SidebarInboxCard({
                     />
                   )}
                   {workspace.notification_count > 0 && (
-                    <span className="flex h-[15px] min-w-[15px] shrink-0 items-center justify-center rounded-full bg-foreground/10 px-1 text-[9.5px] font-bold text-muted-foreground">
+                    <span className="flex h-[15px] min-w-[15px] shrink-0 items-center justify-center rounded-full bg-foreground/10 px-1 text-[10px] font-bold text-muted-foreground">
                       {workspace.notification_count}
                     </span>
                   )}

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -385,11 +385,11 @@ function ShelfHeader({
           !collapsed && "rotate-90",
         )}
       />
-      <span className="font-mono text-[9.5px] uppercase tracking-[0.13em] text-muted-foreground/70">
+      <span className="font-mono text-[10px] uppercase tracking-[0.13em] text-muted-foreground/70">
         {label}
       </span>
       {showCount && (
-        <span className="font-mono text-[9.5px] tabular-nums text-muted-foreground/70">
+        <span className="font-mono text-[10px] tabular-nums text-muted-foreground/70">
           ({count})
         </span>
       )}
@@ -414,7 +414,7 @@ function WrappingUpDivider() {
       data-wrapping-up-divider
       className="flex w-full items-center gap-2 px-1 pb-1.5 pt-3"
     >
-      <span className="font-mono text-[9.5px] uppercase tracking-[0.13em] text-muted-foreground/70">
+      <span className="font-mono text-[10px] uppercase tracking-[0.13em] text-muted-foreground/70">
         Wrapping up
       </span>
       <span aria-hidden="true" className="h-px flex-1 bg-border/60" />
@@ -559,7 +559,7 @@ function SettledRow({
               : `Pull request — ${prState}`
           }
           className={cn(
-            "inline-flex h-5 shrink-0 items-center gap-1 rounded px-1 font-mono text-[9.5px] font-medium",
+            "inline-flex h-5 shrink-0 items-center gap-1 rounded px-1 font-mono text-[10px] font-medium",
             "transition-colors duration-150",
             prStatusTextClass(prState),
             workspace.pr_url
@@ -572,7 +572,7 @@ function SettledRow({
         </button>
       )}
       {time && (
-        <span className="shrink-0 text-[10.5px] text-muted-foreground/70 group-hover/settled:hidden group-focus-within/settled:hidden">
+        <span className="shrink-0 text-[11px] text-muted-foreground/70 group-hover/settled:hidden group-focus-within/settled:hidden">
           {time}
         </span>
       )}
@@ -702,7 +702,7 @@ function SnoozeRow({
         </span>
         <span
           aria-label={`Wakes in ${timeUntil}`}
-          className="shrink-0 text-[10.5px] tabular-nums text-muted-foreground/70 group-hover/snoozed:hidden group-focus-within/snoozed:hidden"
+          className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70 group-hover/snoozed:hidden group-focus-within/snoozed:hidden"
         >
           {timeUntil}
         </span>
@@ -1721,7 +1721,7 @@ export function SidebarInbox() {
                     onClick={() =>
                       setSettledVisibleCount((c) => c + SETTLED_PAGE_COUNT)
                     }
-                    className="flex h-7 w-full items-center justify-center rounded-lg font-mono text-[10.5px] text-muted-foreground/70 transition-colors duration-150 hover:text-foreground"
+                    className="flex h-7 w-full items-center justify-center rounded-lg font-mono text-[11px] text-muted-foreground/70 transition-colors duration-150 hover:text-foreground"
                   >
                     {`Show ${next} more (${settledHidden} hidden)`}
                   </button>

--- a/src/components/layout/sidebar-live-section.tsx
+++ b/src/components/layout/sidebar-live-section.tsx
@@ -64,10 +64,10 @@ export function SidebarLiveSection({ entries, activeWorkspaceId }: Props) {
       aria-label="Live agents"
     >
       <div className="flex items-center gap-1.5 px-2 pb-1 pt-1">
-        <span className="font-mono text-[9.5px] font-semibold uppercase tracking-[0.14em] text-accent-ember">
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-accent-ember">
           LIVE
         </span>
-        <span className="font-mono text-[9.5px] font-semibold tracking-[0.14em] text-muted-foreground">
+        <span className="font-mono text-[10px] font-semibold tracking-[0.14em] text-muted-foreground">
           · {entries.length}
         </span>
       </div>

--- a/src/components/layout/sidebar-needs-you-strip.tsx
+++ b/src/components/layout/sidebar-needs-you-strip.tsx
@@ -216,7 +216,7 @@ export function SidebarNeedsYouStrip({
       {/* Header line: small red dot + mono uppercase label with a count. */}
       <div className="flex items-center gap-1.5 px-1 pb-1">
         <span className="size-1.5 rounded-full bg-status-attention shrink-0" />
-        <span className="font-mono text-[9.5px] font-semibold tracking-[0.14em] text-status-attention">
+        <span className="font-mono text-[10px] font-semibold tracking-[0.14em] text-status-attention">
           NEEDS YOU · {entries.length}
         </span>
       </div>
@@ -242,10 +242,10 @@ export function SidebarNeedsYouStrip({
                   shape="square"
                   className="font-bold"
                 />
-                <span className="min-w-0 flex-1 truncate text-[11.5px] text-foreground">
+                <span className="min-w-0 flex-1 truncate text-[12px] text-foreground">
                   {permissionBlockerText(workspace)}
                 </span>
-                <span className="ml-auto flex items-center gap-1 shrink-0 font-mono text-[9.5px] text-muted-foreground tabular-nums">
+                <span className="ml-auto flex items-center gap-1 shrink-0 font-mono text-[10px] text-muted-foreground tabular-nums">
                   {age}
                   <ArrowDown className="size-2.5" aria-hidden />
                 </span>
@@ -255,7 +255,7 @@ export function SidebarNeedsYouStrip({
         {/* Never let the cap hide work silently — say how many blocked
             workspaces are only reachable by scrolling. */}
         {entries.length > MAX_VISIBLE_ENTRIES && (
-          <span className="px-1 pt-1 font-mono text-[9.5px] text-status-attention/70">
+          <span className="px-1 pt-1 font-mono text-[10px] text-status-attention/70">
             +{entries.length - MAX_VISIBLE_ENTRIES} more below
           </span>
         )}

--- a/src/components/layout/sidebar-workspace-row.tsx
+++ b/src/components/layout/sidebar-workspace-row.tsx
@@ -1107,7 +1107,7 @@ export function SidebarWorkspaceRow({ workspace, isActive, projectChip }: Props)
                   className={cn(
                   "truncate leading-tight",
                   isCard
-                    ? "text-[12.5px] font-semibold text-foreground"
+                    ? "text-[13px] font-semibold text-foreground"
                     : cn(
                         "text-[13px]",
                         isActive
@@ -1161,7 +1161,7 @@ export function SidebarWorkspaceRow({ workspace, isActive, projectChip }: Props)
                             type="button"
                             onClick={(e) => e.stopPropagation()}
                             aria-label={`${shippedCount} shipped`}
-                            className="flex items-center gap-1 font-mono text-[10.5px] leading-none tabular-nums text-muted-foreground select-none transition-transform group-hover/row:-translate-x-8"
+                            className="flex items-center gap-1 font-mono text-[11px] leading-none tabular-nums text-muted-foreground select-none transition-transform group-hover/row:-translate-x-8"
                           >
                             <span className="text-status-open">✓</span>
                             {shippedCount} shipped
@@ -1172,7 +1172,7 @@ export function SidebarWorkspaceRow({ workspace, isActive, projectChip }: Props)
                           align="start"
                           className="w-64 p-2"
                         >
-                          <div className="mb-1.5 font-mono text-[9.5px] uppercase tracking-wide text-muted-foreground/70">
+                          <div className="mb-1.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground/70">
                             Shipped from this workspace
                           </div>
                           <ul className="space-y-1">
@@ -1199,7 +1199,7 @@ export function SidebarWorkspaceRow({ workspace, isActive, projectChip }: Props)
                         opacity decays over ~1h, then it disappears. */}
                     {showSettledCheck && (
                       <span
-                        className="text-status-open text-[10.5px] leading-none tabular-nums select-none"
+                        className="text-status-open text-[11px] leading-none tabular-nums select-none"
                         style={{ opacity: settledOpacity }}
                         aria-label="Recently finished"
                       >

--- a/src/components/layout/workspace-hover-card.tsx
+++ b/src/components/layout/workspace-hover-card.tsx
@@ -206,7 +206,7 @@ export function WorkspaceHoverCardBody({
           ))}
           <span
             className={cn(
-              "shrink-0 text-[10.5px] font-semibold",
+              "shrink-0 text-[11px] font-semibold",
               status ? STATUS_TONE[status] : "text-muted-foreground/70",
             )}
           >
@@ -220,7 +220,7 @@ export function WorkspaceHoverCardBody({
         </div>
         {/* Full title — the row truncates it, so this is often the whole
             reason the user hovered. */}
-        <div className="mt-1 text-[12.5px] font-bold leading-[1.35] text-foreground">
+        <div className="mt-1 text-[13px] font-bold leading-[1.35] text-foreground">
           {workspace.title}
         </div>
         {issue && (
@@ -336,7 +336,7 @@ function DetailRow({
     // So the label holds its width and the VALUE truncates — the reverse
     // would leave you reading "Bran…" next to the thing you came to see.
     <div className="flex items-center gap-3 rounded-md px-2 py-1.5">
-      <span className="shrink-0 text-[11.5px] text-muted-foreground">
+      <span className="shrink-0 text-[12px] text-muted-foreground">
         {label}
       </span>
       <span

--- a/src/components/overlays/confirm-push-dialog.tsx
+++ b/src/components/overlays/confirm-push-dialog.tsx
@@ -93,7 +93,7 @@ export function ConfirmPushDialog({
         </DialogHeader>
 
         <div className="px-5 pb-4 space-y-3">
-          <ul className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-[11.5px] text-muted-foreground/85 leading-relaxed space-y-1">
+          <ul className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-[12px] text-muted-foreground/85 leading-relaxed space-y-1">
             <li>
               • Copies the workspace files to{" "}
               <span className="font-medium text-foreground/90">
@@ -118,7 +118,7 @@ export function ConfirmPushDialog({
               onChange={(e) => setDontAskAgain(e.target.checked)}
               className="rounded border-border"
             />
-            <span className="text-[11.5px] text-muted-foreground">
+            <span className="text-[12px] text-muted-foreground">
               Don't ask again for {host.name}
             </span>
           </label>

--- a/src/components/settings/archive-section.tsx
+++ b/src/components/settings/archive-section.tsx
@@ -343,7 +343,7 @@ export function ArchiveSection() {
         <p className="text-[13px] text-muted-foreground">
           No archived workspaces
         </p>
-        <p className="text-[11.5px] text-muted-foreground/70 max-w-prose">
+        <p className="text-[12px] text-muted-foreground/70 max-w-prose">
           Archive a workspace from the sidebar to park it here without
           touching its files.
         </p>

--- a/src/components/settings/hosts-section.tsx
+++ b/src/components/settings/hosts-section.tsx
@@ -424,7 +424,7 @@ export function HostsSection() {
                             : "text-muted-foreground/70",
                         )}
                       />
-                      <span className="text-[10.5px] font-medium leading-tight">
+                      <span className="text-[11px] font-medium leading-tight">
                         {kind.label}
                       </span>
                     </button>
@@ -613,7 +613,7 @@ export function HostsSection() {
               <div className="mb-3 flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <p className="text-[13px] font-medium text-foreground">Test connection</p>
-                  <p className="text-[11.5px] text-muted-foreground/75 leading-relaxed mt-0.5">
+                  <p className="text-[12px] text-muted-foreground/75 leading-relaxed mt-0.5">
                     Probes SSH reachability and the remote codemux-remote helper.
                   </p>
                 </div>
@@ -693,7 +693,7 @@ export function HostsSection() {
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0">
                   <p className="text-[13px] font-medium text-foreground">Reinstall agent</p>
-                  <p className="text-[11.5px] text-muted-foreground/75 leading-relaxed mt-0.5">
+                  <p className="text-[12px] text-muted-foreground/75 leading-relaxed mt-0.5">
                     Re-upload codemux-remote and restart it on the host. Use after
                     rebuilding the agent locally — pushes skip the update when the
                     version string is unchanged.
@@ -763,7 +763,7 @@ function AutoInstallToggle() {
     setEnabled(localStorage.getItem(AUTO_INSTALL_KEY) === "1");
   }, []);
   return (
-    <label className="mt-3 flex items-start gap-2 text-[11.5px] text-muted-foreground/85 cursor-pointer leading-relaxed select-none hover:text-foreground transition-colors">
+    <label className="mt-3 flex items-start gap-2 text-[12px] text-muted-foreground/85 cursor-pointer leading-relaxed select-none hover:text-foreground transition-colors">
       <input
         type="checkbox"
         className="mt-0.5 size-3 shrink-0 accent-foreground"

--- a/src/components/settings/keybind-editor.tsx
+++ b/src/components/settings/keybind-editor.tsx
@@ -270,14 +270,14 @@ function KeybindRow({
       <div className="space-y-0.5 min-w-0 flex-1 pt-1">
         <span className="text-[13px] text-foreground">{entry.label}</span>
         {entry.description && (
-          <p className="text-[11.5px] text-muted-foreground/75 leading-relaxed">
+          <p className="text-[12px] text-muted-foreground/75 leading-relaxed">
             {entry.description}
           </p>
         )}
 
         {/* Recording timeout hint */}
         {isRecording && recordingTimedOut && !pendingConflict && (
-          <p className="text-[11.5px] text-muted-foreground/80 mt-1.5 leading-relaxed">
+          <p className="text-[12px] text-muted-foreground/80 mt-1.5 leading-relaxed">
             Some shortcuts (e.g. Ctrl+W, Ctrl+T) are captured by the system and
             can't be recorded. Press Escape to cancel.
           </p>
@@ -289,7 +289,7 @@ function KeybindRow({
           return (
             <div className="space-y-1.5 mt-2 rounded-md border border-warning/30 bg-warning/10 px-2.5 py-2">
               <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-[11.5px] text-warning">
+                <span className="text-[12px] text-warning">
                   Already used by{" "}
                   <span className="font-medium">
                     {pendingConflict.conflictIds
@@ -343,7 +343,7 @@ function KeybindRow({
           ref={badgeRef}
           onClick={isRecording ? undefined : onStartRecording}
           className={cn(
-            "text-[11.5px] font-mono px-2.5 h-7 inline-flex items-center justify-center rounded-md border min-w-[88px] tracking-tight transition-all",
+            "text-[12px] font-mono px-2.5 h-7 inline-flex items-center justify-center rounded-md border min-w-[88px] tracking-tight transition-all",
             isRecording
               ? "border-primary/40 bg-primary/10 text-primary-foreground animate-pulse cursor-default"
               : isUnbound

--- a/src/components/settings/remote-access-section.tsx
+++ b/src/components/settings/remote-access-section.tsx
@@ -173,7 +173,7 @@ function EndpointRow({ endpoint }: { endpoint: WebRemoteEndpoint }) {
     <div className="flex items-start gap-3 py-2.5">
       <div className="min-w-0 flex-1 space-y-1">
         <div className="flex flex-wrap items-center gap-2">
-          <code className="truncate font-mono text-[12.5px] text-foreground">
+          <code className="truncate font-mono text-[13px] text-foreground">
             {endpoint.url}
           </code>
           {endpoint.recommended && (
@@ -202,7 +202,7 @@ function EndpointRow({ endpoint }: { endpoint: WebRemoteEndpoint }) {
             </Badge>
           )}
         </div>
-        <p className="text-[11.5px] leading-relaxed text-muted-foreground/80">
+        <p className="text-[12px] leading-relaxed text-muted-foreground/80">
           {hint.detail}
         </p>
       </div>
@@ -233,7 +233,7 @@ function EndpointGroupBlock({ group }: { group: EndpointGroupView }) {
   if (group.collapsible) {
     return (
       <details className="group rounded-md border border-border/50 bg-muted/20 px-3 py-2">
-        <summary className="flex cursor-pointer list-none items-center gap-1.5 text-[12.5px] font-semibold text-foreground marker:content-none">
+        <summary className="flex cursor-pointer list-none items-center gap-1.5 text-[13px] font-semibold text-foreground marker:content-none">
           <span className="text-muted-foreground/70 transition-transform group-open:rotate-90">
             ›
           </span>
@@ -243,7 +243,7 @@ function EndpointGroupBlock({ group }: { group: EndpointGroupView }) {
           </span>
         </summary>
         <div className="mt-1.5 space-y-1">
-          <p className="text-[11.5px] leading-relaxed text-muted-foreground/70">
+          <p className="text-[12px] leading-relaxed text-muted-foreground/70">
             {group.explanation}
           </p>
           <EndpointGroupRows endpoints={group.endpoints} />
@@ -253,10 +253,10 @@ function EndpointGroupBlock({ group }: { group: EndpointGroupView }) {
   }
   return (
     <div className="space-y-1">
-      <p className="text-[12.5px] font-semibold text-foreground">
+      <p className="text-[13px] font-semibold text-foreground">
         {group.title}
       </p>
-      <p className="text-[11.5px] leading-relaxed text-muted-foreground/70">
+      <p className="text-[12px] leading-relaxed text-muted-foreground/70">
         {group.explanation}
       </p>
       <EndpointGroupRows endpoints={group.endpoints} />
@@ -383,14 +383,14 @@ function PairingPanel({
               </p>
               <span
                 className={cn(
-                  "font-mono text-[11.5px] tabular-nums",
+                  "font-mono text-[12px] tabular-nums",
                   expired ? "text-status-attention" : "text-muted-foreground",
                 )}
               >
                 {expired ? "Expired" : `Expires in ${formatCountdown(remainingMs)}`}
               </span>
             </div>
-            <p className="mt-1 text-[11.5px] leading-relaxed text-muted-foreground/80">
+            <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground/80">
               One-time link — it pairs a single device, then can't be reused.
               Open it on your phone or laptop to connect.
             </p>
@@ -485,7 +485,7 @@ function PendingRow({
             </Badge>
           )}
         </div>
-        <p className="truncate text-[11.5px] text-muted-foreground/80">
+        <p className="truncate text-[12px] text-muted-foreground/80">
           {d.platform || "Unknown platform"} ·{" "}
           {session.source === "account"
             ? "signed in and awaiting approval"
@@ -560,7 +560,7 @@ function DeviceRow({
             </span>
           )}
         </div>
-        <p className="truncate text-[11.5px] text-muted-foreground/80">
+        <p className="truncate text-[12px] text-muted-foreground/80">
           {d.platform || "Unknown platform"} ·{" "}
           {isAccount ? "signed in" : "paired"} {relativeTime(session.created_at)}{" "}
           · last seen {relativeTime(session.last_seen_at)}
@@ -1090,7 +1090,7 @@ export function RemoteAccessSection() {
             Remote Access
           </h2>
         </div>
-        <p className="mt-1.5 max-w-prose text-[13.5px] leading-relaxed text-muted-foreground/80">
+        <p className="mt-1.5 max-w-prose text-[14px] leading-relaxed text-muted-foreground/80">
           Open this desktop to a browser on another device — a laptop or phone
           on your network or mesh VPN — and drive the same projects, sessions,
           and agents from there.
@@ -1147,7 +1147,7 @@ export function RemoteAccessSection() {
               rebindPhase.status === "cutoff" ? (
                 <div
                   role="status"
-                  className="flex items-start gap-2.5 rounded-lg border border-status-attention/40 bg-status-attention/[0.08] px-3.5 py-3 text-[12.5px] leading-relaxed text-status-attention"
+                  className="flex items-start gap-2.5 rounded-lg border border-status-attention/40 bg-status-attention/[0.08] px-3.5 py-3 text-[13px] leading-relaxed text-status-attention"
                 >
                   <WifiOff className="mt-0.5 h-4 w-4 shrink-0" />
                   <span>{rebindPhase.message}</span>
@@ -1155,7 +1155,7 @@ export function RemoteAccessSection() {
               ) : (
                 <div
                   role="status"
-                  className="flex items-center gap-2.5 rounded-lg border border-status-working/40 bg-status-working/[0.08] px-3.5 py-3 text-[12.5px] text-status-working"
+                  className="flex items-center gap-2.5 rounded-lg border border-status-working/40 bg-status-working/[0.08] px-3.5 py-3 text-[13px] text-status-working"
                 >
                   <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
                   <span>Applying change — reconnecting to this device…</span>
@@ -1187,7 +1187,7 @@ export function RemoteAccessSection() {
                       disabled={scopePending || rebindBusy}
                       onClick={() => handleSetScope(opt.value)}
                       className={cn(
-                        "rounded-[7px] px-3 py-1.5 text-[12.5px] font-medium transition-colors disabled:opacity-60",
+                        "rounded-[7px] px-3 py-1.5 text-[13px] font-medium transition-colors disabled:opacity-60",
                         active
                           ? "bg-accent-ember/15 text-accent-ember shadow-sm"
                           : "text-muted-foreground hover:text-foreground",
@@ -1216,7 +1216,7 @@ export function RemoteAccessSection() {
                   invalidates any open pairing link.
                 </p>
                 {portDraft !== "" && !portValidation.valid && (
-                  <p className="text-[11.5px] text-status-attention">
+                  <p className="text-[12px] text-status-attention">
                     {portValidation.error}
                   </p>
                 )}
@@ -1300,7 +1300,7 @@ export function RemoteAccessSection() {
             {accountModeEnabled && !accountSignedIn && (
               <div
                 role="status"
-                className="flex items-start gap-2.5 rounded-lg border border-status-attention/40 bg-status-attention/[0.08] px-3.5 py-3 text-[12.5px] leading-relaxed text-status-attention"
+                className="flex items-start gap-2.5 rounded-lg border border-status-attention/40 bg-status-attention/[0.08] px-3.5 py-3 text-[13px] leading-relaxed text-status-attention"
               >
                 <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
                 <span>
@@ -1338,7 +1338,7 @@ export function RemoteAccessSection() {
           <section className="space-y-2">
             <SubHeading>Reachable at</SubHeading>
             {endpoints.length === 0 ? (
-              <p className="py-2 text-[12.5px] text-muted-foreground/70">
+              <p className="py-2 text-[13px] text-muted-foreground/70">
                 {running
                   ? "No reachable endpoints found."
                   : "Starting the server…"}
@@ -1360,7 +1360,7 @@ export function RemoteAccessSection() {
               />
             ) : (
               <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 bg-muted/30 p-4">
-                <p className="text-[12.5px] leading-relaxed text-muted-foreground/85">
+                <p className="text-[13px] leading-relaxed text-muted-foreground/85">
                   Create a one-time link, then scan its QR code or open it on the
                   other device to pair.
                 </p>
@@ -1430,7 +1430,7 @@ export function RemoteAccessSection() {
               )}
             </div>
             {approved.length === 0 ? (
-              <div className="flex items-center gap-2.5 rounded-lg border border-dashed border-border/60 px-3.5 py-4 text-[12.5px] text-muted-foreground/70">
+              <div className="flex items-center gap-2.5 rounded-lg border border-dashed border-border/60 px-3.5 py-4 text-[13px] text-muted-foreground/70">
                 <Server className="h-4 w-4" />
                 No devices paired yet. Create a pairing link above to connect
                 one.

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -246,7 +246,7 @@ function SettingRow({ label, description, children }: {
   return (
     <div className="flex items-center justify-between gap-8 py-4">
       <div className="space-y-1 min-w-0">
-        <p className="text-[13.5px] font-semibold leading-tight text-foreground">{label}</p>
+        <p className="text-[14px] font-semibold leading-tight text-foreground">{label}</p>
         {description && (
           <p className="text-[12px] text-muted-foreground/80 leading-relaxed">{description}</p>
         )}
@@ -260,7 +260,7 @@ function SectionHeader({ title, description }: { title: string; description: str
   return (
     <div className="mb-7">
       <h2 className="text-[21px] font-bold tracking-tight text-foreground">{title}</h2>
-      <p className="text-[13.5px] text-muted-foreground/80 mt-1.5 leading-relaxed max-w-prose">{description}</p>
+      <p className="text-[14px] text-muted-foreground/80 mt-1.5 leading-relaxed max-w-prose">{description}</p>
     </div>
   );
 }
@@ -466,7 +466,7 @@ function WorkingIndicatorTiles({
             <span className="flex h-5 items-center justify-center">
               <WorkingIndicator variant={opt.value} color={color} preview />
             </span>
-            <span className="text-[10.5px] text-muted-foreground">
+            <span className="text-[11px] text-muted-foreground">
               {opt.label}
             </span>
           </button>
@@ -1668,7 +1668,7 @@ export function SettingsView() {
                 <SubsectionHeader title="Session" />
                 <SettingsCard className="flex items-center justify-between gap-4 border-destructive/25 bg-destructive/[0.07]">
                   <div className="min-w-0">
-                    <p className="text-[13.5px] font-semibold text-foreground">Sign out of Codemux</p>
+                    <p className="text-[14px] font-semibold text-foreground">Sign out of Codemux</p>
                     <p className="text-[12px] text-muted-foreground/80 mt-0.5">
                       You'll need to sign in again to sync settings and use cloud features.
                     </p>
@@ -1861,7 +1861,7 @@ export function SettingsView() {
 
               {/* Live preview at the sidebar row's scale. */}
               <div className="mt-4">
-                <p className="mb-1.5 font-mono text-[9.5px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/55">
+                <p className="mb-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/55">
                   Preview
                 </p>
                 <div className="flex max-w-[300px] items-center gap-2 rounded-[10px] border border-border/60 bg-muted/30 px-2.5 py-2">
@@ -1871,7 +1871,7 @@ export function SettingsView() {
                       color={indicatorColor}
                     />
                   </span>
-                  <span className="text-[12.5px] font-semibold text-foreground">
+                  <span className="text-[13px] font-semibold text-foreground">
                     Fix scroll pinning on send
                   </span>
                   <span className="ml-auto font-mono text-[11px] text-muted-foreground">
@@ -2361,7 +2361,7 @@ export function SettingsView() {
                   </SettingsCard>
                 )}
                 <Textarea
-                  className="font-mono text-[12.5px] min-h-[90px] leading-relaxed"
+                  className="font-mono text-[13px] min-h-[90px] leading-relaxed"
                   placeholder={".env\n.env.*\n.env.local"}
                   value={worktreeIncludes}
                   onChange={(e) => setWorktreeIncludes(e.target.value)}
@@ -2374,7 +2374,7 @@ export function SettingsView() {
                 helper="Runs when a new workspace is created. One command per line."
               >
                 <Textarea
-                  className="font-mono text-[12.5px] min-h-[90px] leading-relaxed"
+                  className="font-mono text-[13px] min-h-[90px] leading-relaxed"
                   placeholder="e.g. npm install"
                   value={setupScripts}
                   onChange={(e) => setSetupScripts(e.target.value)}
@@ -2387,7 +2387,7 @@ export function SettingsView() {
                 helper="Runs when a workspace is deleted. One command per line."
               >
                 <Textarea
-                  className="font-mono text-[12.5px] min-h-[90px] leading-relaxed"
+                  className="font-mono text-[13px] min-h-[90px] leading-relaxed"
                   placeholder="e.g. docker compose down"
                   value={teardownScripts}
                   onChange={(e) => setTeardownScripts(e.target.value)}
@@ -2405,7 +2405,7 @@ export function SettingsView() {
                 }
               >
                 <Input
-                  className="font-mono text-[12.5px] h-9"
+                  className="font-mono text-[13px] h-9"
                   placeholder="e.g. npm run dev"
                   value={runCommand}
                   onChange={(e) => setRunCommand(e.target.value)}

--- a/src/components/settings/smooth-scrolling-section.tsx
+++ b/src/components/settings/smooth-scrolling-section.tsx
@@ -44,7 +44,7 @@ export function SmoothScrollingSection() {
       <div className="space-y-1">
         <div className="flex items-center justify-between gap-8 py-4">
           <div className="space-y-1 min-w-0">
-            <p className="text-[13.5px] font-semibold leading-tight text-foreground">
+            <p className="text-[14px] font-semibold leading-tight text-foreground">
               Smooth scrolling
             </p>
             <p className="text-[12px] text-muted-foreground/80 leading-relaxed">

--- a/src/components/workflow/orchestration-panel.tsx
+++ b/src/components/workflow/orchestration-panel.tsx
@@ -101,12 +101,12 @@ export function OrchestrationPanel({ workspace, run, threadId }: Props) {
               <ChevronLeft className="h-3.5 w-3.5" strokeWidth={1.7} aria-hidden />
             </button>
           )}
-          <span className="min-w-0 flex-1 truncate text-[13.5px] font-bold text-foreground">
+          <span className="min-w-0 flex-1 truncate text-[14px] font-bold text-foreground">
             {level === "agent" ? "Agent detail" : (run.name ?? "Workflow")}
           </span>
           <span
             className={cn(
-              "shrink-0 rounded-[5px] px-2 py-0.5 text-[10.5px] font-bold uppercase tracking-wide",
+              "shrink-0 rounded-[5px] px-2 py-0.5 text-[11px] font-bold uppercase tracking-wide",
               tone.chipBg,
             )}
           >
@@ -185,7 +185,7 @@ function Stat({ label, value }: { label: string; value: string }) {
   return (
     <span className="flex flex-col">
       <span className="font-mono text-[13px] font-semibold text-foreground">{value}</span>
-      <span className="text-[9.5px] uppercase tracking-wide text-muted-foreground">{label}</span>
+      <span className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</span>
     </span>
   );
 }

--- a/src/components/workflow/workflow-agent-detail.tsx
+++ b/src/components/workflow/workflow-agent-detail.tsx
@@ -96,7 +96,7 @@ export function WorkflowAgentDetail({
         )}
         <div className="min-w-0 flex-1">
           <div className="truncate font-mono text-[12px] font-semibold text-foreground">{label}</div>
-          <div className="truncate text-[10.5px] text-muted-foreground">
+          <div className="truncate text-[11px] text-muted-foreground">
             Phase {phaseIndex} · {phaseTitle} · agent {agentIndex} of {agentsInPhase}
             {agent.model ? ` · ${agent.model}` : ""}
           </div>
@@ -104,7 +104,7 @@ export function WorkflowAgentDetail({
         {badge && (
           <span
             className={cn(
-              "shrink-0 rounded-[5px] px-2 py-0.5 text-[9.5px] font-bold uppercase",
+              "shrink-0 rounded-[5px] px-2 py-0.5 text-[10px] font-bold uppercase",
               tone.chipBg,
             )}
           >
@@ -147,7 +147,7 @@ export function WorkflowAgentDetail({
         <SectionLabel>Result</SectionLabel>
         {running ? (
           <div className="rounded-[9px] border border-border/60 bg-muted/30 px-2.5 py-2.5 text-[12px] text-muted-foreground">
-            <span className="shimmer font-mono text-[11.5px]">{subagentActivityLine(agent)}</span>
+            <span className="shimmer font-mono text-[12px]">{subagentActivityLine(agent)}</span>
           </div>
         ) : (
           <div
@@ -164,7 +164,7 @@ export function WorkflowAgentDetail({
       <div className="flex gap-2 pt-1">
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="outline" size="sm" className="text-[11.5px]" disabled>
+            <Button variant="outline" size="sm" className="text-[12px]" disabled>
               Restart agent
             </Button>
           </TooltipTrigger>
@@ -175,7 +175,7 @@ export function WorkflowAgentDetail({
             type="button"
             variant="ghost"
             size="sm"
-            className="text-[11.5px] text-muted-foreground hover:text-foreground"
+            className="text-[12px] text-muted-foreground hover:text-foreground"
             onClick={() => {
               openEditorTab(workspace.workspace_id, workspace.tabs, label).catch(console.error);
             }}
@@ -190,7 +190,7 @@ export function WorkflowAgentDetail({
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mb-1.5 font-mono text-[9.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+    <div className="mb-1.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
       {children}
     </div>
   );

--- a/src/components/workflow/workflow-phase-list.tsx
+++ b/src/components/workflow/workflow-phase-list.tsx
@@ -115,14 +115,14 @@ function PhaseCard({
     <>
       {statusIcon}
       <div className="min-w-0 flex-1">
-        <div className="text-[12.5px] font-bold text-foreground">
+        <div className="text-[13px] font-bold text-foreground">
           {index} · {phase.title}
         </div>
         <div className="truncate text-[11px] text-muted-foreground">{subLine}</div>
       </div>
       <div className="shrink-0 text-right">
         <div className="font-mono text-[11px] text-foreground/80">{agentCountLabel}</div>
-        <div className="font-mono text-[9.5px] text-muted-foreground">{metaLabel}</div>
+        <div className="font-mono text-[10px] text-muted-foreground">{metaLabel}</div>
       </div>
     </>
   );
@@ -179,7 +179,7 @@ function PhaseAgents({
   return (
     <div className="border-t border-border/60 p-1.5">
       <div className="flex items-center gap-1.5 px-1.5 py-1">
-        <span className="font-mono text-[9.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
           Agents
         </span>
         <div className="ml-auto flex gap-1">
@@ -192,7 +192,7 @@ function PhaseAgents({
                 setFilter(f);
               }}
               className={cn(
-                "rounded-full px-2 py-0.5 text-[9.5px] font-semibold",
+                "rounded-full px-2 py-0.5 text-[10px] font-semibold",
                 filter === f
                   ? "bg-foreground/[0.12] text-foreground"
                   : "text-muted-foreground hover:text-foreground/80",
@@ -246,7 +246,7 @@ function AgentRow({ agent, onSelect }: { agent: SubagentView; onSelect: () => vo
       {badge && (
         <span
           className={cn(
-            "shrink-0 rounded-[4px] px-1.5 py-0.5 text-[9.5px] font-semibold",
+            "shrink-0 rounded-[4px] px-1.5 py-0.5 text-[10px] font-semibold",
             findingTone(badge.tone).chipBg,
           )}
         >

--- a/src/components/workspaces-overview/how-it-works-popover.tsx
+++ b/src/components/workspaces-overview/how-it-works-popover.tsx
@@ -84,7 +84,7 @@ export function HowItWorksPopover() {
         className="w-[320px] p-0 overflow-hidden"
       >
         <div className="bg-gradient-to-br from-status-remote/10 via-transparent to-status-open/8 px-4 py-3 border-b border-border/40">
-          <p className="text-[12.5px] font-semibold text-foreground">
+          <p className="text-[13px] font-semibold text-foreground">
             How workspaces sync across devices
           </p>
           <p className="mt-0.5 text-[11px] text-muted-foreground/75 leading-relaxed">
@@ -92,7 +92,7 @@ export function HowItWorksPopover() {
             device of your account where each workspace is.
           </p>
         </div>
-        <ol className="px-4 py-3 space-y-3 text-[11.5px] leading-relaxed">
+        <ol className="px-4 py-3 space-y-3 text-[12px] leading-relaxed">
           <Step
             n="1"
             icon={<ArrowUpRight className="size-3 text-status-open" />}
@@ -115,7 +115,7 @@ export function HowItWorksPopover() {
           />
         </ol>
         <div className="px-4 py-2.5 border-t border-border/40 bg-muted/20">
-          <p className="text-[10.5px] text-muted-foreground/65 leading-relaxed">
+          <p className="text-[11px] text-muted-foreground/65 leading-relaxed">
             Every push and pull is undoable for 10 seconds. Workspace
             files never sync silently — they only move when you say so.
           </p>

--- a/src/components/workspaces-overview/pull-to-device-dialog.tsx
+++ b/src/components/workspaces-overview/pull-to-device-dialog.tsx
@@ -409,7 +409,7 @@ function HostBackedAdoptionForm({
 }) {
   return (
     <>
-      <dl className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[12.5px] space-y-1.5">
+      <dl className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[13px] space-y-1.5">
         <SummaryRow
           label="From"
           icon={<Cloud className="size-3 text-status-remote/80" />}
@@ -420,7 +420,7 @@ function HostBackedAdoptionForm({
           {remoteProjectName(syncRow) ?? "—"}
         </SummaryRow>
         <SummaryRow label="Branch">
-          <span className="font-mono text-[11.5px]">
+          <span className="font-mono text-[12px]">
             {syncRow.git_branch ?? "—"}
           </span>
         </SummaryRow>
@@ -434,7 +434,7 @@ function HostBackedAdoptionForm({
       <button
         type="button"
         onClick={onToggleDisclosure}
-        className="flex w-full items-center gap-1 text-[11.5px] text-muted-foreground/75 hover:text-foreground transition-colors"
+        className="flex w-full items-center gap-1 text-[12px] text-muted-foreground/75 hover:text-foreground transition-colors"
       >
         {disclosureOpen ? (
           <ChevronDown className="size-3" />
@@ -445,7 +445,7 @@ function HostBackedAdoptionForm({
       </button>
 
       {disclosureOpen && (
-        <ul className="rounded-md bg-muted/20 border border-border/40 px-3 py-2 text-[11.5px] text-muted-foreground/85 leading-relaxed space-y-1">
+        <ul className="rounded-md bg-muted/20 border border-border/40 px-3 py-2 text-[12px] text-muted-foreground/85 leading-relaxed space-y-1">
           <li>
             • Copies the workspace files from{" "}
             <span className="font-medium text-foreground/90">
@@ -494,7 +494,7 @@ function HostNotConfiguredBlock({
       <Button
         variant="outline"
         size="sm"
-        className="h-7 px-2.5 text-[11.5px] gap-1.5 border-warning/30 hover:bg-warning/15"
+        className="h-7 px-2.5 text-[12px] gap-1.5 border-warning/30 hover:bg-warning/15"
         onClick={() => {
           onClose();
           // TODO: deep-link to Settings → Devices when that route lands.
@@ -521,9 +521,9 @@ function CloneFallbackBlock({
         We'll clone it from git.
       </p>
 
-      <dl className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[12.5px] space-y-1.5">
+      <dl className="rounded-md border border-border/60 bg-muted/30 px-3 py-2.5 text-[13px] space-y-1.5">
         <SummaryRow label="Clone from">
-          <span className="font-mono text-[11.5px] break-all">
+          <span className="font-mono text-[12px] break-all">
             {syncRow.project_remote ?? "—"}
           </span>
         </SummaryRow>
@@ -531,7 +531,7 @@ function CloneFallbackBlock({
           label="Branch"
           icon={<GitBranch className="size-3 text-muted-foreground/70" />}
         >
-          <span className="font-mono text-[11.5px]">
+          <span className="font-mono text-[12px]">
             {syncRow.git_branch ?? "main"}
           </span>
         </SummaryRow>
@@ -542,7 +542,7 @@ function CloneFallbackBlock({
         </SummaryRow>
       </dl>
 
-      <div className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[11.5px] text-warning/90 leading-relaxed">
+      <div className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning/90 leading-relaxed">
         <AlertTriangle className="size-3.5 shrink-0 mt-0.5" />
         <div>
           <p className="font-medium text-warning">
@@ -608,7 +608,7 @@ function SameBranchProjectBlock({
       <Button
         variant="secondary"
         size="sm"
-        className="h-7 px-2.5 text-[11.5px]"
+        className="h-7 px-2.5 text-[12px]"
         onClick={onOpenExisting}
       >
         Open the existing workspace
@@ -624,7 +624,7 @@ function AlreadyAdoptedBlock({ onOpen }: { onOpen: () => void }) {
       <Button
         variant="secondary"
         size="sm"
-        className="h-7 px-2.5 text-[11.5px]"
+        className="h-7 px-2.5 text-[12px]"
         onClick={onOpen}
       >
         Open it
@@ -652,7 +652,7 @@ function SummaryRow({
 }) {
   return (
     <div className="flex items-baseline gap-2">
-      <dt className="w-[68px] shrink-0 text-[10.5px] uppercase tracking-wider text-muted-foreground/55">
+      <dt className="w-[68px] shrink-0 text-[11px] uppercase tracking-wider text-muted-foreground/55">
         {label}
       </dt>
       <dd

--- a/src/components/workspaces-overview/workspace-overview-row.tsx
+++ b/src/components/workspaces-overview/workspace-overview-row.tsx
@@ -430,7 +430,7 @@ function LocalRow({
           <div className="flex items-center gap-2">
             <h4
               className={cn(
-                "min-w-0 flex-1 truncate text-[13.5px] font-semibold leading-tight tracking-[-0.01em]",
+                "min-w-0 flex-1 truncate text-[14px] font-semibold leading-tight tracking-[-0.01em]",
                 isAttached ? "text-foreground" : "text-foreground/90",
               )}
               title={workspace.title}
@@ -480,7 +480,7 @@ function LocalRow({
               </span>
             )}
           </div>
-          <p className="mt-[3px] truncate text-[11.5px] text-muted-foreground/65">
+          <p className="mt-[3px] truncate text-[12px] text-muted-foreground/65">
             {project ? project.name : "—"}
             {isWorking && (
               <span className="ml-1.5 text-status-working/90">
@@ -781,7 +781,7 @@ function RemoteRow({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <h4
-              className="min-w-0 flex-1 truncate text-[13.5px] font-semibold leading-tight tracking-[-0.01em] text-foreground/90"
+              className="min-w-0 flex-1 truncate text-[14px] font-semibold leading-tight tracking-[-0.01em] text-foreground/90"
               title={row.title}
             >
               {row.title}
@@ -806,7 +806,7 @@ function RemoteRow({
               other device
             </span>
           </div>
-          <p className="mt-[3px] truncate text-[11.5px] text-muted-foreground/65">
+          <p className="mt-[3px] truncate text-[12px] text-muted-foreground/65">
             {item.projectName ?? "—"}
             <span className="ml-1.5 text-status-remote/70">
               · not on this device

--- a/src/components/workspaces-overview/workspaces-overview-section.tsx
+++ b/src/components/workspaces-overview/workspaces-overview-section.tsx
@@ -83,7 +83,7 @@ function filterTriggerCls(active: boolean): string {
   // replaces the SelectTrigger's own `data-[size=default]:h-8` instead of
   // colliding with it at equal specificity (the bare class would lose).
   return cn(
-    "data-[size=default]:h-10 rounded-lg text-[12.5px] font-semibold transition-colors",
+    "data-[size=default]:h-10 rounded-lg text-[13px] font-semibold transition-colors",
     active
       ? "border-primary/45 bg-primary/5 text-foreground"
       : "text-muted-foreground",
@@ -501,7 +501,7 @@ export function WorkspacesOverviewSection() {
             <h3 className="text-[15px] font-semibold tracking-tight text-foreground">
               No workspaces yet
             </h3>
-            <p className="text-[12.5px] leading-relaxed text-muted-foreground/80">
+            <p className="text-[13px] leading-relaxed text-muted-foreground/80">
               Workspaces hold a worktree, an agent, and any panes you open.
               Create one here, then push it to a host whenever you want it
               to run somewhere else — every device of your account shows up
@@ -512,7 +512,7 @@ export function WorkspacesOverviewSection() {
             type="button"
             variant="secondary"
             size="sm"
-            className="h-8 gap-1.5 text-[12.5px]"
+            className="h-8 gap-1.5 text-[13px]"
             onClick={() => {
               setShowWorkspacesOverview(false);
               setShowNewWorkspaceDialog(true);
@@ -660,7 +660,7 @@ export function WorkspacesOverviewSection() {
       <div className="shrink-0 border-b border-border/40 px-6 py-2">
         <div className="mx-auto flex max-w-[1180px] items-center justify-between gap-3">
           <div className="flex items-center gap-1.5">
-            <p className="text-[11.5px] text-muted-foreground/70 tabular-nums">
+            <p className="text-[12px] text-muted-foreground/70 tabular-nums">
               {totalShown === totalAll
                 ? `${totalAll} ${totalAll === 1 ? "workspace" : "workspaces"}`
                 : `${totalShown} of ${totalAll} shown`}
@@ -682,7 +682,7 @@ export function WorkspacesOverviewSection() {
               type="button"
               variant="secondary"
               size="sm"
-              className="h-9 gap-1.5 px-3.5 text-[12.5px] font-semibold"
+              className="h-9 gap-1.5 px-3.5 text-[13px] font-semibold"
               onClick={() => {
                 setShowWorkspacesOverview(false);
                 setShowSettings(true, "hosts");
@@ -696,7 +696,7 @@ export function WorkspacesOverviewSection() {
             <Button
               type="button"
               size="sm"
-              className="h-9 gap-1.5 px-3.5 text-[12.5px] font-bold"
+              className="h-9 gap-1.5 px-3.5 text-[13px] font-bold"
               onClick={() => {
                 setShowWorkspacesOverview(false);
                 setShowNewWorkspaceDialog(true);
@@ -863,7 +863,7 @@ function DeviceSection({
                 {hiddenByFilter} filtered
               </span>
             )}
-            <span className="text-[11.5px] tabular-nums text-muted-foreground/65">
+            <span className="text-[12px] tabular-nums text-muted-foreground/65">
               {bucket.items.length}{" "}
               {bucket.items.length === 1 ? "workspace" : "workspaces"}
             </span>
@@ -1161,7 +1161,7 @@ function EmptyBucketCTA({
   if (isLocal) {
     return (
       <div className="rounded-lg border border-dashed border-border/50 bg-muted/20 px-4 py-5 text-center space-y-3">
-        <p className="text-[12.5px] text-muted-foreground/85">
+        <p className="text-[13px] text-muted-foreground/85">
           No workspaces on this device yet.
         </p>
         <div className="flex flex-wrap items-center justify-center gap-2">
@@ -1203,7 +1203,7 @@ function EmptyBucketCTA({
   // construct a "push" CTA (which needs a workspace pre-selected).
   return (
     <div className="rounded-lg border border-dashed border-border/50 bg-muted/20 px-4 py-5 text-center space-y-2">
-      <p className="text-[12.5px] text-muted-foreground/85">
+      <p className="text-[13px] text-muted-foreground/85">
         No workspaces pushed to {bucketLabel} yet.
       </p>
       <p className="text-[11px] text-muted-foreground/65 leading-relaxed">
@@ -1223,7 +1223,7 @@ function EmptyFilters({ onClear }: { onClear: () => void }) {
         <p className="text-[13px] font-medium text-foreground">
           No workspaces match these filters
         </p>
-        <p className="text-[11.5px] text-muted-foreground/70">
+        <p className="text-[12px] text-muted-foreground/70">
           Try a different search, or clear the filter to see everything.
         </p>
       </div>

--- a/src/globals.css
+++ b/src/globals.css
@@ -303,9 +303,6 @@ body.pane-resizing iframe {
     }
   body {
     @apply bg-background text-foreground;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
     }
   html {
     @apply font-sans;
@@ -710,4 +707,3 @@ body.pane-resizing iframe {
   box-shadow: 0 0 0 2px var(--accent-ember);
   transition: box-shadow 0.3s ease;
 }
-


### PR DESCRIPTION
## Summary

- use platform-native font rasterization instead of global smoothing overrides
- align primary chat and composer typography at 14px with relaxed line height
- normalize fractional UI font sizes to a whole-pixel 10–14px scale
- document the typography and rasterization conventions

## Verification

- `npm run check`
- `npm run build`
- `npm run test` — 3367 tests passed; one load-sensitive clipboard test failed in the full run and passed on isolated rerun
- browser mock visual check for typography hierarchy, clipping, and layout regressions