### PR TITLE
Put every chat surface on one shared column

### DIFF
--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -2861,7 +2861,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
               hidden while drilled into a subagent (the design only shows
               it in the conversation view) and hidden entirely while idle. */}
           {!enteredSubagent && (
-            <div className="px-7 pt-2.5">
+            <div className="pt-2.5">
               <SubagentActivityBar
                 messages={messages}
                 threadId={threadId}

--- a/src/components/chat/ChatHomeLanding.tsx
+++ b/src/components/chat/ChatHomeLanding.tsx
@@ -12,13 +12,14 @@ interface Props {
  */
 export function ChatHomeLanding({ composer }: Props) {
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-8 px-4 pb-12">
-      <h1 className="text-3xl font-medium tracking-tight text-foreground text-center">
+    <div className="flex h-full w-full flex-col items-center justify-center gap-8 pb-12">
+      <h1 className="px-4 text-3xl font-medium tracking-tight text-foreground text-center">
         What should we do today?
       </h1>
-      {/* Match the composer's own 760px column (design D10/D12) so the
-          landing card lines up with the mid-conversation composer. */}
-      <div className="w-full max-w-[760px]">{composer}</div>
+      {/* The composer carries the shared column rails itself (see
+          chat-column.ts), so the landing card lines up with the
+          mid-conversation composer at every pane width. */}
+      <div className="w-full">{composer}</div>
     </div>
   );
 }

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -77,6 +77,7 @@ import { ComposerCommandMenu } from "./ComposerCommandMenu";
 import { ComposerFooter } from "./ComposerFooter";
 import { ModePill, type ActivePillMode } from "./pickers/ModePill";
 import { SlashCommandPopup } from "./SlashCommandPopup";
+import { CHAT_COLUMN_INNER, CHAT_COLUMN_OUTER } from "./chat-column";
 
 const EMPTY_ATTACHMENTS: Attachment[] = [];
 const EMPTY_FILE_MATCHES: FileMatch[] = [];
@@ -1954,8 +1955,8 @@ export function Composer({
   };
 
   return (
-    <div className="w-full px-4 pb-3">
-      <div className="mx-auto w-full max-w-[760px]">
+    <div className={cn(CHAT_COLUMN_OUTER, "pb-3")}>
+      <div className={CHAT_COLUMN_INNER}>
         {zone1Override !== null && zone1Override !== undefined ? (
           <div className="pb-1">{zone1Override}</div>
         ) : zone1Override === undefined && cwd ? (

--- a/src/components/chat/ComposerPendingInputPanel.tsx
+++ b/src/components/chat/ComposerPendingInputPanel.tsx
@@ -15,7 +15,10 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { cn } from "@/lib/utils";
+
 import type { PermissionRequestItem } from "@/lib/agent-chat/types";
+
+import { CHAT_COLUMN_INNER, CHAT_COLUMN_OUTER } from "./chat-column";
 
 /** Matches the Claude Agent SDK's `AskUserQuestionOutput` (sdk-tools.d.ts):
  *  `answers` is an object keyed by question text, value is the chosen
@@ -256,8 +259,8 @@ export function ComposerPendingInputPanel({ item, onSubmit }: Props) {
 
   if (questions.length === 0) {
     return (
-      <div className="w-full px-4 pb-2">
-        <div className="mx-auto w-full max-w-[760px]">
+      <div className={cn(CHAT_COLUMN_OUTER, "pb-2")}>
+        <div className={CHAT_COLUMN_INNER}>
           <div className="rounded-[20px] border border-border bg-muted/40 shadow-sm px-4 py-3 text-xs text-muted-foreground">
             AskUserQuestion with no questions.
           </div>
@@ -271,8 +274,8 @@ export function ComposerPendingInputPanel({ item, onSubmit }: Props) {
   const primaryLabel = isLast ? "Send" : "Next";
 
   return (
-    <div className="w-full px-4 pb-2">
-      <div className="mx-auto w-full max-w-[760px]">
+    <div className={cn(CHAT_COLUMN_OUTER, "pb-2")}>
+      <div className={CHAT_COLUMN_INNER}>
         <div className="rounded-[20px] border border-border bg-muted/40 shadow-sm px-4 py-3 space-y-3">
           {/* Header row: optional uppercase header on the left, pagination on the right. */}
           <div className="flex items-center gap-2">

--- a/src/components/chat/DebugCleanupBanner.tsx
+++ b/src/components/chat/DebugCleanupBanner.tsx
@@ -1,6 +1,9 @@
 import { Bug } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { CHAT_COLUMN_INNER, CHAT_COLUMN_OUTER } from "./chat-column";
 
 interface Props {
   /** Click triggers the cleanup turn (synthetic user prompt that
@@ -18,8 +21,13 @@ interface Props {
  *  cleanup turn — see `triggerDebugCleanup` in AgentChatPane. */
 export function DebugCleanupBanner({ onCleanup, busy = false }: Props) {
   return (
-    <div className="px-4 pb-2">
-      <div className="mx-auto flex w-full max-w-2xl items-center gap-2 rounded-md border border-danger/20 bg-danger/10 px-3 py-2 text-xs">
+    <div className={cn(CHAT_COLUMN_OUTER, "pb-2")}>
+      <div
+        className={cn(
+          CHAT_COLUMN_INNER,
+          "flex items-center gap-2 rounded-md border border-danger/20 bg-danger/10 px-3 py-2 text-xs"
+        )}
+      >
         <Bug className="size-3.5 text-danger" aria-hidden />
         <span>Debug markers detected in this project.</span>
         <Button

--- a/src/components/chat/DraftChatSurface.tsx
+++ b/src/components/chat/DraftChatSurface.tsx
@@ -77,6 +77,9 @@ import { Composer } from "./Composer";
 import { UserMessage } from "./UserMessage";
 import type { ActivePillMode } from "./pickers/ModePill";
 import { ThreadScopeRow } from "./pickers/ThreadScopeRow";
+import { cn } from "@/lib/utils";
+
+import { CHAT_COLUMN } from "./chat-column";
 
 /** Grace period between `markPromoted` and `clearDraft`. Gives any
  *  in-flight selector a chance to observe the promotion before the
@@ -1067,8 +1070,10 @@ function DraftPendingConversation({
   };
   return (
     <div className="flex h-full w-full flex-col">
-      <div className="flex-1 min-h-0 overflow-y-auto">
-        <div className="mx-auto flex w-full max-w-[760px] flex-col gap-4 px-7 py-6">
+      {/* Both-edges gutter so the column stays concentric with the pane
+          (and with the composer below) once this view can scroll. */}
+      <div className="flex-1 min-h-0 overflow-y-auto [scrollbar-gutter:stable_both-edges]">
+        <div className={cn(CHAT_COLUMN, "flex flex-col gap-4 py-6")}>
           <UserMessage item={item} />
           <div
             className="flex items-center gap-[13px] pt-0.5"
@@ -1088,7 +1093,9 @@ function DraftPendingConversation({
           </div>
         </div>
       </div>
-      <div className="mx-auto w-full max-w-[760px] px-7 pb-4">{composer}</div>
+      {/* The composer owns its own column rails (see chat-column.ts), so
+          this wrapper only adds the gap below it. */}
+      <div className="pb-4">{composer}</div>
     </div>
   );
 }

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -44,6 +44,7 @@ import { UserInputAnswer } from "./UserInputAnswer";
 import { UserMessage } from "./UserMessage";
 import { WorkflowRunCard } from "./WorkflowRunCard";
 import { ScrollAnchoringShim } from "./scroll-anchoring-shim";
+import { CHAT_COLUMN } from "./chat-column";
 import {
   subscribeTranscriptFade,
   transcriptFadeEnabled,
@@ -287,7 +288,7 @@ export function MessageList({
         >
           <MessageScrollerContent
             aria-busy={showThinking || undefined}
-            className="mx-auto w-full max-w-[760px] gap-0 px-7 pb-[30px] pt-[26px]"
+            className={cn(CHAT_COLUMN, "gap-0 pb-[30px] pt-[26px]")}
           >
             <SessionStartMarker startedAt={sessionStartedAt} />
 

--- a/src/components/chat/SubagentActivityBar.tsx
+++ b/src/components/chat/SubagentActivityBar.tsx
@@ -11,6 +11,8 @@ import {
 import type { ChatViewItem } from "@/lib/agent-chat/types";
 import { cn } from "@/lib/utils";
 
+import { CHAT_COLUMN } from "./chat-column";
+
 /** How long the green "just finished" flash stays up before the bar
  *  disappears entirely (design "for ~2.5s, then disappears"). */
 const FINISHED_FLASH_MS = 2500;
@@ -110,7 +112,7 @@ export const SubagentActivityBar = memo(function SubagentActivityBar({
       if (finishedCardId) onJump(finishedCardId);
     };
     return (
-      <div className="mx-auto w-full max-w-[760px]">
+      <div className={CHAT_COLUMN}>
         <div
           data-testid="subagent-activity-bar"
           data-tone="finished"
@@ -170,7 +172,7 @@ export const SubagentActivityBar = memo(function SubagentActivityBar({
   };
 
   return (
-    <div className="mx-auto w-full max-w-[760px]">
+    <div className={CHAT_COLUMN}>
       {multi && open && (
         <div
           id={listId}

--- a/src/components/chat/SubagentView.tsx
+++ b/src/components/chat/SubagentView.tsx
@@ -21,6 +21,7 @@ import { isTaskSummaryTool, TaskSummaryCard } from "./TaskSummaryCard";
 import { ToolCallCard } from "./ToolCallCard";
 import { UserMessage } from "./UserMessage";
 import { buildTranscriptSlots } from "./transcript-slots";
+import { CHAT_COLUMN } from "./chat-column";
 
 const NOOP = () => {};
 
@@ -57,7 +58,7 @@ export function SubagentView({
   }, [subagent.items, requests]);
 
   return (
-    <div className="mx-auto w-full max-w-[760px] px-7 pb-[30px] pt-[26px]">
+    <div className={cn(CHAT_COLUMN, "pb-[30px] pt-[26px]")}>
       {/* Read-only banner */}
       <div
         className={cn(

--- a/src/components/chat/chat-column.ts
+++ b/src/components/chat/chat-column.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared chat column rails.
+ *
+ * The transcript, the docked activity bar, the pending-input panel and the
+ * composer card all sit on one centered column so their left/right edges
+ * line up at every pane width. The rule is: the horizontal gutter lives
+ * *outside* the max-width box, so the effective content width is always
+ *
+ *   min(760px, paneWidth - 2 * 16px)
+ *
+ * Tailwind only sees literal class strings, so the two numbers are spelled
+ * out here (once) rather than computed. `CHAT_COLUMN` folds the gutter into
+ * a single element via `max-w-[792px] px-4` (792 - 2*16 = 760, since the
+ * box is border-box); the OUTER/INNER pair is the same rails split across
+ * two elements, for containers whose inner box is a visible card.
+ */
+
+/** One-element form: content resolves to min(760px, paneWidth - 32px). */
+export const CHAT_COLUMN = "mx-auto w-full max-w-[792px] px-4";
+
+/** Two-element form — gutter element. Pair with `CHAT_COLUMN_INNER`. */
+export const CHAT_COLUMN_OUTER = "w-full px-4";
+
+/** Two-element form — the centered 760px box itself. */
+export const CHAT_COLUMN_INNER = "mx-auto w-full max-w-[760px]";

--- a/src/components/ui/message-scroller.tsx
+++ b/src/components/ui/message-scroller.tsx
@@ -40,7 +40,14 @@ function MessageScrollerViewport({
     <MessageScrollerPrimitive.Viewport
       data-slot="message-scroller-viewport"
       className={cn(
-        "size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain contain-content [overflow-anchor:none] [scrollbar-gutter:stable] data-[scrollable~=end]:[overflow-anchor:auto]",
+        // `scrollbar-gutter: stable both-edges` (not plain `stable`):
+        // reserving the gutter on one side only would shrink the box the
+        // centered content column is measured against, sliding the whole
+        // transcript half a scrollbar to the left of the composer, which
+        // sits outside this scroller. Both edges keeps the column
+        // concentric with the pane, so transcript and composer share the
+        // same rails (see chat/chat-column.ts).
+        "size-full min-h-0 min-w-0 overflow-y-auto overscroll-contain contain-content [overflow-anchor:none] [scrollbar-gutter:stable_both-edges] data-[scrollable~=end]:[overflow-anchor:auto]",
         className
       )}
       {...props}


### PR DESCRIPTION
The transcript, composer, pending-input panel, subagent activity bar, draft surface, and debug banner each carried their own centering wrapper (`max-w-[760px] px-7`, `px-4`, `max-w-2xl`, …), so their edges never quite lined up: the transcript was 6px narrower than the composer at full width, drifted further apart as the pane narrowed, and sat half a scrollbar to the left of the composer — which lives outside the scroller and never paid the gutter.

## What changed

- **New `src/components/chat/chat-column.ts`** owns the column rails once. The rule: the horizontal gutter lives *outside* the max-width box, so effective content width is always `min(760px, paneWidth - 2×16px)`. Exported as a one-element form (`CHAT_COLUMN` = `mx-auto w-full max-w-[792px] px-4`) and a split `CHAT_COLUMN_OUTER`/`CHAT_COLUMN_INNER` pair for containers whose inner box is a visible card. Tailwind only sees literal class strings, so the two numbers are spelled out there once rather than computed.
- Every chat surface adopts the shared rails: `MessageList`, `Composer`, `ComposerPendingInputPanel` (both branches), `SubagentActivityBar` (both tones), `SubagentView`, `DraftChatSurface`, `DebugCleanupBanner` (previously a different width entirely at `max-w-2xl`), and `ChatHomeLanding` (which now lets the composer carry its own rails instead of double-wrapping).
- **`message-scroller.tsx`**: `scrollbar-gutter: stable` → `stable both-edges`. Reserving the gutter on one side only shrinks the box the centered column is measured against, sliding the whole transcript half a scrollbar left of the composer. Both edges keeps the column concentric with the pane, so transcript and composer share the same rails. `DraftPendingConversation`'s scroller gets the same treatment.

## Verification

- `tsc` clean, 3368 frontend tests passing (223 files).
- No stray `max-w-[760px]`/`px-7` wrappers left in chat components — the rails exist in exactly one module.