### PR TITLE
Agent Chat: add provider-native Tasks panel

### DIFF
--- a/docs/core/STATUS.md
+++ b/docs/core/STATUS.md
@@ -304,7 +304,11 @@ The frontend is React + Tailwind v4 + shadcn + Vite. The Rust backend is unchang
 - Workspace list from real Tauri backend data (zustand + app-state-changed events, coalesced into 16ms windows)
 - Terminal panes with xterm.js WebGL (hardware-GL gated) + DOM fallback + PTY via Tauri Channel, persistent across workspace switch
 - Pane splits (horizontal/vertical) with CSS Grid, resize handles, drag-to-swap
-- Right panel with Changes panel, File tree, and Review (PR) panel tabs
+- Right panel with Changes, Files, Review, conditional Orchestration, and
+  conditional Agent Tasks tabs. Agent Tasks is a durable, thread-focused,
+  read-only provider plan fed by Claude (`TodoWrite` + `Task*`), Codex
+  (`turn/plan/updated`), and OpenCode (`todo.updated`); its compact composer
+  toggle appears only after a non-empty plan exists
 - OpenFlow UI: orchestration view, agent config, communication panel, agent graph
 - Agent Chat UI: chat pane, composer (with `+` popup, `@` mention popup, slash command popup, image paste/drop), transcript, mode pill, model picker, session selector, attachment chips, plan proposal block, AskUserQuestion panel, thinking indicator, permission request block, tool-call card with per-tool body rendering, debug-mode banner + exit dialog; runtime events (incl. `content_delta` token stream) arrive per-thread over a Tauri Channel (`attach_agent_chat_output`, issue #75) instead of the global event bus; transcript body uses LegendList bounded-DOM virtualization while preserving the issue #77 stick-to-bottom contract; docked `SubagentActivityBar` between transcript and composer while subagents run
 - Settings panel (15+ sections including Beta Features, Sync, Skills, MCP, Permissions)

--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -648,8 +648,8 @@ the plan and progress but cannot check, reorder, or rewrite its rows.
 - **Provider mapping.** Codex maps `turn/plan/updated`; OpenCode maps
   `todo.updated`; Claude maps legacy `TodoWrite` and the current
   `TaskCreate` / `TaskUpdate` / `TaskList` result stream. Child/subagent plans
-  remain child-scoped and never replace the orchestrator's panel. There is no
-  Cursor provider adapter in Codemux today; the canonical event is deliberately
+  remain child-scoped and never replace the orchestrator's panel. No ACP-based
+  provider adapter exists in Codemux today; the canonical event is deliberately
   provider-neutral so a future adapter can map ACP `plan` updates without UI
   changes.
 - **Thread focus.** `useActiveChatTasks` resolves the active surface's focused

--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -68,7 +68,8 @@ The chat pane stack:
   reasoning + tool calls, working/settled — see "Activity block" below;
   `activity-steps.ts` holds its pure step/summary/duration derivations),
   `DiffView` (red/green edit surface), `TaskSummaryCard` (TodoWrite
-  checklist), `StreamingMarker` (shimmer tail status), `tool-visuals.ts`
+  receipt line — see "Thread receipt" under the Agent Tasks panel),
+  `StreamingMarker` (shimmer tail status), `tool-visuals.ts`
   (icon/tint mapping), `PlanProposalBlock`, `ComposerPendingInputPanel`
   for AskUserQuestion, `PermissionRequestBlock`, `ModePill`,
   `SessionSelector`, `DraftChatSurface`, `ChatHomeLanding`,
@@ -637,6 +638,54 @@ Card styling (all in `globals.css`, all on design tokens):
   in CI to dodge the `fake_codex_app_server` helper-binary build race
   under cargo's parallel scheduler.
 
+## Agent Tasks panel
+
+Provider-authored plans are normalized into the durable
+`ProviderRuntimeEvent::TasksUpdated { thread_id, tasks }` snapshot. This is
+agent state, not a second editable project-management surface: users can inspect
+the plan and progress but cannot check, reorder, or rewrite its rows.
+
+- **Provider mapping.** Codex maps `turn/plan/updated`; OpenCode maps
+  `todo.updated`; Claude maps legacy `TodoWrite` and the current
+  `TaskCreate` / `TaskUpdate` / `TaskList` result stream. Child/subagent plans
+  remain child-scoped and never replace the orchestrator's panel. There is no
+  Cursor provider adapter in Codemux today; the canonical event is deliberately
+  provider-neutral so a future adapter can map ACP `plan` updates without UI
+  changes.
+- **Thread focus.** `useActiveChatTasks` resolves the active surface's focused
+  leaf pane, then reads only that pane's thread snapshot. Switching panes or
+  split focus therefore switches the task source instead of leaking another
+  chat's plan into the workspace panel.
+- **Conditional chrome.** A compact `Tasks N/M` composer control and right-panel
+  Tasks tab appear only for a non-empty snapshot. Clicking the composer control
+  toggles the shared right panel. A stale persisted `tasks` panel selection
+  falls back to Files when the focused pane has no task state. Both controls
+  carry run state so progress stays readable from any tab: the composer chip
+  turns amber with a spinner while a step is in flight and green with a check
+  once every row is done, and the Tasks tab shows a blinking amber dot while a
+  step is running and the tab is not the active one.
+- **Presentation.** The read-only panel preserves provider order and renders
+  flat, numbered rows (no per-row card chrome) with three visually distinct
+  states — done (green circled check, dimmed, struck through), in-progress
+  (amber spinner, tinted row, full-strength text), pending (hollow dot,
+  muted) — so the eye lands on the active step. The header carries a
+  Queued / Working / Complete status badge, `N/M done`, the last-update time
+  (`tasksUpdatedAt`, stamped by the reducer on each `tasks_updated`), and a
+  3px tone-colored progress bar; the provider's one-line explanation renders
+  above the rows as run intent. Dependency ids resolve to task titles when
+  possible, and a footer offers a Copy action (markdown checklist via
+  `tasksToMarkdown`). Snapshots persist in `agent_chat_messages` and hydrate
+  through the ordinary event reducer, so reopening a thread restores the same
+  toggle and panel (`tasksUpdatedAt` then reflects hydration time, not the
+  original wall time).
+- **Thread receipt.** `TaskSummaryCard` no longer prints the full todo list in
+  the transcript — that duplicated the panel with a copy that never updated.
+  Each `TodoWrite`-style call collapses to a one-line receipt ("Task list
+  created · 3 items" / "Task list updated · 2/3 done") that flips the right
+  panel to Tasks when a `workspaceId` is threaded (same pattern as
+  `WorkflowRunCard`'s "Open panel"); without one the row renders inert. The
+  panel is the live truth; the thread just records that a plan landed.
+
 ## Transcript scroller (issue #77 contract, LegendList)
 
 The transcript body (`MessageList.tsx`) is a real windowed list built on
@@ -854,7 +903,7 @@ derivations (unit-tested in `activity-steps.test.ts`).
 - **What stays standalone (breaks the run).** Approval-gated tool calls
   (`approval_request_id` set — the inline approval footer must render),
   TodoWrite / task-summary tools (`TaskSummaryCard` stays a visible
-  checklist), `permission_request`/plan/AskUserQuestion rows, assistant
+  receipt row), `permission_request`/plan/AskUserQuestion rows, assistant
   and user prose. Errored tool calls **do** fold in but stay
   discoverable: a red ✕ step row, and the settled header appends a
   subtle red `· N failed` to the meta. A lone reasoning run with no

--- a/src-tauri/src/agent_provider/claude/translate.rs
+++ b/src-tauri/src/agent_provider/claude/translate.rs
@@ -27,8 +27,8 @@ use regex::Regex;
 
 use crate::agent_provider::{
     CompletedItem, ContentDelta, ProviderRuntimeEvent, ProviderSessionId, RequestId,
-    SessionStatus, SubagentSnapshot, SubagentStatus, ThreadId, TurnId, TurnStatus, TurnUsage,
-    WorkflowPhaseSnapshot, WorkflowSnapshot,
+    SessionStatus, SubagentSnapshot, SubagentStatus, TaskSnapshotItem, TaskStatus, TasksSnapshot,
+    ThreadId, TurnId, TurnStatus, TurnUsage, WorkflowPhaseSnapshot, WorkflowSnapshot,
 };
 
 use super::protocol::{SidecarError, SidecarNotification};
@@ -64,6 +64,11 @@ pub struct SubagentDemux {
     /// snapshot is stamped with this id (see [`stamp_workflow_attribution`])
     /// so the frontend can route it into the workflow's phase view.
     active_workflow: Option<String>,
+    /// In-flight Claude TaskCreate/TaskUpdate/TaskList calls, keyed by
+    /// tool_use_id until their structured result arrives.
+    task_tools: HashMap<String, (String, serde_json::Value)>,
+    /// Current task state accumulated from Claude's modern Task* tools.
+    claude_tasks: Vec<TaskSnapshotItem>,
 }
 
 impl SubagentDemux {
@@ -143,6 +148,181 @@ fn is_agent_tool(name: &str) -> bool {
 /// naming it launches a `Workflow` run (see [`translate_assistant`]).
 fn is_workflow_tool(name: &str) -> bool {
     name == "Workflow"
+}
+
+fn is_claude_task_tool(name: &str) -> bool {
+    matches!(name, "TaskCreate" | "TaskUpdate" | "TaskList")
+}
+
+fn task_status(value: Option<&str>) -> TaskStatus {
+    match value {
+        Some("completed") | Some("cancelled") => TaskStatus::Completed,
+        Some("in_progress") | Some("inProgress") => TaskStatus::InProgress,
+        _ => TaskStatus::Pending,
+    }
+}
+
+fn string_array(value: Option<&serde_json::Value>) -> Vec<String> {
+    value
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn tasks_event(thread_id: &ThreadId, tasks: Vec<TaskSnapshotItem>) -> ProviderRuntimeEvent {
+    ProviderRuntimeEvent::TasksUpdated {
+        thread_id: thread_id.clone(),
+        tasks: TasksSnapshot {
+            explanation: None,
+            tasks,
+        },
+    }
+}
+
+/// Legacy TodoWrite is already a complete replacement snapshot, so it can
+/// publish as soon as the assistant's finalized tool input arrives.
+fn todo_write_event(
+    thread_id: &ThreadId,
+    input: &serde_json::Value,
+) -> Option<ProviderRuntimeEvent> {
+    let todos = input.get("todos")?.as_array()?;
+    let tasks = todos
+        .iter()
+        .enumerate()
+        .filter_map(|(index, todo)| {
+            let title = todo
+                .get("content")
+                .and_then(|value| value.as_str())
+                .unwrap_or("Task")
+                .trim();
+            let title = if title.is_empty() { "Task" } else { title };
+            Some(TaskSnapshotItem {
+                task_id: todo
+                    .get("id")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("claude-todo-{index}")),
+                title: title.to_string(),
+                status: task_status(todo.get("status").and_then(|value| value.as_str())),
+                detail: todo
+                    .get("activeForm")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.trim().is_empty())
+                    .map(str::to_string),
+                blocked_by: Vec::new(),
+            })
+        })
+        .collect();
+    Some(tasks_event(thread_id, tasks))
+}
+
+fn task_from_value(value: &serde_json::Value) -> Option<TaskSnapshotItem> {
+    let task_id = value.get("id")?.as_str()?.to_string();
+    let title = value.get("subject")?.as_str()?.trim().to_string();
+    if task_id.is_empty() || title.is_empty() {
+        return None;
+    }
+    Some(TaskSnapshotItem {
+        task_id,
+        title,
+        status: task_status(value.get("status").and_then(|status| status.as_str())),
+        detail: value
+            .get("activeForm")
+            .and_then(|detail| detail.as_str())
+            .map(str::to_string),
+        blocked_by: string_array(value.get("blockedBy")),
+    })
+}
+
+/// Apply a successful modern Task* result to the per-session task map.
+/// Returns a complete replacement snapshot when the tool supplied enough
+/// structured data to change state.
+fn apply_claude_task_result(
+    thread_id: &ThreadId,
+    tool_use_id: &str,
+    result: Option<&serde_json::Value>,
+    is_error: bool,
+    demux: &mut SubagentDemux,
+) -> Option<ProviderRuntimeEvent> {
+    let (tool_name, input) = demux.task_tools.remove(tool_use_id)?;
+    if is_error {
+        return None;
+    }
+    match tool_name.as_str() {
+        "TaskList" => {
+            let values = result?.get("tasks")?.as_array()?;
+            demux.claude_tasks = values.iter().filter_map(task_from_value).collect();
+        }
+        "TaskCreate" => {
+            let task = result
+                .and_then(|value| value.get("task"))
+                .and_then(task_from_value)
+                .or_else(|| {
+                    let id = result
+                        .and_then(|value| value.get("task"))
+                        .and_then(|task| task.get("id"))
+                        .and_then(|id| id.as_str())?;
+                    let title = input.get("subject")?.as_str()?.trim();
+                    if title.is_empty() {
+                        return None;
+                    }
+                    Some(TaskSnapshotItem {
+                        task_id: id.to_string(),
+                        title: title.to_string(),
+                        status: TaskStatus::Pending,
+                        detail: input
+                            .get("activeForm")
+                            .and_then(|value| value.as_str())
+                            .map(str::to_string),
+                        blocked_by: string_array(input.get("blockedBy")),
+                    })
+                })?;
+            if let Some(index) = demux
+                .claude_tasks
+                .iter()
+                .position(|existing| existing.task_id == task.task_id)
+            {
+                demux.claude_tasks[index] = task;
+            } else {
+                demux.claude_tasks.push(task);
+            }
+        }
+        "TaskUpdate" => {
+            let task_id = input
+                .get("taskId")
+                .and_then(|value| value.as_str())
+                .or_else(|| result.and_then(|value| value.get("taskId")).and_then(|v| v.as_str()))?;
+            let task = demux
+                .claude_tasks
+                .iter_mut()
+                .find(|task| task.task_id == task_id)?;
+            if let Some(title) = input.get("subject").and_then(|value| value.as_str()) {
+                if !title.trim().is_empty() {
+                    task.title = title.trim().to_string();
+                }
+            }
+            if let Some(status) = input.get("status").and_then(|value| value.as_str()) {
+                task.status = task_status(Some(status));
+            }
+            if let Some(detail) = input.get("activeForm").and_then(|value| value.as_str()) {
+                task.detail = Some(detail.to_string());
+            }
+            for dependency in string_array(input.get("addBlockedBy")) {
+                if !task.blocked_by.contains(&dependency) {
+                    task.blocked_by.push(dependency);
+                }
+            }
+            let removed = string_array(input.get("removeBlockedBy"));
+            task.blocked_by.retain(|dependency| !removed.contains(dependency));
+        }
+        _ => return None,
+    }
+    Some(tasks_event(thread_id, demux.claude_tasks.clone()))
 }
 
 // ---------------------------------------------------------------------------
@@ -499,6 +679,21 @@ fn translate_assistant(
                         .unwrap_or_default()
                         .to_string();
                     let input = block.get("input").cloned().unwrap_or_default();
+                    if subagent_id.is_none() {
+                        // Claude integrations occasionally namespace tool
+                        // names (for example `mcp__...__TodoWrite`). Match
+                        // the semantic suffix just as the SDK adapter does.
+                        if tool_name.to_ascii_lowercase().contains("todowrite") {
+                            if let Some(event) = todo_write_event(thread_id, &input) {
+                                out.push(event);
+                            }
+                        } else if is_claude_task_tool(&tool_name) {
+                            demux.task_tools.insert(
+                                tool_use_id.clone(),
+                                (tool_name.clone(), input.clone()),
+                            );
+                        }
+                    }
                     // A top-level `Workflow` launch becomes a
                     // WorkflowUpdated card and suppresses the generic
                     // ToolUse, exactly like a top-level Agent launch does
@@ -843,6 +1038,17 @@ fn translate_user(
                 .get("is_error")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
+            if parent.is_none() {
+                if let Some(event) = apply_claude_task_result(
+                    thread_id,
+                    &tool_use_id,
+                    msg.get("tool_use_result"),
+                    is_error,
+                    demux,
+                ) {
+                    out.push(event);
+                }
+            }
             // Parent-level completion of the active Workflow tool run.
             if parent.is_none() && demux.active_workflow.as_deref() == Some(tool_use_id.as_str())
             {
@@ -2939,5 +3145,56 @@ async function run() {
         ))
         .clone();
         assert_eq!(snap.workflow_id.as_deref(), Some("toolu_wf1"));
+    }
+
+    #[test]
+    fn todo_write_emits_complete_tasks_snapshot() {
+        let message = json!({
+            "type": "assistant",
+            "message": {"id": "turn-1", "content": [{
+                "type": "tool_use",
+                "id": "todo-1",
+                "name": "TodoWrite",
+                "input": {"todos": [
+                    {"content": "Research", "status": "completed"},
+                    {"content": "Implement", "status": "in_progress", "activeForm": "Implementing"}
+                ]}
+            }]}
+        });
+        let events = translate_sdk_message(&tid(), &message);
+        let tasks = events.iter().find_map(|event| match event {
+            ProviderRuntimeEvent::TasksUpdated { tasks, .. } => Some(tasks),
+            _ => None,
+        }).expect("tasks snapshot");
+        assert_eq!(tasks.tasks.len(), 2);
+        assert_eq!(tasks.tasks[1].status, TaskStatus::InProgress);
+        assert_eq!(tasks.tasks[1].detail.as_deref(), Some("Implementing"));
+    }
+
+    #[test]
+    fn modern_task_create_result_updates_snapshot() {
+        let mut state = SubagentDemux::default();
+        let use_message = json!({
+            "type": "assistant",
+            "message": {"id": "turn-1", "content": [{
+                "type": "tool_use", "id": "create-1", "name": "TaskCreate",
+                "input": {"subject": "Test the panel", "activeForm": "Testing"}
+            }]}
+        });
+        translate_sdk_message_with(&tid(), &use_message, &mut state);
+        let result_message = json!({
+            "type": "user",
+            "message": {"id": "turn-1", "content": [{
+                "type": "tool_result", "tool_use_id": "create-1", "content": "created"
+            }]},
+            "tool_use_result": {"task": {"id": "42", "subject": "Test the panel", "status": "pending"}}
+        });
+        let events = translate_sdk_message_with(&tid(), &result_message, &mut state);
+        let tasks = events.iter().find_map(|event| match event {
+            ProviderRuntimeEvent::TasksUpdated { tasks, .. } => Some(tasks),
+            _ => None,
+        }).expect("tasks snapshot");
+        assert_eq!(tasks.tasks[0].task_id, "42");
+        assert_eq!(tasks.tasks[0].title, "Test the panel");
     }
 }

--- a/src-tauri/src/agent_provider/codex/protocol.rs
+++ b/src-tauri/src/agent_provider/codex/protocol.rs
@@ -477,6 +477,8 @@ pub enum NotificationMessage {
     McpToolCallProgress(McpToolCallProgressParams),
     /// `item/plan/delta` — plan content streaming chunk.
     PlanDelta(DeltaParams),
+    /// `turn/plan/updated` — complete structured plan replacement.
+    TurnPlanUpdated(TurnPlanUpdatedParams),
     /// `item/started` — an item has just been created. The `item.type`
     /// tag indicates whether it's a tool call, reasoning block, etc.
     ItemStarted(ItemEnvelope),
@@ -528,6 +530,7 @@ impl NotificationMessage {
             "item/fileChange/patchUpdated" => decode!(FileChangePatchUpdated),
             "item/mcpToolCall/progress" => decode!(McpToolCallProgress),
             "item/plan/delta" => decode!(PlanDelta),
+            "turn/plan/updated" => decode!(TurnPlanUpdated),
             "item/started" => decode!(ItemStarted),
             "item/completed" => decode!(ItemCompleted),
             _ => Self::Unknown {
@@ -536,6 +539,27 @@ impl NotificationMessage {
             },
         }
     }
+}
+
+/// Complete structured plan pushed by current Codex app-server builds.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TurnPlanUpdatedParams {
+    pub thread_id: String,
+    #[serde(default)]
+    pub turn_id: Option<String>,
+    #[serde(default)]
+    pub explanation: Option<String>,
+    #[serde(default)]
+    pub plan: Vec<TurnPlanStep>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TurnPlanStep {
+    #[serde(default)]
+    pub step: String,
+    #[serde(default)]
+    pub status: String,
 }
 
 /// Params for `thread/started`.
@@ -1607,5 +1631,29 @@ mod tests {
         assert_eq!(act.agent_thread_id, "child-1");
         assert_eq!(act.agent_path.as_deref(), Some("root/child"));
         assert_eq!(act.kind, "interacted");
+    }
+
+    #[test]
+    fn turn_plan_updated_decodes_structured_plan() {
+        let message = NotificationMessage::from_raw(
+            "turn/plan/updated",
+            json!({
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "explanation": "Implement in phases",
+                "plan": [
+                    {"step": "Research", "status": "completed"},
+                    {"step": "Build", "status": "inProgress"}
+                ]
+            }),
+        );
+        match message {
+            NotificationMessage::TurnPlanUpdated(plan) => {
+                assert_eq!(plan.thread_id, "thread-1");
+                assert_eq!(plan.turn_id.as_deref(), Some("turn-1"));
+                assert_eq!(plan.plan.len(), 2);
+            }
+            other => panic!("expected TurnPlanUpdated, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/agent_provider/codex/translate.rs
+++ b/src-tauri/src/agent_provider/codex/translate.rs
@@ -28,7 +28,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::agent_provider::{
     CompletedItem, ContentDelta, ProviderRuntimeEvent, ProviderSessionId, RequestId,
-    SessionStatus, SubagentSnapshot, SubagentStatus, ThreadId, TurnId, TurnStatus,
+    SessionStatus, SubagentSnapshot, SubagentStatus, TaskSnapshotItem, TaskStatus, TasksSnapshot,
+    ThreadId, TurnId, TurnStatus,
 };
 
 use super::protocol::{
@@ -158,6 +159,12 @@ pub fn translate_notification_with(
         NotificationMessage::TurnCompleted(p) if demux.is_subagent(&p.thread_id) => {
             return handle_subagent_turn_completed(thread_id, p);
         }
+        // The right-panel plan belongs to the orchestrator. A child may
+        // maintain its own plan, but projecting it over the parent would
+        // make the toggle jump between unrelated scopes.
+        NotificationMessage::TurnPlanUpdated(p) if demux.is_subagent(&p.thread_id) => {
+            return vec![];
+        }
         NotificationMessage::Error(e) => {
             if let Some(child) = e.thread_id.as_deref() {
                 if demux.is_subagent(child) {
@@ -239,6 +246,38 @@ fn translate_parent(
             text_delta(thread_id, p, ContentStream::FileChange)
         }
         NotificationMessage::PlanDelta(p) => text_delta(thread_id, p, ContentStream::Plan),
+        NotificationMessage::TurnPlanUpdated(p) => {
+            let tasks = p
+                .plan
+                .into_iter()
+                .enumerate()
+                .filter_map(|(index, step)| {
+                    let title = step.step.trim().to_string();
+                    if title.is_empty() {
+                        return None;
+                    }
+                    let status = match step.status.as_str() {
+                        "completed" => TaskStatus::Completed,
+                        "inProgress" | "in_progress" => TaskStatus::InProgress,
+                        _ => TaskStatus::Pending,
+                    };
+                    Some(TaskSnapshotItem {
+                        task_id: format!("codex-{index}"),
+                        title,
+                        status,
+                        detail: None,
+                        blocked_by: Vec::new(),
+                    })
+                })
+                .collect();
+            vec![ProviderRuntimeEvent::TasksUpdated {
+                thread_id: thread_id.clone(),
+                tasks: TasksSnapshot {
+                    explanation: p.explanation,
+                    tasks,
+                },
+            }]
+        }
         NotificationMessage::ReasoningTextDelta(p) => translate_reasoning_text(thread_id, p),
         NotificationMessage::ReasoningSummaryTextDelta(p) => {
             translate_reasoning_summary_text(thread_id, p)
@@ -579,6 +618,7 @@ fn generic_wire_thread_id(msg: &NotificationMessage) -> Option<&str> {
         | CommandExecutionOutputDelta(p)
         | FileChangeOutputDelta(p)
         | PlanDelta(p) => Some(&p.thread_id),
+        TurnPlanUpdated(p) => Some(&p.thread_id),
         ReasoningTextDelta(p) => Some(&p.thread_id),
         ReasoningSummaryTextDelta(p) => Some(&p.thread_id),
         ReasoningSummaryPartAdded(p) => Some(&p.thread_id),
@@ -1826,6 +1866,34 @@ mod tests {
                 assert_eq!(subagent.activity.as_deref(), Some("child exploded"));
             }
             other => panic!("expected SubagentUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn structured_plan_maps_to_tasks_snapshot() {
+        let events = translate_notification(
+            &tid(),
+            NotificationMessage::from_raw(
+                "turn/plan/updated",
+                json!({
+                    "threadId": "c-1",
+                    "explanation": "Finish the feature",
+                    "plan": [
+                        {"step": "Research", "status": "completed"},
+                        {"step": "Implement", "status": "inProgress"},
+                        {"step": "Test", "status": "pending"}
+                    ]
+                }),
+            ),
+        );
+        match &events[0] {
+            ProviderRuntimeEvent::TasksUpdated { tasks, .. } => {
+                assert_eq!(tasks.explanation.as_deref(), Some("Finish the feature"));
+                assert_eq!(tasks.tasks[0].status, TaskStatus::Completed);
+                assert_eq!(tasks.tasks[1].status, TaskStatus::InProgress);
+                assert_eq!(tasks.tasks[2].status, TaskStatus::Pending);
+            }
+            other => panic!("expected TasksUpdated, got {other:?}"),
         }
     }
 }

--- a/src-tauri/src/agent_provider/events.rs
+++ b/src-tauri/src/agent_provider/events.rs
@@ -168,6 +168,44 @@ pub struct WorkflowSnapshot {
     pub duration_ms: Option<u64>,
 }
 
+/// Provider-neutral lifecycle state for one agent-authored task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Completed,
+}
+
+/// One row in the agent's current task plan.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TaskSnapshotItem {
+    /// Provider-native id when one exists; positional adapters synthesize a
+    /// stable id so persisted replay and the live UI share row identity.
+    #[serde(default)]
+    pub task_id: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub status: TaskStatus,
+    /// Optional provider-authored detail (for example Claude's active form).
+    #[serde(default)]
+    pub detail: Option<String>,
+    /// Provider-native dependency ids that currently block this task.
+    #[serde(default)]
+    pub blocked_by: Vec<String>,
+}
+
+/// Complete replacement snapshot of the task plan for one chat thread.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct TasksSnapshot {
+    #[serde(default)]
+    pub explanation: Option<String>,
+    #[serde(default)]
+    pub tasks: Vec<TaskSnapshotItem>,
+}
+
 /// A streamed fragment produced mid-turn.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -285,6 +323,12 @@ pub enum ProviderRuntimeEvent {
     WorkflowUpdated {
         thread_id: ThreadId,
         workflow: WorkflowSnapshot,
+    },
+    /// The provider replaced its current task plan. This durable, thread-
+    /// scoped state drives both the composer toggle and the Tasks panel.
+    TasksUpdated {
+        thread_id: ThreadId,
+        tasks: TasksSnapshot,
     },
     /// The turn finished — either successfully or with a terminal error.
     TurnCompleted {

--- a/src-tauri/src/agent_provider/mod.rs
+++ b/src-tauri/src/agent_provider/mod.rs
@@ -18,8 +18,9 @@ pub mod types;
 pub use errors::{ProviderError, SerializableProviderError};
 pub use events::{
     child_exit_events, CompletedItem, ContentDelta, ProviderRuntimeEvent,
-    RequestResponseFailureReason, SubagentSnapshot, SubagentStatus, TurnStatus, TurnUsage,
-    WorkflowPhaseSnapshot, WorkflowSnapshot, CHILD_EXITED_SUBTYPE,
+    RequestResponseFailureReason, SubagentSnapshot, SubagentStatus, TaskSnapshotItem, TaskStatus,
+    TasksSnapshot, TurnStatus, TurnUsage, WorkflowPhaseSnapshot, WorkflowSnapshot,
+    CHILD_EXITED_SUBTYPE,
 };
 pub use instance::ProviderInstanceId;
 pub use provider::{AgentProvider, ProviderEventStream};

--- a/src-tauri/src/agent_provider/opencode/protocol.rs
+++ b/src-tauri/src/agent_provider/opencode/protocol.rs
@@ -185,6 +185,27 @@ pub enum KnownEvent {
     PermissionAsked(PermissionAskedEvent),
     #[serde(rename = "permission.replied")]
     PermissionReplied(PermissionRepliedEvent),
+    #[serde(rename = "todo.updated")]
+    TodoUpdated(TodoUpdatedEvent),
+}
+
+/// OpenCode's complete session todo-list replacement event.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TodoUpdatedEvent {
+    #[serde(rename = "sessionID")]
+    pub session_id: String,
+    #[serde(default)]
+    pub todos: Vec<OpenCodeTodo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OpenCodeTodo {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub status: String,
 }
 
 /// Wraps a session payload — emitted by `session.created/updated/deleted`.

--- a/src-tauri/src/agent_provider/opencode/sse.rs
+++ b/src-tauri/src/agent_provider/opencode/sse.rs
@@ -428,6 +428,7 @@ fn event_session_id(known: &KnownEvent) -> Option<&str> {
         K::MessagePartRemoved(p) => Some(p.session_id.as_str()),
         K::PermissionAsked(p) => Some(p.session_id.as_str()),
         K::PermissionReplied(p) => Some(p.session_id.as_str()),
+        K::TodoUpdated(p) => Some(p.session_id.as_str()),
     }
 }
 

--- a/src-tauri/src/agent_provider/opencode/translate.rs
+++ b/src-tauri/src/agent_provider/opencode/translate.rs
@@ -16,7 +16,8 @@
 //! dropping them — adapter drift must be observable.
 
 use crate::agent_provider::events::{
-    CompletedItem, ContentDelta, ProviderRuntimeEvent, SubagentSnapshot, SubagentStatus, TurnStatus,
+    CompletedItem, ContentDelta, ProviderRuntimeEvent, SubagentSnapshot, SubagentStatus,
+    TaskSnapshotItem, TaskStatus, TasksSnapshot, TurnStatus,
 };
 use crate::agent_provider::types::{
     ApprovalDecision, ProviderSessionId, RequestId, SessionStatus, ThreadId, TurnId,
@@ -251,6 +252,46 @@ fn translate_known(
                 thread_id: ctx.thread_id.clone(),
                 request_id: RequestId(reply.request_id),
                 decision,
+            }]
+        }
+        KnownEvent::TodoUpdated(update) => {
+            // The shared panel follows the orchestrator. A child session's
+            // private todo list must not replace the parent's plan.
+            if subagent_id.is_some() {
+                return vec![];
+            }
+            let tasks = update
+                .todos
+                .into_iter()
+                .enumerate()
+                .filter_map(|(index, todo)| {
+                    let title = todo.content.trim().to_string();
+                    if title.is_empty() {
+                        return None;
+                    }
+                    Some(TaskSnapshotItem {
+                        task_id: if todo.id.is_empty() {
+                            format!("opencode-{index}")
+                        } else {
+                            todo.id
+                        },
+                        title,
+                        status: match todo.status.as_str() {
+                            "completed" | "cancelled" => TaskStatus::Completed,
+                            "in_progress" | "inProgress" => TaskStatus::InProgress,
+                            _ => TaskStatus::Pending,
+                        },
+                        detail: None,
+                        blocked_by: Vec::new(),
+                    })
+                })
+                .collect();
+            vec![ProviderRuntimeEvent::TasksUpdated {
+                thread_id: ctx.thread_id.clone(),
+                tasks: TasksSnapshot {
+                    explanation: None,
+                    tasks,
+                },
             }]
         }
         // session.created/updated/deleted — Codemux already knows
@@ -1378,5 +1419,28 @@ mod tests {
             }),
         }));
         assert!(opencode_event_to_runtime(event, &ctx(), None).is_empty());
+    }
+
+    #[test]
+    fn todo_updated_maps_to_parent_tasks_snapshot() {
+        let event: OpenCodeEvent = serde_json::from_value(serde_json::json!({
+            "type": "todo.updated",
+            "properties": {
+                "sessionID": "ses_root",
+                "todos": [
+                    {"id": "a", "content": "Inspect", "status": "completed"},
+                    {"id": "b", "content": "Build", "status": "in_progress"}
+                ]
+            }
+        }))
+        .unwrap();
+        let out = opencode_event_to_runtime(event, &ctx(), None);
+        match &out[0] {
+            ProviderRuntimeEvent::TasksUpdated { tasks, .. } => {
+                assert_eq!(tasks.tasks.len(), 2);
+                assert_eq!(tasks.tasks[1].status, TaskStatus::InProgress);
+            }
+            other => panic!("expected TasksUpdated, got {other:?}"),
+        }
     }
 }

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -2965,7 +2965,8 @@ fn map_event_to_pane_status(
         // status transition — the subagents it spawns and the turn it
         // runs within already drive `Working`/`Review` via their own
         // events above.
-        ProviderRuntimeEvent::WorkflowUpdated { .. } => None,
+        ProviderRuntimeEvent::WorkflowUpdated { .. }
+        | ProviderRuntimeEvent::TasksUpdated { .. } => None,
     }
 }
 
@@ -3121,6 +3122,7 @@ fn activity_update(
         | ProviderRuntimeEvent::ItemCompleted { .. }
         | ProviderRuntimeEvent::SubagentUpdated { .. }
         | ProviderRuntimeEvent::WorkflowUpdated { .. }
+        | ProviderRuntimeEvent::TasksUpdated { .. }
         | ProviderRuntimeEvent::QueuedTurnDispatched { .. }
         | ProviderRuntimeEvent::RequestResolved { .. } => mid_turn(false),
         // A turn started (Codex/OpenCode emit this reliably per turn).
@@ -3290,6 +3292,9 @@ pub fn should_persist_event(event: &ProviderRuntimeEvent) -> bool {
             // workflow run card and its phase attribution must survive a
             // restart via hydrate-replay, not a bespoke schema.
             | ProviderRuntimeEvent::WorkflowUpdated { .. }
+            // Task plans are durable conversation state. Persist the full
+            // replacement event so hydrate uses the same reducer path.
+            | ProviderRuntimeEvent::TasksUpdated { .. }
     )
     // NOTE: `RunStalled` is deliberately NOT persisted. It is a transient
     // advisory recomputed live by the stall watchdog; the durable record of
@@ -3423,6 +3428,7 @@ pub fn thread_id_for_event(event: &ProviderRuntimeEvent) -> Option<ThreadId> {
         | ProviderRuntimeEvent::SessionStateChanged { thread_id, .. }
         | ProviderRuntimeEvent::SubagentUpdated { thread_id, .. }
         | ProviderRuntimeEvent::WorkflowUpdated { thread_id, .. }
+        | ProviderRuntimeEvent::TasksUpdated { thread_id, .. }
         | ProviderRuntimeEvent::ResumeCursorUpdated { thread_id, .. }
         | ProviderRuntimeEvent::TurnQueued { thread_id, .. }
         | ProviderRuntimeEvent::QueuedTurnDispatched { thread_id, .. }
@@ -3992,7 +3998,8 @@ mod tests {
     // means adding a `not persisted` row.
 
     use crate::agent_provider::events::{
-        CompletedItem, ContentDelta, SubagentSnapshot, SubagentStatus, TurnStatus, TurnUsage,
+        CompletedItem, ContentDelta, SubagentSnapshot, SubagentStatus, TaskSnapshotItem,
+        TaskStatus, TasksSnapshot, TurnStatus, TurnUsage,
     };
     use crate::agent_provider::types::{
         ApprovalDecision, ProviderSessionId, RequestId, SessionStatus,
@@ -4006,6 +4013,26 @@ mod tests {
     }
     fn req() -> RequestId {
         RequestId("req-1".into())
+    }
+
+    #[test]
+    fn should_persist_tasks_snapshot_for_hydration() {
+        let event = ProviderRuntimeEvent::TasksUpdated {
+            thread_id: tid(),
+            tasks: TasksSnapshot {
+                explanation: Some("Ship the feature".into()),
+                tasks: vec![TaskSnapshotItem {
+                    task_id: "implement".into(),
+                    title: "Implement the panel".into(),
+                    status: TaskStatus::InProgress,
+                    detail: None,
+                    blocked_by: Vec::new(),
+                }],
+            },
+        };
+
+        assert!(should_persist_event(&event));
+        assert_eq!(thread_id_for_event(&event), Some(tid()));
     }
 
     #[test]

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -55,6 +55,7 @@ import {
   type Attachment,
 } from "@/stores/agent-chat-store";
 import { useChatDraftStore } from "@/stores/chat-draft-store";
+import { useUIStore } from "@/stores/ui-store";
 import { useShallow } from "zustand/react/shallow";
 import {
   selectCapabilities,
@@ -381,6 +382,10 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   const paneWorkspaceId = useAppStore(
     (s) => workspaceIdForPane ?? s.appState?.active_workspace_id ?? null,
   );
+  const rightPanelTab = useUIStore((state) =>
+    paneWorkspaceId ? state.rightPanelTabs?.[paneWorkspaceId] ?? null : null,
+  );
+  const toggleRightPanel = useUIStore((state) => state.toggleRightPanel);
   // The pane workspace's actual checked-out branch (from the workspace
   // snapshot's git watcher). Thread Scope prefers this over the branch
   // picker's main/master heuristic for the "current checkout" display,
@@ -459,6 +464,18 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   const draft = slice?.inputDraft ?? "";
   const messages = slice?.messages ?? EMPTY_MESSAGES;
   const streaming = slice?.streaming ?? false;
+  const tasks = slice?.tasks ?? null;
+  const taskSummary = useMemo(() => {
+    if (!tasks || tasks.tasks.length === 0) return null;
+    return {
+      completed: tasks.tasks.filter((task) => task.status === "completed").length,
+      total: tasks.tasks.length,
+      running: tasks.tasks.some((task) => task.status === "in_progress"),
+    };
+  }, [tasks]);
+  const handleTasksClick = useCallback(() => {
+    if (paneWorkspaceId) toggleRightPanel?.(paneWorkspaceId, "tasks");
+  }, [paneWorkspaceId, toggleRightPanel]);
 
   // Warm the MCP servers once when a fresh (empty) chat pane mounts, so
   // the prime cost overlaps the user composing rather than blocking the
@@ -2705,6 +2722,9 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       }
       zone1Override={zone1Override}
       belowComposerSlot={belowComposerSlot}
+      tasks={taskSummary}
+      tasksOpen={rightPanelTab === "tasks"}
+      onTasksClick={handleTasksClick}
       provider={provider}
       model={model}
       permissionMode={permissionMode}

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -174,6 +174,12 @@ interface Props {
    *  (the default) renders nothing — existing non-draft call sites are
    *  unaffected. */
   belowComposerSlot?: React.ReactNode;
+  /** Provider-authored plan summary. Non-null reveals the Tasks toggle;
+   *  `running` tints the chip amber with a spinner while a step is in
+   *  flight (green check once completed === total). */
+  tasks?: { completed: number; total: number; running?: boolean } | null;
+  tasksOpen?: boolean;
+  onTasksClick?: () => void;
   /** Step 8 Stage 1 — staged attachments rendered as a chip strip
    *  inside the composer card, above the textarea. Empty array hides
    *  the strip. Defaults to `[]` so existing call sites keep working
@@ -282,6 +288,9 @@ export function Composer({
   showStopButton = true,
   zone1Override,
   belowComposerSlot,
+  tasks = null,
+  tasksOpen = false,
+  onTasksClick,
   stagedAttachments = EMPTY_ATTACHMENTS,
   onRemoveAttachment,
   onToggleExpandPr,
@@ -2431,6 +2440,9 @@ export function Composer({
             onAttachClick={handleAttachClick}
             attachOpen={attachOpen}
             modelPickerOpenSignal={modelPickerOpenSignal}
+            tasks={tasks}
+            tasksOpen={tasksOpen}
+            onTasksClick={onTasksClick}
           />
         </div>
         {/* No gap here — the scope strip / context strip attaches

--- a/src/components/chat/ComposerFooter.test.tsx
+++ b/src/components/chat/ComposerFooter.test.tsx
@@ -171,4 +171,37 @@ describe("ComposerFooter — Stage 3 refactor (unified + popup)", () => {
     expect(onProviderModelChange).toHaveBeenCalledWith("codex", "gpt-5.4");
     expect(onModelChange).not.toHaveBeenCalled();
   });
+
+  it("reveals the Tasks toggle only for a non-empty provider plan", () => {
+    const onTasksClick = vi.fn();
+    const { rerender } = renderFooter();
+    expect(screen.queryByTestId("composer-tasks-toggle")).toBeNull();
+
+    rerender(
+      <TooltipProvider>
+        <ComposerFooter
+          {...baseProps()}
+          tasks={{ completed: 2, total: 5 }}
+          onTasksClick={onTasksClick}
+        />
+      </TooltipProvider>,
+    );
+    const toggle = screen.getByTestId("composer-tasks-toggle");
+    expect(toggle).toHaveTextContent("Tasks");
+    expect(toggle).toHaveTextContent("2/5");
+    fireEvent.click(toggle);
+    expect(onTasksClick).toHaveBeenCalledOnce();
+  });
+
+  it("marks the Tasks toggle pressed while its panel is open", () => {
+    renderFooter({
+      tasks: { completed: 0, total: 3 },
+      tasksOpen: true,
+      onTasksClick: vi.fn(),
+    });
+    expect(screen.getByTestId("composer-tasks-toggle")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
 });

--- a/src/components/chat/ComposerFooter.tsx
+++ b/src/components/chat/ComposerFooter.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Plus, Square } from "lucide-react";
+import { ArrowUp, Check, ListTodo, LoaderCircle, Plus, Square } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import type { ChatMode } from "@/stores/agent-chat-store";
@@ -60,6 +60,9 @@ interface Props {
    *  `/model` slash command. Forwarded to whichever picker variant
    *  renders. Optional; omitted by call sites that predate `/model`. */
   modelPickerOpenSignal?: number;
+  tasks?: { completed: number; total: number; running?: boolean } | null;
+  tasksOpen?: boolean;
+  onTasksClick?: () => void;
 }
 
 export function ComposerFooter({
@@ -90,6 +93,9 @@ export function ComposerFooter({
   onAttachClick,
   attachOpen = false,
   modelPickerOpenSignal,
+  tasks = null,
+  tasksOpen = false,
+  onTasksClick,
 }: Props) {
   const modeIsActive = mode !== "default";
 
@@ -182,6 +188,45 @@ export function ComposerFooter({
           disabled={controlsDisabled || modeIsActive}
           withSeparator
         />
+        {tasks && tasks.total > 0 && onTasksClick && (
+          <>
+            <span className="mx-0.5 h-4 w-px bg-border/50" aria-hidden />
+            {/* Same slot, but the chip reports run state instead of
+                reading as a setting: amber + spinner while a step is in
+                flight, green + check when the plan is complete, muted
+                checklist glyph before the run starts. Right of the
+                hairline so it scans as status, not another picker. */}
+            <button
+              type="button"
+              onClick={onTasksClick}
+              data-testid="composer-tasks-toggle"
+              aria-pressed={tasksOpen}
+              className={cn(
+                "inline-flex h-7 items-center gap-1.5 rounded-md border px-2 text-xs font-medium transition-colors",
+                tasks.running
+                  ? "border-status-working/25 bg-status-working/8 text-status-working hover:bg-status-working/15"
+                  : tasks.completed === tasks.total
+                    ? "border-status-open/25 bg-status-open/8 text-status-open hover:bg-status-open/15"
+                    : tasksOpen
+                      ? "border-transparent bg-accent-ember/15 text-accent-ember"
+                      : "border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+              )}
+              title={`${tasks.completed} of ${tasks.total} tasks complete`}
+            >
+              {tasks.running ? (
+                <LoaderCircle className="size-3 animate-spin" aria-hidden />
+              ) : tasks.completed === tasks.total ? (
+                <Check className="size-3" aria-hidden />
+              ) : (
+                <ListTodo className="size-3.5" aria-hidden />
+              )}
+              <span>Tasks</span>
+              <span className="text-[10px] tabular-nums opacity-70">
+                {tasks.completed}/{tasks.total}
+              </span>
+            </button>
+          </>
+        )}
         {/* Host (Local / Remote) is a *workspace* property, not a
             chat-session property: pushing a workspace to a remote
             via right-click ships every pane it contains together —

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -675,6 +675,7 @@ function ItemRow({
       {renderAssistantBody(item, {
         approval,
         subagentName,
+        workspaceId,
         handleDecide,
         handleAcceptPlan,
         handleRejectPlan,
@@ -688,6 +689,7 @@ function renderAssistantBody(
   handlers: {
     approval: PermissionRequestItem | null;
     subagentName: string | null;
+    workspaceId?: string | null;
     handleDecide: (decision: ApprovalDecision) => void;
     handleAcceptPlan: () => void | Promise<void>;
     handleRejectPlan: () => void | Promise<void>;
@@ -700,7 +702,7 @@ function renderAssistantBody(
       return <ReasoningBlock item={item} />;
     case "tool_call":
       return isTaskSummaryTool(item) ? (
-        <TaskSummaryCard item={item} />
+        <TaskSummaryCard item={item} workspaceId={handlers.workspaceId} />
       ) : (
         <ToolCallCard
           item={item}

--- a/src/components/chat/TaskSummaryCard.test.tsx
+++ b/src/components/chat/TaskSummaryCard.test.tsx
@@ -1,8 +1,9 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { afterEach, describe, it, expect } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import type { ToolCallItem } from "@/lib/agent-chat/types";
+import { useUIStore } from "@/stores/ui-store";
 
 import {
   TaskSummaryCard,
@@ -62,9 +63,29 @@ describe("isTaskSummaryTool", () => {
 });
 
 describe("TaskSummaryCard", () => {
-  it("renders every todo label and a done/total summary", () => {
+  it("collapses a fresh plan to a created-receipt line", () => {
     render(
       <TaskSummaryCard
+        item={todoTool({
+          todos: [
+            { content: "Branch off origin/main", status: "pending" },
+            { content: "Add regression test", status: "pending" },
+            { content: "Open the PR", status: "pending" },
+          ],
+        })}
+      />,
+    );
+    const receipt = screen.getByTestId("task-receipt");
+    expect(receipt).toHaveTextContent("Task list created");
+    expect(receipt).toHaveTextContent("3 items");
+    // The thread no longer duplicates the panel's row list.
+    expect(screen.queryByText("Branch off origin/main")).toBeNull();
+  });
+
+  it("shows progress for an updated plan and opens the Tasks panel", () => {
+    render(
+      <TaskSummaryCard
+        workspaceId="ws-1"
         item={todoTool({
           todos: [
             { content: "Branch off origin/main", status: "completed" },
@@ -74,10 +95,23 @@ describe("TaskSummaryCard", () => {
         })}
       />,
     );
-    expect(screen.getByText("Task list · 2/3 done")).toBeInTheDocument();
-    expect(screen.getByText("Branch off origin/main")).toBeInTheDocument();
-    expect(screen.getByText("Add regression test")).toBeInTheDocument();
-    expect(screen.getByText("Open the PR")).toBeInTheDocument();
+    const receipt = screen.getByTestId("task-receipt");
+    expect(receipt).toHaveTextContent("Task list updated");
+    expect(receipt).toHaveTextContent("2/3 done");
+    expect(receipt).toHaveTextContent("Open in panel");
+    fireEvent.click(receipt);
+    expect(useUIStore.getState().rightPanelTabs["ws-1"]).toBe("tasks");
+  });
+
+  it("is inert without a workspace id", () => {
+    render(
+      <TaskSummaryCard
+        item={todoTool({ todos: [{ content: "a", status: "pending" }] })}
+      />,
+    );
+    const receipt = screen.getByTestId("task-receipt");
+    expect(receipt).toBeDisabled();
+    expect(receipt).not.toHaveTextContent("Open in panel");
   });
 
   it("renders nothing when there are no todos", () => {

--- a/src/components/chat/TaskSummaryCard.tsx
+++ b/src/components/chat/TaskSummaryCard.tsx
@@ -1,60 +1,78 @@
-import { Circle, CircleCheck } from "lucide-react";
-import { memo } from "react";
+import { ChevronRight, ListTodo } from "lucide-react";
+import { memo, useCallback } from "react";
 
 import { cn } from "@/lib/utils";
+import { useUIStore } from "@/stores/ui-store";
 import type { ToolCallItem } from "@/lib/agent-chat/types";
 
 /**
- * Task-list summary card (design D8). Rendered for `TodoWrite`-style tool
- * calls — a tool whose input carries a `todos` array. Completed items get
- * a green circled check; everything else a hollow circle. We never
- * fabricate a summary from prose: no `todos` array → this component is
- * not used (see `extractTodos` / the MessageList dispatch).
+ * Task-list receipt line. Rendered for `TodoWrite`-style tool calls — a
+ * tool whose input carries a `todos` array. The full list used to be
+ * printed here, duplicating the Tasks panel with a copy that never
+ * updated; now the thread just records that a plan landed ("Task list
+ * created · 3 items") and the panel stays the single live truth.
+ * Clicking the receipt flips the right panel to the Tasks tab when a
+ * `workspaceId` is available (same pattern as `WorkflowRunCard`'s
+ * "Open panel"); absent → the row is inert rather than throwing. We
+ * never fabricate a receipt from prose: no `todos` array → this
+ * component is not used (see `extractTodos` / the MessageList dispatch).
  */
 export const TaskSummaryCard = memo(function TaskSummaryCard({
   item,
+  workspaceId = null,
 }: {
   item: ToolCallItem;
+  workspaceId?: string | null;
 }) {
+  const openPanel = useCallback(() => {
+    if (workspaceId) useUIStore.getState().setRightPanelTab(workspaceId, "tasks");
+  }, [workspaceId]);
+
   const todos = extractTodos(item.input);
   if (todos.length === 0) return null;
 
   const done = todos.filter((t) => t.status === "completed").length;
+  const interactive = workspaceId != null;
 
   return (
-    <div className="rounded-[11px] border border-border/60 bg-foreground/[0.025] px-[15px] py-[14px]">
-      <div className="mb-2.5 text-[13px] font-bold text-foreground">
-        Task list · {done}/{todos.length} done
-      </div>
-      <div className="flex flex-col gap-2">
-        {todos.map((todo, i) => {
-          const complete = todo.status === "completed";
-          return (
-            <div
-              key={i}
-              className="flex items-start gap-[9px] text-[13px] leading-[1.5] text-foreground"
-            >
-              {complete ? (
-                <CircleCheck
-                  className="mt-px h-[15px] w-[15px] shrink-0 text-status-open"
-                  strokeWidth={1.7}
-                  aria-hidden
-                />
-              ) : (
-                <Circle
-                  className="mt-px h-[15px] w-[15px] shrink-0 text-muted-foreground/40"
-                  strokeWidth={1.7}
-                  aria-hidden
-                />
-              )}
-              <span className={cn(complete && "text-muted-foreground")}>
-                {todo.label}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
+    <button
+      type="button"
+      onClick={openPanel}
+      disabled={!interactive}
+      data-testid="task-receipt"
+      className={cn(
+        "flex w-full items-center gap-2.5 rounded-[11px] border border-border/60 bg-foreground/[0.025] px-3 py-2 text-left transition-colors",
+        interactive
+          ? "cursor-pointer hover:border-border hover:bg-foreground/[0.05]"
+          : "cursor-default",
+      )}
+    >
+      <ListTodo
+        className="size-[15px] shrink-0 text-muted-foreground"
+        strokeWidth={1.6}
+        aria-hidden
+      />
+      <span className="min-w-0 flex-1 truncate text-xs text-foreground/80">
+        {done > 0 ? "Task list updated" : "Task list created"} ·{" "}
+        <span className="font-semibold text-foreground">
+          {done > 0
+            ? `${done}/${todos.length} done`
+            : `${todos.length} item${todos.length === 1 ? "" : "s"}`}
+        </span>
+      </span>
+      {interactive && (
+        <>
+          <span className="shrink-0 font-mono text-[10.5px] text-muted-foreground">
+            Open in panel
+          </span>
+          <ChevronRight
+            className="size-3 shrink-0 text-muted-foreground"
+            strokeWidth={1.7}
+            aria-hidden
+          />
+        </>
+      )}
+    </button>
   );
 });
 

--- a/src/components/chat/TasksPanel.test.tsx
+++ b/src/components/chat/TasksPanel.test.tsx
@@ -1,0 +1,102 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TasksPanel, tasksToMarkdown } from "./TasksPanel";
+import type { TasksSnapshot } from "@/tauri/events";
+
+afterEach(cleanup);
+
+const midRunSnapshot: TasksSnapshot = {
+  explanation: "Implement the task surface end-to-end.",
+  tasks: [
+    {
+      task_id: "research",
+      title: "Research providers",
+      status: "completed",
+      blocked_by: [],
+    },
+    {
+      task_id: "build",
+      title: "Build the panel",
+      status: "in_progress",
+      blocked_by: [],
+    },
+    {
+      task_id: "verify",
+      title: "Verify visually",
+      status: "pending",
+      blocked_by: ["build"],
+    },
+  ],
+};
+
+describe("TasksPanel", () => {
+  it("renders status, progress, provider explanation, and blockers", () => {
+    render(<TasksPanel snapshot={midRunSnapshot} />);
+
+    expect(screen.getByTestId("tasks-status-badge")).toHaveTextContent(
+      "Working",
+    );
+    expect(screen.getByText("1/3 done")).toBeInTheDocument();
+    expect(
+      screen.getByText("Implement the task surface end-to-end."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "33",
+    );
+    expect(screen.getByText("Blocked by Build the panel")).toBeInTheDocument();
+    expect(screen.getByText("Research providers")).toHaveClass("line-through");
+    // Rows are numbered so "step 2" in the thread can be matched up.
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("reports Complete once every row is done, Queued before any starts", () => {
+    const done: TasksSnapshot = {
+      tasks: midRunSnapshot.tasks.map((task) => ({
+        ...task,
+        status: "completed",
+      })),
+    };
+    const { rerender } = render(<TasksPanel snapshot={done} />);
+    expect(screen.getByTestId("tasks-status-badge")).toHaveTextContent(
+      "Complete",
+    );
+
+    const queued: TasksSnapshot = {
+      tasks: midRunSnapshot.tasks.map((task) => ({
+        ...task,
+        status: "pending",
+      })),
+    };
+    rerender(<TasksPanel snapshot={queued} />);
+    expect(screen.getByTestId("tasks-status-badge")).toHaveTextContent(
+      "Queued",
+    );
+  });
+
+  it("shows the last-update time when provided", () => {
+    render(
+      <TasksPanel
+        snapshot={midRunSnapshot}
+        updatedAt={new Date(2026, 0, 1, 16, 45, 39).getTime()}
+      />,
+    );
+    expect(screen.getByText(/45:39/)).toBeInTheDocument();
+  });
+});
+
+describe("tasksToMarkdown", () => {
+  it("emits a checklist with the explanation as preamble", () => {
+    expect(tasksToMarkdown(midRunSnapshot)).toBe(
+      [
+        "Implement the task surface end-to-end.",
+        "",
+        "- [x] Research providers",
+        "- [ ] Build the panel",
+        "- [ ] Verify visually",
+      ].join("\n"),
+    );
+  });
+});

--- a/src/components/chat/TasksPanel.tsx
+++ b/src/components/chat/TasksPanel.tsx
@@ -1,0 +1,247 @@
+import { Check, CircleCheck, Copy, LoaderCircle } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import type { TaskSnapshotItem, TasksSnapshot } from "@/tauri/events";
+
+/** Overall run state, derived from the rows: every row done → complete;
+ *  any row in progress → working; otherwise the plan is still queued. */
+type RunState = "queued" | "working" | "complete";
+
+function runStateOf(snapshot: TasksSnapshot): RunState {
+  const total = snapshot.tasks.length;
+  const completed = snapshot.tasks.filter(
+    (task) => task.status === "completed",
+  ).length;
+  if (total > 0 && completed === total) return "complete";
+  if (snapshot.tasks.some((task) => task.status === "in_progress"))
+    return "working";
+  return "queued";
+}
+
+const RUN_STATE_LABEL: Record<RunState, string> = {
+  queued: "Queued",
+  working: "Working",
+  complete: "Complete",
+};
+
+const BADGE_TONE: Record<RunState, string> = {
+  queued: "bg-muted text-muted-foreground",
+  working: "bg-status-working/14 text-status-working",
+  complete: "bg-status-open/14 text-status-open",
+};
+
+const BAR_TONE: Record<RunState, string> = {
+  queued: "bg-muted-foreground/60",
+  working: "bg-status-working",
+  complete: "bg-status-open",
+};
+
+function StatusGlyph({ task }: { task: TaskSnapshotItem }) {
+  if (task.status === "completed") {
+    return (
+      <CircleCheck
+        className="size-4 text-status-open"
+        strokeWidth={1.8}
+        aria-hidden
+      />
+    );
+  }
+  if (task.status === "in_progress") {
+    return (
+      <LoaderCircle
+        className="size-[15px] animate-spin text-status-working"
+        strokeWidth={1.9}
+        aria-hidden
+      />
+    );
+  }
+  return (
+    <span
+      className="size-[9px] rounded-full border-[1.6px] border-foreground/25"
+      aria-hidden
+    />
+  );
+}
+
+/** Snapshot → markdown checklist, for the footer's Copy action. */
+export function tasksToMarkdown(snapshot: TasksSnapshot): string {
+  const lines = snapshot.tasks.map(
+    (task) => `- [${task.status === "completed" ? "x" : " "}] ${task.title}`,
+  );
+  return (snapshot.explanation ? [snapshot.explanation, ""] : [])
+    .concat(lines)
+    .join("\n");
+}
+
+export function TasksPanel({
+  snapshot,
+  updatedAt = null,
+}: {
+  snapshot: TasksSnapshot;
+  /** Clock time (ms) the snapshot was last applied; null hides the caption. */
+  updatedAt?: number | null;
+}) {
+  const total = snapshot.tasks.length;
+  const completed = snapshot.tasks.filter(
+    (task) => task.status === "completed",
+  ).length;
+  const progress = total === 0 ? 0 : Math.round((completed / total) * 100);
+  const runState = runStateOf(snapshot);
+  const titleById = new Map(
+    snapshot.tasks.map((task) => [task.task_id, task.title]),
+  );
+
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (copyTimer.current != null) window.clearTimeout(copyTimer.current);
+    },
+    [],
+  );
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard
+      ?.writeText(tasksToMarkdown(snapshot))
+      .then(() => {
+        setCopied(true);
+        if (copyTimer.current != null) window.clearTimeout(copyTimer.current);
+        copyTimer.current = window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* best-effort */
+      });
+  }, [snapshot]);
+
+  return (
+    <div
+      className="flex h-full min-h-0 flex-col bg-background"
+      data-testid="tasks-panel"
+    >
+      {/* Header earns its space: run state + counts + freshness on one
+          line over a 3px tone-colored bar. The tab already says "Tasks",
+          so the header doesn't restate it. */}
+      <div className="shrink-0 border-b border-border/60 px-3.5 pb-3 pt-3">
+        <div className="mb-2 flex items-center gap-2">
+          <span
+            data-testid="tasks-status-badge"
+            className={cn(
+              "inline-flex items-center rounded-[5px] px-1.5 py-px font-mono text-[10px] font-semibold uppercase tracking-[0.09em]",
+              BADGE_TONE[runState],
+            )}
+          >
+            {RUN_STATE_LABEL[runState]}
+          </span>
+          <span className="min-w-0 flex-1 font-mono text-[10.5px] tabular-nums text-muted-foreground">
+            {completed}/{total} done
+          </span>
+          {updatedAt != null && (
+            <span className="shrink-0 font-mono text-[10.5px] tabular-nums text-muted-foreground">
+              {new Date(updatedAt).toLocaleTimeString([], {
+                hour: "numeric",
+                minute: "2-digit",
+                second: "2-digit",
+              })}
+            </span>
+          )}
+        </div>
+        <div
+          className="h-[3px] overflow-hidden rounded-full bg-foreground/12"
+          role="progressbar"
+          aria-label="Task progress"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progress}
+        >
+          <div
+            className={cn(
+              "h-full rounded-full transition-[width] duration-300",
+              BAR_TONE[runState],
+            )}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="px-2.5 py-3">
+          {/* One-line intent in the agent's words — what makes an old
+              list legible when scrolling back. */}
+          {snapshot.explanation && (
+            <p className="mx-1.5 mb-3 text-xs leading-relaxed text-muted-foreground">
+              {snapshot.explanation}
+            </p>
+          )}
+          <ol className="flex flex-col gap-0.5" aria-label="Agent task list">
+            {snapshot.tasks.map((task, index) => {
+              const blockers = task.blocked_by
+                .map((id) => titleById.get(id) ?? id)
+                .filter(Boolean);
+              return (
+                <li
+                  key={task.task_id}
+                  className={cn(
+                    "flex items-start gap-2 rounded-lg px-2 py-1.5 transition-colors",
+                    task.status === "in_progress" && "bg-status-working/8",
+                    task.status === "completed" && "bg-status-open/8",
+                    task.status === "pending" && "hover:bg-foreground/4",
+                  )}
+                >
+                  <span className="mt-[3px] flex size-4 shrink-0 items-center justify-center">
+                    <StatusGlyph task={task} />
+                  </span>
+                  <span className="mt-0.5 w-4 shrink-0 text-right font-mono text-[10px] tabular-nums leading-4 text-muted-foreground/70">
+                    {index + 1}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={cn(
+                        "text-[13px] leading-5",
+                        task.status === "completed" &&
+                          "text-muted-foreground line-through decoration-border",
+                        task.status === "in_progress" && "text-foreground",
+                        task.status === "pending" && "text-foreground/75",
+                      )}
+                    >
+                      {task.title}
+                    </p>
+                    {task.detail && task.detail !== task.title && (
+                      <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                        {task.detail}
+                      </p>
+                    )}
+                    {blockers.length > 0 && (
+                      <p className="mt-1 text-[11px] leading-relaxed text-status-working">
+                        Blocked by {blockers.join(", ")}
+                      </p>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+      </ScrollArea>
+
+      <div className="flex shrink-0 items-center gap-2 border-t border-border/60 px-3 py-2">
+        <span className="min-w-0 flex-1 font-mono text-[10px] text-muted-foreground">
+          agent plan · updates live
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          data-testid="tasks-copy"
+          className="inline-flex h-[23px] items-center gap-1.5 rounded-[7px] border border-border/60 px-2 text-[11px] font-semibold text-muted-foreground transition-colors hover:border-border hover:bg-foreground/6 hover:text-foreground"
+        >
+          {copied ? (
+            <Check className="size-3" aria-hidden />
+          ) : (
+            <Copy className="size-3" aria-hidden />
+          )}
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/right-panel.test.tsx
+++ b/src/components/layout/right-panel.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 
 import type { WorkflowRunItem } from "@/lib/agent-chat/types";
+import type { TasksSnapshot } from "@/tauri/events";
 import type { PaneNodeSnapshot, WorkspaceSnapshot } from "@/tauri/types";
 
 // ── Mocks ──
@@ -22,9 +23,13 @@ vi.mock("@/components/workflow/orchestration-panel", () => ({
 
 const mocks = vi.hoisted(() => ({
   workflow: { run: null as WorkflowRunItem | null, threadId: null as string | null },
+  tasks: null as TasksSnapshot | null,
 }));
 vi.mock("@/components/workflow/use-workspace-workflow", () => ({
   useWorkspaceWorkflow: () => mocks.workflow,
+}));
+vi.mock("@/hooks/use-active-chat-tasks", () => ({
+  useActiveChatTasks: () => ({ threadId: "thread-1", tasks: mocks.tasks }),
 }));
 
 import { RightPanel } from "./right-panel";
@@ -97,6 +102,42 @@ function makeRun(overrides: Partial<WorkflowRunItem> = {}): WorkflowRunItem {
 afterEach(() => {
   cleanup();
   mocks.workflow = { run: null, threadId: null };
+  mocks.tasks = null;
+});
+
+describe("RightPanel Tasks tab", () => {
+  it("is absent until the focused chat has tasks", () => {
+    render(<RightPanel workspace={makeWorkspace()} activeTab="files" />);
+    expect(screen.queryByTestId("tasks-tab")).toBeNull();
+  });
+
+  it("shows progress and renders the task body for the focused chat", () => {
+    mocks.tasks = {
+      tasks: [
+        { task_id: "1", title: "Done", status: "completed", blocked_by: [] },
+        { task_id: "2", title: "Working", status: "in_progress", blocked_by: [] },
+      ],
+    };
+    render(<RightPanel workspace={makeWorkspace()} activeTab="tasks" />);
+    expect(screen.getByTestId("tasks-tab")).toHaveTextContent("1/2");
+    expect(screen.getByTestId("tasks-panel")).toBeInTheDocument();
+  });
+
+  it("shows a live dot for an in-flight step only while another tab is active", () => {
+    mocks.tasks = {
+      tasks: [
+        { task_id: "1", title: "Done", status: "completed", blocked_by: [] },
+        { task_id: "2", title: "Working", status: "in_progress", blocked_by: [] },
+      ],
+    };
+    const { rerender } = render(
+      <RightPanel workspace={makeWorkspace()} activeTab="files" />,
+    );
+    expect(screen.getByTestId("tasks-live-dot")).toBeInTheDocument();
+
+    rerender(<RightPanel workspace={makeWorkspace()} activeTab="tasks" />);
+    expect(screen.queryByTestId("tasks-live-dot")).toBeNull();
+  });
 });
 
 describe("RightPanel Orchestration tab", () => {

--- a/src/components/layout/right-panel.tsx
+++ b/src/components/layout/right-panel.tsx
@@ -7,7 +7,9 @@ import { ChangesPanel } from "@/components/workspace/changes-panel";
 import { FileTreePanel } from "@/components/workspace/file-tree-panel";
 import { ReviewPanel } from "@/components/workspace/review-panel";
 import { OrchestrationPanel } from "@/components/workflow/orchestration-panel";
+import { TasksPanel } from "@/components/chat/TasksPanel";
 import { useWorkspaceWorkflow } from "@/components/workflow/use-workspace-workflow";
+import { useActiveChatTasks } from "@/hooks/use-active-chat-tasks";
 import type {
   WorkspaceSnapshot,
   CheckInfo,
@@ -98,6 +100,12 @@ const TAB_TRIGGER_CLS = cn(
 export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Props) {
   const setRightPanelTab = useUIStore((s) => s.setRightPanelTab);
   const workspaceWorkflow = useWorkspaceWorkflow(workspace);
+  const { tasks: activeChatTasks, updatedAt: tasksUpdatedAt } =
+    useActiveChatTasks(workspace);
+  const tasksSnapshot =
+    activeChatTasks && activeChatTasks.tasks.length > 0 ? activeChatTasks : null;
+  const tasksRunning =
+    tasksSnapshot?.tasks.some((task) => task.status === "in_progress") ?? false;
   // The Orchestration tab appears only once a run is approved (design:
   // the approval card in the thread owns the pending_approval state; the
   // panel would just duplicate the planned phases as "queued").
@@ -156,6 +164,28 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
                 )}
               </TabsTrigger>
             )}
+            {tasksSnapshot && (
+              <TabsTrigger
+                value="tasks"
+                className={TAB_TRIGGER_CLS}
+                data-testid="tasks-tab"
+              >
+                Tasks
+                <span className="ml-1 text-[10px] tabular-nums text-muted-foreground/60">
+                  {tasksSnapshot.tasks.filter((task) => task.status === "completed").length}/
+                  {tasksSnapshot.tasks.length}
+                </span>
+                {/* Progress stays readable from any tab: a live dot marks
+                    an in-flight step until the user is actually looking. */}
+                {tasksRunning && activeTab !== "tasks" && (
+                  <span
+                    data-testid="tasks-live-dot"
+                    className="cm-blink ml-1.5 h-1.5 w-1.5 rounded-full bg-status-working"
+                    aria-hidden
+                  />
+                )}
+              </TabsTrigger>
+            )}
           </TabsList>
         </div>
         <TabsContent value="files" className="flex-1 overflow-hidden">
@@ -174,6 +204,11 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
               run={workflowRun}
               threadId={workflowThreadId}
             />
+          </TabsContent>
+        )}
+        {tasksSnapshot && (
+          <TabsContent value="tasks" className="flex-1 overflow-hidden">
+            <TasksPanel snapshot={tasksSnapshot} updatedAt={tasksUpdatedAt} />
           </TabsContent>
         )}
       </Tabs>

--- a/src/components/layout/workspace-main.test.tsx
+++ b/src/components/layout/workspace-main.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render } from "@testing-library/react";
 
 import type { WorkflowRunItem } from "@/lib/agent-chat/types";
+import type { TasksSnapshot } from "@/tauri/events";
 import type { WorkspaceSnapshot } from "@/tauri/types";
 
 // ── Mutable mock state ──
@@ -12,11 +13,16 @@ const state = {
   enableLazy: false,
   activeDraftId: null as string | null,
   workflowRun: null as WorkflowRunItem | null,
+  tasks: null as TasksSnapshot | null,
   rightPanelTabs: {} as Record<string, string | null>,
 };
 
 vi.mock("@/components/workflow/use-workspace-workflow", () => ({
   useWorkspaceWorkflow: () => ({ run: state.workflowRun, threadId: null }),
+}));
+
+vi.mock("@/hooks/use-active-chat-tasks", () => ({
+  useActiveChatTasks: () => ({ threadId: null, tasks: state.tasks }),
 }));
 
 // Child rows → sentinels so we can assert which chrome rendered.
@@ -151,6 +157,7 @@ beforeEach(() => {
   state.enableLazy = false;
   state.activeDraftId = null;
   state.workflowRun = null;
+  state.tasks = null;
   state.rightPanelTabs = {};
 });
 
@@ -235,5 +242,29 @@ describe("WorkspaceMain right-panel stale-tab guard", () => {
     state.workflowRun = null;
     const { getByTestId } = render(<WorkspaceMain />);
     expect(getByTestId("right-panel").dataset.activeTab).toBe("changes");
+  });
+
+  it("coerces a persisted 'tasks' tab to 'files' when the focused pane has no tasks", () => {
+    state.rightPanelTabs = { "ws-1": "tasks" };
+    const { getByTestId } = render(<WorkspaceMain />);
+    expect(getByTestId("right-panel").dataset.activeTab).toBe("files");
+  });
+
+  it("keeps 'tasks' active while the focused chat has a task snapshot", () => {
+    state.rightPanelTabs = { "ws-1": "tasks" };
+    state.tasks = {
+      explanation: null,
+      tasks: [
+        {
+          task_id: "one",
+          title: "First task",
+          status: "pending",
+          detail: null,
+          blocked_by: [],
+        },
+      ],
+    };
+    const { getByTestId } = render(<WorkspaceMain />);
+    expect(getByTestId("right-panel").dataset.activeTab).toBe("tasks");
   });
 });

--- a/src/components/layout/workspace-main.tsx
+++ b/src/components/layout/workspace-main.tsx
@@ -14,6 +14,7 @@ import { EditorPane } from "@/components/editor/EditorPane";
 import { OpenFlowWorkspace } from "@/components/openflow/openflow-workspace";
 import { ProjectOnboarding } from "@/components/overlays/project-onboarding";
 import { useWorkspaceWorkflow } from "@/components/workflow/use-workspace-workflow";
+import { useActiveChatTasks } from "@/hooks/use-active-chat-tasks";
 
 const RIGHT_PANEL_MIN = 240;
 const RIGHT_PANEL_MAX = 500;
@@ -101,9 +102,13 @@ export function WorkspaceMain() {
   const { run: activeWorkflowRun } = useWorkspaceWorkflow(activeWorkspace);
   const showableWorkflowRun =
     activeWorkflowRun != null && activeWorkflowRun.status !== "pending_approval";
+  const { tasks: activeChatTasks } = useActiveChatTasks(activeWorkspace);
+  const hasActiveChatTasks = (activeChatTasks?.tasks.length ?? 0) > 0;
   const rightPanelTab =
     rightPanelTabRaw === "orchestration" && !showableWorkflowRun
       ? "files"
+      : rightPanelTabRaw === "tasks" && !hasActiveChatTasks
+        ? "files"
       : rightPanelTabRaw;
   const rightPanelWidth = useUIStore((s) => s.rightPanelWidth);
 

--- a/src/dev/mock-fixtures.ts
+++ b/src/dev/mock-fixtures.ts
@@ -1058,6 +1058,28 @@ export function richChatTurnEnvelopes(
       type: "item_completed",
       item: { kind: "tool_result", tool_use_id: editId, content: "Applied edit to gateway/run.py", is_error: false },
     }),
+    // Durable provider-normalized task snapshot: drives the conditional
+    // composer toggle and the right-side Tasks panel.
+    {
+      type: "tasks_updated",
+      thread_id: threadId,
+      tasks: {
+        explanation: "Fix the traceback regression and prepare it for review.",
+        tasks: [
+          { task_id: "branch", title: "Branch fix/57298 off origin/main", status: "completed", blocked_by: [] },
+          { task_id: "patch", title: "Patch the traceback chain walker", status: "completed", blocked_by: [] },
+          { task_id: "test", title: "Add a regression test", status: "completed", blocked_by: [] },
+          {
+            task_id: "pr",
+            title: "Open a PR against origin/main",
+            status: "in_progress",
+            detail: "Preparing the change summary and visual evidence",
+            blocked_by: [],
+          },
+          { task_id: "review", title: "Address review feedback", status: "pending", blocked_by: ["pr"] },
+        ],
+      },
+    },
     // Task summary card: a TodoWrite with a todos array.
     evt({
       type: "item_completed",

--- a/src/hooks/use-active-chat-tasks.test.tsx
+++ b/src/hooks/use-active-chat-tasks.test.tsx
@@ -1,0 +1,91 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useAgentChatStore } from "@/stores/agent-chat-store";
+import type { WorkspaceSnapshot } from "@/tauri/types";
+
+import { useActiveChatTasks } from "./use-active-chat-tasks";
+
+function workspaceWithFocus(activePaneId: string): WorkspaceSnapshot {
+  return {
+    active_surface_id: "surface-1",
+    surfaces: [
+      {
+        surface_id: "surface-1",
+        title: "Split chat",
+        active_pane_id: activePaneId,
+        root: {
+          kind: "split",
+          pane_id: "split-1",
+          direction: "horizontal",
+          child_sizes: [0.5, 0.5],
+          children: [
+            {
+              kind: "agent_chat",
+              pane_id: "chat-pane",
+              title: "Agent Chat",
+              thread_id: "thread-1",
+              provider: "codex",
+              cwd: "/repo",
+            },
+            {
+              kind: "terminal",
+              pane_id: "terminal-pane",
+              session_id: "session-1",
+              title: "Terminal",
+            },
+          ],
+        },
+      },
+    ],
+  } as WorkspaceSnapshot;
+}
+
+beforeEach(() => {
+  useAgentChatStore.setState({ threads: {} });
+  act(() => {
+    const store = useAgentChatStore.getState();
+    store.ensureThread("thread-1");
+    store.applyEvent("thread-1", {
+      type: "tasks_updated",
+      thread_id: "thread-1",
+      tasks: {
+        explanation: null,
+        tasks: [
+          {
+            task_id: "inspect",
+            title: "Inspect the implementation",
+            status: "in_progress",
+            detail: null,
+            blocked_by: [],
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe("useActiveChatTasks", () => {
+  it("returns the task snapshot for the focused chat leaf", () => {
+    const { result } = renderHook(() =>
+      useActiveChatTasks(workspaceWithFocus("chat-pane")),
+    );
+
+    expect(result.current.threadId).toBe("thread-1");
+    expect(result.current.tasks?.tasks[0]?.title).toBe(
+      "Inspect the implementation",
+    );
+  });
+
+  it("does not leak a sibling chat's tasks when focus moves to a terminal", () => {
+    const { result } = renderHook(() =>
+      useActiveChatTasks(workspaceWithFocus("terminal-pane")),
+    );
+
+    expect(result.current).toEqual({
+      threadId: null,
+      tasks: null,
+      updatedAt: null,
+    });
+  });
+});

--- a/src/hooks/use-active-chat-tasks.ts
+++ b/src/hooks/use-active-chat-tasks.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+
+import { useAgentChatStore } from "@/stores/agent-chat-store";
+import type { TasksSnapshot } from "@/tauri/events";
+import type { PaneNodeSnapshot, WorkspaceSnapshot } from "@/tauri/types";
+
+function findPane(
+  node: PaneNodeSnapshot,
+  paneId: string,
+): PaneNodeSnapshot | null {
+  if (node.pane_id === paneId) return node;
+  if (node.kind !== "split") return null;
+  for (const child of node.children) {
+    const match = findPane(child, paneId);
+    if (match) return match;
+  }
+  return null;
+}
+
+/** Resolve task state for the focused leaf in the workspace's active surface. */
+export function useActiveChatTasks(workspace: WorkspaceSnapshot | null): {
+  threadId: string | null;
+  tasks: TasksSnapshot | null;
+  /** When the snapshot was last applied (ms), for the panel caption. */
+  updatedAt?: number | null;
+} {
+  const threadId = useMemo(() => {
+    if (!workspace) return null;
+    const surface = workspace.surfaces.find(
+      (candidate) => candidate.surface_id === workspace.active_surface_id,
+    );
+    if (!surface) return null;
+    const pane = findPane(surface.root, surface.active_pane_id);
+    return pane?.kind === "agent_chat" ? pane.thread_id : null;
+  }, [workspace]);
+
+  const tasks = useAgentChatStore((state) =>
+    threadId ? (state.threads[threadId]?.tasks ?? null) : null,
+  );
+  const updatedAt = useAgentChatStore((state) =>
+    threadId ? (state.threads[threadId]?.tasksUpdatedAt ?? null) : null,
+  );
+  return { threadId, tasks, updatedAt };
+}

--- a/src/lib/agent-chat/reducer.test.ts
+++ b/src/lib/agent-chat/reducer.test.ts
@@ -40,6 +40,46 @@ describe("agent-chat reducer", () => {
     __resetReducerIdCounterForTests();
   });
 
+  it("stores complete task snapshots without adding transcript rows", () => {
+    const state = applyEvent(createEmptyThreadState(), {
+      type: "tasks_updated",
+      thread_id: "t1",
+      tasks: {
+        explanation: "Ship the feature",
+        tasks: [
+          {
+            task_id: "1",
+            title: "Wire provider events",
+            status: "in_progress",
+            blocked_by: [],
+          },
+        ],
+      },
+    });
+    expect(state.tasks?.explanation).toBe("Ship the feature");
+    expect(state.tasks?.tasks[0].status).toBe("in_progress");
+    expect(state.tasksUpdatedAt).toEqual(expect.any(Number));
+    expect(state.messages).toEqual([]);
+  });
+
+  it("replaces rather than merges task snapshots", () => {
+    const first = applyEvent(createEmptyThreadState(), {
+      type: "tasks_updated",
+      thread_id: "t1",
+      tasks: {
+        tasks: [{ task_id: "1", title: "Old", status: "pending", blocked_by: [] }],
+      },
+    });
+    const next = applyEvent(first, {
+      type: "tasks_updated",
+      thread_id: "t1",
+      tasks: {
+        tasks: [{ task_id: "2", title: "New", status: "completed", blocked_by: [] }],
+      },
+    });
+    expect(next.tasks?.tasks.map((task) => task.task_id)).toEqual(["2"]);
+  });
+
   it("accumulates text deltas into a single assistant message", () => {
     const state = runEvents([
       {

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -1247,6 +1247,10 @@ function applyEventInner(
       return applyWorkflowUpdated(state, event.workflow, now);
     }
 
+    case "tasks_updated": {
+      return { ...state, tasks: event.tasks, tasksUpdatedAt: now() };
+    }
+
     case "turn_completed": {
       // A completed turn is a hard boundary — seal any trailing streaming
       // reasoning block alongside the assistant message.

--- a/src/lib/agent-chat/types.ts
+++ b/src/lib/agent-chat/types.ts
@@ -2,6 +2,7 @@ import type {
   ApprovalDecision,
   ProviderRuntimeEvent,
   SubagentStatus,
+  TasksSnapshot,
   TurnStatus,
 } from "@/tauri/events";
 
@@ -332,6 +333,13 @@ export type ChatViewItem =
 
 export interface ChatThreadState {
   messages: ChatViewItem[];
+  /** Latest complete provider-authored task plan for this thread. */
+  tasks: TasksSnapshot | null;
+  /** Clock time (ms) the latest task snapshot was applied. Hydration
+   *  replays through the same reducer path, so after a reopen this is
+   *  "when this session learned about the plan", not the original wall
+   *  time — good enough for the panel's "last update" caption. */
+  tasksUpdatedAt: number | null;
   streaming: boolean;
   pendingRequestIds: string[];
   /** Next `seq` to assign to a freshly-appended item. Strictly
@@ -356,6 +364,8 @@ export interface ChatThreadState {
 export function emptyThreadState(): ChatThreadState {
   return {
     messages: [],
+    tasks: null,
+    tasksUpdatedAt: null,
     streaming: false,
     pendingRequestIds: [],
     nextSeq: 0,

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { ModelSelection, PendingWorkspace } from "@/tauri/types";
 
-export type RightPanelTab = "changes" | "files" | "review" | "orchestration";
+export type RightPanelTab = "changes" | "files" | "review" | "orchestration" | "tasks";
 
 interface UIStore {
   rightPanelTabs: Record<string, RightPanelTab | null>;

--- a/src/tauri/events.ts
+++ b/src/tauri/events.ts
@@ -263,6 +263,23 @@ export interface WorkflowSnapshot {
   duration_ms?: number | null;
 }
 
+// Provider-neutral agent task plan. Each provider adapter emits complete
+// replacement snapshots so replay and live updates follow the same path.
+export type TaskStatus = "pending" | "in_progress" | "completed";
+
+export interface TaskSnapshotItem {
+  task_id: string;
+  title: string;
+  status: TaskStatus;
+  detail?: string | null;
+  blocked_by: string[];
+}
+
+export interface TasksSnapshot {
+  explanation?: string | null;
+  tasks: TaskSnapshotItem[];
+}
+
 export type TurnStatus =
   | { kind: "success" }
   | { kind: "error"; subtype: string; message: string }
@@ -310,6 +327,11 @@ export type ProviderRuntimeEvent =
       type: "workflow_updated";
       thread_id: string;
       workflow: WorkflowSnapshot;
+    }
+  | {
+      type: "tasks_updated";
+      thread_id: string;
+      tasks: TasksSnapshot;
     }
   | {
       type: "turn_completed";


### PR DESCRIPTION
## Summary

- normalize Codex plan updates, OpenCode todo updates, and Claude task tools into durable task snapshots
- show a conditional Tasks progress control and focused-thread right-side panel
- keep subagent plans isolated and restore task state during chat hydration
- replace duplicated TodoWrite transcript lists with compact panel links
- add development fixtures, provider translation coverage, UI regression tests, and feature documentation

## Verification

- Rust provider, persistence, command, and library test suites
- npm run check
- NODE_OPTIONS=--no-experimental-webstorage npm run test (225 files, 3425 tests)
- focused Tasks regression suite (7 files, 146 tests)
- browser verification for empty, active, completed, and hydrated task states

## Notes

Node 25 exposes an incomplete experimental localStorage global, so the frontend suite uses --no-experimental-webstorage in NODE_OPTIONS.