### PR TITLE
feat(sidebar): recede background workspace cards that don't need attention

### DIFF
--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -20,6 +20,12 @@ at rest and *which workspace you are in* reads as lightness — no accent color
 for that. Accent is reserved for the claims lightness can't make: the
 needs-you red border, the ember unread dot, the ember ring that marks a row as
 checked for a bulk action, and the green "Woke" pill.
+The same doctrine runs in the other direction as **background recede**: full
+brightness is reserved for the cards that want a human — the workspace you are
+in, needs-you, done-review, unread, just-woke, and multi-selected — while a
+card whose agent is quietly working, or that is idle and already read, sits at
+reduced opacity. Nothing is hidden: hovering or focusing a receded card
+restores it in full.
 
 ## Current Model
 
@@ -163,7 +169,16 @@ visual only — nothing is archived, closed, or deleted.
   accent color — the sidebar surface is darker than the main pane, so cards
   sit flat/transparent at rest and lift on hover); needs-you cards a
   red-tinted border; multi-selected cards an **ember ring** layered over
-  whatever the card already is. Click activates; the right-click context menu
+  whatever the card already is. A card that is **none** of those and whose
+  agent is either working or absent (idle) — and that has been read and has no
+  "Woke" pill — **recedes** to `opacity-70`, restored to full by hover or
+  `focus-within` (the dim is suppressed outright while the card's Snooze menu
+  is pinned open, since Radix portals that menu out of the card and neither
+  restore would hold). The dim rides the card's own container, not the settle
+  animation wrapper, which already owns an opacity axis. It deliberately
+  includes "Wrapping up" cards: an open PR on an idle, read card is exactly the
+  work that is nobody's problem this minute. The status label keeps its hue
+  inside a dimmed card — the row is quieter, not recolored. Click activates; the right-click context menu
   is the same `WorkspaceContextMenuItems` (rename, editors, move-to-host,
   archive, delete) shared with the old row, including the delete/push-confirm
   dialogs.
@@ -549,6 +564,12 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
   `sidebar-inbox.tsx` — one implementation, shared so the two views can never
   disagree), so collapsing the sidebar never re-shuffles the order the user
   just memorized. The rail has no tiers: it is a single newest-first list.
+  It mirrors the cards' **background recede**: a button that is not the open
+  workspace, is not unread (`isWorkspaceUnread` on the two backend stamps,
+  imported from `sidebar-inbox.tsx` — the rail has no manual-unread override),
+  and whose agent is working or idle drops to `opacity-70`, restored on hover.
+  The status dot dims with the button on purpose. There is no "Woke" term in
+  the predicate here, since the rail carries no woke marker.
 - **Footer**: Automations, Workspaces, Ports (badge), Settings — same order
   as the expanded footer row.
 - **Setup banner** (`sidebar-setup-banner.tsx`): hidden in the rail.
@@ -575,6 +596,9 @@ Replaced the old project-avatar rail (aggregate dots + hover flyout,
 - Backend-owned `last_active_at` / `last_visited_at` stamps that survive
   restarts and reinstalls, with a one-time boot backfill from git history.
 - Unread markers derived from those stamps, plus a "Mark unread" override.
+- Background recede on cards and rail buttons: quietly-working and idle-read
+  rows sit at reduced opacity so the current, needs-you, done-review, unread,
+  woke and multi-selected rows are the bright ones; hover/focus restores.
 - Cmd/Ctrl-click and Shift-click multi-select with a bulk Settle/Snooze menu.
 - Forward navigation when parking the workspace you are currently viewing.
 - Search affordance opening the command palette; neutral-ghost new-agent button.

--- a/src/components/layout/sidebar-inbox-card.test.tsx
+++ b/src/components/layout/sidebar-inbox-card.test.tsx
@@ -303,6 +303,42 @@ describe("SidebarInboxCard — multi-select", () => {
   });
 });
 
+describe("SidebarInboxCard — background recede", () => {
+  // Prominence is reserved for rows that want a human: the one you are in,
+  // needs-you, done-review, unread, woke, and anything ticked for a bulk
+  // action. A quietly-working agent and an idle row you have already read sit
+  // back instead, and hover/focus brings them straight back to full.
+  it("dims a background card whose agent is quietly working", () => {
+    const { card } = renderCard({ status: "working" });
+    expect(card.className).toContain("opacity-70");
+    expect(card.className).toContain("hover:opacity-100");
+    expect(card.className).toContain("focus-within:opacity-100");
+  });
+
+  it("dims an idle background card the same way", () => {
+    const { card } = renderCard({ status: null });
+    expect(card.className).toContain("opacity-70");
+    expect(card.className).toContain("hover:opacity-100");
+  });
+
+  it("keeps every card that wants a human at full brightness", () => {
+    const cases: Array<[string, Partial<CardProps>]> = [
+      ["the workspace you are in", { isActive: true, status: "working" }],
+      ["a card ticked for a bulk action", { selected: true, status: "working" }],
+      ["unread agent output", { unread: true, status: "working" }],
+      ["a card just back from a snooze", { woke: true, status: null }],
+      ["an agent blocked on you", { status: "permission" as ActivePaneStatus }],
+      ["work finished and waiting on a review", { status: "review" as ActivePaneStatus }],
+    ];
+
+    for (const [label, overrides] of cases) {
+      const { card } = renderCard(overrides);
+      expect(card.className, label).not.toContain("opacity-70");
+      cleanup();
+    }
+  });
+});
+
 describe("SidebarInboxCard — meta line alignment", () => {
   function metaLine(container: HTMLElement) {
     return container.querySelector("[data-meta-line]") as HTMLElement;

--- a/src/components/layout/sidebar-inbox-card.tsx
+++ b/src/components/layout/sidebar-inbox-card.tsx
@@ -164,6 +164,22 @@ export function SidebarInboxCard({
   const isNeeds = status === "permission";
   const isDone = status === "review";
 
+  // Background recede. Prominence is a scarce resource, so it is reserved for
+  // the rows that actually want a human right now: the workspace you are in,
+  // one that is blocked on you, one that has finished and wants a review, one
+  // holding output you have not read, and one that just came back from a
+  // snooze — plus anything you have ticked for a bulk action. Everything else
+  // is either an agent quietly working (not your problem yet) or an idle row
+  // you have already read, so it sits back at reduced opacity and the ones
+  // that need you read as the bright rows in the list. Hovering or focusing a
+  // receded card restores it in full, so nothing is ever hidden — only ranked.
+  const receded =
+    !isActive &&
+    !selected &&
+    !unread &&
+    !woke &&
+    (status === "working" || status === null);
+
   // Settle safety net: a live or blocked agent can never be swept out of
   // sight. Only finished ("review") and idle cards offer Settle — sweeping
   // completed work aside is the whole point of the gesture.
@@ -333,7 +349,12 @@ export function SidebarInboxCard({
                 "group/card relative mb-1.5 cursor-pointer rounded-[10px] border px-[11px] pt-[9px] pb-[10px]",
                 // select-none: a shift-click range gesture would otherwise
                 // drag a text highlight across every card it spans.
-                "select-none outline-none transition-colors duration-150",
+                "select-none outline-none duration-150",
+                // The opacity axis lives on this node, not on the animation
+                // wrapper above — that wrapper already owns one (the leaving
+                // collapse and the rise-in keyframe both drive opacity), and a
+                // second declaration there would fight them.
+                "transition-[color,background-color,border-color,opacity]",
                 isActive
                   ? "border-border bg-foreground/[0.09]"
                   : isNeeds
@@ -346,6 +367,14 @@ export function SidebarInboxCard({
                 // resting/active treatments stay pure lightness.
                 selected &&
                   "border-transparent bg-accent-ember/[0.08] ring-1 ring-accent-ember/55",
+                // Hover restores by pointer, focus-within by keyboard. The
+                // pinned exception is the Snooze dropdown: Radix portals the
+                // open menu out of this card, so the pointer has left and
+                // focus sits outside — neither restore would hold, and the
+                // card the user is actively operating on would dim mid-menu.
+                receded &&
+                  !actionsPinned &&
+                  "opacity-70 hover:opacity-100 focus-within:opacity-100",
               )}
             >
               {/* Jump-shortcut hint: the digit that activates this card while

--- a/src/components/layout/sidebar-rail-workspaces.test.tsx
+++ b/src/components/layout/sidebar-rail-workspaces.test.tsx
@@ -273,6 +273,34 @@ describe("SidebarRailWorkspaces", () => {
     }
   });
 
+  it("recedes background buttons that are not asking for anything", async () => {
+    // Rail parity with the expanded inbox: a quietly-working agent and an
+    // idle, already-read workspace sit back so the needs-you / done-review /
+    // unread buttons are the bright ones. Hover restores them.
+    workspaces = [
+      makeWorkspace({ title: "Needs", surfaces: surfaceWithPane("p1") }),
+      makeWorkspace({ title: "Working", surfaces: surfaceWithPane("p2") }),
+      makeWorkspace({ title: "Review", surfaces: surfaceWithPane("p3") }),
+      makeWorkspace({ title: "Idle" }),
+      makeWorkspace({ title: "Unread", last_active_at: 100 }),
+      makeWorkspace({ title: "Open now" }),
+    ];
+    paneStatuses = { p1: "permission", p2: "working", p3: "review" };
+    activeWorkspaceId = "ws-6";
+    const { container } = await renderRail();
+
+    const btn = (id: string) =>
+      container.querySelector(`[data-rail-ws="${id}"]`)!;
+
+    expect(btn("ws-2").className).toContain("opacity-70");
+    expect(btn("ws-2").className).toContain("hover:opacity-100");
+    expect(btn("ws-4").className).toContain("opacity-70");
+
+    for (const id of ["ws-1", "ws-3", "ws-5", "ws-6"]) {
+      expect(btn(id).className, id).not.toContain("opacity-70");
+    }
+  });
+
   it("prunes persisted entries whose workspace no longer exists", async () => {
     // A session spent entirely in the collapsed rail must still trim the
     // persisted blob, otherwise it grows without bound.

--- a/src/components/layout/sidebar-rail-workspaces.tsx
+++ b/src/components/layout/sidebar-rail-workspaces.tsx
@@ -9,7 +9,7 @@ import {
 import { useHosts } from "@/stores/hosts-store";
 import { useChatDraftStore } from "@/stores/chat-draft-store";
 import { useSidebarInboxStore } from "@/stores/sidebar-inbox-store";
-import { compareNewestFirst } from "./sidebar-inbox";
+import { compareNewestFirst, isWorkspaceUnread } from "./sidebar-inbox";
 import { activateWorkspace } from "@/tauri/commands";
 import { getWorkspaceStatus } from "@/lib/pane-status";
 import { useProjectAppearance } from "./use-project-appearance";
@@ -50,6 +50,21 @@ function RailWorkspaceItem({
     });
   };
 
+  // Rail parity with the expanded inbox's background recede: a button whose
+  // agent is quietly working, or that is idle and already read, is not asking
+  // for anything yet, so it sits back and lets the needs-you / done-review /
+  // unread buttons be the bright ones. Hover restores it in full. Unread is
+  // the pure stamp predicate the inbox derives from — the rail carries no
+  // unread affordance of its own and no manual override, hence `false`; and
+  // it has no "Woke" concept at all, so there is nothing to skip for.
+  const unread = isWorkspaceUnread(
+    workspace.last_active_at,
+    workspace.last_visited_at,
+    false,
+  );
+  const receded =
+    !isActive && !unread && (status === "working" || status === null);
+
   // Per-workspace status dot: red (pulse) needs-you > amber working >
   // green review. Idle / null shows nothing.
   const dotClass: Record<ActivePaneStatus, string> = {
@@ -69,10 +84,15 @@ function RailWorkspaceItem({
           onClick={handleClick}
           aria-label={workspace.title}
           className={cn(
-            "relative flex size-7 items-center justify-center rounded-lg border transition-colors duration-150",
+            "relative flex size-7 items-center justify-center rounded-lg border duration-150",
+            "transition-[color,background-color,border-color,opacity]",
             isActive
               ? "border-border bg-foreground/[0.09]"
               : "border-transparent hover:bg-foreground/[0.04]",
+            // The status dot inherits the dim along with the avatar, which is
+            // the point: a quietly-working button should read as quieter as a
+            // whole, not as a dim avatar wearing a full-strength badge.
+            receded && "opacity-70 hover:opacity-100",
           )}
         >
           <ProjectAvatar


### PR DESCRIPTION
## What

Status-based visual ranking in the left-sidebar workspace inbox: cards that don't currently need the user **recede to 70% opacity**, while cards that do stay at full brightness.

**Full brightness** (needs a human):
- the workspace you're in (active)
- `permission` — needs you (red border)
- `review` — done, waiting on review
- unread output
- freshly woken from snooze
- multi-selected for a bulk action

**Receded** (not your problem yet):
- background cards whose agent is quietly `working` (the amber Working label keeps its hue so they stay findable)
- idle cards you've already read (including the "Wrapping up" tier, deliberately)

Hover or keyboard focus restores a receded card in full (150ms), so nothing is ever hidden — only ranked. The collapsed rail's avatar buttons get the same treatment, with unread derived from the backend activity stamps.

## Implementation notes

- The dim is derived from existing props (`isActive` / `selected` / `unread` / `woke` / `status`) — no new props, no new state.
- It lives on the inner card node, not the outer animation wrapper, which already owns an opacity axis (settle collapse + `rise-in`).
- The card stays bright while its Snooze dropdown is pinned open: the menu is portaled out of the card, so neither `hover:` nor `focus-within:` would hold it.
- Transition widened to `transition-[color,background-color,border-color,opacity]` (composing `transition-colors` + `transition-opacity` collides in tailwind-merge).
- Opacity utilities only — no color changes, consistent with the token rules in `docs/reference/DESIGN-SYSTEM.md`.

## Tests & docs

- 4 new test cases: card dims on background `working` and idle, and stays bright across all six full-brightness states; same coverage for the rail buttons.
- `docs/features/sidebar.md` updated (visual doctrine, card bullet, rail parity, What Works Today).
- `npm run check` clean; full suite 3372/3372 passing.
- Visually verified against the dev mock runtime seed data: 16 cards → 11 receded, 5 bright (1 active + 2 needs-you + 2 done-review).