### PR TITLE
Preserve Codex context when continuing runs after restart

### DIFF
--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -514,10 +514,17 @@ examples for visual verification.
   `agent_chat_send_turn` — reusing the
   SAME `thread_id` (keeping the attached Channel, pane snapshot, and store
   slice valid) and passing `resume_cursor: {"resume": sdk_session_id}`
-  when the row carries one (falling back to a fresh session, whose
-  transcript still hydrates from the DB, when it does not or when the
-  resume-start fails). Each thread's picker config (`model`, `effort`,
-  `context_window`, `permission_mode`, `fast_mode`) is persisted on the session row —
+  when the row carries one. Codex's adapter returns its provider-native
+  `{"threadId": ...}` cursor at session start; the command layer now persists
+  that id, and the adapter accepts the database/frontend's generic `resume`
+  wrapper before emitting the official `thread/resume { threadId }` RPC. This
+  keeps the prior Codex thread's complete model-visible history, including
+  image inputs, available when the user clicks **Continue run** after an app
+  restart; the Continue turn itself remains a plain follow-up and does not
+  duplicate the prior attachments. The adapters fall back to a fresh session,
+  whose transcript still hydrates from the DB, when no durable provider id
+  exists or when the resume-start fails. Each thread's picker config (`model`,
+  `effort`, `context_window`, `permission_mode`, `fast_mode`) is persisted on the session row —
   written at `agent_chat_start_session`, updated fire-and-forget by the
   picker handlers via `agent_chat_update_session_config`, always persisted
   by `agent_chat_set_model` / `agent_chat_set_permission_mode` (which now

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -303,10 +303,7 @@ impl CodexSession {
         // --- thread/start or thread/resume ----------------------------------
         let codex_thread_id = match &resume_cursor {
             Some(cursor) => {
-                let resume_id = cursor
-                    .get("threadId")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string());
+                let resume_id = codex_thread_id_from_resume_cursor(cursor);
                 match resume_id {
                     Some(rid) => {
                         let (approval_policy, sandbox) = match codex_permission_mode_to_policy_pair(
@@ -903,6 +900,18 @@ fn is_recoverable_resume_error(err_msg: &str) -> bool {
         .any(|s| lower.contains(&s.to_lowercase()))
 }
 
+/// Extract the Codex thread id from either the provider-native cursor returned
+/// by this adapter or CodeMux's provider-neutral persisted resume shape.
+/// `ThreadResumeParams::thread_id` still serializes to the official `threadId`
+/// field at the app-server RPC boundary.
+fn codex_thread_id_from_resume_cursor(cursor: &Value) -> Option<String> {
+    cursor
+        .get("threadId")
+        .or_else(|| cursor.get("resume"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
 /// Background task: consume notifications from the child, translate
 /// each into canonical events, and broadcast.
 fn spawn_notifications_task(
@@ -1125,6 +1134,27 @@ mod tests {
         assert!(is_recoverable_resume_error("unknown thread"));
         assert!(is_recoverable_resume_error("NO SUCH THREAD"));
         assert!(!is_recoverable_resume_error("network is unreachable"));
+    }
+
+    #[test]
+    fn resume_cursor_accepts_native_and_persisted_shapes() {
+        assert_eq!(
+            codex_thread_id_from_resume_cursor(&json!({"threadId": "native-thread"})),
+            Some("native-thread".into())
+        );
+        assert_eq!(
+            codex_thread_id_from_resume_cursor(&json!({"resume": "persisted-thread"})),
+            Some("persisted-thread".into())
+        );
+    }
+
+    #[test]
+    fn resume_cursor_prefers_provider_native_thread_id() {
+        let both = json!({"threadId": "native", "resume": "persisted"});
+        assert_eq!(
+            codex_thread_id_from_resume_cursor(&both),
+            Some("native".into())
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -687,10 +687,8 @@ pub async fn agent_chat_start_session<R: Runtime>(
         // UPDATE racing this upsert across a spawned bridge task — when the
         // event wins it updates 0 rows and the cursor is silently lost,
         // leaving the FIRST dead-run rebuild with no conversation context
-        // (OpenCode returns its cursor at start; Claude's SDK id arrives
-        // later by event and Codex's start-time cursor carries no
-        // extractable id, so this is a no-op for them). Best-effort like the
-        // neighboring persists.
+        // (OpenCode and Codex return their cursors at start; Claude's SDK id
+        // arrives later by event). Best-effort like the neighboring persists.
         if let Some(sdk_session_id) = session
             .resume_cursor
             .as_ref()
@@ -3734,15 +3732,16 @@ pub fn should_persist_event(event: &ProviderRuntimeEvent) -> bool {
 
 /// Pull the SDK session UUID out of the opaque `resume_cursor` JSON.
 ///
-/// The Claude adapter wraps the id under a `resume` or `sessionId`
-/// key (same shape the adapter accepts on the way in — see
-/// `agent_provider/claude/session.rs`). Extracted so the logic is
-/// unit-testable without spinning up an app handle.
+/// Providers wrap the id under a provider-native key (`threadId` for Codex,
+/// `sessionId` for Claude) or the generic `resume` key accepted when a
+/// persisted scalar is reconstructed. Extracted so the logic is unit-testable
+/// without spinning up an app handle.
 pub fn extract_sdk_session_id(cursor: &serde_json::Value) -> Option<String> {
     cursor
         .get("resume")
         .or_else(|| cursor.get("sessionId"))
         .or_else(|| cursor.get("session_id"))
+        .or_else(|| cursor.get("threadId"))
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
@@ -4549,7 +4548,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_sdk_session_id_handles_all_three_keys() {
+    fn extract_sdk_session_id_handles_all_provider_keys() {
         assert_eq!(
             extract_sdk_session_id(&json!({"resume": "uuid-a"})),
             Some("uuid-a".into())
@@ -4561,6 +4560,10 @@ mod tests {
         assert_eq!(
             extract_sdk_session_id(&json!({"session_id": "uuid-c"})),
             Some("uuid-c".into())
+        );
+        assert_eq!(
+            extract_sdk_session_id(&json!({"threadId": "codex-thread"})),
+            Some("codex-thread".into())
         );
     }
 

--- a/src-tauri/tests/codex_adapter.rs
+++ b/src-tauri/tests/codex_adapter.rs
@@ -211,6 +211,7 @@ async fn starts_session_and_reports_ready() {
     let session = start_session_resilient(&provider, start_input("t-ready")).await.unwrap();
     assert_eq!(session.thread_id.0, "t-ready");
     assert!(matches!(session.status, SessionStatus::Ready));
+    assert_eq!(session.resume_cursor, Some(json!({"threadId": "c-1"})));
 
     let events = handle.await.unwrap();
     assert!(events.iter().any(|e| matches!(
@@ -326,6 +327,39 @@ async fn thread_resume_with_recoverable_error_falls_back_to_start() {
     assert!(collect.is_ok(), "timed out waiting for warning");
     assert!(saw_warning, "expected fallback warning");
     provider.stop_session(ThreadId("t-resume".into())).await.ok();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn persisted_resume_cursor_reaches_codex_thread_resume() {
+    let wrapper = wrapper_with_env(&[("FAKE_CODEX_FAIL_RESUME", "1")]);
+    let provider = provider_with_fixture_and_binary(wrapper.to_path_buf());
+    let mut stream = provider.event_stream();
+
+    let mut input = start_input("t-persisted-resume");
+    input.resume_cursor = Some(json!({"resume":"stored-codex-thread"}));
+    let session = start_session_resilient(&provider, input).await.unwrap();
+    assert!(matches!(session.status, SessionStatus::Ready));
+
+    // The fake server emits this warning only if the generic persisted cursor
+    // was translated into a real thread/resume request before fresh fallback.
+    let mut saw_warning = false;
+    let collect = timeout(Duration::from_secs(3), async {
+        while let Some(ev) = stream.next().await {
+            if let ProviderRuntimeEvent::RuntimeWarning { message, .. } = &ev {
+                if message.contains("thread/resume") && message.contains("fall") {
+                    saw_warning = true;
+                    break;
+                }
+            }
+        }
+    })
+    .await;
+    assert!(collect.is_ok(), "timed out waiting for warning");
+    assert!(saw_warning, "persisted cursor did not reach thread/resume");
+    provider
+        .stop_session(ThreadId("t-persisted-resume".into()))
+        .await
+        .ok();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

- persist native Codex thread IDs from provider resume cursors
- normalize persisted generic resume cursors before calling Codex thread/resume
- preserve model-visible conversation and image context across app restarts without duplicating attachments
- document the continuation behavior and add focused regression coverage

## Verification

- `mise exec node@22 -- env -u LD_LIBRARY_PATH CARGO_BUILD_JOBS=2 npm run verify`
- Rust library tests: 2,530 passed
- Frontend tests: 3,801 passed across 250 files
- `git diff --check`