### PR TITLE
Refine agent chat composer focus treatment

### DIFF
--- a/src/components/chat/Composer.polish.test.tsx
+++ b/src/components/chat/Composer.polish.test.tsx
@@ -100,6 +100,20 @@ function prAttachment(num = 42, overrides: Partial<Attachment> = {}): Attachment
 }
 
 describe("Composer Stage 7 polish", () => {
+  describe("focus treatment", () => {
+    it("keeps the border stable and uses surface elevation for focus", () => {
+      const { getByTestId } = renderControlled();
+      const wrapper = getByTestId("composer-wrapper");
+
+      expect(wrapper.className).not.toContain("focus-within:border-");
+      expect(wrapper.className).toContain("focus-within:bg-muted/60");
+      expect(wrapper.className).toContain(
+        "focus-within:shadow-[0_16px_38px_-14px]",
+      );
+      expect(wrapper.className).toContain("focus-within:shadow-black/60");
+    });
+  });
+
   describe("drag-drop visual feedback", () => {
     it("does not show the dragging state initially", () => {
       const { getByTestId } = renderControlled();

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -1998,7 +1998,9 @@ export function Composer({
             // the slightly-elevated surface, and a deep low-opacity
             // shadow so the card lifts off the pane background and
             // the scope strip below reads as a layer tucked under it.
-            // Focus sharpens the border rather than stacking a ring.
+            // The border deliberately stays identical at rest and on focus.
+            // Focus comes from the surface and elevation instead, avoiding a
+            // bright wireframe around this large rounded rectangle.
             "rounded-[20px] border border-border/80 bg-muted/40",
             // Geometry and color split so the tint stays a themeable
             // utility rather than a baked-in rgba literal.
@@ -2011,7 +2013,7 @@ export function Composer({
             // border shift) so the compositor only has work to do on
             // those changes.
             "transition-[box-shadow,border-color,background-color]",
-            "focus-within:border-muted-foreground/50",
+            "focus-within:bg-muted/60 focus-within:shadow-[0_16px_38px_-14px] focus-within:shadow-black/60",
             // Drag-over uses a neutral foreground-tinted ring instead
             // of the primary accent: the chat-ui skill reserves accent
             // for the app shell, and the brightness shift alone is


### PR DESCRIPTION
## Summary

- keep the composer border stable between rest and focus
- communicate focus through a lighter surface and softer elevation
- add regression coverage for the focus-state utility contract

## Verification

- npm run test -- --run src/components/chat/Composer.polish.test.tsx
- npm run check
- visually verified focused and unfocused states in the dark-theme dev UI

## Environment notes

- full Cargo verification is blocked in the AppImage shell by an OpenSSL/libcurl version mismatch
- the full Vitest suite currently has unrelated localStorage failures under this Node environment