### PR TITLE
Make the active-card PR chip match the settled-row badge

### DIFF
--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -148,8 +148,9 @@ visual only — nothing is archived, closed, or deleted.
   logos · remote cloud icon · notification badge. The PR chip is **the same
   borderless badge settled rows use**: a state-colored `PrStatusIcon` + `#n`
   (open green, merged violet, closed red, draft muted), no border or fill, with
-  a hover tint only when there is a `pr_url` to open (dimmed and non-interactive
-  otherwise). Active and settled therefore render one PR the same way, so a card
+  a hover tint only when there is a `pr_url` to open (dimmed and `disabled`
+  otherwise, so the chip itself swallows the click instead of passing it to the
+  card). Active and settled therefore render one PR the same way, so a card
   settling no longer looks like the badge changed. The spacer sits *before* the
   PR chip deliberately: with it after, the chip began wherever the branch name
   happened to end, so chips landed at a different x on every card and the column
@@ -236,7 +237,9 @@ visual only — nothing is archived, closed, or deleted.
   scoped to the row node by `isRowActivationKey` (`Enter`/`Space` **and**
   `e.target === e.currentTarget`), so pressing Enter/Space on an inner control —
   the PR badge, Un-settle, Wake now — runs only that control's action instead of
-  also activating the workspace. Snoozed rows use the same guard. Because it is
+  also activating the workspace. Snoozed rows and active inbox cards share the
+  same guard (`sidebar-row-activation.ts`), so Enter/Space on a card's PR chip
+  opens the PR without also yanking the main pane onto the workspace. Because it is
   DOM-identity based, any inner interactive element added later is exempt
   automatically. Hover/focus
   reveals **Un-settle**, which reverses it (the returning card eases back in

--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -144,12 +144,17 @@ visual only — nothing is archived, closed, or deleted.
   agent is live, worktree name when idle) + issue chip; a red blocker line
   (needs-you only); and a mono meta line. The meta line is **two columns, not
   one flow**: the git-local facts (branch · `↑ahead` · `+/−` diff) flow from the
-  left, then a `flex-1` spacer pins the rest to the right — PR chip (`PR #n`
-  green / `merged` violet, opens the PR) · provider logos · remote cloud icon ·
-  notification badge. The spacer sits *before* the PR chip deliberately: with it
-  after, the chip began wherever the branch name happened to end, so chips landed
-  at a different x on every card and the column read as ragged. Right-aligning
-  also makes the chip's own variable width (`merged` vs `PR #1234`) harmless. The
+  left, then a `flex-1` spacer pins the rest to the right — PR chip · provider
+  logos · remote cloud icon · notification badge. The PR chip is **the same
+  borderless badge settled rows use**: a state-colored `PrStatusIcon` + `#n`
+  (open green, merged violet, closed red, draft muted), no border or fill, with
+  a hover tint only when there is a `pr_url` to open (dimmed and non-interactive
+  otherwise). Active and settled therefore render one PR the same way, so a card
+  settling no longer looks like the badge changed. The spacer sits *before* the
+  PR chip deliberately: with it after, the chip began wherever the branch name
+  happened to end, so chips landed at a different x on every card and the column
+  read as ragged. Right-aligning also makes the chip's variable width
+  (`#7` vs `#1234`) harmless. The
   trailing indicator cluster owns the far-right column and reserves a
   `min-w-[15px]` slot — sized to the *widest* single indicator (the notification
   pill, not the 13px provider logo) so neither a bare card nor a card showing a

--- a/src/components/layout/sidebar-inbox-card.tsx
+++ b/src/components/layout/sidebar-inbox-card.tsx
@@ -13,8 +13,9 @@ import { ProviderLogo } from "@/components/chat/provider-logo";
 import { WorkingIndicator } from "@/components/ui/working-indicator";
 import { IssueDetailPopover } from "@/components/github/issue-detail-popover";
 import {
-  PR_CHIP_TONE,
+  PrStatusIcon,
   normalizePrState,
+  prStatusTextClass,
 } from "@/components/github/pr-status-icon";
 import { WorkspaceInboxMenu } from "./workspace-inbox-menu";
 import { WorkspaceHoverCard } from "./workspace-hover-card";
@@ -207,7 +208,6 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
       : workspace.title;
 
   const prState = normalizePrState(workspace.pr_state);
-  const prMerged = prState === "merged";
   const hasAhead = showGitStats && workspace.git_ahead > 0;
   const hasStats =
     showGitStats &&
@@ -552,7 +552,10 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                   the chip started wherever the branch name happened to end, so
                   chips landed at a different x on every card and the column read
                   as ragged noise down a scrolling list. Right-aligning also makes
-                  the chip's own variable width ("merged" vs "PR #1234") harmless. */}
+                  the chip's own variable width (#7 vs #1234) harmless.
+                  The chip is deliberately chrome-free — state-colored icon +
+                  number, no border or fill — so an active card's PR reads
+                  identically to the same PR once the row settles. */}
               <div
                 data-meta-line
                 className="mt-[5px] flex min-w-0 items-center gap-2 font-mono text-[11px] leading-tight text-muted-foreground/60"
@@ -591,13 +594,18 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                         : `Pull request — ${prState}`
                     }
                     className={cn(
-                      "shrink-0 rounded-[5px] border px-[5px] py-px font-mono text-[10px] font-medium",
+                      "inline-flex shrink-0 items-center gap-1 rounded px-1 py-px font-mono text-[10px] font-medium",
                       "transition-colors duration-150",
-                      PR_CHIP_TONE[prState],
-                      !workspace.pr_url && "pointer-events-none",
+                      prStatusTextClass(prState),
+                      workspace.pr_url
+                        ? "hover:bg-foreground/[0.055]"
+                        : "pointer-events-none opacity-65",
                     )}
                   >
-                    {prMerged ? "merged" : `PR #${workspace.pr_number ?? ""}`}
+                    <PrStatusIcon state={prState} size={3} className="shrink-0" />
+                    {workspace.pr_number != null && (
+                      <span>#{workspace.pr_number}</span>
+                    )}
                   </button>
                 )}
                 {/* Trailing indicators keep the far-right column. The reserved

--- a/src/components/layout/sidebar-inbox-card.tsx
+++ b/src/components/layout/sidebar-inbox-card.tsx
@@ -31,6 +31,7 @@ import {
   permissionBlockerText,
 } from "@/stores/sidebar-density-store";
 import { useProjectAppearance } from "./use-project-appearance";
+import { isRowActivationKey } from "./sidebar-row-activation";
 import { getWorkspaceProviders } from "@/lib/pane-status";
 import { computeSnoozePresets, type SnoozePreset } from "./sidebar-snooze";
 import type { ActivePaneStatus, WorkspaceSnapshot } from "@/tauri/types";
@@ -344,7 +345,13 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
               data-selected={selected || undefined}
               onClick={handleClick}
               onKeyDown={(e) => {
-                if (e.key !== "Enter" && e.key !== " ") return;
+                // Same guard the settled and snoozed rows use: this card hosts
+                // its own buttons (PR chip, snooze menu), and a key press on
+                // one of those bubbles up here. Without the target check, Enter
+                // on the PR chip would open the PR *and* yank the main pane
+                // onto the workspace, and Space would never reach the button at
+                // all — the preventDefault below would eat its native click.
+                if (!isRowActivationKey(e)) return;
                 // Space would otherwise scroll the sidebar as it activates
                 // the card.
                 if (e.key === " ") e.preventDefault();
@@ -599,7 +606,13 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                       prStatusTextClass(prState),
                       workspace.pr_url
                         ? "hover:bg-foreground/[0.055]"
-                        : "pointer-events-none opacity-65",
+                        : // `cursor-default`, not `pointer-events-none`: the
+                          // chip is already `disabled`, so it swallows the
+                          // click. Letting pointer events pass through instead
+                          // would hand the click to the card root and select
+                          // the workspace, and the cursor would still read as
+                          // the card's `cursor-pointer`.
+                          "cursor-default opacity-65",
                     )}
                   >
                     <PrStatusIcon state={prState} size={3} className="shrink-0" />

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -358,7 +358,7 @@ describe("SidebarInbox — cards", () => {
     expect(screen.queryByText("+124")).not.toBeInTheDocument();
   });
 
-  it("shows a PR chip (merged → violet label)", async () => {
+  it("shows a borderless PR chip (icon + number) on active cards", async () => {
     workspaces = [
       makeWorkspace({
         worktree_path: "/wt/a",
@@ -378,8 +378,12 @@ describe("SidebarInbox — cards", () => {
     // remains available while its agent is running.
     paneStatuses = { p1: "working" };
     await renderInbox();
-    expect(screen.getByText("PR #87")).toBeInTheDocument();
-    expect(screen.getByText("merged")).toBeInTheDocument();
+    // Both states render the same way settled rows do: "#<number>", colored
+    // by PR state, with no "PR" prefix or "merged" word riding along.
+    expect(screen.getByText("#87")).toBeInTheDocument();
+    expect(screen.getByText("#203")).toBeInTheDocument();
+    expect(screen.queryByText("PR #87")).not.toBeInTheDocument();
+    expect(screen.queryByText("merged")).not.toBeInTheDocument();
   });
 
   it("shows the provider logo for agent-chat panes in the workspace", async () => {

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -378,12 +378,104 @@ describe("SidebarInbox — cards", () => {
     // remains available while its agent is running.
     paneStatuses = { p1: "working" };
     await renderInbox();
-    // Both states render the same way settled rows do: "#<number>", colored
-    // by PR state, with no "PR" prefix or "merged" word riding along.
-    expect(screen.getByText("#87")).toBeInTheDocument();
-    expect(screen.getByText("#203")).toBeInTheDocument();
+    // Both states render the same way settled rows do: a state-colored icon
+    // plus "#<number>", with no "PR" prefix, no "merged" word and none of the
+    // old bordered-pill chrome riding along.
+    const open = screen.getByRole("button", {
+      name: "Pull request #87 — open",
+    });
+    expect(open).toHaveTextContent("#87");
+    expect(open.querySelector("svg")).not.toBeNull();
+    expect(open.className).not.toMatch(/\bborder\b/);
+    const merged = screen.getByRole("button", {
+      name: "Pull request #203 — merged",
+    });
+    expect(merged).toHaveTextContent("#203");
+    expect(merged.querySelector("svg")).not.toBeNull();
+    expect(merged.className).not.toMatch(/\bborder\b/);
     expect(screen.queryByText("PR #87")).not.toBeInTheDocument();
     expect(screen.queryByText("merged")).not.toBeInTheDocument();
+  });
+
+  it("renders the PR chip icon alone when the number is unknown", async () => {
+    workspaces = [
+      makeWorkspace({
+        worktree_path: "/wt/a",
+        pr_number: null,
+        pr_state: "OPEN",
+        pr_url: "https://github.com/u/r/pull/87",
+      }),
+    ];
+    await renderInbox();
+
+    // A state with no number still says something worth showing, but it must
+    // not degrade into a bare "#".
+    const pr = screen.getByRole("button", { name: "Pull request — open" });
+    expect(pr.querySelector("svg")).not.toBeNull();
+    expect(pr.textContent).not.toContain("#");
+  });
+
+  it("a PR chip with no URL is inert without leaking the click to the card", async () => {
+    workspaces = [
+      makeWorkspace({
+        worktree_path: "/wt/a",
+        pr_number: 87,
+        pr_state: "OPEN",
+        pr_url: null,
+      }),
+    ];
+    await renderInbox();
+
+    const pr = screen.getByRole("button", { name: "Pull request #87 — open" });
+    expect(pr).toBeDisabled();
+    // The disabled button has to stay the hit target for that to matter:
+    // `pointer-events-none` would pass the click straight through to the card
+    // root, which would select and activate the workspace — and show the
+    // card's `cursor-pointer` over a chip that does nothing. jsdom does no hit
+    // testing, so the class is the observable seam for that half.
+    expect(pr.className).toContain("cursor-default");
+    expect(pr.className).not.toContain("pointer-events-none");
+    await userEvent.click(pr);
+    expect(mockOpenUrl).not.toHaveBeenCalled();
+    expect(activateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("Enter and Space on an active card's PR chip do not also activate the card", async () => {
+    workspaces = [
+      makeWorkspace({
+        worktree_path: "/wt/a",
+        pr_number: 87,
+        pr_state: "OPEN",
+        pr_url: "https://github.com/u/r/pull/87",
+      }),
+    ];
+    await renderInbox();
+
+    const card = screen
+      .getByRole("button", { name: "Pull request #87 — open" })
+      .closest("[data-inbox-card]") as HTMLElement;
+    const pr = within(card).getByRole("button", {
+      name: "Pull request #87 — open",
+    });
+
+    // Same contract as a settled row: the card is a `role="button"` container,
+    // so a keydown on the chip bubbles into it. Opening the PR and yanking the
+    // main pane onto the workspace are two different intents.
+    fireEvent.keyDown(pr, { key: "Enter" });
+    expect(activateWorkspace).not.toHaveBeenCalled();
+
+    // Space must also survive untouched — the card cancels Space to stop the
+    // sidebar scrolling, and doing that here would eat the button's own native
+    // activation, so the chip would look focusable but never open anything.
+    // A `true` return means nothing called `preventDefault`.
+    expect(fireEvent.keyDown(pr, { key: " " })).toBe(true);
+    expect(activateWorkspace).not.toHaveBeenCalled();
+
+    // Positive control: the same keys on the card itself still open it (and
+    // Space is still cancelled there), so the guard narrows activation rather
+    // than removing it.
+    expect(fireEvent.keyDown(card, { key: " " })).toBe(false);
+    expect(activateWorkspace).toHaveBeenCalledWith("ws-1");
   });
 
   it("shows the provider logo for agent-chat panes in the workspace", async () => {

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -54,6 +54,7 @@ import {
   type SnoozePreset,
 } from "./sidebar-snooze";
 import { WorkspaceHoverCard } from "./workspace-hover-card";
+import { isRowActivationKey } from "./sidebar-row-activation";
 import {
   normalizePrState,
   PrStatusIcon,
@@ -417,19 +418,6 @@ function WrappingUpDivider() {
       <span aria-hidden="true" className="h-px flex-1 bg-border/60" />
     </div>
   );
-}
-
-/** Does this keydown activate the row *itself*?
- *
- *  Settled and snoozed rows are `role="button"` containers that also host their
- *  own buttons (PR badge, Un-settle, Wake now). Those inner buttons stop click
- *  propagation, but a keyboard activation on a focused inner button still
- *  bubbles its `keydown` up to the row — so without a target check, Enter on
- *  the PR badge would open the PR *and* activate the workspace. Only a keydown
- *  whose target is the row node is a row activation. */
-function isRowActivationKey(e: React.KeyboardEvent<HTMLElement>): boolean {
-  if (e.key !== "Enter" && e.key !== " ") return false;
-  return e.target === e.currentTarget;
 }
 
 interface SettledRowProps {

--- a/src/components/layout/sidebar-row-activation.ts
+++ b/src/components/layout/sidebar-row-activation.ts
@@ -1,0 +1,18 @@
+import type React from "react";
+
+/** Does this keydown activate the sidebar row/card *itself*?
+ *
+ *  Inbox cards, settled rows and snoozed rows are all `role="button"`
+ *  containers that also host their own buttons (PR chip, Un-settle, Wake now).
+ *  Those inner buttons stop click propagation, but a keyboard activation on a
+ *  focused inner button still bubbles its `keydown` up to the container — so
+ *  without a target check, Enter on the PR chip would open the PR *and*
+ *  activate the workspace, and Space would be swallowed by the container's
+ *  `preventDefault()` before the button's own default could fire. Only a
+ *  keydown whose target is the container node is a container activation. */
+export function isRowActivationKey(
+  e: React.KeyboardEvent<HTMLElement>,
+): boolean {
+  if (e.key !== "Enter" && e.key !== " ") return false;
+  return e.target === e.currentTarget;
+}


### PR DESCRIPTION
## Problem

The sidebar rendered the same pull request two different ways depending on which tier its workspace was in:

- **Active card** — a bordered, tinted box reading `PR #248` (or just the word `merged`)
- **Settled row** — a bare state-colored icon + `#248`, no chrome

So a card *settling* looked like the PR badge itself had changed, when the only thing that actually changed was the row's tier. Down a scrolling list the two treatments read as two different kinds of object.

## Change

Drop the chrome from the active card and reuse the settled treatment:

```tsx
<PrStatusIcon state={prState} size={3} />
{workspace.pr_number != null && <span>#{workspace.pr_number}</span>}
```

- No border, no fill, no `PR ` prefix, no `merged` word — just the state-colored icon and `#number` (open green, merged violet, closed red, draft muted).
- Hover tint only when there is a `pr_url` to open; dimmed and non-interactive when there isn't — same rule the settled row already used.
- `aria-label`s and click-to-open-the-PR behaviour are unchanged.

`PR_CHIP_TONE` stays where it is — the Agent Chat Context Row still wants a labeled, bordered action, and that's a different surface.

## Verification

- `npm run check` (tsc) — clean
- Full vitest suite — 254 files / 3885 tests passing
- Visually confirmed against the dev mock: active cards show `#172` / `#12` / `#142` / `#140` and settled rows show `#131` / `#128`, all in one consistent right-hand column