### PR TITLE
test(agent-chat): pin the mid-materialise composer to the shared column rails

### DIFF
--- a/src/components/chat/DraftChatSurface.test.tsx
+++ b/src/components/chat/DraftChatSurface.test.tsx
@@ -655,6 +655,50 @@ describe("DraftChatSurface", () => {
       const [, , cwd] = vi.mocked(materializeAndSend).mock.calls[0];
       expect(cwd).toBe("/home/user");
     });
+
+    it("the mid-materialise composer keeps the shared column rails (no extra inset)", async () => {
+      // Regression guard: the pending view used to wrap the composer in
+      // its own `max-w-[760px] px-7` box, so the composer's own rails
+      // resolved INSIDE it — the card shrank to 672px for the seconds
+      // the workspace was being created, then snapped back to 760px
+      // when the real pane took over. The wrapper may only add vertical
+      // spacing; the rails belong to the composer (see chat-column.ts).
+      vi.mocked(materializeAndSend).mockImplementation(
+        () => new Promise(() => {}),
+      );
+      const draft = useChatDraftStore
+        .getState()
+        .getOrCreateProjectDraft("/projects/foo");
+      useChatDraftStore.getState().updateDraftInput(draft.draftId, "hello");
+      useChatDraftStore.getState().setActiveDraft(draft.draftId);
+      const { container, getByRole } = renderSurface();
+      const ta = container.querySelector("textarea") as HTMLTextAreaElement;
+      fireEvent.keyDown(ta, { key: "Enter" });
+      // The pending view is up (status line) and the composer is still
+      // mounted below it.
+      await vi.waitFor(() => {
+        expect(getByRole("status", { name: "Starting the agent" })).toBeTruthy();
+      });
+
+      const card = container.querySelector(
+        '[data-testid="composer-wrapper"]',
+      ) as HTMLElement;
+      const inner = card.parentElement as HTMLElement;
+      const outer = inner.parentElement as HTMLElement;
+      expect(inner.className).toContain("max-w-[760px]");
+      expect(outer.className).toContain("px-4");
+
+      // Nothing between the composer's own rails and the surface root
+      // may constrain width or add a horizontal gutter.
+      for (
+        let node = outer.parentElement;
+        node && node !== container;
+        node = node.parentElement
+      ) {
+        expect(node.className).not.toMatch(/(^|\s)max-w-/);
+        expect(node.className).not.toMatch(/(^|\s)-?p[xlr]-/);
+      }
+    });
   });
 
   describe("config handlers", () => {


### PR DESCRIPTION
## Why

While a new workspace was being created, the composer card visibly narrowed — 672px through "Creating worktree…", then snapping back to 760px the moment the real pane took over.

Cause: the pending view (`DraftPendingConversation`) wrapped the composer in its own `mx-auto w-full max-w-[760px] px-7` box. `Composer` already owns rails (`w-full px-4` outside a `max-w-[760px]` inner box), so nested inside that wrapper it resolved against 760 − 2×28 = 704, then shaved another 32 for its own `px-4` → **672px**. The live `AgentChatPane` renders the composer unwrapped and got the full 760.

The markup fix already landed in 6361bce ("put every chat surface on one shared column"), which introduced `chat-column.ts` — but nothing guards it, and re-adding a wrapper for vertical spacing would silently bring the jump back. Note the fix is unreleased: v0.15.6 still shows the narrow input.

## What

One regression test in `DraftChatSurface.test.tsx`: it drives a real submit with a never-resolving `materializeAndSend`, waits for the "Starting the agent" status line, then asserts

- the composer's rails are its own (`px-4` outer, `max-w-[760px]` inner), and
- no ancestor between them and the surface root constrains width or adds a horizontal gutter.

## Verification

`npx vitest run src/components/chat/DraftChatSurface.test.tsx` → 31/31 pass. Re-inserting the old `max-w-[760px] px-7` wrapper fails exactly this test and nothing else.