### PR TITLE
Fix stuck Working status after runs with background tasks; badge side-branch PRs

### DIFF
--- a/docs/core/STATUS.md
+++ b/docs/core/STATUS.md
@@ -45,11 +45,20 @@ refinement commits that shipped alongside PR #245, grouped by subsystem below:
   Backstop**: the 30s stall-watchdog sweep gained a second pass that
   force-settles an owed `Review` gone silent for the existing 600s
   `STALL_THRESHOLD`, routed through `apply_pane_status` — the helper extracted
-  out of `publish_pane_status`, so the forced settle runs the identical
-  status/release/emit policy instead of a second copy. Real post-turn subagent
-  activity re-arms the clock; a flagged background tick deliberately does not.
-  This can't cut a live turn short — `review_pending` is only ever set by
-  `TurnCompleted`. **(3) Frontend**: live affordances now respect the end of
+  out of `publish_pane_status` — so the `Review`→`Idle` downgrade and the
+  stamped emit are shared rather than copied. Any tick from a real tracked
+  entry re-arms the clock (a flagged background tick deliberately does not), so
+  the threshold means "every remaining blocker has been silent for ten
+  minutes". Silence still cannot prove death — one long `cargo test` inside a
+  live subagent looks identical — so the forced path is deliberately
+  non-destructive: it passes `SettleOrigin::ForcedBackstop`, which **withholds
+  the detached-browser release** (a premature dot is repainted by the next real
+  event; a browser torn down under a live subagent is not recoverable), and it
+  **tombstones** the tracker entry (`forced_settled`) instead of removing it,
+  so a late real completion drains normally, publishes nothing, and leaves no
+  orphaned entry rather than recreating an uncollectable husk. It can't cut a
+  live turn short — `review_pending` is only ever set by `TurnCompleted`.
+  **(3) Frontend**: live affordances now respect the end of
   the run. Background-task rows drop out of `runningSubagentEntries` /
   `countRunningSubagents` once the thread stops streaming (shared
   `isLiveActivity` predicate; the flag merges stickily), and the Tasks chip's
@@ -70,12 +79,17 @@ refinement commits that shipped alongside PR #245, grouped by subsystem below:
   records parsed out of the last 50 per-worktree HEAD reflog entries, up to 5
   distinct names newest-first, excluding the current branch, the default
   branch, and detached-HEAD SHAs — and resolves each through the existing
-  `select_branch_pr` policy, first hit winning. The fallback never runs on the
-  repository default branch, and it costs one repo-wide `gh pr list --state
-  all` matched client-side against every candidate (not one query per
-  candidate), memoized per origin URL for 60s so the 5s active-workspace sweep
-  can't multiply it. A failed fallback collapses to "no PR" rather than
-  `Preserve` — the current branch already answered authoritatively. **The
+  `select_branch_pr` policy, first hit winning. It badges **open PRs only**
+  (unlike the current-branch path, which keeps showing merged/closed state):
+  the case it exists for is always an open PR, and admitting history would let
+  a `gh pr checkout` of someone else's merged PR donate its badge for the whole
+  reflog window. The fallback never runs on the repository default branch, and
+  it costs one repo-wide `gh pr list --state open` matched client-side against
+  every candidate (not one query per candidate) — memoized per origin URL for
+  60s, with the local probes memoized per `(worktree, branch)` for the same
+  60s and owner resolution done lazily, so a repeat 5s active-workspace tick
+  spawns no subprocess at all. A failed fallback collapses to "no PR" rather
+  than `Preserve` — the current branch already answered authoritatively. **The
   association is badge-only.** The workspace snapshot gained
   `pr_head_branch` (snapshot-local, serde-defaulted, never synced) and the
   shared frontend predicate `isPrOnCurrentBranch` compares it to `git_branch`:
@@ -84,8 +98,11 @@ refinement commits that shipped alongside PR #245, grouped by subsystem below:
   that may still hold uncommitted work — such a workspace still ages out via
   the ordinary inactivity rule), the **"Wrapping up"** demotion refuses it,
   and the **Review tab** stays strictly current-branch so "Create PR" is not
-  hidden for the branch the user is actually on. A `null` head branch reads as
-  a match, so existing persisted snapshots settle exactly as before. The
+  hidden for the branch the user is actually on. Missing information on either
+  side reads as a match — a `null` head branch (an association predating the
+  field) *and* a `null` `git_branch` (detached HEAD during a rebase or bisect,
+  where the stored head branch outlives the branch name) — so only two known,
+  differing names ever un-associate a workspace from its PR. The
   hover/details card gains a **"PR branch"** row in the mismatching case only.
   See `docs/features/sidebar.md` §§ "Side-branch PR badges", "A side-branch
   association is a badge and nothing more" and

--- a/docs/core/STATUS.md
+++ b/docs/core/STATUS.md
@@ -19,8 +19,77 @@ implementation notes (`v0.6.1`–`v0.13.2`) were moved to `docs/archive/release-
 Codemux is past Linux MVP and shipping cross-platform binaries. The workspace shell, terminal management, git integration, presets, settings sync, and most ADE features are real and daily-drivable on both Linux and Windows. The latest released version is **`v0.16.0` (2026-08-02)**, the release in which the Agent Chat GUI became the default interface — it also carries the seven-phase GUI responsiveness program, the unified Ctrl+K switcher, the Agent Tasks and context-window surfaces, the compressed web-remote transport, and the one-command remote bootstrap. `v0.15.6` (2026-07-30) was a follow-up release carrying the chat code-rendering, provider-request-lifecycle, skills-discovery, and sidebar-inbox-detail clusters listed below. `v0.15.5` (2026-07-28) carried the sidebar park-intelligence batch (backend-owned activity stamps, a "Wrapping up" tier, snooze, a bulk-action safety net, an oldest-blocked-first needs-you strip, and a shared hover details card), the chat scope + picker rework, the terminal live-cwd hint, and the Linux WebKitGTK accelerated-scrolling restore. `v0.15.0` (2026-07-25) carried the sidebar workspace inbox, the atomic provider/model selection fix, the provider-native Full-access launch repair, and the Codex-only Standard/Fast speed picker. `v0.14.3` shipped headless serve mode, terminal-hook restart recovery, Codex auth/preset migrations, the new-workspace/titlebar and WebKit composer fixes, and safe inline tool-result images; `v0.14.2` shipped the living sidebar, the first Full-access null-mode launch heal, and the transcript scroll/anchoring fix; `v0.14.1` shipped the preceding Agent Chat reliability and polish batch.
 
 Unreleased after `v0.16.0` — eight merged PRs (#239–#246) plus the
-directly-committed new-turn scroll contract (PR #247) and the floating-chrome
+directly-committed new-turn scroll contract (PR #247), the stuck-"Working"
+run-settlement fix, the side-branch PR badge fallback, and the floating-chrome
 refinement commits that shipped alongside PR #245, grouped by subsystem below:
+
+- **A finished run can no longer stay stuck on "Working"** (stuck-status fix).
+  A run that launched a background shell command (`Bash { run_in_background:
+  true }`) kept the sidebar spinner, the background-browser `LIVE` chip, the
+  docked subagent activity bar, and the composer's `Tasks N/M` spinner alive
+  indefinitely after the turn finished. Claude emits the same `system.task_*`
+  family for a background tool run as for a real subagent, so the pane-status
+  tracker put a dev server — which never exits, and therefore never sends the
+  terminal `task_notification` — into the per-thread running-set;
+  `TurnCompleted` then deferred `Review` forever, and because
+  `release_detached_agent_browser` only fires on a settled status, the browser
+  chip never cleared either. Three-part fix. **(1) Root cause**:
+  `SubagentSnapshot` gained an additive `background_task: bool`
+  (`#[serde(default)]`) stamped by the Claude adapter from the discriminator
+  it already had — only a real `Agent`/`Task` launch is registered as a
+  top-level launch in `SubagentDemux` — and `map_event_to_pane_status` never
+  tracks a flagged row, returns `None` for it even when a `Review` is owed
+  (so a progress tick can't resurrect `Working` after the run settled), and
+  defensively evicts an id an unflagged snapshot inserted earlier. Real async
+  `Task` launches keep their deliberate deferred-`Review` flow. **(2)
+  Backstop**: the 30s stall-watchdog sweep gained a second pass that
+  force-settles an owed `Review` gone silent for the existing 600s
+  `STALL_THRESHOLD`, routed through `apply_pane_status` — the helper extracted
+  out of `publish_pane_status`, so the forced settle runs the identical
+  status/release/emit policy instead of a second copy. Real post-turn subagent
+  activity re-arms the clock; a flagged background tick deliberately does not.
+  This can't cut a live turn short — `review_pending` is only ever set by
+  `TurnCompleted`. **(3) Frontend**: live affordances now respect the end of
+  the run. Background-task rows drop out of `runningSubagentEntries` /
+  `countRunningSubagents` once the thread stops streaming (shared
+  `isLiveActivity` predicate; the flag merges stickily), and the Tasks chip's
+  spinner and the Tasks tab's blinking dot are gated on `streaming` rather
+  than on an `in_progress` row in the durable snapshot — the chip stays and
+  renders its counts statically instead of disappearing. See
+  `docs/features/agent-chat.md` §§ "Sidebar status indicators", "Docked live
+  activity bar", "Agent Tasks panel" and `docs/features/browser.md`
+  § "Run-finished release".
+
+- **A PR opened from a side branch no longer goes unbadged** (sidebar PR
+  fallback). An agent working in a workspace that ran `git checkout -b
+  side-branch`, committed, pushed, opened a PR, and checked the worktree back
+  left the sidebar with no PR badge at all: association is strictly by
+  checked-out branch, and the checked-out branch had none. When the current
+  branch resolves to no PR, `github::get_workspace_pr` now falls back to
+  branches this worktree checked out recently — `checkout: moving from X to Y`
+  records parsed out of the last 50 per-worktree HEAD reflog entries, up to 5
+  distinct names newest-first, excluding the current branch, the default
+  branch, and detached-HEAD SHAs — and resolves each through the existing
+  `select_branch_pr` policy, first hit winning. The fallback never runs on the
+  repository default branch, and it costs one repo-wide `gh pr list --state
+  all` matched client-side against every candidate (not one query per
+  candidate), memoized per origin URL for 60s so the 5s active-workspace sweep
+  can't multiply it. A failed fallback collapses to "no PR" rather than
+  `Preserve` — the current branch already answered authoritatively. **The
+  association is badge-only.** The workspace snapshot gained
+  `pr_head_branch` (snapshot-local, serde-defaulted, never synced) and the
+  shared frontend predicate `isPrOnCurrentBranch` compares it to `git_branch`:
+  the badge renders identically everywhere, but PR-completion **auto-settle**
+  refuses a side-branch PR (that branch merging says nothing about a checkout
+  that may still hold uncommitted work — such a workspace still ages out via
+  the ordinary inactivity rule), the **"Wrapping up"** demotion refuses it,
+  and the **Review tab** stays strictly current-branch so "Create PR" is not
+  hidden for the branch the user is actually on. A `null` head branch reads as
+  a match, so existing persisted snapshots settle exactly as before. The
+  hover/details card gains a **"PR branch"** row in the mismatching case only.
+  See `docs/features/sidebar.md` §§ "Side-branch PR badges", "A side-branch
+  association is a badge and nothing more" and
+  `docs/features/review-integration.md`.
 
 - **New-turn scroll contract for the chat transcript** (PR #247). A composer submission is now an explicit navigation intent rather than a data update. `AgentChatPane` issues a `sendAnchor` (`{ clientNonce, nonce }`) in the same batch as the optimistic `appendUserMessage`, reusing that bubble's existing correlation token; `MessageList` resolves the matching `user_message` slot **by nonce** (last match wins) — not by last index, which queued follow-ups and control rows break — feeds it to LegendList's `anchoredEndSpace` (`anchorOffset: 16`), and positions the row from the `onReady` measurement callback with an instant `scrollToIndex`, retrying per frame rather than assuming layout finishes in N ms. Three states replace the old one-shot scalar signal: `following-end`, `anchoring-turn`, `free-scrolling`. While an anchor is mounted the built-in `maintainScrollAtEnd` is disabled and an effect advances by exactly `scrollDeltaToRevealEnd`, so the prompt stays parked near the top while the turn fits and moves only enough to reveal the growing tail. Follow is released **only** by `wheel`, `touchmove`, a `pointerdown` that targets the scroll container itself (a scrollbar drag — presses on rows, so plan-accept/approval/expand clicks and text selection, deliberately do not count), or subagent-jump navigation; a generation counter invalidates every in-flight continuation at once, and scrolling back to the edge re-claims follow. The anchor expires on failed-send rollback, on thread switch, and on the falling edge of the live-turn signal, so a settled thread reopens at the latest row and LegendList's own item/footer-layout pin comes back; expiry never re-claims the viewport from a reader already browsing history. "Jump to latest" is shown on a 150ms trailing debounce and hidden immediately, so it no longer flashes during mount/layout settling or sticks on during programmatic anchoring. Geometry lives in the pure, unit-tested `send-scroll-state.ts`. Frontend-only; the previous `scrollToBottomSignal` scalar and its single `scrollToEnd` call are gone. See `docs/features/agent-chat.md` § "Transcript scroller" → "The new-turn scroll contract".
 

--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -796,6 +796,18 @@ the plan and progress but cannot check, reorder, or rewrite its rows.
   turns amber with a spinner while a step is in flight and green with a check
   once every row is done, and the Tasks tab shows a blinking amber dot while a
   step is running and the tab is not the active one.
+- **Live affordances end with the run.** The snapshot is durable and
+  nothing rewrites it when a turn finishes, so an `in_progress` row is not
+  evidence that work is happening — the thread's `streaming` flag is. Both
+  live affordances are therefore gated on it: the composer chip's spinner
+  (`taskChipSummary` in `src/lib/agent-chat/task-summary.ts`, consumed by
+  `AgentChatPane`) and the Tasks tab's blinking dot (`right-panel.tsx`, via
+  the `streaming` field `useActiveChatTasks` now returns). A plan the
+  provider left mid-step otherwise spun forever, including across a restart
+  (`TasksUpdated` is persisted and hydrate-replayed). The chip is **not**
+  hidden when the run ends — the durable snapshot is by design — it simply
+  renders the same `N/M` counts statically. Rows inside the panel keep
+  their provider-reported state.
 - **Presentation.** The read-only panel preserves provider order and renders
   flat, numbered rows (no per-row card chrome) with three visually distinct
   states — done (green circled check, dimmed, struck through), in-progress
@@ -1441,13 +1453,25 @@ composer, hidden while `enteredSubagentId` is set (design: the bar only
 shows in the conversation view) and rendered as `null` entirely while
 idle — no resting state.
 
-- **Whole-thread rollup.** `runningSubagentEntries` (`subagents.ts`)
-  flattens every `running`/`pending` subagent across **every**
-  `subagent_run` card in the thread, tagging each with its card id and a
-  `from task N` label (omitted when the thread has only one card — there
-  is nothing to disambiguate). The bar's count and expand-list both key
-  off this list, so scattered work from different replies still reads as
-  one signal.
+- **Whole-thread rollup.** `runningSubagentEntries(messages, streaming)`
+  (`subagents.ts`) flattens every `running`/`pending` subagent across
+  **every** `subagent_run` card in the thread, tagging each with its card
+  id and a `from task N` label (omitted when the thread has only one card
+  — there is nothing to disambiguate). The bar's count and expand-list
+  both key off this list, so scattered work from different replies still
+  reads as one signal.
+- **Live activity respects the end of the run.** `isLiveActivity` (the
+  shared predicate behind `runningSubagentEntries` and
+  `countRunningSubagents`) drops rows carrying `backgroundTask` once
+  `streaming` is false. That flag mirrors the wire
+  `SubagentSnapshot.background_task` (see [Sidebar status
+  indicators](#sidebar-status-indicators)) and is merged **stickily** in
+  `mergeSnapshot` — a later snapshot that omits it never promotes the row
+  back to "real subagent". Without this, a background shell command that
+  never reports a terminal status kept the bar and its spinner up forever
+  after the turn settled, including across a restart (subagent snapshots
+  are persisted and hydrate-replayed). `AgentChatPane` passes the thread's
+  streaming flag; mid-run nothing changes.
 - **1 running** → the whole bar is one click target labelled "View";
   clicking jumps straight to that subagent's card.
 - **>1 running** → the action chip reads "Show all" / "Hide" with a
@@ -2903,6 +2927,51 @@ parent-scoped `content_delta`/`item_completed` (`subagent_id == None`) do
 pane at `Working`. `review_pending` is cleared only by publishing the
 owed/normal `Review`, a new-turn reset, session `Closed`/`Error`, or
 `agent_chat_close_pane`.
+
+**Background tasks are excluded from all of that.** Claude emits the same
+`system.task_started` / `task_progress` / `task_updated` /
+`task_notification` family for a background *tool* run — a
+`Bash { run_in_background: true }` — keyed by the Bash `tool_use_id`.
+Such a job can legitimately outlive the turn and never report a terminal
+status (a dev server never exits, so its `task_notification` never
+arrives), so tracking it as a subagent deferred the owed `Review`
+**forever**: the sidebar stayed "Working" and, downstream,
+`release_detached_agent_browser` never fired, leaving the background
+browser chip on `LIVE` indefinitely. `SubagentSnapshot` therefore carries
+an additive `background_task: bool` (`#[serde(default)]`, so old persisted
+payloads and the other providers decode as `false`). The Claude adapter
+stamps it from the exact discriminator it already has:
+`SubagentDemux::is_top_level_launch` is true only for a `tool_use_id`
+registered by a real `Agent`/`Task` launch, so `!is_top_level_launch(id)`
+on a task event means "background job, not subagent". In
+`map_event_to_pane_status` a flagged `running`/`pending` snapshot is never
+inserted into `running`, always returns `None` — even when a `Review` is
+owed, so a progress tick cannot resurrect `Working` after the turn
+settled — and defensively removes the id in case an unflagged variant
+inserted it earlier. Terminal flagged snapshots still `remove` and keep
+the owed-`Review` emptiness check unchanged. Real async `Task` launches
+are untouched: their deferred-`Review` flow above is deliberate.
+
+**The stall watchdog force-settles an owed `Review` that goes silent.**
+The rule above removes the known cause, but any *other* missed terminal
+signal (a crashed notification, a provider quirk) would pin `Working` the
+same way, and `RunStalled` is advisory only — it maps to pane-status
+`None`. So the 30s sweep (`spawn_stall_watchdog`) has a second pass,
+`force_settle_overdue_reviews`. `ThreadSubagentState` tracks
+`review_owed_since`, stamped when `TurnCompleted` defers the `Review` and
+re-armed by real post-turn run activity (`refreshes_owed_review` — a
+flagged background-task snapshot deliberately does **not** count, so a
+busy async subagent is never cut short while a never-ending shell job
+can't stall the clock forever). `SubagentTracker::take_overdue_reviews`
+removes and returns every thread silent past the same `STALL_THRESHOLD`
+(600s), under the tracker lock so the settle happens exactly once and the
+mutex is released before any `AppStateStore` call. Each id then goes
+through `apply_pane_status` — the helper extracted out of
+`publish_pane_status`, so the forced settle applies the identical policy
+(`Review`, downgraded to `Idle` in the active workspace, plus the
+background-browser release and the stamped `app-state-changed` emit)
+rather than a second copy of it. This can never cut a live turn short:
+`review_pending` is set exclusively by `TurnCompleted`.
 
 Only *live* provider events reach the tracker: transcript hydration/resume
 replays persisted events through the frontend reducer

--- a/docs/features/agent-chat.md
+++ b/docs/features/agent-chat.md
@@ -2959,18 +2959,43 @@ same way, and `RunStalled` is advisory only — it maps to pane-status
 `None`. So the 30s sweep (`spawn_stall_watchdog`) has a second pass,
 `force_settle_overdue_reviews`. `ThreadSubagentState` tracks
 `review_owed_since`, stamped when `TurnCompleted` defers the `Review` and
-re-armed by real post-turn run activity (`refreshes_owed_review` — a
-flagged background-task snapshot deliberately does **not** count, so a
-busy async subagent is never cut short while a never-ending shell job
-can't stall the clock forever). `SubagentTracker::take_overdue_reviews`
-removes and returns every thread silent past the same `STALL_THRESHOLD`
-(600s), under the tracker lock so the settle happens exactly once and the
-mutex is released before any `AppStateStore` call. Each id then goes
-through `apply_pane_status` — the helper extracted out of
-`publish_pane_status`, so the forced settle applies the identical policy
-(`Review`, downgraded to `Idle` in the active workspace, plus the
-background-browser release and the stamped `app-state-changed` emit)
-rather than a second copy of it. This can never cut a live turn short:
+re-armed by *any* tick from a real tracked entry (`refreshes_owed_review`
+— a flagged background-task snapshot deliberately does **not** count, so
+a never-ending shell job can't hold the clock open). Because any real
+tick re-arms it, the 600s `STALL_THRESHOLD` means "every remaining
+blocker has been silent for ten minutes", not "the thread has been quiet
+since the turn ended".
+
+**What that threshold cannot prove is that the run is dead.** A single
+long tool call — a `cargo test`, a big build — emits nothing for longer
+than ten minutes, so the sweep will sometimes fire on a subagent that is
+perfectly alive. The forced path is therefore deliberately
+*non-destructive*: it publishes a pane status and does nothing else.
+
+- **It never releases the detached browser.** `apply_pane_status` takes a
+  `SettleOrigin`; `publish_pane_status` passes `ProviderEvent` (a real
+  transition is evidence the run reached that state, so the browser
+  session may go) and the watchdog passes `ForcedBackstop`, which
+  withholds the release. A prematurely settled dot is repainted by the
+  next real event; a browser torn down under a live subagent is not
+  recoverable. Everything else — the `Review`→`Idle` downgrade in the
+  active workspace, the stamped `app-state-changed` emit — is shared.
+- **It tombstones the tracker entry instead of dropping it.**
+  `take_overdue_reviews` clears only what it publishes (`review_pending`,
+  the silence clock) and sets `ThreadSubagentState::forced_settled`,
+  leaving `running` intact. That keeps the settle take-once (a later
+  sweep sees no owed `Review`), and a late-but-real terminal snapshot
+  then drains `running` through the ordinary path, publishes **nothing**
+  (the `Review` was already announced, possibly already cleared by the
+  user), and lets the now-clear entry be dropped. Removing the entry at
+  settle time instead would leave that snapshot to recreate a
+  `review_pending: false` husk that nothing ever collects. The tombstone
+  is cleared by every genuine turn boundary — a new
+  `SessionStatus::Running`, session teardown, or the send-message
+  `clear_thread`.
+
+The sweep still runs under the tracker lock, and the mutex is released
+before any `AppStateStore` call. It can never cut a live *turn* short:
 `review_pending` is set exclusively by `TurnCompleted`.
 
 Only *live* provider events reach the tracker: transcript hydration/resume

--- a/docs/features/browser.md
+++ b/docs/features/browser.md
@@ -92,6 +92,24 @@ explicit-close path, the session's URL and `cli_session_name` are kept, so
 the agent's next browser action simply re-marks it active and the chip
 returns. Daemon-death detection remains out of scope either way.
 
+Because the release is gated on that settled status, anything that stopped
+the turn from settling also stopped the chip from clearing. Two changes
+close that off:
+
+- **A background shell task can no longer block the release.** A
+  `Bash { run_in_background: true }` used to be tracked as a subagent, and
+  a dev server never exits — so the tracker deferred `Review` forever and
+  the chip sat on `LIVE · agent is navigating…` indefinitely. Those rows
+  now carry `SubagentSnapshot.background_task` and are excluded from the
+  running-set, so the turn settles and the release fires normally. See
+  `docs/features/agent-chat.md` (§ Sidebar status indicators).
+- **A watchdog backstop.** If a `Review` is still owed 10 minutes after
+  the turn completed with no real run activity, the stall-watchdog sweep
+  force-settles it through `apply_pane_status` — the same helper
+  `publish_pane_status` uses — which runs this exact release. So any
+  future missed terminal subagent signal releases the browser on the next
+  sweep instead of never.
+
 Known accepted edge case: if two chat threads are both driving browser
 activity in the *same* workspace, one thread finishing its run releases the
 chip even while the other thread is still mid-run. This self-heals — the

--- a/docs/features/browser.md
+++ b/docs/features/browser.md
@@ -103,12 +103,18 @@ close that off:
   now carry `SubagentSnapshot.background_task` and are excluded from the
   running-set, so the turn settles and the release fires normally. See
   `docs/features/agent-chat.md` (§ Sidebar status indicators).
-- **A watchdog backstop.** If a `Review` is still owed 10 minutes after
-  the turn completed with no real run activity, the stall-watchdog sweep
-  force-settles it through `apply_pane_status` — the same helper
-  `publish_pane_status` uses — which runs this exact release. So any
-  future missed terminal subagent signal releases the browser on the next
-  sweep instead of never.
+- **A watchdog backstop that stops short of this release.** If a `Review`
+  is still owed 10 minutes after the turn completed with no real run
+  activity, the stall-watchdog sweep force-settles the *pane status*
+  through `apply_pane_status`. It passes `SettleOrigin::ForcedBackstop`,
+  which deliberately withholds the browser release: the trigger is
+  silence, and a subagent sitting inside one long quiet tool call is
+  silent too. Publishing a settled dot early is repainted by the next
+  real event; closing a browser session the agent is still driving is
+  not. So the sidebar unsticks on the next sweep, while the chip clears
+  only on a real terminal transition (or when the pane/session closes).
+  See `docs/features/agent-chat.md` (§ Sidebar status indicators) for the
+  full forced-settle semantics.
 
 Known accepted edge case: if two chat threads are both driving browser
 activity in the *same* workspace, one thread finishing its run releases the

--- a/docs/features/review-integration.md
+++ b/docs/features/review-integration.md
@@ -43,6 +43,13 @@ a branch the user is not on *and* hide the "Create PR" affordance for the
 branch they are. The Review tab's own badge needs no separate guard — it only
 renders from cached PR query data, which a disabled panel never populates.
 
+The guard is a *mismatch* test, not an equality test: when either name is
+unknown it holds the association. `git_branch_info` reports no branch on a
+detached HEAD — mid-rebase, mid-bisect, `gh pr checkout` of a SHA — while
+`pr_head_branch` survives, and treating that unknown as "different branch"
+would offer "Create PR" for a workspace that already has an open one, for as
+long as the rebase ran.
+
 ## What Works Today
 
 - PR creation from panel when no PR exists for the current branch (title, body, base branch, draft toggle)

--- a/docs/features/review-integration.md
+++ b/docs/features/review-integration.md
@@ -31,6 +31,18 @@ A successful empty result clears the association, while an unanswerable lookup
 The frontend renders sub-components for each PR aspect. Auth status is checked
 before fetching. The panel updates when workspace state changes.
 
+**The Review tab is strictly current-branch, deliberately.** The sidebar shows
+a PR badge for a *side branch* the worktree merely checked out recently (the
+agent-opened-a-PR-from-a-side-branch case — see `docs/features/sidebar.md`
+§ "Side-branch PR badges"), and the workspace snapshot records that PR's head
+branch in `pr_head_branch`. This panel gates `hasPr` on that head branch
+matching `git_branch`, and its detail queries still call the strict
+`get_branch_pull_request` command. A badge is a pointer at GitHub; this panel
+is a working surface, so honouring a side-branch association here would review
+a branch the user is not on *and* hide the "Create PR" affordance for the
+branch they are. The Review tab's own badge needs no separate guard — it only
+renders from cached PR query data, which a disabled panel never populates.
+
 ## What Works Today
 
 - PR creation from panel when no PR exists for the current branch (title, body, base branch, draft toggle)

--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -439,16 +439,31 @@ visual only — nothing is archived, closed, or deleted.
   `select_branch_pr` policy. Both sides of each record are read (`Y` then `X`)
   so a branch whose arrival scrolled out of the window is still found; the
   current branch, the default branch, and detached-HEAD SHAs are excluded.
-  Recency decides between candidates — the first one with a PR wins outright,
-  because "what this workspace was just doing" is the question being answered.
-  The fallback never runs on the repository **default branch**, where "recently
-  checked out" describes ordinary branch hopping rather than this checkout's
-  work. It costs one repo-wide `gh pr list --state all` matched client-side
-  against every candidate (not one query per candidate), memoized per origin
-  URL for 60s so the 5s active-workspace sweep can't multiply it. A failed
-  fallback collapses to "no PR" rather than `Preserve`: the current branch
-  already answered authoritatively, and a missing bonus badge must not
-  resurrect an old one.
+  Recency decides between candidates — the first one with a qualifying PR wins
+  outright, because "what this workspace was just doing" is the question being
+  answered. The fallback never runs on the repository **default branch**, where
+  "recently checked out" describes ordinary branch hopping rather than this
+  checkout's work. A failed fallback collapses to "no PR" rather than
+  `Preserve`: the current branch already answered authoritatively, and a
+  missing bonus badge must not resurrect an old one.
+- **The fallback badges open PRs only**, unlike the current-branch path, which
+  keeps showing merged and closed state. The case it exists for — "an agent
+  just pushed a PR from a side branch" — is always an open PR, while admitting
+  history would let any branch that passed through this worktree donate its
+  badge: `gh pr checkout <n>` on someone else's merged PR and a switch back
+  would badge the workspace with that PR for the whole reflog window. Both the
+  query (`gh pr list --state open`, which includes drafts) and the client-side
+  selector enforce it, so the two cannot drift.
+- **Cost.** One repo-wide `gh pr list` matched client-side against every
+  candidate (not one query per candidate), memoized per origin URL for 60s, and
+  the local probes memoized per `(worktree, branch)` for the same 60s. Both
+  caches matter: the `gh` memo alone still left a `git reflog` — plus a
+  `git config` read per candidate — running on every 5s active-workspace tick.
+  Owner resolution is also lazy, so it costs `git config` only for a candidate
+  that already matched an open PR. On a repeat tick within the TTL the whole
+  fallback spawns nothing. A branch switch is a new cache key and is answered
+  at once; only a PR opened on an already-scanned branch waits out the TTL,
+  which is the latency the memoized `gh` list imposed anyway.
 - **A side-branch association is a badge and nothing more.** The workspace
   snapshot carries `pr_head_branch` (snapshot-local, serde-defaulted, never
   synced) alongside `pr_number`/`pr_state`/`pr_url`, and the frontend predicate
@@ -468,10 +483,16 @@ visual only — nothing is archived, closed, or deleted.
     badge, and honouring a side-branch PR there would hide "Create PR" for the
     branch the user is actually on.
 
-  A `null` head branch means "association predates the field", not "side
-  branch", and is read as a match so old persisted snapshots settle exactly as
-  they used to. The hover/details card adds a **"PR branch"** row only in the
-  mismatching case, where it answers the question the badge raises.
+  **Missing information on either side reads as a match.** A `null` head branch
+  means "association predates the field", not "side branch", so old persisted
+  snapshots settle exactly as they used to. A `null` `git_branch` is the same
+  unknown from the other end — `git_branch_info` reports no branch during a
+  rebase, a bisect, or any detached HEAD, while the stored head branch survives
+  — and reading that as a mismatch would silently un-associate a workspace from
+  its own open PR for the length of the rebase, down to offering "Create PR" in
+  the Review tab. Only two *known*, differing names count as a side-branch
+  association. The hover/details card adds a **"PR branch"** row only in that
+  case, where it answers the question the badge raises.
 - **The anti-oscillation invariant.** Four states (active / settled / snoozed /
   pinned-active) and five park-mutating effects (auto-settle, the auto-un-settle
   safety net, the snooze hand-raise, the wake sweep, the precise wake timer)

--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -380,7 +380,9 @@ visual only — nothing is archived, closed, or deleted.
 - **Auto-settle** — the Settled shelf fills itself using PR-completion
   semantics. A workspace whose PR is **merged or closed** settles
   immediately once it is neither working nor blocked; no activity stamp or
-  extra idle grace is required. A completed **review** status is settleable —
+  extra idle grace is required — provided that PR is the **checked-out
+  branch's** and not a badge-only side-branch association (see "Side-branch PR
+  badges" below). A completed **review** status is settleable —
   it says the run finished, not that work is still executing. An **open** PR
   never settles a card by itself; it demotes it into the "Wrapping up" tier
   described above. Work without a finished PR auto-settles when:
@@ -425,6 +427,51 @@ visual only — nothing is archived, closed, or deleted.
   matrix cannot drift between the manual refresh command and the two pollers.
   These rules are what let a real `MERGED`/`CLOSED` transition reach auto-settle
   reliably.
+- **Side-branch PR badges (badge only).** Strict current-branch association has
+  one visible blind spot: an agent that runs `git checkout -b side-branch`,
+  commits, pushes, opens a PR, and checks the worktree back leaves a workspace
+  that plainly produced a pull request and no badge to show for it. So when the
+  checked-out branch resolves to *no* PR, `github::get_workspace_pr` falls back
+  to branches the worktree checked out recently: it parses `checkout: moving
+  from X to Y` records out of the last **50** HEAD reflog entries (that reflog
+  is per-worktree, so it describes this checkout's own history), takes up to
+  **5** distinct branch names newest-first, and resolves them through the same
+  `select_branch_pr` policy. Both sides of each record are read (`Y` then `X`)
+  so a branch whose arrival scrolled out of the window is still found; the
+  current branch, the default branch, and detached-HEAD SHAs are excluded.
+  Recency decides between candidates — the first one with a PR wins outright,
+  because "what this workspace was just doing" is the question being answered.
+  The fallback never runs on the repository **default branch**, where "recently
+  checked out" describes ordinary branch hopping rather than this checkout's
+  work. It costs one repo-wide `gh pr list --state all` matched client-side
+  against every candidate (not one query per candidate), memoized per origin
+  URL for 60s so the 5s active-workspace sweep can't multiply it. A failed
+  fallback collapses to "no PR" rather than `Preserve`: the current branch
+  already answered authoritatively, and a missing bonus badge must not
+  resurrect an old one.
+- **A side-branch association is a badge and nothing more.** The workspace
+  snapshot carries `pr_head_branch` (snapshot-local, serde-defaulted, never
+  synced) alongside `pr_number`/`pr_state`/`pr_url`, and the frontend predicate
+  `isPrOnCurrentBranch` (in `pr-status-icon.tsx`, shared because neither the
+  sidebar nor the hover card may import the other) compares it to `git_branch`.
+  Everything that *renders* the PR ignores the distinction; everything that
+  *draws a conclusion* from it asks first:
+  - **auto-settle** refuses the merged/closed shortcut for a side-branch PR.
+    That branch merging says nothing about the checkout in front of the user,
+    which may still be full of uncommitted work. Such a workspace still ages
+    out through the ordinary inactivity rule — the guard removes the shortcut,
+    not the workspace's eventual settlement.
+  - the **"Wrapping up" tier** likewise refuses it: an open PR off a side
+    branch is not this workspace winding down.
+  - the **Review tab** stays strictly current-branch (see
+    `docs/features/review-integration.md`) — it is a working surface, not a
+    badge, and honouring a side-branch PR there would hide "Create PR" for the
+    branch the user is actually on.
+
+  A `null` head branch means "association predates the field", not "side
+  branch", and is read as a match so old persisted snapshots settle exactly as
+  they used to. The hover/details card adds a **"PR branch"** row only in the
+  mismatching case, where it answers the question the badge raises.
 - **The anti-oscillation invariant.** Four states (active / settled / snoozed /
   pinned-active) and five park-mutating effects (auto-settle, the auto-un-settle
   safety net, the snooze hand-raise, the wake sweep, the precise wake timer)

--- a/src-tauri/src/agent_provider/claude/translate.rs
+++ b/src-tauri/src/agent_provider/claude/translate.rs
@@ -828,6 +828,9 @@ fn snapshot_from_launch(tool_use_id: &str, input: &serde_json::Value) -> Subagen
         provider_ref: None,
         workflow_id: None,
         phase: None,
+        // A launch snapshot only ever comes from a real `Agent`/`Task`
+        // tool_use block, so it is by definition not a background task.
+        background_task: false,
     }
 }
 
@@ -1032,7 +1035,25 @@ fn base_snapshot(subagent_id: &str) -> SubagentSnapshot {
         provider_ref: None,
         workflow_id: None,
         phase: None,
+        // Task-event snapshots stamp this from the demux — see
+        // [`stamp_background_task`].
+        background_task: false,
     }
+}
+
+/// Mark `snap` as a provider background task when its id is not a
+/// registered top-level `Agent`/`Task` launch.
+///
+/// Claude emits the same `system.task_*` family for a real delegated
+/// subagent **and** for a background tool run (`Bash { run_in_background:
+/// true }`), keyed by the spawning `tool_use_id`. Only a real launch is
+/// registered in the demux ([`SubagentDemux::register_top_level_launch`]),
+/// so "not a top-level launch" is the exact discriminator: those rows can
+/// outlive the turn forever (a dev server never exits, so its terminal
+/// `task_notification` never arrives) and must never pin the workspace to
+/// `Working` after `TurnCompleted`.
+fn stamp_background_task(snap: &mut SubagentSnapshot, demux: &SubagentDemux) {
+    snap.background_task = !demux.is_top_level_launch(&snap.subagent_id);
 }
 
 /// `type: "user"` — sent by the SDK when a tool_result is appended
@@ -1480,6 +1501,12 @@ fn apply_task_usage(snap: &mut SubagentSnapshot, usage: Option<&serde_json::Valu
 /// emits a `Running` snapshot whose activity is the description.
 /// Ambient / housekeeping tasks (`skip_transcript: true`) are dropped so
 /// they never spawn a card.
+///
+/// The SDK emits this family for background *tool* runs too (a
+/// `Bash { run_in_background: true }`), keyed by the Bash tool_use_id.
+/// Those are stamped `background_task` (see [`stamp_background_task`]) so
+/// the pane-status tracker never lets them hold the workspace in
+/// `Working` after the turn ends.
 fn translate_task_started(
     thread_id: &ThreadId,
     msg: &serde_json::Value,
@@ -1500,6 +1527,7 @@ fn translate_task_started(
     if !description.is_empty() {
         snap.activity = Some(description);
     }
+    stamp_background_task(&mut snap, demux);
     stamp_workflow_attribution(&mut snap, demux);
     vec![ProviderRuntimeEvent::SubagentUpdated {
         thread_id: thread_id.clone(),
@@ -1526,6 +1554,7 @@ fn translate_task_progress(
     snap.status = SubagentStatus::Running;
     snap.activity = opt_str_field(msg, "summary").or_else(|| opt_str_field(msg, "last_tool_name"));
     apply_task_usage(&mut snap, msg.get("usage"));
+    stamp_background_task(&mut snap, demux);
     stamp_workflow_attribution(&mut snap, demux);
     vec![ProviderRuntimeEvent::SubagentUpdated {
         thread_id: thread_id.clone(),
@@ -1574,6 +1603,7 @@ fn translate_task_updated(
     if !changed {
         return Vec::new();
     }
+    stamp_background_task(&mut snap, demux);
     stamp_workflow_attribution(&mut snap, demux);
     vec![ProviderRuntimeEvent::SubagentUpdated {
         thread_id: thread_id.clone(),
@@ -1606,6 +1636,7 @@ fn translate_task_notification(
         snap.result_text = Some(summary);
     }
     apply_task_usage(&mut snap, msg.get("usage"));
+    stamp_background_task(&mut snap, demux);
     stamp_workflow_attribution(&mut snap, demux);
     vec![ProviderRuntimeEvent::SubagentUpdated {
         thread_id: thread_id.clone(),
@@ -2774,6 +2805,88 @@ mod tests {
         let snap = only_subagent(&translate_sdk_message_with(&tid(), &updated, &mut demux)).clone();
         assert_eq!(snap.subagent_id, "toolu_root");
         assert_eq!(snap.status, SubagentStatus::Completed);
+    }
+
+    // A background *tool* run (`Bash { run_in_background: true }`) rides
+    // the same `system.task_*` family as a real subagent, keyed by the
+    // Bash tool_use_id — which is never registered as a top-level
+    // `Agent`/`Task` launch. Those snapshots must carry `background_task`
+    // so the pane-status tracker refuses to let a never-exiting dev server
+    // hold the workspace in "Working" after the turn ends.
+    #[test]
+    fn background_shell_task_events_are_flagged_as_background_tasks() {
+        let mut demux = SubagentDemux::default();
+        // No `register_top_level_launch` — a Bash tool_use never registers.
+        let started = json!({
+            "type": "system", "subtype": "task_started",
+            "task_id": "task_bg", "tool_use_id": "toolu_bash",
+            "description": "npm run dev"
+        });
+        let snap = only_subagent(&translate_sdk_message_with(&tid(), &started, &mut demux)).clone();
+        assert_eq!(snap.subagent_id, "toolu_bash");
+        assert!(
+            snap.background_task,
+            "an unregistered tool_use id is a background task, not a subagent"
+        );
+
+        // The same flag rides progress / updated / notification, so no
+        // later event can quietly re-enter the running-set unflagged.
+        let progress = json!({
+            "type": "system", "subtype": "task_progress",
+            "task_id": "task_bg", "tool_use_id": "toolu_bash",
+            "last_tool_name": "Bash"
+        });
+        let snap =
+            only_subagent(&translate_sdk_message_with(&tid(), &progress, &mut demux)).clone();
+        assert!(snap.background_task);
+
+        let updated = json!({
+            "type": "system", "subtype": "task_updated",
+            "task_id": "task_bg", "patch": {"status": "running"}
+        });
+        let snap = only_subagent(&translate_sdk_message_with(&tid(), &updated, &mut demux)).clone();
+        assert!(snap.background_task);
+
+        let note = json!({
+            "type": "system", "subtype": "task_notification",
+            "task_id": "task_bg", "tool_use_id": "toolu_bash",
+            "status": "completed", "summary": "server stopped"
+        });
+        let snap = only_subagent(&translate_sdk_message_with(&tid(), &note, &mut demux)).clone();
+        assert!(snap.background_task);
+        assert_eq!(snap.status, SubagentStatus::Completed);
+    }
+
+    // The counterpart: a real `Agent`/`Task` launch is registered in the
+    // demux, so its task events stay unflagged and keep the deliberate
+    // deferred-`Review` behavior.
+    #[test]
+    fn real_agent_launch_task_events_are_not_background_tasks() {
+        let mut demux = SubagentDemux::default();
+        let launch = translate_sdk_message_with(
+            &tid(),
+            &launch_msg("Agent", "toolu_root", json!({"subagent_type": "Explore"})),
+            &mut demux,
+        );
+        assert!(
+            !only_subagent(&launch).background_task,
+            "the launch snapshot itself is never a background task"
+        );
+        let started = json!({
+            "type": "system", "subtype": "task_started",
+            "task_id": "task_1", "tool_use_id": "toolu_root",
+            "description": "Exploring the tree"
+        });
+        let snap = only_subagent(&translate_sdk_message_with(&tid(), &started, &mut demux)).clone();
+        assert!(!snap.background_task);
+
+        let note = json!({
+            "type": "system", "subtype": "task_notification",
+            "task_id": "task_1", "tool_use_id": "toolu_root",
+            "status": "completed", "summary": "done"
+        });
+        let snap = only_subagent(&translate_sdk_message_with(&tid(), &note, &mut demux)).clone();
+        assert!(!snap.background_task);
     }
 
     #[test]

--- a/src-tauri/src/agent_provider/claude/translate.rs
+++ b/src-tauri/src/agent_provider/claude/translate.rs
@@ -1052,6 +1052,13 @@ fn base_snapshot(subagent_id: &str) -> SubagentSnapshot {
 /// outlive the turn forever (a dev server never exits, so its terminal
 /// `task_notification` never arrives) and must never pin the workspace to
 /// `Working` after `TurnCompleted`.
+///
+/// The discriminator is *top-level* launch, so a **nested** subagent — one
+/// an already-delegated agent spawns — is also stamped `background_task`,
+/// since only the root launch is registered. That is deliberate and benign:
+/// the root stays in the run-blocking set for as long as the whole subtree
+/// is alive, so the nested row has nothing left to hold open, and the flag
+/// only ever means "do not let this row block settlement on its own".
 fn stamp_background_task(snap: &mut SubagentSnapshot, demux: &SubagentDemux) {
     snap.background_task = !demux.is_top_level_launch(&snap.subagent_id);
 }

--- a/src-tauri/src/agent_provider/codex/translate.rs
+++ b/src-tauri/src/agent_provider/codex/translate.rs
@@ -400,6 +400,9 @@ fn subagent_snapshot(subagent_id: &str, status: SubagentStatus) -> SubagentSnaps
         provider_ref: Some(subagent_id.to_string()),
         workflow_id: None,
         phase: None,
+        // Codex has no background-task concept on this path — every row
+        // here is a real delegated agent.
+        background_task: false,
     }
 }
 

--- a/src-tauri/src/agent_provider/events.rs
+++ b/src-tauri/src/agent_provider/events.rs
@@ -118,6 +118,16 @@ pub struct SubagentSnapshot {
     /// last planned phase title).
     #[serde(default)]
     pub phase: Option<String>,
+    /// This row is a provider **background task** (e.g. a background
+    /// shell command) rather than a real delegated subagent: it can
+    /// legitimately outlive the turn and never emit a terminal update, so
+    /// it must not hold the workspace in `Working` after `TurnCompleted`.
+    ///
+    /// `#[serde(default)]` like every other additive field, so snapshots
+    /// persisted before this existed — and every provider that never sets
+    /// it — decode as `false` (an ordinary subagent).
+    #[serde(default)]
+    pub background_task: bool,
 }
 
 /// One planned phase of a `Workflow` run, parsed best-effort out of the
@@ -649,6 +659,7 @@ mod tests {
             provider_ref: None,
             workflow_id: None,
             phase: None,
+            background_task: false,
         }
     }
 
@@ -679,6 +690,10 @@ mod tests {
         let snap: SubagentSnapshot = serde_json::from_value(json!({})).unwrap();
         assert_eq!(snap.subagent_id, "");
         assert_eq!(snap.status, SubagentStatus::Pending);
+        assert!(
+            !snap.background_task,
+            "an older payload without the flag decodes as an ordinary subagent"
+        );
     }
 
     #[test]

--- a/src-tauri/src/agent_provider/opencode/translate.rs
+++ b/src-tauri/src/agent_provider/opencode/translate.rs
@@ -686,6 +686,9 @@ fn empty_snapshot(id: &str) -> SubagentSnapshot {
         provider_ref: None,
         workflow_id: None,
         phase: None,
+        // OpenCode's `task` tool always spawns a real child session — it
+        // has no background-task shape on this path.
+        background_task: false,
     }
 }
 

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -3374,6 +3374,13 @@ struct ThreadSubagentState {
     /// A turn finished while `running` was non-empty, so the `Review`
     /// transition is owed once the last tracked subagent goes terminal.
     review_pending: bool,
+    /// Wall clock of the last event that could still justify deferring the
+    /// owed `Review`. Stamped when `review_pending` is first set and
+    /// refreshed by real post-turn run activity (see
+    /// [`refreshes_owed_review`]), so the watchdog can force-settle a
+    /// review that is owed but has gone silent. `None` whenever no review
+    /// is owed.
+    review_owed_since: Option<SystemTime>,
 }
 
 impl ThreadSubagentState {
@@ -3383,6 +3390,48 @@ impl ThreadSubagentState {
     fn is_clear(&self) -> bool {
         self.running.is_empty() && !self.review_pending
     }
+}
+
+/// Whether `event` is evidence that a thread's owed `Review` may still
+/// legitimately be deferred — i.e. real run activity arriving after
+/// `TurnCompleted`. Refreshes [`ThreadSubagentState::review_owed_since`]
+/// so a genuinely busy async subagent is never force-settled by the
+/// watchdog while it keeps reporting.
+///
+/// A `background_task` snapshot deliberately does NOT count: those tick
+/// for as long as the background job lives (forever, for a dev server) and
+/// must never keep a finished run pinned to `Working`.
+fn refreshes_owed_review(event: &ProviderRuntimeEvent) -> bool {
+    match event {
+        ProviderRuntimeEvent::SubagentUpdated { subagent, .. } => !subagent.background_task,
+        ProviderRuntimeEvent::ContentDelta { .. }
+        | ProviderRuntimeEvent::ItemCompleted { .. }
+        | ProviderRuntimeEvent::RequestOpened { .. }
+        | ProviderRuntimeEvent::RequestResolved { .. }
+        | ProviderRuntimeEvent::WorkflowUpdated { .. }
+        | ProviderRuntimeEvent::TasksUpdated { .. } => true,
+        _ => false,
+    }
+}
+
+/// Pure sweep predicate: whether `state` owes a `Review` that has gone
+/// silent for at least `threshold` and should therefore be force-settled.
+///
+/// `review_pending` is only ever set by `TurnCompleted`, so this can never
+/// fire mid-turn — that is the guard that keeps the backstop from cutting
+/// a live run short.
+fn select_overdue_review(
+    state: &ThreadSubagentState,
+    now: SystemTime,
+    threshold: Duration,
+) -> bool {
+    if !state.review_pending {
+        return false;
+    }
+    let Some(since) = state.review_owed_since else {
+        return false;
+    };
+    now.duration_since(since).unwrap_or_default() >= threshold
 }
 
 /// Tauri-managed, per-thread running-subagent tracker.
@@ -3404,10 +3453,25 @@ impl SubagentTracker {
     /// Run the pane-status decision for `event` against `thread_id`'s
     /// tracked subagent state, mutating it in place. Drops the entry once
     /// it returns to the clear state so the map stays bounded.
-    fn decide(&self, thread_id: &str, event: &ProviderRuntimeEvent) -> Option<PaneStatus> {
+    ///
+    /// `now` also maintains the owed-`Review` silence clock read by
+    /// [`SubagentTracker::take_overdue_reviews`].
+    fn decide(
+        &self,
+        thread_id: &str,
+        event: &ProviderRuntimeEvent,
+        now: SystemTime,
+    ) -> Option<PaneStatus> {
         let mut threads = self.threads.lock().expect("subagent tracker poisoned");
         let state = threads.entry(thread_id.to_string()).or_default();
         let status = map_event_to_pane_status(event, state);
+        if state.review_pending {
+            if state.review_owed_since.is_none() || refreshes_owed_review(event) {
+                state.review_owed_since = Some(now);
+            }
+        } else {
+            state.review_owed_since = None;
+        }
         if state.is_clear() {
             threads.remove(thread_id);
         }
@@ -3420,6 +3484,32 @@ impl SubagentTracker {
     pub fn clear_thread(&self, thread_id: &str) {
         let mut threads = self.threads.lock().expect("subagent tracker poisoned");
         threads.remove(thread_id);
+    }
+
+    /// Force-settle every thread whose owed `Review` has gone silent for
+    /// at least `threshold`: the entries are **removed** and their thread
+    /// ids returned so the caller can publish the settled status once.
+    ///
+    /// The safety net behind [`map_event_to_pane_status`]: even with
+    /// background tasks excluded from the running-set, a future missed
+    /// terminal subagent signal (a crashed notification, a provider quirk)
+    /// would otherwise pin the sidebar to "Working" and block the
+    /// background-browser release forever.
+    ///
+    /// Removing under the same lock makes this take-once — a later sweep
+    /// can't re-settle the same stall — and releases the mutex before the
+    /// caller touches `AppStateStore`.
+    fn take_overdue_reviews(&self, now: SystemTime, threshold: Duration) -> Vec<String> {
+        let mut threads = self.threads.lock().expect("subagent tracker poisoned");
+        let overdue: Vec<String> = threads
+            .iter()
+            .filter(|(_, state)| select_overdue_review(state, now, threshold))
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in &overdue {
+            threads.remove(id);
+        }
+        overdue
     }
 }
 
@@ -3451,6 +3541,20 @@ impl SubagentTracker {
 /// - `SubagentUpdated` with a terminal status (`Completed`/`Failed`/
 ///   `Stopped`) drops the subagent; when the last one clears and a
 ///   `Review` was owed, it finally publishes `Review`.
+///
+/// **Background tasks are excluded from all of that.** A snapshot carrying
+/// `background_task` is a provider background job (Claude emits the same
+/// `system.task_*` family for `Bash { run_in_background: true }`, keyed by
+/// the Bash tool_use_id). A dev server never exits, so its terminal
+/// notification never arrives — tracking it in `running` would defer the
+/// owed `Review` forever and pin the sidebar to "Working" (and, downstream,
+/// keep the background-browser `LIVE` chip up, since the release only fires
+/// on a settled status). So a live background-task snapshot is never
+/// inserted into `running`, always returns `None` — even when a `Review` is
+/// owed, so a progress tick cannot resurrect `Working` after the turn
+/// settled — and defensively removes any id an unflagged earlier variant
+/// may have inserted. Terminal background-task snapshots still `remove`
+/// (a no-op) and keep the owed-`Review` emptiness check unchanged.
 ///
 /// A genuine **new user turn** resets the thread's tracker (both
 /// `running` and `review_pending`). The authoritative, provider-agnostic
@@ -3488,6 +3592,16 @@ fn map_event_to_pane_status(
         ProviderRuntimeEvent::RequestResponseFailed { .. } => Some(PaneStatus::Review),
         ProviderRuntimeEvent::SubagentUpdated { subagent, .. } => match subagent.status {
             SubagentStatus::Pending | SubagentStatus::Running => {
+                if subagent.background_task {
+                    // A background shell job can outlive the turn forever
+                    // and never go terminal, so it must never join the
+                    // running-set nor move the dot — not even to restore
+                    // `Working` on an owed `Review`. Defensive removal
+                    // covers a snapshot for the same id that arrived
+                    // earlier in the session without the flag.
+                    state.running.remove(&subagent.subagent_id);
+                    return None;
+                }
                 if !subagent.subagent_id.is_empty() {
                     state.running.insert(subagent.subagent_id.clone());
                 }
@@ -3608,17 +3722,31 @@ fn publish_pane_status<R: Runtime>(
     // The status decision is per-thread and stateful (subagents can
     // outlive the parent turn), so resolve the thread first and route the
     // event through that thread's tracker.
-    let Some(mut status) = tracker.decide(&thread_id.0, event) else {
+    let Some(status) = tracker.decide(&thread_id.0, event, SystemTime::now()) else {
         return;
     };
+    apply_pane_status(app, &thread_id.0, status);
+}
+
+/// Write `status` for `thread_id` into the shared `pane_statuses` store,
+/// release the workspace's background agent browser once the run is over,
+/// and emit a stamped `app-state-changed` snapshot when either actually
+/// changed.
+///
+/// Extracted from [`publish_pane_status`] so the stall watchdog's forced
+/// settle ([`force_settle_overdue_reviews`]) applies exactly the same
+/// policy — the Review→Idle downgrade, the release, and the stamped emit —
+/// instead of growing a second copy of it. Takes no tracker lock, so the
+/// caller must release the tracker mutex before calling.
+fn apply_pane_status<R: Runtime>(app: &AppHandle<R>, thread_id: &str, mut status: PaneStatus) {
     let state: State<'_, AppStateStore> = app.state();
     // Mirror the terminal path: a turn that finishes in the workspace the
     // user is already looking at clears to Idle instead of nagging with a
     // review dot for output they can already see.
-    if status == PaneStatus::Review && state.is_thread_pane_in_active_workspace(&thread_id.0) {
+    if status == PaneStatus::Review && state.is_thread_pane_in_active_workspace(thread_id) {
         status = PaneStatus::Idle;
     }
-    let status_changed = state.set_pane_status_by_thread(&thread_id.0, status.clone());
+    let status_changed = state.set_pane_status_by_thread(thread_id, status.clone());
     // A finished run (turn complete and settled to `Review`/`Idle`, or the
     // session closed/errored into `Idle`) releases the workspace's
     // background agent browser session, if any, so the GUI-mode chip /
@@ -3628,7 +3756,7 @@ fn publish_pane_status<R: Runtime>(
     // time we see a terminal status here the run really is over.
     let released = run_finished(status)
         && state
-            .agent_chat_pane_id_for_thread(&thread_id.0)
+            .agent_chat_pane_id_for_thread(thread_id)
             .and_then(|pane_id| state.workspace_id_for_pane(&pane_id))
             .map(|workspace_id| state.release_detached_agent_browser(&workspace_id))
             .unwrap_or(false);
@@ -3832,6 +3960,35 @@ impl RunActivityTracker {
     }
 }
 
+/// Force-settle every thread whose owed `Review` has gone silent past
+/// [`STALL_THRESHOLD`], publishing the settled pane status through the same
+/// policy [`publish_pane_status`] uses (Review, downgraded to Idle in the
+/// active workspace, plus the background-browser release and the stamped
+/// app-state emit).
+///
+/// This is the backstop for a missed terminal subagent signal: without it a
+/// thread that completed its turn while something was still tracked as
+/// running stays "Working" — and keeps the browser `LIVE` chip up —
+/// indefinitely, because the only exit is a terminal snapshot that never
+/// arrives. `review_pending` is set exclusively by `TurnCompleted`, so a
+/// mid-flight turn can never be cut short here.
+///
+/// The tracker mutex is released by `take_overdue_reviews` before any
+/// `AppStateStore` call, so the two locks are never held together.
+fn force_settle_overdue_reviews<R: Runtime>(app: &AppHandle<R>, now: SystemTime) {
+    let overdue = {
+        let tracker: State<'_, SubagentTracker> = app.state();
+        tracker.take_overdue_reviews(now, STALL_THRESHOLD)
+    };
+    for thread_id in overdue {
+        eprintln!(
+            "[codemux::agent_chat] force-settling an overdue Review for thread {thread_id} (turn completed, no subagent activity for {}s)",
+            STALL_THRESHOLD.as_secs()
+        );
+        apply_pane_status(app, &thread_id, PaneStatus::Review);
+    }
+}
+
 /// Background sweep: every [`STALL_SWEEP_INTERVAL`] flag any thread that
 /// has been mid-turn and silent for at least [`STALL_THRESHOLD`] by
 /// forwarding a [`ProviderRuntimeEvent::RunStalled`]. Advisory only — the
@@ -3839,6 +3996,11 @@ impl RunActivityTracker {
 /// stalled is intentional: it keeps the UI's "no activity for Nm" duration
 /// fresh, and the event is transient (never persisted, cleared by the
 /// frontend on the next real activity).
+///
+/// The same sweep also force-settles an **owed `Review`** that has gone
+/// silent for the same threshold (see [`force_settle_overdue_reviews`]).
+/// That case is not a stall — the turn already completed — so it is not
+/// advisory: it actually publishes the settled status the run never got.
 ///
 /// Spawned once from `lib.rs` right after `spawn_event_bridge`, inside the
 /// same `agent_chat_enabled` gate. Generic over the Tauri runtime so the
@@ -3879,6 +4041,10 @@ pub async fn spawn_stall_watchdog<R: Runtime>(app: AppHandle<R>) {
                     },
                 );
             }
+            // Second pass: a turn that already completed but never got its
+            // owed `Review` published. Runs after the stall pass so a
+            // forced settle is never masked by the advisory notice.
+            force_settle_overdue_reviews(&app, now_wall);
         }
     });
 }
@@ -4863,6 +5029,7 @@ mod tests {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             tabs: Vec::new(),
@@ -5817,25 +5984,221 @@ mod tests {
         let tracker = SubagentTracker::default();
         // Live turn with a subagent that outlives it.
         assert_eq!(
-            tracker.decide("t", &subagent_event("s1", SubagentStatus::Running)),
+            tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), SystemTime::now()),
             None
         );
         assert_eq!(
-            tracker.decide("t", &turn_completed()),
+            tracker.decide("t", &turn_completed(), SystemTime::now()),
             Some(PaneStatus::Working)
         );
         assert_eq!(
-            tracker.decide("t", &subagent_event("s1", SubagentStatus::Completed)),
+            tracker.decide(
+                "t",
+                &subagent_event("s1", SubagentStatus::Completed),
+                SystemTime::now()
+            ),
             Some(PaneStatus::Review)
         );
         // Entry is dropped; a stray duplicate terminal is a harmless None.
         assert_eq!(
-            tracker.decide("t", &subagent_event("s1", SubagentStatus::Completed)),
+            tracker.decide(
+                "t",
+                &subagent_event("s1", SubagentStatus::Completed),
+                SystemTime::now()
+            ),
             None
         );
         // clear_thread is idempotent on an already-gone thread.
         tracker.clear_thread("t");
         tracker.clear_thread("does-not-exist");
+    }
+
+    // ── Background tasks must not block run settlement ──
+
+    /// A `SubagentUpdated` for a provider **background task** (Claude's
+    /// `Bash { run_in_background: true }` shape), which never emits a
+    /// terminal update when the job outlives the turn.
+    fn background_task_event(id: &str, status: SubagentStatus) -> ProviderRuntimeEvent {
+        ProviderRuntimeEvent::SubagentUpdated {
+            thread_id: tid(),
+            subagent: SubagentSnapshot {
+                subagent_id: id.into(),
+                status,
+                background_task: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    // The root-cause regression: a turn that launched a background shell
+    // command (a dev server that never exits, so no terminal
+    // `task_notification` ever arrives) must still settle to `Review` on
+    // `TurnCompleted` — no owed Review, no stuck "Working", so the
+    // background-browser release downstream actually fires.
+    #[test]
+    fn background_task_does_not_defer_review_on_turn_completed() {
+        let mut st = ThreadSubagentState::default();
+        let bg_running = background_task_event("toolu_bash", SubagentStatus::Running);
+        assert_eq!(
+            map_event_to_pane_status(&bg_running, &mut st),
+            None,
+            "a background task never moves the dot on its own"
+        );
+        assert!(
+            st.running.is_empty(),
+            "a background task is never tracked as a live subagent"
+        );
+        assert_eq!(
+            map_event_to_pane_status(&turn_completed(), &mut st),
+            Some(PaneStatus::Review),
+            "the turn settles even though the background job is still alive"
+        );
+        assert!(!st.review_pending, "no Review is owed");
+        assert!(st.is_clear());
+    }
+
+    // A background-task progress tick arriving AFTER the run settled must
+    // not resurrect `Working` — that is what kept the sidebar spinning and
+    // the browser chip on `LIVE` overnight.
+    #[test]
+    fn background_task_tick_after_settle_does_not_resurrect_working() {
+        let bg_running = background_task_event("toolu_bash", SubagentStatus::Running);
+        let mut st = ThreadSubagentState::default();
+        map_event_to_pane_status(&bg_running, &mut st);
+        map_event_to_pane_status(&turn_completed(), &mut st);
+        assert_eq!(map_event_to_pane_status(&bg_running, &mut st), None);
+
+        // Even with a genuine subagent owing a Review, a background tick
+        // must stay silent rather than re-publishing Working.
+        let mut st = ThreadSubagentState::default();
+        map_event_to_pane_status(&subagent_event("s1", SubagentStatus::Running), &mut st);
+        map_event_to_pane_status(&turn_completed(), &mut st);
+        assert!(st.review_pending);
+        assert_eq!(map_event_to_pane_status(&bg_running, &mut st), None);
+        assert!(st.review_pending, "the real subagent still owes its Review");
+    }
+
+    // Defensive path: an id inserted by an earlier unflagged snapshot (an
+    // older build, a provider that learns the shape late) is dropped from
+    // the running-set the moment a flagged snapshot for it arrives.
+    #[test]
+    fn flagged_snapshot_evicts_a_previously_unflagged_background_id() {
+        let mut st = ThreadSubagentState::default();
+        map_event_to_pane_status(&subagent_event("toolu_bash", SubagentStatus::Running), &mut st);
+        assert!(st.running.contains("toolu_bash"));
+        let bg_running = background_task_event("toolu_bash", SubagentStatus::Running);
+        map_event_to_pane_status(&bg_running, &mut st);
+        assert!(st.running.is_empty());
+        assert_eq!(
+            map_event_to_pane_status(&turn_completed(), &mut st),
+            Some(PaneStatus::Review)
+        );
+    }
+
+    // The deliberate async-subagent flow must be untouched: a real
+    // (unflagged) subagent still holds `Working` past `TurnCompleted` and
+    // its terminal snapshot still publishes the owed `Review`.
+    #[test]
+    fn real_subagent_still_defers_review_until_it_finishes() {
+        let mut st = ThreadSubagentState::default();
+        map_event_to_pane_status(&subagent_event("s1", SubagentStatus::Running), &mut st);
+        assert_eq!(
+            map_event_to_pane_status(&turn_completed(), &mut st),
+            Some(PaneStatus::Working)
+        );
+        assert!(st.review_pending);
+        assert_eq!(
+            map_event_to_pane_status(&subagent_event("s1", SubagentStatus::Completed), &mut st),
+            Some(PaneStatus::Review)
+        );
+        assert!(st.is_clear());
+    }
+
+    // ── Watchdog force-settle of an owed Review ──
+
+    #[test]
+    fn select_overdue_review_only_fires_on_a_silent_owed_review() {
+        let now = SystemTime::now();
+        let stale = now - STALL_THRESHOLD - Duration::from_secs(1);
+
+        // Nothing owed → never overdue, however old the state is.
+        let mid_turn = ThreadSubagentState {
+            running: ["s1".to_string()].into_iter().collect(),
+            review_pending: false,
+            review_owed_since: Some(stale),
+        };
+        assert!(!select_overdue_review(&mid_turn, now, STALL_THRESHOLD));
+
+        // Owed but still fresh → the deferred Review is allowed to stand.
+        let fresh = ThreadSubagentState {
+            running: ["s1".to_string()].into_iter().collect(),
+            review_pending: true,
+            review_owed_since: Some(now),
+        };
+        assert!(!select_overdue_review(&fresh, now, STALL_THRESHOLD));
+
+        // Owed and silent past the threshold → force-settle.
+        let overdue = ThreadSubagentState {
+            review_pending: true,
+            review_owed_since: Some(stale),
+            ..fresh.clone()
+        };
+        assert!(select_overdue_review(&overdue, now, STALL_THRESHOLD));
+    }
+
+    #[test]
+    fn take_overdue_reviews_settles_once_and_drops_the_entry() {
+        let tracker = SubagentTracker::default();
+        let start = SystemTime::now();
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), start);
+        assert_eq!(
+            tracker.decide("t", &turn_completed(), start),
+            Some(PaneStatus::Working),
+            "Review deferred behind a subagent that never goes terminal"
+        );
+
+        // Not yet silent long enough.
+        assert!(tracker
+            .take_overdue_reviews(start + Duration::from_secs(60), STALL_THRESHOLD)
+            .is_empty());
+
+        let later = start + STALL_THRESHOLD + Duration::from_secs(1);
+        assert_eq!(tracker.take_overdue_reviews(later, STALL_THRESHOLD), vec!["t".to_string()]);
+        // Take-once: the entry is gone, so a later sweep re-settles nothing.
+        assert!(tracker
+            .take_overdue_reviews(later + STALL_THRESHOLD, STALL_THRESHOLD)
+            .is_empty());
+    }
+
+    // Real post-turn subagent activity refreshes the silence clock, so a
+    // busy async subagent is never force-settled out from under a live run.
+    #[test]
+    fn real_subagent_activity_defers_the_forced_settle() {
+        let tracker = SubagentTracker::default();
+        let start = SystemTime::now();
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), start);
+        tracker.decide("t", &turn_completed(), start);
+
+        let almost = start + STALL_THRESHOLD - Duration::from_secs(1);
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), almost);
+        assert!(
+            tracker
+                .take_overdue_reviews(almost + Duration::from_secs(2), STALL_THRESHOLD)
+                .is_empty(),
+            "a live subagent snapshot re-arms the clock"
+        );
+
+        // A background-task tick, by contrast, is not activity — the clock
+        // keeps running from the last real signal.
+        tracker.decide(
+            "t",
+            &background_task_event("toolu_bash", SubagentStatus::Running),
+            almost + Duration::from_secs(2),
+        );
+        assert_eq!(
+            tracker.take_overdue_reviews(almost + STALL_THRESHOLD, STALL_THRESHOLD),
+            vec!["t".to_string()]
+        );
     }
 
     fn session_running() -> ProviderRuntimeEvent {
@@ -5891,9 +6254,9 @@ mod tests {
     fn send_command_clear_resets_tracking_across_turns() {
         let tracker = SubagentTracker::default();
         // Turn 1: subagent outlives the turn, Review deferred.
-        tracker.decide("t", &subagent_event("bg", SubagentStatus::Running));
+        tracker.decide("t", &subagent_event("bg", SubagentStatus::Running), SystemTime::now());
         assert_eq!(
-            tracker.decide("t", &turn_completed()),
+            tracker.decide("t", &turn_completed(), SystemTime::now()),
             Some(PaneStatus::Working)
         );
 
@@ -5902,7 +6265,7 @@ mod tests {
 
         // Turn 2 completes clean → Review, not a stuck Working.
         assert_eq!(
-            tracker.decide("t", &turn_completed()),
+            tracker.decide("t", &turn_completed(), SystemTime::now()),
             Some(PaneStatus::Review)
         );
     }

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -3381,12 +3381,35 @@ struct ThreadSubagentState {
     /// review that is owed but has gone silent. `None` whenever no review
     /// is owed.
     review_owed_since: Option<SystemTime>,
+    /// **Tombstone.** The watchdog already force-settled this thread's owed
+    /// `Review` ([`SubagentTracker::take_overdue_reviews`]) while ids were
+    /// still in `running`.
+    ///
+    /// The entry deliberately survives the forced settle instead of being
+    /// removed. Those ids may belong to a subagent that is genuinely alive
+    /// and merely quiet (one long tool call), and its real terminal
+    /// snapshot can still arrive minutes later. With the entry gone that
+    /// snapshot would land on a fresh `ThreadSubagentState` and leave a
+    /// `review_pending: false` husk behind, tracked until session close.
+    /// With the tombstone, the late terminal snapshot drains `running`
+    /// normally, publishes nothing (the `Review` was already published),
+    /// and the now-clear entry is dropped by [`Self::is_clear`].
+    ///
+    /// Cleared by every genuine turn boundary (a new
+    /// `SessionStatus::Running`, session teardown, or the send-message
+    /// `clear_thread`), so it never outlives the run it describes.
+    forced_settled: bool,
 }
 
 impl ThreadSubagentState {
     /// Whether this thread tracks no live subagents and owes no `Review`
     /// — the entry can be dropped from [`SubagentTracker`] so the map
     /// never grows unbounded.
+    ///
+    /// A [`Self::forced_settled`] tombstone is not itself a reason to keep
+    /// the entry: once the last force-settled id drains out of `running`
+    /// there is nothing left to disambiguate, so the tombstone is bounded
+    /// by the live ids it was recorded against.
     fn is_clear(&self) -> bool {
         self.running.is_empty() && !self.review_pending
     }
@@ -3397,6 +3420,11 @@ impl ThreadSubagentState {
 /// `TurnCompleted`. Refreshes [`ThreadSubagentState::review_owed_since`]
 /// so a genuinely busy async subagent is never force-settled by the
 /// watchdog while it keeps reporting.
+///
+/// *Any* tick from a real subagent counts, not just a state change, which
+/// is what makes the watchdog's threshold mean "every remaining blocker
+/// has been silent for 10 minutes" rather than "the thread has been silent
+/// since the turn ended".
 ///
 /// A `background_task` snapshot deliberately does NOT count: those tick
 /// for as long as the background job lives (forever, for a dev server) and
@@ -3417,9 +3445,22 @@ fn refreshes_owed_review(event: &ProviderRuntimeEvent) -> bool {
 /// Pure sweep predicate: whether `state` owes a `Review` that has gone
 /// silent for at least `threshold` and should therefore be force-settled.
 ///
-/// `review_pending` is only ever set by `TurnCompleted`, so this can never
-/// fire mid-turn — that is the guard that keeps the backstop from cutting
-/// a live run short.
+/// Two guards keep this off a healthy run:
+///
+/// * `review_pending` is only ever set by `TurnCompleted`, so it can never
+///   fire mid-turn.
+/// * `review_owed_since` is re-armed by *any* tick from a real (non
+///   `background_task`) tracked entry — see [`refreshes_owed_review`] —
+///   so the clock only advances while **every** remaining blocker is
+///   silent.
+///
+/// What it therefore cannot rule out is a live-but-quiet subagent: one
+/// long tool call (a `cargo test`, a big build) emits nothing for longer
+/// than the threshold, and the sweep will fire on it. That is accepted
+/// deliberately, and is why the forced path is non-destructive: it
+/// publishes the settled status but leaves the browser session alone and
+/// tombstones the entry rather than dropping it (see
+/// [`SubagentTracker::take_overdue_reviews`] and [`SettleOrigin`]).
 fn select_overdue_review(
     state: &ThreadSubagentState,
     now: SystemTime,
@@ -3487,29 +3528,53 @@ impl SubagentTracker {
     }
 
     /// Force-settle every thread whose owed `Review` has gone silent for
-    /// at least `threshold`: the entries are **removed** and their thread
-    /// ids returned so the caller can publish the settled status once.
+    /// at least `threshold`, returning their thread ids so the caller can
+    /// publish the settled status once.
     ///
     /// The safety net behind [`map_event_to_pane_status`]: even with
-    /// background tasks excluded from the running-set, a future missed
-    /// terminal subagent signal (a crashed notification, a provider quirk)
-    /// would otherwise pin the sidebar to "Working" and block the
-    /// background-browser release forever.
+    /// background tasks excluded from the running-set, a missed terminal
+    /// subagent signal (a crashed notification, a provider quirk) would
+    /// otherwise pin the sidebar to "Working" forever.
     ///
-    /// Removing under the same lock makes this take-once — a later sweep
-    /// can't re-settle the same stall — and releases the mutex before the
-    /// caller touches `AppStateStore`.
+    /// **The entries are tombstoned, not removed.** The sweep cannot prove
+    /// the tracked ids are dead — silence is not death — so it clears only
+    /// what it is publishing (`review_pending`, the silence clock) and
+    /// leaves `running` intact under a
+    /// [`ThreadSubagentState::forced_settled`] marker. That keeps the
+    /// forced settle take-once (a later sweep sees `review_pending: false`
+    /// and skips it) while letting a late-but-real terminal snapshot drain
+    /// `running` through the ordinary path, publish nothing, and drop the
+    /// entry — instead of resurrecting it as an untracked husk.
+    ///
+    /// Mutating under the same lock releases the mutex before the caller
+    /// touches `AppStateStore`, so the two locks are never held together.
     fn take_overdue_reviews(&self, now: SystemTime, threshold: Duration) -> Vec<String> {
         let mut threads = self.threads.lock().expect("subagent tracker poisoned");
-        let overdue: Vec<String> = threads
-            .iter()
-            .filter(|(_, state)| select_overdue_review(state, now, threshold))
-            .map(|(id, _)| id.clone())
-            .collect();
-        for id in &overdue {
-            threads.remove(id);
+        let mut overdue = Vec::new();
+        for (thread_id, state) in threads.iter_mut() {
+            if !select_overdue_review(state, now, threshold) {
+                continue;
+            }
+            state.review_pending = false;
+            state.review_owed_since = None;
+            state.forced_settled = true;
+            overdue.push(thread_id.clone());
         }
+        // A thread force-settled with nothing left in `running` has no
+        // tombstone left to carry, so it is dropped like any other clear
+        // entry rather than lingering in the map.
+        threads.retain(|_, state| !state.is_clear());
         overdue
+    }
+
+    /// Number of threads currently tracked. Test-only: the leak the
+    /// tombstone exists to prevent is only observable as map growth.
+    #[cfg(test)]
+    fn tracked_thread_count(&self) -> usize {
+        self.threads
+            .lock()
+            .expect("subagent tracker poisoned")
+            .len()
     }
 }
 
@@ -3620,6 +3685,13 @@ fn map_event_to_pane_status(
                     state.review_pending = false;
                     Some(PaneStatus::Review)
                 } else {
+                    // Also the late-completion-after-a-forced-settle case
+                    // (`forced_settled`): the watchdog already published
+                    // this thread's `Review`, so the real terminal snapshot
+                    // must stay silent rather than re-announcing a
+                    // transition the user has already seen and possibly
+                    // already cleared. Draining `running` here is the whole
+                    // point — it is what lets `is_clear` drop the tombstone.
                     None
                 }
             }
@@ -3650,6 +3722,9 @@ fn map_event_to_pane_status(
                 // `agent_chat_send_turn`).
                 state.running.clear();
                 state.review_pending = false;
+                // A new turn supersedes any forced settle of the previous
+                // one, so the tombstone goes with the rest of the state.
+                state.forced_settled = false;
                 Some(PaneStatus::Working)
             }
             SessionStatus::WaitingApproval { .. } => Some(PaneStatus::Permission),
@@ -3660,6 +3735,7 @@ fn map_event_to_pane_status(
                 // later `task_notification`) cannot pin the spinner.
                 state.running.clear();
                 state.review_pending = false;
+                state.forced_settled = false;
                 Some(PaneStatus::Idle)
             }
             SessionStatus::Starting | SessionStatus::Ready => None,
@@ -3725,20 +3801,53 @@ fn publish_pane_status<R: Runtime>(
     let Some(status) = tracker.decide(&thread_id.0, event, SystemTime::now()) else {
         return;
     };
-    apply_pane_status(app, &thread_id.0, status);
+    apply_pane_status(app, &thread_id.0, status, SettleOrigin::ProviderEvent);
+}
+
+/// Where a pane-status write came from. The one policy that differs
+/// between the two callers of [`apply_pane_status`]: whether a terminal
+/// status may also tear down the workspace's detached agent browser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SettleOrigin {
+    /// A real provider transition. The status is *evidence* the run
+    /// reached that state, so the browser session it was using can go.
+    ProviderEvent,
+    /// The stall watchdog's backstop
+    /// ([`force_settle_overdue_reviews`]). Silence is not proof of death:
+    /// the run may still be alive inside one long quiet tool call, and it
+    /// would then keep driving a browser session that this settle has no
+    /// standing to destroy. Publishing a settled dot is recoverable — the
+    /// next real event repaints it — whereas closing a live browser is
+    /// not, so the forced path publishes the status and stops there.
+    ForcedBackstop,
+}
+
+/// Whether a settle at `origin` reaching `status` should release the
+/// workspace's detached agent browser.
+///
+/// Pure, so the "a forced settle never releases the browser" rule is
+/// unit-testable without an `AppHandle`/`AppStateStore`.
+fn should_release_browser(origin: SettleOrigin, status: PaneStatus) -> bool {
+    matches!(origin, SettleOrigin::ProviderEvent) && run_finished(status)
 }
 
 /// Write `status` for `thread_id` into the shared `pane_statuses` store,
-/// release the workspace's background agent browser once the run is over,
-/// and emit a stamped `app-state-changed` snapshot when either actually
-/// changed.
+/// release the workspace's background agent browser once the run is
+/// provably over, and emit a stamped `app-state-changed` snapshot when
+/// either actually changed.
 ///
 /// Extracted from [`publish_pane_status`] so the stall watchdog's forced
-/// settle ([`force_settle_overdue_reviews`]) applies exactly the same
-/// policy — the Review→Idle downgrade, the release, and the stamped emit —
-/// instead of growing a second copy of it. Takes no tracker lock, so the
-/// caller must release the tracker mutex before calling.
-fn apply_pane_status<R: Runtime>(app: &AppHandle<R>, thread_id: &str, mut status: PaneStatus) {
+/// settle ([`force_settle_overdue_reviews`]) shares the Review→Idle
+/// downgrade and the stamped emit instead of growing a second copy of
+/// them. The browser release is the deliberate exception, gated on
+/// `origin` — see [`SettleOrigin`]. Takes no tracker lock, so the caller
+/// must release the tracker mutex before calling.
+fn apply_pane_status<R: Runtime>(
+    app: &AppHandle<R>,
+    thread_id: &str,
+    mut status: PaneStatus,
+    origin: SettleOrigin,
+) {
     let state: State<'_, AppStateStore> = app.state();
     // Mirror the terminal path: a turn that finishes in the workspace the
     // user is already looking at clears to Idle instead of nagging with a
@@ -3753,8 +3862,10 @@ fn apply_pane_status<R: Runtime>(app: &AppHandle<R>, thread_id: &str, mut status
     // context-bar indicator stop showing "LIVE" once the agent has nothing
     // left to do. `Working`/`Permission` must NOT release — the tracker
     // already defers `Review` while subagents are still running, so by the
-    // time we see a terminal status here the run really is over.
-    let released = run_finished(status)
+    // time we see a terminal status *from a provider event* the run really
+    // is over. A forced backstop settle carries no such proof and never
+    // releases.
+    let released = should_release_browser(origin, status)
         && state
             .agent_chat_pane_id_for_thread(thread_id)
             .and_then(|pane_id| state.workspace_id_for_pane(&pane_id))
@@ -3961,17 +4072,30 @@ impl RunActivityTracker {
 }
 
 /// Force-settle every thread whose owed `Review` has gone silent past
-/// [`STALL_THRESHOLD`], publishing the settled pane status through the same
-/// policy [`publish_pane_status`] uses (Review, downgraded to Idle in the
-/// active workspace, plus the background-browser release and the stamped
-/// app-state emit).
+/// [`STALL_THRESHOLD`], publishing the settled pane status through
+/// [`apply_pane_status`] (Review, downgraded to Idle in the active
+/// workspace, plus the stamped app-state emit).
 ///
 /// This is the backstop for a missed terminal subagent signal: without it a
 /// thread that completed its turn while something was still tracked as
-/// running stays "Working" — and keeps the browser `LIVE` chip up —
-/// indefinitely, because the only exit is a terminal snapshot that never
-/// arrives. `review_pending` is set exclusively by `TurnCompleted`, so a
-/// mid-flight turn can never be cut short here.
+/// running stays "Working" indefinitely, because the only exit is a
+/// terminal snapshot that never arrives.
+///
+/// **Deliberately non-destructive.** The trigger is silence, and silence
+/// cannot distinguish a dead subagent from a live one sitting inside one
+/// long tool call. So the forced path only ever writes a pane status:
+///
+/// * it passes [`SettleOrigin::ForcedBackstop`], which withholds the
+///   detached-browser release — tearing down the browser under a live
+///   subagent would be unrecoverable, while a premature dot is repainted
+///   by the next real event;
+/// * `take_overdue_reviews` tombstones rather than removes the tracker
+///   entry, so a late real completion drains normally, publishes nothing,
+///   and leaves no orphaned entry behind.
+///
+/// `review_pending` is set exclusively by `TurnCompleted`, so a mid-flight
+/// turn can never be cut short here, and every remaining blocker must have
+/// been silent for the full threshold (see [`refreshes_owed_review`]).
 ///
 /// The tracker mutex is released by `take_overdue_reviews` before any
 /// `AppStateStore` call, so the two locks are never held together.
@@ -3985,7 +4109,7 @@ fn force_settle_overdue_reviews<R: Runtime>(app: &AppHandle<R>, now: SystemTime)
             "[codemux::agent_chat] force-settling an overdue Review for thread {thread_id} (turn completed, no subagent activity for {}s)",
             STALL_THRESHOLD.as_secs()
         );
-        apply_pane_status(app, &thread_id, PaneStatus::Review);
+        apply_pane_status(app, &thread_id, PaneStatus::Review, SettleOrigin::ForcedBackstop);
     }
 }
 
@@ -3999,8 +4123,10 @@ fn force_settle_overdue_reviews<R: Runtime>(app: &AppHandle<R>, now: SystemTime)
 ///
 /// The same sweep also force-settles an **owed `Review`** that has gone
 /// silent for the same threshold (see [`force_settle_overdue_reviews`]).
-/// That case is not a stall — the turn already completed — so it is not
-/// advisory: it actually publishes the settled status the run never got.
+/// That case is not a stall — the turn already completed — so it does more
+/// than advise: it publishes the settled status the run never got. It stops
+/// there, though. It never releases the detached browser and never drops
+/// tracker state, because silence alone cannot prove the run is dead.
 ///
 /// Spawned once from `lib.rs` right after `spawn_event_bridge`, inside the
 /// same `agent_chat_enabled` gate. Generic over the Tauri runtime so the
@@ -6126,6 +6252,7 @@ mod tests {
             running: ["s1".to_string()].into_iter().collect(),
             review_pending: false,
             review_owed_since: Some(stale),
+            forced_settled: false,
         };
         assert!(!select_overdue_review(&mid_turn, now, STALL_THRESHOLD));
 
@@ -6134,6 +6261,7 @@ mod tests {
             running: ["s1".to_string()].into_iter().collect(),
             review_pending: true,
             review_owed_since: Some(now),
+            forced_settled: false,
         };
         assert!(!select_overdue_review(&fresh, now, STALL_THRESHOLD));
 
@@ -6147,7 +6275,7 @@ mod tests {
     }
 
     #[test]
-    fn take_overdue_reviews_settles_once_and_drops_the_entry() {
+    fn take_overdue_reviews_settles_once_and_tombstones_the_entry() {
         let tracker = SubagentTracker::default();
         let start = SystemTime::now();
         tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), start);
@@ -6163,11 +6291,111 @@ mod tests {
             .is_empty());
 
         let later = start + STALL_THRESHOLD + Duration::from_secs(1);
-        assert_eq!(tracker.take_overdue_reviews(later, STALL_THRESHOLD), vec!["t".to_string()]);
-        // Take-once: the entry is gone, so a later sweep re-settles nothing.
+        assert_eq!(
+            tracker.take_overdue_reviews(later, STALL_THRESHOLD),
+            vec!["t".to_string()]
+        );
+        // Take-once: the owed Review was cleared, so a later sweep
+        // re-settles nothing...
         assert!(tracker
             .take_overdue_reviews(later + STALL_THRESHOLD, STALL_THRESHOLD)
             .is_empty());
+        // ...but the entry itself survives as a tombstone, because `s1` may
+        // still be alive and its terminal snapshot still has to land
+        // somewhere that knows a Review was already published.
+        assert_eq!(tracker.tracked_thread_count(), 1);
+    }
+
+    // Finding (b): a forced settle must not strand tracker state. The late
+    // real completion drains the tombstone, publishes nothing, and leaves
+    // the map empty — as opposed to dropping the entry at settle time,
+    // where the same snapshot would recreate a `review_pending: false` husk
+    // that nothing ever collects.
+    #[test]
+    fn a_late_completion_after_a_forced_settle_is_silent_and_leaks_nothing() {
+        let tracker = SubagentTracker::default();
+        let start = SystemTime::now();
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), start);
+        tracker.decide("t", &turn_completed(), start);
+        let settled_at = start + STALL_THRESHOLD + Duration::from_secs(1);
+        assert_eq!(
+            tracker.take_overdue_reviews(settled_at, STALL_THRESHOLD),
+            vec!["t".to_string()]
+        );
+
+        // The subagent was alive all along — just quiet inside one long
+        // tool call — and reports again after the forced settle.
+        assert_eq!(
+            tracker.decide(
+                "t",
+                &subagent_event("s1", SubagentStatus::Running),
+                settled_at + Duration::from_secs(5)
+            ),
+            None,
+            "a post-settle progress tick must not resurrect Working"
+        );
+        assert_eq!(
+            tracker.decide(
+                "t",
+                &subagent_event("s1", SubagentStatus::Completed),
+                settled_at + Duration::from_secs(10)
+            ),
+            None,
+            "the Review was already published; do not re-announce it"
+        );
+        assert_eq!(
+            tracker.tracked_thread_count(),
+            0,
+            "the tombstone is collected once the last tracked id drains"
+        );
+    }
+
+    // A forced settle on a thread whose next turn simply starts again must
+    // behave like any other thread: the tombstone is part of the state a
+    // new turn resets, so turn 2 settles normally.
+    #[test]
+    fn a_new_turn_clears_the_forced_settle_tombstone() {
+        let tracker = SubagentTracker::default();
+        let start = SystemTime::now();
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), start);
+        tracker.decide("t", &turn_completed(), start);
+        let settled_at = start + STALL_THRESHOLD + Duration::from_secs(1);
+        tracker.take_overdue_reviews(settled_at, STALL_THRESHOLD);
+
+        assert_eq!(
+            tracker.decide("t", &session_running(), settled_at + Duration::from_secs(1)),
+            Some(PaneStatus::Working)
+        );
+        assert_eq!(
+            tracker.decide("t", &turn_completed(), settled_at + Duration::from_secs(2)),
+            Some(PaneStatus::Review),
+            "turn 2 settles through the ordinary path"
+        );
+        assert_eq!(tracker.tracked_thread_count(), 0);
+    }
+
+    // Finding (a), the destructive half: the watchdog's trigger is silence,
+    // which a live subagent inside one long quiet tool call also produces.
+    // Publishing a settled dot too early is repainted by the next real
+    // event; tearing down the browser session that subagent is driving is
+    // not recoverable, so only a provider event may do it.
+    #[test]
+    fn a_forced_settle_never_releases_the_detached_browser() {
+        for status in [PaneStatus::Review, PaneStatus::Idle] {
+            assert!(
+                should_release_browser(SettleOrigin::ProviderEvent, status.clone()),
+                "a real terminal transition still releases"
+            );
+            assert!(
+                !should_release_browser(SettleOrigin::ForcedBackstop, status),
+                "the watchdog's backstop must never tear down a live browser"
+            );
+        }
+        // Mid-run statuses are unchanged from either origin.
+        for origin in [SettleOrigin::ProviderEvent, SettleOrigin::ForcedBackstop] {
+            assert!(!should_release_browser(origin, PaneStatus::Working));
+            assert!(!should_release_browser(origin, PaneStatus::Permission));
+        }
     }
 
     // Real post-turn subagent activity refreshes the silence clock, so a

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -303,7 +303,7 @@ pub async fn refresh_workspace_pr<R: tauri::Runtime>(
 
     let cwd_for_pr = cwd.clone();
     let lookup =
-        tokio::task::spawn_blocking(move || crate::github::get_branch_pr(Path::new(&cwd_for_pr)))
+        tokio::task::spawn_blocking(move || crate::github::get_workspace_pr(Path::new(&cwd_for_pr)))
             .await
             .map_err(|e| format!("refresh_workspace_pr task join failed: {e}"))?;
     // Decision matrix, shared with both background pollers via
@@ -318,10 +318,11 @@ pub async fn refresh_workspace_pr<R: tauri::Runtime>(
                 Some(pr.number),
                 Some(pr.display_state()),
                 Some(pr.url),
+                pr.head_branch,
             );
         }
         crate::github::BranchPrOutcome::Clear => {
-            state.update_workspace_pr_info(&workspace_id, None, None, None);
+            state.update_workspace_pr_info(&workspace_id, None, None, None, None);
         }
         crate::github::BranchPrOutcome::Preserve => {}
     }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -667,7 +667,18 @@ pub(crate) async fn create_worktree_workspace_impl<R: tauri::Runtime>(
     populate_git_info_async(&state, &workspace_id.0, wt_path_buf.clone()).await;
 
     if let Some(pr_num) = pr_number {
-        state.update_workspace_pr_info(&workspace_id.0, Some(pr_num), None, None);
+        // Seed values only — the pollers replace all four the moment they
+        // reach this workspace. The head branch is the branch we just
+        // checked out for the PR, so the association starts out as a
+        // current-branch one (settlement-eligible) rather than looking like
+        // the side-branch fallback's weaker badge.
+        state.update_workspace_pr_info(
+            &workspace_id.0,
+            Some(pr_num),
+            None,
+            None,
+            Some(branch.clone()),
+        );
     }
 
     let snapshot = state.snapshot();

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1928,6 +1928,7 @@ mod tests {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             tabs: Vec::new(),

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -1,7 +1,7 @@
 use crate::execution::{sanitize_gui_env_std, sanitize_gui_env_std_keep_dbus};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -1021,14 +1021,65 @@ const REFLOG_CANDIDATE_LIMIT: usize = 5;
 /// out in the recent past, whose PRs are correspondingly recent.
 const FALLBACK_PR_LIST_LIMIT: &str = "50";
 
-/// How long one repo-wide fallback list is reused. Sized to the 60s PR
-/// poller so the 5s active-workspace sweep can't multiply it: several
-/// no-PR workspaces sharing a repo cost one `gh` call per minute between
-/// them, not one per workspace per sweep.
+/// How long one fallback result is reused. Sized to the 60s PR poller so
+/// the 5s active-workspace sweep can't multiply it.
+///
+/// It gates **both** fallback caches, and between them the whole fallback
+/// costs nothing on a repeat call: several no-PR workspaces sharing a repo
+/// cost one `gh` call per minute between them, and each workspace runs its
+/// local git probes (`reflog show`, plus at most a couple of `config`
+/// reads) at most once a minute — not once per 5s sweep.
 const FALLBACK_PR_LIST_TTL: Duration = Duration::from_secs(60);
 
 type FallbackPrListCache = Mutex<HashMap<String, (Instant, Arc<Vec<serde_json::Value>>)>>;
 static FALLBACK_PR_LIST_CACHE: OnceLock<FallbackPrListCache> = OnceLock::new();
+
+/// Memoized fallback outcome, keyed by `(worktree path, current branch)`.
+///
+/// The reflog is per-worktree and the answer depends on which branch is
+/// checked out, so neither part of the key can be dropped. This is the
+/// cache that keeps the *local* side of the fallback off the 5s sweep: the
+/// `gh` list alone being memoized still left a `git reflog` and a `git
+/// config` per tick.
+///
+/// A branch switch is a new key and is answered immediately; only a PR
+/// opened on an already-scanned branch waits out the TTL, which is the same
+/// latency the memoized `gh` list already imposes.
+type SideBranchPrCache = Mutex<HashMap<(PathBuf, String), (Instant, Option<PullRequestInfo>)>>;
+static SIDE_BRANCH_PR_CACHE: OnceLock<SideBranchPrCache> = OnceLock::new();
+
+/// TTL memoization over a `Mutex<HashMap>`: `compute` runs only when no
+/// entry younger than `ttl` exists for `key`.
+///
+/// Errors are never cached — a dropped network or an expired `gh` token
+/// must be retried on the next call, not pinned for a minute. Expired
+/// entries are swept on write, so the map is bounded by the repos actually
+/// polled in one TTL window.
+///
+/// The lock is released while `compute` runs, so two racing callers may
+/// both compute; the outcome is identical either way and holding a global
+/// mutex across a subprocess would be worse.
+fn memoize_ok<K, V, E>(
+    cache: &Mutex<HashMap<K, (Instant, V)>>,
+    key: K,
+    ttl: Duration,
+    compute: impl FnOnce() -> Result<V, E>,
+) -> Result<V, E>
+where
+    K: Eq + std::hash::Hash,
+    V: Clone,
+{
+    if let Some((fetched_at, value)) = cache.lock().expect("PR fallback cache poisoned").get(&key) {
+        if fetched_at.elapsed() < ttl {
+            return Ok(value.clone());
+        }
+    }
+    let value = compute()?;
+    let mut guard = cache.lock().expect("PR fallback cache poisoned");
+    guard.retain(|_, (fetched_at, _)| fetched_at.elapsed() < ttl);
+    guard.insert(key, (Instant::now(), value.clone()));
+    Ok(value)
+}
 
 /// True for a name that is really a commit id — what `git checkout <sha>`
 /// and `git bisect` write into the reflog. A branch named entirely of hex
@@ -1099,64 +1150,79 @@ fn fallback_pr_list_key(repo_path: &Path) -> String {
         .unwrap_or_else(|| repo_path.to_string_lossy().into_owned())
 }
 
-/// One repo-wide `gh pr list`, memoized for [`FALLBACK_PR_LIST_TTL`].
+/// One repo-wide `gh pr list` of **open** PRs, memoized for
+/// [`FALLBACK_PR_LIST_TTL`].
 ///
 /// Listing the repo once and matching every candidate branch against it
 /// client-side keeps the fallback at a flat one extra `gh` call, instead of
 /// one per candidate.
+///
+/// `--state open` (which includes drafts) rather than `--state all`: the
+/// fallback only ever badges an open PR — see [`select_first_candidate_pr`]
+/// — so fetching history would be paid-for rows that the selector discards.
+/// The selector re-checks the state anyway, so the two cannot drift.
 fn fallback_pr_list(repo_path: &Path) -> Result<Arc<Vec<serde_json::Value>>, String> {
     let key = fallback_pr_list_key(repo_path);
     let cache = FALLBACK_PR_LIST_CACHE.get_or_init(FallbackPrListCache::default);
 
-    if let Some((fetched_at, rows)) = cache.lock().unwrap().get(&key) {
-        if fetched_at.elapsed() < FALLBACK_PR_LIST_TTL {
-            return Ok(Arc::clone(rows));
-        }
-    }
-
-    let output = run_gh_timed(
-        repo_path,
-        &[
-            "pr",
-            "list",
-            "--state",
-            "all",
-            "--limit",
-            FALLBACK_PR_LIST_LIMIT,
-            "--json",
-            BRANCH_PR_JSON_FIELDS,
-        ],
-        BRANCH_PR_LOOKUP_TIMEOUT,
-    )?;
-    let value: serde_json::Value =
-        serde_json::from_str(&output).map_err(|e| format!("Failed to parse PR JSON: {e}"))?;
-    let rows = Arc::new(
-        value
-            .as_array()
-            .ok_or_else(|| "Expected JSON array from gh pr list".to_string())?
-            .clone(),
-    );
-
-    let mut guard = cache.lock().unwrap();
-    guard.retain(|_, (fetched_at, _)| fetched_at.elapsed() < FALLBACK_PR_LIST_TTL);
-    guard.insert(key, (Instant::now(), Arc::clone(&rows)));
-    Ok(rows)
+    memoize_ok(cache, key, FALLBACK_PR_LIST_TTL, || {
+        let output = run_gh_timed(
+            repo_path,
+            &[
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--limit",
+                FALLBACK_PR_LIST_LIMIT,
+                "--json",
+                BRANCH_PR_JSON_FIELDS,
+            ],
+            BRANCH_PR_LOOKUP_TIMEOUT,
+        )?;
+        let value: serde_json::Value =
+            serde_json::from_str(&output).map_err(|e| format!("Failed to parse PR JSON: {e}"))?;
+        Ok(Arc::new(
+            value
+                .as_array()
+                .ok_or_else(|| "Expected JSON array from gh pr list".to_string())?
+                .clone(),
+        ))
+    })
 }
 
-/// Badge-only fallback: the PR of a branch this worktree checked out recently.
+/// Badge-only fallback: the open PR of a branch this worktree checked out
+/// recently, memoized per `(worktree, branch)` for
+/// [`FALLBACK_PR_LIST_TTL`].
 ///
 /// Answers the "agent opened the PR from a side branch, then checked the
 /// worktree back" case, where the workspace has visibly produced a pull
 /// request that strict current-branch association cannot see. Candidates are
-/// tried newest-first and the first branch with a PR wins — each one is
-/// resolved through the same [`select_branch_pr`] policy as the current
-/// branch, so open/draft still beats history and fork owners are still
-/// scoped.
+/// tried newest-first and the first branch with an open PR wins; fork owners
+/// are still scoped exactly as on the current-branch path.
+///
+/// The memoization is what makes this affordable on the 5s active-workspace
+/// sweep — see [`SIDE_BRANCH_PR_CACHE`]. Without it every tick of every
+/// no-PR workspace re-ran `git reflog` and a `git config` or three.
 ///
 /// The result is deliberately weaker than a current-branch association: it
 /// carries the PR's own `head_branch`, and auto-settlement refuses any
 /// association whose head branch is not the checked-out one.
 fn get_side_branch_pr(
+    repo_path: &Path,
+    lookup: &BranchPrLookup,
+) -> Result<Option<PullRequestInfo>, String> {
+    let cache = SIDE_BRANCH_PR_CACHE.get_or_init(SideBranchPrCache::default);
+    let key = (repo_path.to_path_buf(), lookup.branch.clone());
+    memoize_ok(cache, key, FALLBACK_PR_LIST_TTL, || {
+        resolve_side_branch_pr(repo_path, lookup)
+    })
+}
+
+/// The uncached body of [`get_side_branch_pr`] — every local git probe the
+/// fallback makes lives here, so the memo above is the only thing standing
+/// between it and the 5s sweep.
+fn resolve_side_branch_pr(
     repo_path: &Path,
     lookup: &BranchPrLookup,
 ) -> Result<Option<PullRequestInfo>, String> {
@@ -1189,28 +1255,54 @@ fn get_side_branch_pr(
     }))
 }
 
-/// Newest-first candidate scan: the first recently-checked-out branch that
-/// has a PR wins outright.
+/// Newest-first candidate scan: the first recently-checked-out branch with
+/// an **open or draft** PR wins outright.
 ///
-/// Recency decides, not PR state. A branch checked out more recently is the
-/// better description of what this workspace was just doing, and ranking an
-/// older branch's open PR above it would resurrect stale work as the badge.
-/// Within a single candidate the ordinary [`select_branch_pr`] policy still
-/// applies, so open/draft beats that branch's own history.
+/// Merged and closed PRs are excluded here, unlike the current-branch path.
+/// The motivating case is narrow — "an agent just pushed a PR from a side
+/// branch" — and it is always an open one. Admitting history instead lets
+/// any branch that passed through this worktree in the last
+/// [`REFLOG_SCAN_ENTRIES`] checkouts donate its badge: `gh pr checkout <n>`
+/// on somebody else's merged PR and a switch back would badge the workspace
+/// with that PR for as long as the checkout stayed in the reflog window.
+/// The current branch's own association keeps showing merged/closed state,
+/// because there branch identity — not recency — owns the badge.
+///
+/// Recency decides between candidates, not PR freshness: a branch checked
+/// out more recently is the better description of what this workspace was
+/// just doing.
 ///
 /// `expected_owner` is injected rather than resolved inline because it costs
 /// a `git config` read per candidate — the caller owns that, the selection
-/// rule stays pure.
+/// rule stays pure. It is consulted **lazily**, only for a candidate that
+/// already has at least one open PR row to disambiguate, so the common
+/// "recently visited branches, none of them with a PR" case spawns no git
+/// processes at all.
 fn select_first_candidate_pr(
     prs: &[PullRequestInfo],
     candidates: &[String],
     expected_owner: &dyn Fn(&str) -> Option<String>,
 ) -> Option<PullRequestInfo> {
+    let open: Vec<&PullRequestInfo> = prs
+        .iter()
+        .filter(|pr| !is_historical_pr_state(&pr.state))
+        .collect();
     candidates.iter().find_map(|candidate| {
-        // Never the default branch — `parse_recent_checkout_branches`
-        // excludes it — so historical PRs stay eligible here.
+        let matching: Vec<PullRequestInfo> = open
+            .iter()
+            .filter(|pr| pr.head_branch.as_deref() == Some(candidate.as_str()))
+            .map(|pr| (*pr).clone())
+            .collect();
+        if matching.is_empty() {
+            // Nothing to disambiguate, so `expected_owner` — and the
+            // `git config` reads behind it — is never reached.
+            return None;
+        }
+        // `is_default_branch` is irrelevant now that only open/draft rows
+        // reach here — it exists to suppress historical PRs — so the
+        // cheaper `false` is passed rather than re-deriving the default.
         select_branch_pr(
-            prs.iter().cloned(),
+            matching,
             candidate,
             expected_owner(candidate).as_deref(),
             false,
@@ -1220,10 +1312,13 @@ fn select_first_candidate_pr(
 
 /// The PR a workspace should show a badge for.
 ///
-/// The current branch owns the association whenever it has one. Only when it
-/// authoritatively has none does the recently-checked-out fallback run, and
-/// never on the repository default branch, where "recently checked out"
-/// describes ordinary branch hopping rather than this checkout's own work.
+/// The current branch owns the association whenever it has one, in any state
+/// — branch identity, not freshness, decides there. Only when the current
+/// branch authoritatively has none does the recently-checked-out fallback
+/// run, and never on the repository default branch, where "recently checked
+/// out" describes ordinary branch hopping rather than this checkout's own
+/// work. The fallback badges **open PRs only**, so a `gh pr checkout` of
+/// somebody's merged PR cannot leave its badge behind.
 ///
 /// The three-way [`BranchPrOutcome`] contract is preserved exactly: an
 /// unanswerable *current-branch* lookup is still `Err` (preserve the badge),
@@ -2092,17 +2187,112 @@ ccc9999 HEAD@{8}: checkout: moving from a to b";
     }
 
     #[test]
-    fn test_fallback_takes_the_most_recently_checked_out_branch_with_a_pr() {
-        // Recency decides between candidates: `newer`'s merged PR outranks
-        // `older`'s open one, because "what this workspace was just doing"
-        // is the question being answered.
+    fn test_fallback_takes_the_most_recently_checked_out_branch_with_an_open_pr() {
+        // Recency decides between candidates that both qualify.
         let prs = vec![
             branch_pr(70, "OPEN", "older", "2026-08-05T10:00:00Z", None),
-            branch_pr(71, "MERGED", "newer", "2026-08-04T10:00:00Z", None),
+            branch_pr(71, "OPEN", "newer", "2026-08-04T10:00:00Z", None),
         ];
         let candidates = vec!["newer".to_string(), "older".to_string()];
         let selected = select_first_candidate_pr(&prs, &candidates, &|_| None).unwrap();
         assert_eq!(selected.number, 71);
+    }
+
+    #[test]
+    fn test_fallback_ignores_merged_and_closed_candidate_prs() {
+        // The fallback answers "an agent just pushed a PR from a side
+        // branch", which is always an open PR. Admitting history would let
+        // `gh pr checkout <n>` on somebody else's finished PR badge this
+        // workspace with it for the whole reflog window — so `newer`'s
+        // merged PR is skipped and `older`'s open one wins despite being
+        // less recent, and a candidate with only history contributes
+        // nothing at all.
+        let prs = vec![
+            branch_pr(70, "OPEN", "older", "2026-08-05T10:00:00Z", None),
+            branch_pr(71, "MERGED", "newer", "2026-08-04T10:00:00Z", None),
+            branch_pr(72, "CLOSED", "abandoned", "2026-08-06T10:00:00Z", None),
+        ];
+        let selected = select_first_candidate_pr(
+            &prs,
+            &[
+                "abandoned".to_string(),
+                "newer".to_string(),
+                "older".to_string(),
+            ],
+            &|_| None,
+        )
+        .unwrap();
+        assert_eq!(selected.number, 70);
+
+        assert!(
+            select_first_candidate_pr(
+                &prs,
+                &["newer".to_string(), "abandoned".to_string()],
+                &|_| None
+            )
+            .is_none(),
+            "a workspace whose recent branches only have finished PRs gets no badge"
+        );
+    }
+
+    #[test]
+    fn test_fallback_resolves_the_owner_only_for_candidates_that_have_a_pr() {
+        // Owner resolution costs `git config` reads, and the common case is
+        // a handful of recently-visited branches with no open PR at all.
+        // Resolving eagerly inside the scan spent those subprocesses on
+        // every 5s active-workspace tick for nothing.
+        let prs = vec![branch_pr(73, "OPEN", "has-pr", "2026-08-05T10:00:00Z", None)];
+        let asked = std::cell::RefCell::new(Vec::new());
+        let selected = select_first_candidate_pr(
+            &prs,
+            &["no-pr-a".to_string(), "no-pr-b".to_string(), "has-pr".to_string()],
+            &|branch| {
+                asked.borrow_mut().push(branch.to_string());
+                None
+            },
+        )
+        .unwrap();
+        assert_eq!(selected.number, 73);
+        assert_eq!(
+            asked.into_inner(),
+            vec!["has-pr".to_string()],
+            "only the candidate with a matching open PR costs a git config read"
+        );
+    }
+
+    #[test]
+    fn test_memoize_ok_reuses_a_fresh_entry_and_never_caches_an_error() {
+        // The seam that keeps the fallback off the 5s sweep: within the TTL
+        // a repeat lookup must not re-run the closure (which is where every
+        // `git`/`gh` subprocess lives).
+        let cache: Mutex<HashMap<String, (Instant, u32)>> = Mutex::new(HashMap::new());
+        let calls = std::cell::Cell::new(0u32);
+        let ttl = Duration::from_secs(60);
+        let mut compute = || -> Result<u32, String> {
+            calls.set(calls.get() + 1);
+            Ok(calls.get())
+        };
+
+        assert_eq!(memoize_ok(&cache, "k".to_string(), ttl, &mut compute), Ok(1));
+        assert_eq!(memoize_ok(&cache, "k".to_string(), ttl, &mut compute), Ok(1));
+        assert_eq!(memoize_ok(&cache, "k".to_string(), ttl, &mut compute), Ok(1));
+        assert_eq!(calls.get(), 1, "one compute per key per TTL window");
+
+        // A different key is a different question — here, another worktree
+        // or the same worktree on a new branch — and is answered at once.
+        assert_eq!(memoize_ok(&cache, "other".to_string(), ttl, &mut compute), Ok(2));
+
+        // A zero TTL expires immediately, so the entry is not reused.
+        assert_eq!(
+            memoize_ok(&cache, "k".to_string(), Duration::ZERO, &mut compute),
+            Ok(3)
+        );
+
+        // Errors are transient (dropped network, expired token) and must be
+        // retried rather than pinned for a minute.
+        let failing = |_: ()| -> Result<u32, String> { Err("gh failed".to_string()) };
+        assert!(memoize_ok(&cache, "err".to_string(), ttl, || failing(())).is_err());
+        assert_eq!(memoize_ok(&cache, "err".to_string(), ttl, &mut compute), Ok(4));
     }
 
     #[test]
@@ -2116,9 +2306,8 @@ ccc9999 HEAD@{8}: checkout: moving from a to b";
 
     #[test]
     fn test_fallback_applies_the_open_over_history_policy_within_one_candidate() {
-        // The fallback resolves each candidate through `select_branch_pr`,
-        // so a reused branch name still prefers its open PR over its own
-        // history.
+        // A reused branch name resolves to its open PR, not the merged one
+        // that happens to be more recently updated.
         let prs = vec![
             branch_pr(80, "MERGED", "reused", "2026-08-05T10:00:00Z", None),
             branch_pr(81, "OPEN", "reused", "2026-08-01T10:00:00Z", None),

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -1,8 +1,10 @@
 use crate::execution::{sanitize_gui_env_std, sanitize_gui_env_std_keep_dbus};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PullRequestInfo {
@@ -928,6 +930,34 @@ fn select_branch_pr(
 /// question is unanswerable rather than answered "no PR". Returning `Ok(None)`
 /// there would let a routine rebase clear an OPEN badge.
 pub fn get_branch_pr(repo_path: &Path) -> Result<Option<PullRequestInfo>, String> {
+    Ok(resolve_branch_pr(repo_path)?.pr)
+}
+
+/// The `--json` field set every branch-PR query asks for. Shared by the
+/// per-branch lookup and the repo-wide fallback list so `parse_pr_json` can
+/// never be handed a row that is missing a field one caller relies on.
+const BRANCH_PR_JSON_FIELDS: &str = "number,url,state,title,headRefName,baseRefName,isDraft,mergeable,additions,deletions,reviewDecision,updatedAt,headRefOid,headRepositoryOwner";
+
+/// The current branch's PR plus the branch context that produced it.
+///
+/// The context is not decoration: the side-branch fallback needs to know
+/// which branch already answered "no PR" (to exclude it from the candidate
+/// list) and whether that branch is the repository default (where no fallback
+/// may run at all), and re-deriving either would mean re-running local git
+/// commands the primary lookup already ran.
+struct BranchPrLookup {
+    branch: String,
+    default_branch: Option<String>,
+    pr: Option<PullRequestInfo>,
+}
+
+impl BranchPrLookup {
+    fn is_default_branch(&self) -> bool {
+        self.default_branch.as_deref() == Some(self.branch.as_str())
+    }
+}
+
+fn resolve_branch_pr(repo_path: &Path) -> Result<BranchPrLookup, String> {
     let Some(branch) = run_git_optional(repo_path, &["branch", "--show-current"]) else {
         return Err("detached HEAD: no branch to resolve a PR for".to_string());
     };
@@ -950,7 +980,7 @@ pub fn get_branch_pr(repo_path: &Path) -> Result<Option<PullRequestInfo>, String
             "--limit",
             "100",
             "--json",
-            "number,url,state,title,headRefName,baseRefName,isDraft,mergeable,additions,deletions,reviewDecision,updatedAt,headRefOid,headRepositoryOwner",
+            BRANCH_PR_JSON_FIELDS,
         ],
         BRANCH_PR_LOOKUP_TIMEOUT,
     )?;
@@ -959,14 +989,256 @@ pub fn get_branch_pr(repo_path: &Path) -> Result<Option<PullRequestInfo>, String
     let rows = value
         .as_array()
         .ok_or_else(|| "Expected JSON array from gh pr list".to_string())?;
-    let is_default_branch = crate::git::find_default_branch(repo_path).as_deref() == Some(&branch);
+    let default_branch = crate::git::find_default_branch(repo_path);
+    let is_default_branch = default_branch.as_deref() == Some(branch.as_str());
 
-    Ok(select_branch_pr(
+    let pr = select_branch_pr(
         rows.iter().map(parse_pr_json),
         &branch,
         expected_owner.as_deref(),
         is_default_branch,
-    ))
+    );
+    Ok(BranchPrLookup {
+        branch,
+        default_branch,
+        pr,
+    })
+}
+
+/// How many HEAD reflog entries the side-branch fallback reads.
+///
+/// The window is bounded by entry count rather than wall-clock age on
+/// purpose: reflog timestamps are rewritten by `git gc` and absent from a
+/// fresh clone, while "the last handful of things this worktree checked out"
+/// is exactly the question the fallback wants answered.
+const REFLOG_SCAN_ENTRIES: usize = 50;
+
+/// How many distinct recently-checked-out branches the fallback considers.
+const REFLOG_CANDIDATE_LIMIT: usize = 5;
+
+/// Repo-wide PR page size for the fallback. Smaller than the per-branch
+/// query's 100 because the fallback only ever asks about branches checked
+/// out in the recent past, whose PRs are correspondingly recent.
+const FALLBACK_PR_LIST_LIMIT: &str = "50";
+
+/// How long one repo-wide fallback list is reused. Sized to the 60s PR
+/// poller so the 5s active-workspace sweep can't multiply it: several
+/// no-PR workspaces sharing a repo cost one `gh` call per minute between
+/// them, not one per workspace per sweep.
+const FALLBACK_PR_LIST_TTL: Duration = Duration::from_secs(60);
+
+type FallbackPrListCache = Mutex<HashMap<String, (Instant, Arc<Vec<serde_json::Value>>)>>;
+static FALLBACK_PR_LIST_CACHE: OnceLock<FallbackPrListCache> = OnceLock::new();
+
+/// True for a name that is really a commit id — what `git checkout <sha>`
+/// and `git bisect` write into the reflog. A branch named entirely of hex
+/// digits is theoretically possible and is deliberately sacrificed: reading
+/// a detached-HEAD SHA as a branch name would send a `gh` query after
+/// something that can never match.
+fn looks_like_commit_id(name: &str) -> bool {
+    (7..=40).contains(&name.len()) && name.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Branch names this worktree checked out recently, newest first.
+///
+/// Input is raw `git reflog` output for HEAD, which in a linked worktree is
+/// that worktree's own reflog — so the candidates describe where *this*
+/// checkout has been, not the repo at large.
+///
+/// Only `checkout: moving from X to Y` records carry branch identity, and
+/// both sides of one are used: `Y` is the state the worktree entered and `X`
+/// the one it left, so reading `Y` then `X` per record, newest record first,
+/// yields true recency order. Taking only `Y` would miss a branch whose
+/// arrival scrolled off the end of the window while its departure did not.
+///
+/// The current branch is excluded (it already answered "no PR"), as is the
+/// repository default branch (its PR history is reverse-merge noise, the same
+/// reason `select_branch_pr` suppresses historical PRs there).
+///
+/// A branch name containing " to " is ambiguous in this format and is split
+/// at the first occurrence; git writes no delimiter that would resolve it,
+/// and the failure mode is a candidate that matches no PR.
+fn parse_recent_checkout_branches(
+    reflog: &str,
+    current_branch: &str,
+    default_branch: Option<&str>,
+    limit: usize,
+) -> Vec<String> {
+    let mut candidates: Vec<String> = Vec::new();
+    for line in reflog.lines() {
+        let Some((_, moved)) = line.split_once("checkout: moving from ") else {
+            continue;
+        };
+        let Some((from, to)) = moved.split_once(" to ") else {
+            continue;
+        };
+        for name in [to.trim(), from.trim()] {
+            if name.is_empty()
+                || name == current_branch
+                || default_branch == Some(name)
+                || looks_like_commit_id(name)
+                || candidates.iter().any(|existing| existing == name)
+            {
+                continue;
+            }
+            candidates.push(name.to_string());
+            if candidates.len() >= limit {
+                return candidates;
+            }
+        }
+    }
+    candidates
+}
+
+/// Cache key for the repo-wide fallback list: the origin URL, so sibling
+/// worktrees of one repo share a single entry (they share the PR list too).
+/// Repos without an origin fall back to their own path, which is still
+/// correct, just unshared.
+fn fallback_pr_list_key(repo_path: &Path) -> String {
+    run_git_optional(repo_path, &["config", "--get", "remote.origin.url"])
+        .unwrap_or_else(|| repo_path.to_string_lossy().into_owned())
+}
+
+/// One repo-wide `gh pr list`, memoized for [`FALLBACK_PR_LIST_TTL`].
+///
+/// Listing the repo once and matching every candidate branch against it
+/// client-side keeps the fallback at a flat one extra `gh` call, instead of
+/// one per candidate.
+fn fallback_pr_list(repo_path: &Path) -> Result<Arc<Vec<serde_json::Value>>, String> {
+    let key = fallback_pr_list_key(repo_path);
+    let cache = FALLBACK_PR_LIST_CACHE.get_or_init(FallbackPrListCache::default);
+
+    if let Some((fetched_at, rows)) = cache.lock().unwrap().get(&key) {
+        if fetched_at.elapsed() < FALLBACK_PR_LIST_TTL {
+            return Ok(Arc::clone(rows));
+        }
+    }
+
+    let output = run_gh_timed(
+        repo_path,
+        &[
+            "pr",
+            "list",
+            "--state",
+            "all",
+            "--limit",
+            FALLBACK_PR_LIST_LIMIT,
+            "--json",
+            BRANCH_PR_JSON_FIELDS,
+        ],
+        BRANCH_PR_LOOKUP_TIMEOUT,
+    )?;
+    let value: serde_json::Value =
+        serde_json::from_str(&output).map_err(|e| format!("Failed to parse PR JSON: {e}"))?;
+    let rows = Arc::new(
+        value
+            .as_array()
+            .ok_or_else(|| "Expected JSON array from gh pr list".to_string())?
+            .clone(),
+    );
+
+    let mut guard = cache.lock().unwrap();
+    guard.retain(|_, (fetched_at, _)| fetched_at.elapsed() < FALLBACK_PR_LIST_TTL);
+    guard.insert(key, (Instant::now(), Arc::clone(&rows)));
+    Ok(rows)
+}
+
+/// Badge-only fallback: the PR of a branch this worktree checked out recently.
+///
+/// Answers the "agent opened the PR from a side branch, then checked the
+/// worktree back" case, where the workspace has visibly produced a pull
+/// request that strict current-branch association cannot see. Candidates are
+/// tried newest-first and the first branch with a PR wins — each one is
+/// resolved through the same [`select_branch_pr`] policy as the current
+/// branch, so open/draft still beats history and fork owners are still
+/// scoped.
+///
+/// The result is deliberately weaker than a current-branch association: it
+/// carries the PR's own `head_branch`, and auto-settlement refuses any
+/// association whose head branch is not the checked-out one.
+fn get_side_branch_pr(
+    repo_path: &Path,
+    lookup: &BranchPrLookup,
+) -> Result<Option<PullRequestInfo>, String> {
+    let Some(reflog) = run_git_optional(
+        repo_path,
+        &[
+            "reflog",
+            "show",
+            "--max-count",
+            &REFLOG_SCAN_ENTRIES.to_string(),
+            "HEAD",
+        ],
+    ) else {
+        return Ok(None);
+    };
+    let candidates = parse_recent_checkout_branches(
+        &reflog,
+        &lookup.branch,
+        lookup.default_branch.as_deref(),
+        REFLOG_CANDIDATE_LIMIT,
+    );
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    let rows = fallback_pr_list(repo_path)?;
+    let prs: Vec<PullRequestInfo> = rows.iter().map(parse_pr_json).collect();
+    Ok(select_first_candidate_pr(&prs, &candidates, &|candidate| {
+        resolve_branch_head_owner(repo_path, candidate)
+    }))
+}
+
+/// Newest-first candidate scan: the first recently-checked-out branch that
+/// has a PR wins outright.
+///
+/// Recency decides, not PR state. A branch checked out more recently is the
+/// better description of what this workspace was just doing, and ranking an
+/// older branch's open PR above it would resurrect stale work as the badge.
+/// Within a single candidate the ordinary [`select_branch_pr`] policy still
+/// applies, so open/draft beats that branch's own history.
+///
+/// `expected_owner` is injected rather than resolved inline because it costs
+/// a `git config` read per candidate — the caller owns that, the selection
+/// rule stays pure.
+fn select_first_candidate_pr(
+    prs: &[PullRequestInfo],
+    candidates: &[String],
+    expected_owner: &dyn Fn(&str) -> Option<String>,
+) -> Option<PullRequestInfo> {
+    candidates.iter().find_map(|candidate| {
+        // Never the default branch — `parse_recent_checkout_branches`
+        // excludes it — so historical PRs stay eligible here.
+        select_branch_pr(
+            prs.iter().cloned(),
+            candidate,
+            expected_owner(candidate).as_deref(),
+            false,
+        )
+    })
+}
+
+/// The PR a workspace should show a badge for.
+///
+/// The current branch owns the association whenever it has one. Only when it
+/// authoritatively has none does the recently-checked-out fallback run, and
+/// never on the repository default branch, where "recently checked out"
+/// describes ordinary branch hopping rather than this checkout's own work.
+///
+/// The three-way [`BranchPrOutcome`] contract is preserved exactly: an
+/// unanswerable *current-branch* lookup is still `Err` (preserve the badge),
+/// while a failure inside the fallback collapses to `Ok(None)` — the current
+/// branch already answered "no PR" authoritatively, and a missing bonus badge
+/// must not be upgraded into "keep the old one".
+pub fn get_workspace_pr(repo_path: &Path) -> Result<Option<PullRequestInfo>, String> {
+    let lookup = resolve_branch_pr(repo_path)?;
+    if lookup.pr.is_some() {
+        return Ok(lookup.pr);
+    }
+    if lookup.is_default_branch() {
+        return Ok(None);
+    }
+    Ok(get_side_branch_pr(repo_path, &lookup).unwrap_or(None))
 }
 
 /// What a branch-PR lookup should do to a workspace's stored association.
@@ -1718,6 +1990,204 @@ mod tests {
         let descending = select_branch_pr([b, a, c], "feature/reused", None, false).map(|pr| pr.number);
         assert_eq!(ascending, Some(61));
         assert_eq!(descending, Some(61));
+    }
+
+    // ── Side-branch badge fallback ──────────────────────────────
+    //
+    // The case these cover: an agent working in a workspace branches off,
+    // commits, pushes, opens a PR, then checks the worktree back. Strict
+    // current-branch association sees no PR, but the workspace visibly
+    // produced one. The fallback finds it from the worktree's own HEAD
+    // reflog — as a *badge* only. Whether that association may also settle
+    // the workspace is decided downstream, from the PR's head branch.
+
+    /// Real `git reflog` HEAD output shape for exactly that sequence.
+    const SIDE_BRANCH_REFLOG: &str = "\
+7c1a2b3 HEAD@{0}: checkout: moving from appimage-child-env-hygiene to fix-ui-borders
+9d4e5f6 HEAD@{1}: commit: chore: sanitize child env
+1a2b3c4 HEAD@{2}: checkout: moving from fix-ui-borders to appimage-child-env-hygiene
+5e6f7a8 HEAD@{3}: commit: wip: borders
+2b3c4d5 HEAD@{4}: checkout: moving from main to fix-ui-borders";
+
+    #[test]
+    fn test_reflog_candidates_find_the_side_branch_the_worktree_returned_from() {
+        let candidates =
+            parse_recent_checkout_branches(SIDE_BRANCH_REFLOG, "fix-ui-borders", Some("main"), 5);
+        assert_eq!(candidates, vec!["appimage-child-env-hygiene".to_string()]);
+    }
+
+    #[test]
+    fn test_reflog_candidates_exclude_the_current_and_default_branches() {
+        // The current branch already answered "no PR" authoritatively, and
+        // the default branch's PR history is reverse-merge noise rather than
+        // this checkout's work — the same reason `select_branch_pr`
+        // suppresses historical PRs there.
+        let candidates =
+            parse_recent_checkout_branches(SIDE_BRANCH_REFLOG, "fix-ui-borders", Some("main"), 5);
+        assert!(!candidates.iter().any(|b| b == "fix-ui-borders"));
+        assert!(!candidates.iter().any(|b| b == "main"));
+    }
+
+    #[test]
+    fn test_reflog_candidates_are_newest_first_and_deduped() {
+        let reflog = "\
+aaa1111 HEAD@{0}: checkout: moving from third to current
+bbb2222 HEAD@{1}: checkout: moving from second to third
+ccc3333 HEAD@{2}: checkout: moving from third to second
+ddd4444 HEAD@{3}: checkout: moving from first to third
+eee5555 HEAD@{4}: checkout: moving from current to first";
+        let candidates = parse_recent_checkout_branches(reflog, "current", Some("main"), 5);
+        assert_eq!(
+            candidates,
+            vec![
+                "third".to_string(),
+                "second".to_string(),
+                "first".to_string()
+            ],
+            "each branch appears once, at its most recent position"
+        );
+    }
+
+    #[test]
+    fn test_reflog_candidates_skip_detached_head_shas() {
+        // `git checkout <sha>`, `git bisect`, and `gh pr checkout` of a
+        // commit all write a raw object id here. Querying gh for a branch by
+        // that name can only ever miss.
+        let reflog = "\
+aaa1111 HEAD@{0}: checkout: moving from 9d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e to current
+bbb2222 HEAD@{1}: checkout: moving from side-branch to 9d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e";
+        let candidates = parse_recent_checkout_branches(reflog, "current", Some("main"), 5);
+        assert_eq!(candidates, vec!["side-branch".to_string()]);
+    }
+
+    #[test]
+    fn test_reflog_candidates_ignore_non_checkout_records_and_respect_the_cap() {
+        // Commits, resets, rebases and merges all live in the same reflog
+        // and carry no branch identity. Only `checkout: moving from X to Y`
+        // is parsed, and the candidate list stays small so a long reflog
+        // can't turn into a long scan.
+        let reflog = "\
+aaa1111 HEAD@{0}: commit: some work
+bbb2222 HEAD@{1}: reset: moving to HEAD~1
+ccc3333 HEAD@{2}: rebase (finish): returning to refs/heads/current
+ddd4444 HEAD@{3}: checkout: moving from f to current
+eee5555 HEAD@{4}: checkout: moving from e to f
+fff6666 HEAD@{5}: checkout: moving from d to e
+aaa7777 HEAD@{6}: checkout: moving from c to d
+bbb8888 HEAD@{7}: checkout: moving from b to c
+ccc9999 HEAD@{8}: checkout: moving from a to b";
+        let candidates = parse_recent_checkout_branches(reflog, "current", Some("main"), 3);
+        assert_eq!(
+            candidates,
+            vec!["f".to_string(), "e".to_string(), "d".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_reflog_candidates_are_empty_without_checkout_history() {
+        // A worktree created and never switched away from has nothing to
+        // fall back to, so the fallback never reaches `gh` at all.
+        let reflog = "aaa1111 HEAD@{0}: commit (initial): first";
+        assert!(parse_recent_checkout_branches(reflog, "current", Some("main"), 5).is_empty());
+    }
+
+    #[test]
+    fn test_fallback_takes_the_most_recently_checked_out_branch_with_a_pr() {
+        // Recency decides between candidates: `newer`'s merged PR outranks
+        // `older`'s open one, because "what this workspace was just doing"
+        // is the question being answered.
+        let prs = vec![
+            branch_pr(70, "OPEN", "older", "2026-08-05T10:00:00Z", None),
+            branch_pr(71, "MERGED", "newer", "2026-08-04T10:00:00Z", None),
+        ];
+        let candidates = vec!["newer".to_string(), "older".to_string()];
+        let selected = select_first_candidate_pr(&prs, &candidates, &|_| None).unwrap();
+        assert_eq!(selected.number, 71);
+    }
+
+    #[test]
+    fn test_fallback_skips_candidates_without_a_pr() {
+        let prs = vec![branch_pr(72, "OPEN", "has-pr", "2026-08-05T10:00:00Z", None)];
+        let candidates = vec!["no-pr".to_string(), "has-pr".to_string()];
+        let selected = select_first_candidate_pr(&prs, &candidates, &|_| None).unwrap();
+        assert_eq!(selected.number, 72);
+        assert_eq!(selected.head_branch.as_deref(), Some("has-pr"));
+    }
+
+    #[test]
+    fn test_fallback_applies_the_open_over_history_policy_within_one_candidate() {
+        // The fallback resolves each candidate through `select_branch_pr`,
+        // so a reused branch name still prefers its open PR over its own
+        // history.
+        let prs = vec![
+            branch_pr(80, "MERGED", "reused", "2026-08-05T10:00:00Z", None),
+            branch_pr(81, "OPEN", "reused", "2026-08-01T10:00:00Z", None),
+        ];
+        let selected =
+            select_first_candidate_pr(&prs, &["reused".to_string()], &|_| None).unwrap();
+        assert_eq!(selected.number, 81);
+    }
+
+    #[test]
+    fn test_fallback_honours_fork_owner_scoping() {
+        // Same client-side fork disambiguation as the current-branch path:
+        // an upstream PR that merely shares a branch name must not attach to
+        // a fork-tracking candidate.
+        let prs = vec![branch_pr_owned_by(
+            90,
+            "OPEN",
+            "shared-name",
+            "2026-08-05T10:00:00Z",
+            Some("upstream"),
+        )];
+        let candidates = vec!["shared-name".to_string()];
+        assert!(
+            select_first_candidate_pr(&prs, &candidates, &|_| Some("contributor".to_string()))
+                .is_none()
+        );
+        assert!(
+            select_first_candidate_pr(&prs, &candidates, &|_| Some("upstream".to_string()))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn test_default_branch_checkout_is_recognised_so_the_fallback_can_refuse_it() {
+        // A repo-root workspace sitting on the default branch checks out
+        // every branch in the repo over time; "recently checked out" there
+        // means ordinary branch hopping, not this checkout's own work.
+        let on_default = BranchPrLookup {
+            branch: "main".to_string(),
+            default_branch: Some("main".to_string()),
+            pr: None,
+        };
+        assert!(on_default.is_default_branch());
+
+        let on_feature = BranchPrLookup {
+            branch: "fix-ui-borders".to_string(),
+            default_branch: Some("main".to_string()),
+            pr: None,
+        };
+        assert!(!on_feature.is_default_branch());
+    }
+
+    #[test]
+    fn test_a_fallback_association_carries_its_own_head_branch() {
+        // This is what lets settlement tell the two association kinds
+        // apart: the badge is stored with the PR's head branch, which for a
+        // side-branch association is not the workspace's checked-out branch.
+        let prs = vec![branch_pr(
+            250,
+            "OPEN",
+            "appimage-child-env-hygiene",
+            "2026-08-05T10:00:00Z",
+            None,
+        )];
+        let candidates =
+            parse_recent_checkout_branches(SIDE_BRANCH_REFLOG, "fix-ui-borders", Some("main"), 5);
+        let selected = select_first_candidate_pr(&prs, &candidates, &|_| None).unwrap();
+        assert_eq!(selected.number, 250);
+        assert_ne!(selected.head_branch.as_deref(), Some("fix-ui-borders"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1134,7 +1134,7 @@ fn build_core_app<R: tauri::Runtime>(
                             // failed lookup preserves the last known state;
                             // a successful empty result is authoritative and
                             // clears any stale association.
-                            let lookup = github::get_branch_pr(&path);
+                            let lookup = github::get_workspace_pr(&path);
                             match &lookup {
                                 Err(e) => {
                                     let message = format!(
@@ -1163,11 +1163,13 @@ fn build_core_app<R: tauri::Runtime>(
                                         Some(pr.number),
                                         Some(pr.display_state()),
                                         Some(pr.url),
+                                        pr.head_branch,
                                     );
                                 }
                                 github::BranchPrOutcome::Clear => {
                                     changed |= state.update_workspace_pr_info(
                                         &workspace_id,
+                                        None,
                                         None,
                                         None,
                                         None,
@@ -1566,7 +1568,7 @@ fn build_core_app<R: tauri::Runtime>(
                         let pr_result = tokio::time::timeout(
                             std::time::Duration::from_secs(PER_CALL_TIMEOUT_SECS),
                             tokio::task::spawn_blocking(move || {
-                                github::get_branch_pr(&path_for_pr)
+                                github::get_workspace_pr(&path_for_pr)
                             }),
                         )
                         .await;
@@ -1575,7 +1577,7 @@ fn build_core_app<R: tauri::Runtime>(
                             Ok(Ok(lookup)) => {
                                 if let Err(e) = &lookup {
                                     eprintln!(
-                                        "[codemux::pr-poll] get_branch_pr failed for {workspace_id}: {e}"
+                                        "[codemux::pr-poll] get_workspace_pr failed for {workspace_id}: {e}"
                                     );
                                 }
                                 // Shared matrix: match -> write, successful
@@ -1597,12 +1599,14 @@ fn build_core_app<R: tauri::Runtime>(
                                             Some(pr.number),
                                             Some(pr.display_state()),
                                             Some(pr.url),
+                                            pr.head_branch,
                                         );
                                         refreshed += 1;
                                     }
                                     github::BranchPrOutcome::Clear => {
                                         changed |= state.update_workspace_pr_info(
                                             &workspace_id,
+                                            None,
                                             None,
                                             None,
                                             None,

--- a/src-tauri/src/state/state_impl.rs
+++ b/src-tauri/src/state/state_impl.rs
@@ -446,6 +446,23 @@ pub struct WorkspaceSnapshot {
     pub pr_state: Option<String>,
     #[serde(default)]
     pub pr_url: Option<String>,
+    /// Head branch of the associated PR, as GitHub reports it.
+    ///
+    /// Normally this equals `git_branch`. It differs when the association
+    /// came from the sidebar's badge-only fallback — a PR opened from a
+    /// branch this worktree checked out recently and then left (an agent
+    /// that branched off, pushed, opened a PR, and checked the worktree
+    /// back). That badge is worth showing; the *conclusions* drawn from a
+    /// PR are not, so the sidebar's PR-completion auto-settle requires this
+    /// to match the checked-out branch. A side branch merging says nothing
+    /// about whether this workspace's own work is finished.
+    ///
+    /// Snapshot-local, like the other derived git fields: it is re-derived
+    /// on every poll from the checkout in front of us and is never synced
+    /// across devices. Additive — old persisted state reads as `None`,
+    /// which the frontend treats as the pre-field (matching) case.
+    #[serde(default)]
+    pub pr_head_branch: Option<String>,
     #[serde(default)]
     pub linked_issue: Option<crate::github::LinkedIssue>,
     /// When true, agent-completion desktop notifications for panes in this
@@ -1178,6 +1195,7 @@ impl AppStateStore {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             notification_count: 0,
@@ -1259,6 +1277,7 @@ impl AppStateStore {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             notification_count: 0,
@@ -1331,6 +1350,7 @@ impl AppStateStore {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             notification_count: 0,
@@ -1434,6 +1454,7 @@ impl AppStateStore {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             notification_count: 0,
@@ -1579,6 +1600,7 @@ impl AppStateStore {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             notification_count: 0,
@@ -2011,6 +2033,7 @@ impl AppStateStore {
         pr_number: Option<u32>,
         pr_state: Option<String>,
         pr_url: Option<String>,
+        pr_head_branch: Option<String>,
     ) -> bool {
         let mut snapshot = self.inner.lock().unwrap();
         let Some(workspace) = snapshot
@@ -2020,15 +2043,22 @@ impl AppStateStore {
         else {
             return false;
         };
+        // The head branch joins the equality gate rather than riding along
+        // silently: a badge that stays numerically identical while moving
+        // from the current branch to a side branch (or back) changes whether
+        // auto-settle may act on it, and an ungated write would leave that
+        // switch unemitted.
         if workspace.pr_number == pr_number
             && workspace.pr_state == pr_state
             && workspace.pr_url == pr_url
+            && workspace.pr_head_branch == pr_head_branch
         {
             return false;
         }
         workspace.pr_number = pr_number;
         workspace.pr_state = pr_state;
         workspace.pr_url = pr_url;
+        workspace.pr_head_branch = pr_head_branch;
         true
     }
 
@@ -4733,6 +4763,7 @@ fn default_app_state() -> AppStateSnapshot {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             notification_count: 0,
@@ -9317,24 +9348,64 @@ mod metadata_change_tests {
             Some(7),
             Some("OPEN".into()),
             Some("https://example.test/7".into()),
+            Some("feature".into()),
         ));
         assert!(!store.update_workspace_pr_info(
             &id,
             Some(7),
             Some("OPEN".into()),
             Some("https://example.test/7".into()),
+            Some("feature".into()),
         ));
         assert!(
-            store.update_workspace_pr_info(&id, Some(7), Some("MERGED".into()), None),
+            store.update_workspace_pr_info(&id, Some(7), Some("MERGED".into()), None, None),
             "a state transition is a change"
         );
         assert!(
-            store.update_workspace_pr_info(&id, None, None, None),
+            store.update_workspace_pr_info(&id, None, None, None, None),
             "clearing a populated pill is a change"
         );
         assert!(
-            !store.update_workspace_pr_info(&id, None, None, None),
+            !store.update_workspace_pr_info(&id, None, None, None, None),
             "clearing an empty pill is not"
+        );
+    }
+
+    #[test]
+    fn pr_head_branch_is_stored_and_gates_the_change_flag() {
+        // The head branch is what lets the sidebar tell a current-branch
+        // association from the badge-only side-branch fallback, and only the
+        // former may auto-settle a workspace. A badge whose number and state
+        // hold still while its head branch moves has therefore changed
+        // meaning, and must still be emitted.
+        let store = AppStateStore::default();
+        let id = store.create_workspace().0;
+
+        assert!(store.update_workspace_pr_info(
+            &id,
+            Some(250),
+            Some("OPEN".into()),
+            Some("https://example.test/250".into()),
+            Some("side-branch".into()),
+        ));
+        assert_eq!(
+            store
+                .snapshot()
+                .workspaces
+                .iter()
+                .find(|w| w.workspace_id.0 == id)
+                .and_then(|w| w.pr_head_branch.clone()),
+            Some("side-branch".to_string()),
+        );
+        assert!(
+            store.update_workspace_pr_info(
+                &id,
+                Some(250),
+                Some("OPEN".into()),
+                Some("https://example.test/250".into()),
+                Some("current-branch".into()),
+            ),
+            "the same PR re-associating to a different head branch is a change"
         );
     }
 

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -4626,6 +4626,7 @@ mod tests {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             tabs: Vec::new(),

--- a/src-tauri/src/workspaces_sync.rs
+++ b/src-tauri/src/workspaces_sync.rs
@@ -996,6 +996,7 @@ mod tests {
             pr_number: None,
             pr_state: None,
             pr_url: None,
+            pr_head_branch: None,
             linked_issue: None,
             notifications_muted: false,
             tabs: Vec::new(),

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -50,6 +50,7 @@ import {
   findSubagentView,
   subagentOrdinal,
 } from "@/lib/agent-chat/subagents";
+import { taskChipSummary } from "@/lib/agent-chat/task-summary";
 import { hasUltrathinkInBodyText } from "@/lib/agent-chat/ultrathink";
 import { basename } from "@/lib/path";
 import { toast } from "@/lib/toast";
@@ -530,14 +531,13 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   const tasks = useAgentChatStore((s) =>
     threadId ? s.threads[threadId]?.tasks ?? null : null,
   );
-  const taskSummary = useMemo(() => {
-    if (!tasks || tasks.tasks.length === 0) return null;
-    return {
-      completed: tasks.tasks.filter((task) => task.status === "completed").length,
-      total: tasks.tasks.length,
-      running: tasks.tasks.some((task) => task.status === "in_progress"),
-    };
-  }, [tasks]);
+  // The chip's spinner is a LIVE affordance, so `taskChipSummary` gates it
+  // on the thread actually streaming rather than on the snapshot alone —
+  // see the helper for why the durable plan can't settle itself.
+  const taskSummary = useMemo(
+    () => taskChipSummary(tasks, streaming),
+    [tasks, streaming],
+  );
   const handleTasksClick = useCallback(() => {
     if (paneWorkspaceId) toggleRightPanel?.(paneWorkspaceId, "tasks");
   }, [paneWorkspaceId, toggleRightPanel]);
@@ -2996,6 +2996,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
               <SubagentActivityBar
                 messages={messages}
                 threadId={threadId}
+                streaming={transcriptStreaming}
                 onJump={handleJumpToSubagentCard}
               />
             </div>

--- a/src/components/chat/SubagentActivityBar.test.tsx
+++ b/src/components/chat/SubagentActivityBar.test.tsx
@@ -38,7 +38,7 @@ describe("SubagentActivityBar", () => {
       card("run-1", [subagent({ id: "a", status: "completed" })]),
     ];
     const { container } = render(
-      <SubagentActivityBar messages={messages} threadId="t1" onJump={() => {}} />,
+      <SubagentActivityBar messages={messages} threadId="t1" streaming onJump={() => {}} />,
     );
     expect(container.firstChild).toBeNull();
   });
@@ -55,7 +55,7 @@ describe("SubagentActivityBar", () => {
         }),
       ]),
     ];
-    render(<SubagentActivityBar messages={messages} threadId="t1" onJump={onJump} />);
+    render(<SubagentActivityBar messages={messages} threadId="t1" streaming onJump={onJump} />);
 
     expect(screen.getByText("1 subagent running")).toBeInTheDocument();
     expect(screen.getByText("View")).toBeInTheDocument();
@@ -75,7 +75,7 @@ describe("SubagentActivityBar", () => {
       card("run-1", [subagent({ id: "a", name: "Explore", status: "running" })]),
       card("run-2", [subagent({ id: "b", name: "Implement", status: "running" })]),
     ];
-    render(<SubagentActivityBar messages={messages} threadId="t1" onJump={onJump} />);
+    render(<SubagentActivityBar messages={messages} threadId="t1" streaming onJump={onJump} />);
 
     expect(screen.getByText("2 subagents running")).toBeInTheDocument();
     expect(screen.getByText("Show all")).toBeInTheDocument();
@@ -120,7 +120,7 @@ describe("SubagentActivityBar", () => {
       card("run-3", [subagent({ id: "c", name: "Verify", status: "running" })]),
     ];
     const { rerender } = render(
-      <SubagentActivityBar messages={two} threadId="t1" onJump={() => {}} />,
+      <SubagentActivityBar messages={two} threadId="t1" streaming onJump={() => {}} />,
     );
 
     // Open the expand list while two are running.
@@ -129,14 +129,14 @@ describe("SubagentActivityBar", () => {
 
     // One finishes: single-running state, list hidden by design.
     rerender(
-      <SubagentActivityBar messages={one} threadId="t1" onJump={() => {}} />,
+      <SubagentActivityBar messages={one} threadId="t1" streaming onJump={() => {}} />,
     );
     expect(screen.queryByTestId("subagent-activity-bar-list")).toBeNull();
 
     // A new subagent starts (back to 2): the list must NOT pop open with
     // no click — the stale `open` was reset on the multi → single drop.
     rerender(
-      <SubagentActivityBar messages={twoAgain} threadId="t1" onJump={() => {}} />,
+      <SubagentActivityBar messages={twoAgain} threadId="t1" streaming onJump={() => {}} />,
     );
     expect(screen.queryByTestId("subagent-activity-bar-list")).toBeNull();
     expect(screen.getByText("Show all")).toBeInTheDocument();
@@ -152,7 +152,7 @@ describe("SubagentActivityBar", () => {
       card("run-1", [subagent({ id: "a", status: "completed" })]),
     ];
     const { rerender, queryByTestId, getByTestId } = render(
-      <SubagentActivityBar messages={running} threadId="t1" onJump={onJump} />,
+      <SubagentActivityBar messages={running} threadId="t1" streaming onJump={onJump} />,
     );
     expect(getByTestId("subagent-activity-bar")).toHaveAttribute(
       "data-tone",
@@ -160,7 +160,7 @@ describe("SubagentActivityBar", () => {
     );
 
     rerender(
-      <SubagentActivityBar messages={finished} threadId="t1" onJump={onJump} />,
+      <SubagentActivityBar messages={finished} threadId="t1" streaming onJump={onJump} />,
     );
     expect(getByTestId("subagent-activity-bar")).toHaveAttribute(
       "data-tone",
@@ -186,9 +186,37 @@ describe("SubagentActivityBar", () => {
     const messages: ChatViewItem[] = [
       card("run-1", [subagent({ id: "a", status: "completed" })]),
     ];
-    render(<SubagentActivityBar messages={messages} threadId="t1" onJump={() => {}} />);
+    render(<SubagentActivityBar messages={messages} threadId="t1" streaming onJump={() => {}} />);
     expect(screen.queryByTestId("subagent-activity-bar")).toBeNull();
     expect(screen.queryByText("Subagents finished")).toBeNull();
+  });
+
+  it("ignores a background task once the run is over", () => {
+    const messages: ChatViewItem[] = [
+      card("run-1", [
+        subagent({ id: "bg", status: "running", backgroundTask: true }),
+      ]),
+    ];
+    // Mid-run a background job still reads as activity.
+    const { rerender, queryByTestId } = render(
+      <SubagentActivityBar messages={messages} threadId="t1" streaming onJump={() => {}} />,
+    );
+    expect(queryByTestId("subagent-activity-bar")).not.toBeNull();
+    expect(screen.getByText("1 subagent running")).toBeInTheDocument();
+
+    // Turn over: a background shell command that never reports a terminal
+    // status must not keep the live count (and its spinner) up. The count
+    // going to zero is a normal finish, so the bar plays its green flash
+    // and then unmounts — it never sits there claiming live activity.
+    rerender(
+      <SubagentActivityBar
+        messages={messages}
+        threadId="t1"
+        streaming={false}
+        onJump={() => {}}
+      />,
+    );
+    expect(screen.queryByText("1 subagent running")).toBeNull();
   });
 
   it("does not flash when switching to a different thread with zero running subagents", () => {
@@ -199,12 +227,12 @@ describe("SubagentActivityBar", () => {
       card("run-2", [subagent({ id: "b", status: "completed" })]),
     ];
     const { rerender, queryByTestId } = render(
-      <SubagentActivityBar messages={runningThreadA} threadId="thread-a" onJump={() => {}} />,
+      <SubagentActivityBar messages={runningThreadA} threadId="thread-a" streaming onJump={() => {}} />,
     );
     expect(queryByTestId("subagent-activity-bar")).not.toBeNull();
 
     rerender(
-      <SubagentActivityBar messages={idleThreadB} threadId="thread-b" onJump={() => {}} />,
+      <SubagentActivityBar messages={idleThreadB} threadId="thread-b" streaming onJump={() => {}} />,
     );
     // Different thread — this is a hydrate, not an observed transition.
     expect(queryByTestId("subagent-activity-bar")).toBeNull();

--- a/src/components/chat/SubagentActivityBar.tsx
+++ b/src/components/chat/SubagentActivityBar.tsx
@@ -45,13 +45,19 @@ const FINISHED_FLASH_MS = 2500;
 export const SubagentActivityBar = memo(function SubagentActivityBar({
   messages,
   threadId,
+  streaming,
   onJump,
 }: {
   messages: ChatViewItem[];
   threadId: string | null;
+  /** The thread's live-run flag. With the run over, provider background
+   *  tasks (a background shell command that legitimately outlives the
+   *  turn) stop counting as live activity, so the bar can't spin forever
+   *  after the turn settled. */
+  streaming: boolean;
   onJump: (cardId: string) => void;
 }) {
-  const entries = runningSubagentEntries(messages);
+  const entries = runningSubagentEntries(messages, streaming);
   const count = entries.length;
 
   const listId = useId();

--- a/src/components/github/pr-status-icon.tsx
+++ b/src/components/github/pr-status-icon.tsx
@@ -66,6 +66,34 @@ export function normalizePrState(state: string | null | undefined): PrStatusStat
   return null;
 }
 
+/** Does a workspace's PR badge actually describe *this checkout's* work?
+ *
+ *  The backend also shows a badge for a PR opened from a branch the worktree
+ *  merely visited recently — the case an agent creates when it branches off,
+ *  pushes, opens a PR, and checks the worktree back (see the sidebar doc's
+ *  "PR association" section). Surfacing that is right: the workspace visibly
+ *  produced a pull request and the user should be able to reach it. Drawing
+ *  *lifecycle* conclusions from it is not — the branch the user is standing on
+ *  can still be full of uncommitted work, and that PR merging says nothing
+ *  about it.
+ *
+ *  So the badge renders unconditionally, while every rule that moves a card on
+ *  the strength of a PR — auto-settle, and the "Wrapping up" demotion — asks
+ *  this first. It lives beside `normalizePrState` because both the sidebar and
+ *  the hover card need it and neither may import the other.
+ *
+ *  A missing head branch reads as a match: the field is additive, so absent
+ *  means "association predates it" rather than "side branch", and the honest
+ *  default for an unknown is the behaviour that shipped before. Real fallback
+ *  associations always carry one. */
+export function isPrOnCurrentBranch(
+  prHeadBranch: string | null | undefined,
+  gitBranch: string | null | undefined,
+): boolean {
+  if (!prHeadBranch) return true;
+  return prHeadBranch === gitBranch;
+}
+
 interface Props {
   state: string | null | undefined;
   /** Size in Tailwind spacing units (1 = 4px). 3.5 = 14px (default). */

--- a/src/components/github/pr-status-icon.tsx
+++ b/src/components/github/pr-status-icon.tsx
@@ -82,15 +82,21 @@ export function normalizePrState(state: string | null | undefined): PrStatusStat
  *  this first. It lives beside `normalizePrState` because both the sidebar and
  *  the hover card need it and neither may import the other.
  *
- *  A missing head branch reads as a match: the field is additive, so absent
- *  means "association predates it" rather than "side branch", and the honest
- *  default for an unknown is the behaviour that shipped before. Real fallback
- *  associations always carry one. */
+ *  Missing information on *either* side reads as a match. An absent head branch
+ *  means "association predates the field" rather than "side branch", so the
+ *  honest default for an unknown is the behaviour that shipped before; real
+ *  fallback associations always carry one. An absent `gitBranch` is the same
+ *  kind of unknown seen from the other end — `git_branch_info` reports no
+ *  branch during a rebase, a bisect, or any detached HEAD, while the stored
+ *  head branch survives — and comparing a known name against that unknown would
+ *  read as "different branch" and silently un-associate a workspace from its
+ *  own open PR for the length of the rebase. Not knowing which branch you are
+ *  on is not evidence that the PR belongs to another one. */
 export function isPrOnCurrentBranch(
   prHeadBranch: string | null | undefined,
   gitBranch: string | null | undefined,
 ): boolean {
-  if (!prHeadBranch) return true;
+  if (!prHeadBranch || !gitBranch) return true;
   return prHeadBranch === gitBranch;
 }
 

--- a/src/components/layout/right-panel.test.tsx
+++ b/src/components/layout/right-panel.test.tsx
@@ -24,6 +24,10 @@ vi.mock("@/components/workflow/orchestration-panel", () => ({
 const mocks = vi.hoisted(() => ({
   workflow: { run: null as WorkflowRunItem | null, threadId: null as string | null },
   tasks: null as TasksSnapshot | null,
+  // Whether the focused chat thread is mid-run. The live tab dot is gated
+  // on it so a plan the provider left with an `in_progress` row can't blink
+  // forever after the turn settled.
+  tasksStreaming: true,
   // `titlebarOverlay` = "TitleBar renders the floating overlay, not the
   // in-flow legacy h-9 bar"; `remote` = the web remote client, which has no
   // native window controls and (therefore) no overlay drag layer either.
@@ -34,7 +38,11 @@ vi.mock("@/components/workflow/use-workspace-workflow", () => ({
   useWorkspaceWorkflow: () => mocks.workflow,
 }));
 vi.mock("@/hooks/use-active-chat-tasks", () => ({
-  useActiveChatTasks: () => ({ threadId: "thread-1", tasks: mocks.tasks }),
+  useActiveChatTasks: () => ({
+    threadId: "thread-1",
+    tasks: mocks.tasks,
+    streaming: mocks.tasksStreaming,
+  }),
 }));
 vi.mock("@/hooks/use-gui-chrome", () => ({
   useTitlebarOverlay: () => mocks.titlebarOverlay,
@@ -114,6 +122,7 @@ afterEach(() => {
   cleanup();
   mocks.workflow = { run: null, threadId: null };
   mocks.tasks = null;
+  mocks.tasksStreaming = true;
   mocks.titlebarOverlay = true;
   mocks.remote = false;
 });
@@ -182,6 +191,23 @@ describe("RightPanel Tasks tab", () => {
 
     rerender(<RightPanel workspace={makeWorkspace()} activeTab="tasks" />);
     expect(screen.queryByTestId("tasks-live-dot")).toBeNull();
+  });
+
+  // The snapshot is durable state that outlives the run, so a plan the
+  // provider left with an `in_progress` row must not blink forever once
+  // the turn settled (it would also survive a restart via hydrate-replay).
+  it("stops the live dot once the thread is no longer streaming", () => {
+    mocks.tasks = {
+      tasks: [
+        { task_id: "1", title: "Done", status: "completed", blocked_by: [] },
+        { task_id: "2", title: "Working", status: "in_progress", blocked_by: [] },
+      ],
+    };
+    mocks.tasksStreaming = false;
+    render(<RightPanel workspace={makeWorkspace()} activeTab="files" />);
+    expect(screen.queryByTestId("tasks-live-dot")).toBeNull();
+    // The tab itself stays — the plan is still worth showing.
+    expect(screen.getByTestId("tasks-tab")).toHaveTextContent("1/2");
   });
 });
 

--- a/src/components/layout/right-panel.tsx
+++ b/src/components/layout/right-panel.tsx
@@ -111,12 +111,20 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
   // down, so any clearance here would be a blank band above the tabs.
   const titlebarOverlay = useTitlebarOverlay();
   const workspaceWorkflow = useWorkspaceWorkflow(workspace);
-  const { tasks: activeChatTasks, updatedAt: tasksUpdatedAt } =
-    useActiveChatTasks(workspace);
+  const {
+    tasks: activeChatTasks,
+    updatedAt: tasksUpdatedAt,
+    streaming: tasksThreadStreaming = false,
+  } = useActiveChatTasks(workspace);
   const tasksSnapshot =
     activeChatTasks && activeChatTasks.tasks.length > 0 ? activeChatTasks : null;
+  // The blinking tab dot is a live affordance: gate it on the thread
+  // actually running, not on the durable snapshot. A plan the provider
+  // left with an `in_progress` row survives the turn (and a restart, via
+  // hydrate-replay) and would otherwise blink forever.
   const tasksRunning =
-    tasksSnapshot?.tasks.some((task) => task.status === "in_progress") ?? false;
+    tasksThreadStreaming &&
+    (tasksSnapshot?.tasks.some((task) => task.status === "in_progress") ?? false);
   // The Orchestration tab appears only once a run is approved (design:
   // the approval card in the thread owns the pending_approval state; the
   // panel would just duplicate the planned phases as "queued").

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -2337,9 +2337,22 @@ describe("sidebar-inbox pure helpers", () => {
     // so an old persisted snapshot keeps settling exactly as it used to.
     expect(isPrOnCurrentBranch(null, "fix-ui-borders")).toBe(true);
     expect(isPrOnCurrentBranch(undefined, "fix-ui-borders")).toBe(true);
-    // A PR head branch with no local branch to compare against cannot be
-    // confirmed as this checkout's, so it does not get settlement rights.
-    expect(isPrOnCurrentBranch("some-branch", null)).toBe(false);
+  });
+
+  it("isPrOnCurrentBranch keeps the association when the local branch is unknown", () => {
+    // `git_branch_info` reports no branch on a detached HEAD — mid-rebase,
+    // mid-bisect, `gh pr checkout` of a SHA — while the stored head branch
+    // survives. Treating that unknown as a mismatch would flip `hasPr` off
+    // and offer "Create PR" for a workspace that already has an open one,
+    // for as long as the rebase ran. Missing information must never
+    // un-associate a workspace from its own PR.
+    expect(isPrOnCurrentBranch("fix-ui-borders", null)).toBe(true);
+    expect(isPrOnCurrentBranch("fix-ui-borders", undefined)).toBe(true);
+    expect(isPrOnCurrentBranch("fix-ui-borders", "")).toBe(true);
+    // Both unknown is still a match, for the same reason.
+    expect(isPrOnCurrentBranch(null, null)).toBe(true);
+    // Two *known* names that differ is the only real mismatch.
+    expect(isPrOnCurrentBranch("side-branch", "fix-ui-borders")).toBe(false);
   });
 
   it("nextWorkspaceAfterPark steps forward, wraps, and stays put for background parks", () => {

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -159,6 +159,7 @@ import {
   shouldAutoSettle,
   MAX_TIMER_DELAY_MS,
 } from "./sidebar-inbox";
+import { isPrOnCurrentBranch } from "@/components/github/pr-status-icon";
 import {
   __resetSidebarInboxStoreForTests,
   useSidebarInboxStore,
@@ -710,6 +711,49 @@ describe("SidebarInbox — settle / un-settle", () => {
       "sidebar.inbox.settled",
       expect.any(String),
     );
+  });
+
+  it("shows a side-branch PR badge but never settles the card on it", async () => {
+    // The workspace is checked out on `fix-ui-borders`; the PR it opened came
+    // off `appimage-child-env-hygiene`, a branch it has since left. The badge
+    // is the whole point of the fallback and must render like any other. The
+    // merge, however, describes a branch the user is not standing on, so the
+    // card stays active — its own checkout is still unfinished.
+    workspaces = [
+      makeWorkspace({
+        title: "Side-branch PR",
+        worktree_path: "/wt/a",
+        git_branch: "fix-ui-borders",
+        pr_number: 250,
+        pr_state: "MERGED",
+        pr_head_branch: "appimage-child-env-hygiene",
+        last_active_at: Date.now(),
+      }),
+    ];
+    const { container } = await flushRender();
+
+    expect(container.querySelector('[data-settled-row="ws-1"]')).toBeNull();
+    expect(screen.queryByText("Settled")).not.toBeInTheDocument();
+    expect(screen.getByText("merged")).toBeInTheDocument();
+  });
+
+  it("still settles on a PR whose head branch IS the checked-out branch", async () => {
+    // The control for the test above: same badge, same state, association
+    // pointing at the branch actually checked out.
+    workspaces = [
+      makeWorkspace({
+        title: "Own-branch PR",
+        worktree_path: "/wt/a",
+        git_branch: "fix-ui-borders",
+        pr_number: 251,
+        pr_state: "MERGED",
+        pr_head_branch: "fix-ui-borders",
+        last_active_at: Date.now(),
+      }),
+    ];
+    const { container } = await flushRender();
+
+    expect(container.querySelector('[data-settled-row="ws-1"]')).not.toBeNull();
   });
 
   it("auto-settles completed review work when its PR is merged", async () => {
@@ -2259,6 +2303,45 @@ describe("sidebar-inbox pure helpers", () => {
     expect(shouldAutoSettle(null, null, stale, now, null)).toBe(false);
   });
 
+  it("shouldAutoSettle refuses to complete a workspace on a side-branch PR", () => {
+    // The real case: an agent working in a workspace branched off, pushed,
+    // opened a PR, and checked the worktree back — leaving eleven uncommitted
+    // files behind. The badge is real and belongs on the card. Settling that
+    // workspace when the side branch merges would file away work the user
+    // never finished.
+    const now = 10 * 86_400_000;
+    const stale = now - 4 * 86_400_000;
+    const fresh = now - 60_000;
+
+    for (const prState of ["merged", "closed"] as const) {
+      expect(shouldAutoSettle(prState, null, fresh, now, 3, false)).toBe(false);
+      expect(shouldAutoSettle(prState, "review", fresh, now, null, false)).toBe(
+        false,
+      );
+      // Same inputs, current-branch association: settles as it always has.
+      expect(shouldAutoSettle(prState, null, fresh, now, 3, true)).toBe(true);
+      // The guard removes only the PR shortcut. Idle work still ages out —
+      // an unfinished workspace is not made immortal by a side-branch badge.
+      expect(shouldAutoSettle(prState, null, stale, now, 3, false)).toBe(true);
+    }
+  });
+
+  it("isPrOnCurrentBranch treats an unknown head branch as the pre-field case", () => {
+    // Matching association — the ordinary badge.
+    expect(isPrOnCurrentBranch("fix-ui-borders", "fix-ui-borders")).toBe(true);
+    // Side-branch association — badge only.
+    expect(isPrOnCurrentBranch("appimage-child-env-hygiene", "fix-ui-borders")).toBe(
+      false,
+    );
+    // Additive field: absent means "predates the field", not "side branch",
+    // so an old persisted snapshot keeps settling exactly as it used to.
+    expect(isPrOnCurrentBranch(null, "fix-ui-borders")).toBe(true);
+    expect(isPrOnCurrentBranch(undefined, "fix-ui-borders")).toBe(true);
+    // A PR head branch with no local branch to compare against cannot be
+    // confirmed as this checkout's, so it does not get settlement rights.
+    expect(isPrOnCurrentBranch("some-branch", null)).toBe(false);
+  });
+
   it("nextWorkspaceAfterPark steps forward, wraps, and stays put for background parks", () => {
     const ids = ["a", "b", "c"];
     expect(nextWorkspaceAfterPark(["a"], "a", ids)).toBe("b");
@@ -2318,6 +2401,9 @@ describe("sidebar-inbox pure helpers", () => {
     // …and output the user has not seen must never be pushed down.
     expect(isWrappingUp("open", null, true)).toBe(false);
     expect(isWrappingUp("open", null, false)).toBe(true);
+    // …and a PR opened off a side branch is not this workspace winding down:
+    // the checkout in front of the user may not have shipped anything yet.
+    expect(isWrappingUp("open", null, false, false)).toBe(false);
   });
 
   it("isSnoozeable withholds the gesture from live and blocked agents", () => {

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -55,6 +55,7 @@ import {
 } from "./sidebar-snooze";
 import { WorkspaceHoverCard } from "./workspace-hover-card";
 import {
+  isPrOnCurrentBranch,
   normalizePrState,
   PrStatusIcon,
   prStatusTextClass,
@@ -153,9 +154,11 @@ export function isWrappingUp(
   prState: PrStatusState | null,
   status: ActivePaneStatus | null,
   unread: boolean,
+  prOnCurrentBranch = true,
 ): boolean {
-  return prState === "open" && status === null && !unread;
+  return prState === "open" && status === null && !unread && prOnCurrentBranch;
 }
+
 
 /** Completion-driven automatic settlement.
  *
@@ -164,6 +167,13 @@ export function isWrappingUp(
  * required. Inactivity remains a separate fallback for work without a finished
  * PR. A completed `review` status is deliberately settleable: it says the run
  * finished, not that work is still executing.
+ *
+ * The completion rule requires the PR to belong to the **checked-out branch**
+ * (`prOnCurrentBranch`, from `isPrOnCurrentBranch`). A side-branch badge —
+ * a PR the workspace opened from a branch it has since left — must never
+ * settle the workspace: the checkout it settles is not the checkout the PR
+ * merged. Note the guard only removes the PR shortcut; such a workspace still
+ * reaches the inactivity fallback below on its own idle schedule.
  *
  * Explicit keep-active pins, snoozes, and already-settled ids are handled by
  * the caller because they are persisted inbox lifecycle state rather than
@@ -174,9 +184,11 @@ export function shouldAutoSettle(
   lastActivityAt: number | undefined,
   now: number,
   autoSettleDays: number | null,
+  prOnCurrentBranch = true,
 ): boolean {
   if (status === "working" || status === "permission") return false;
-  if (prState === "merged" || prState === "closed") return true;
+  if (prOnCurrentBranch && (prState === "merged" || prState === "closed"))
+    return true;
   if (autoSettleDays === null || lastActivityAt === undefined) return false;
   return now - lastActivityAt > autoSettleDays * 86_400_000;
 }
@@ -975,6 +987,7 @@ export function SidebarInbox() {
       normalizePrState(ws.pr_state),
       statusOf(ws),
       isUnread(ws),
+      isPrOnCurrentBranch(ws.pr_head_branch, ws.git_branch),
     )
       ? wrappingUpTier
       : topTier;
@@ -1408,7 +1421,16 @@ export function SidebarInbox() {
       const status = getWorkspaceStatus(ws.surfaces, paneStatuses);
       const prState = normalizePrState(ws.pr_state);
       const stamp = effectiveActivityAt(ws.last_active_at, activity[id]);
-      if (shouldAutoSettle(prState, status, stamp, now, autoSettleDays)) {
+      if (
+        shouldAutoSettle(
+          prState,
+          status,
+          stamp,
+          now,
+          autoSettleDays,
+          isPrOnCurrentBranch(ws.pr_head_branch, ws.git_branch),
+        )
+      ) {
         store.settle(id, ws.last_active_at ?? undefined);
         markRowIn(setJustSettledId, id);
       }

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -159,7 +159,6 @@ export function isWrappingUp(
   return prState === "open" && status === null && !unread && prOnCurrentBranch;
 }
 
-
 /** Completion-driven automatic settlement.
  *
  * A merged/closed PR is itself the completion signal, so it settles as soon as

--- a/src/components/layout/workspace-hover-card.test.tsx
+++ b/src/components/layout/workspace-hover-card.test.tsx
@@ -239,6 +239,42 @@ describe("WorkspaceHoverCardBody — PR, issue, ports", () => {
     expect(screen.getByText("#140 · merged")).toHaveClass("text-accent-violet");
   });
 
+  it("names the PR's own branch only when it is not the checked-out one", () => {
+    // A side-branch association: the badge is real, but the Branch row says
+    // something else, and this row is what answers "why?". It also explains
+    // why merging that PR will not settle the card.
+    const { unmount } = renderBody(
+      makeWorkspace({
+        git_branch: "fix-ui-borders",
+        pr_number: 250,
+        pr_state: "open",
+        pr_head_branch: "appimage-child-env-hygiene",
+      }),
+    );
+    expect(valueFor("PR branch")).toBe("appimage-child-env-hygiene");
+    unmount();
+
+    // Matching association — the row would only repeat the Branch row above.
+    renderBody(
+      makeWorkspace({
+        git_branch: "fix-ui-borders",
+        pr_number: 251,
+        pr_state: "open",
+        pr_head_branch: "fix-ui-borders",
+      }),
+    );
+    expect(screen.queryByText("PR branch")).not.toBeInTheDocument();
+  });
+
+  it("omits the PR branch row for a pre-field snapshot", () => {
+    // No head branch recorded means "association predates the field", not
+    // "side branch" — inventing a mismatch there would be a lie.
+    renderBody(
+      makeWorkspace({ git_branch: "main", pr_number: 9, pr_state: "open" }),
+    );
+    expect(screen.queryByText("PR branch")).not.toBeInTheDocument();
+  });
+
   it("tones an open issue as success and a closed one as muted", () => {
     const { unmount } = renderBody(
       makeWorkspace({

--- a/src/components/layout/workspace-hover-card.tsx
+++ b/src/components/layout/workspace-hover-card.tsx
@@ -7,6 +7,7 @@ import {
 import { ProjectAvatar } from "@/components/ui/project-avatar";
 import { ProviderLogo } from "@/components/chat/provider-logo";
 import {
+  isPrOnCurrentBranch,
   normalizePrState,
   prStatusTextClass,
 } from "@/components/github/pr-status-icon";
@@ -128,6 +129,7 @@ export function WorkspaceHoverCardBody({
 
   const providers = getWorkspaceProviders(workspace.surfaces);
   const prState = normalizePrState(workspace.pr_state);
+  const prHeadBranch = workspace.pr_head_branch ?? null;
   const issue = workspace.linked_issue;
 
   // Elapsed since the current state began. Stamped client-side (the backend
@@ -253,6 +255,15 @@ export function WorkspaceHoverCardBody({
             value={`#${workspace.pr_number ?? ""} · ${prState}`}
             valueClassName={prStatusTextClass(workspace.pr_state) ?? undefined}
           />
+        )}
+        {/* Only when the PR is NOT the checked-out branch's. This is the
+            details surface, so it can afford to answer the question the badge
+            raises: the workspace has a PR, yet the Branch row above says
+            something else. Naming the head branch says the PR came off a side
+            branch — and explains why merging it will not settle this card. On
+            the ordinary matching case the row would be pure repetition. */}
+        {prState && !isPrOnCurrentBranch(prHeadBranch, workspace.git_branch) && (
+          <DetailRow label="PR branch" value={prHeadBranch!} muted />
         )}
         {issue && (
           <DetailRow

--- a/src/components/workspace/review-panel.tsx
+++ b/src/components/workspace/review-panel.tsx
@@ -36,6 +36,7 @@ import type {
   ReviewComment,
   InlineReviewComment,
 } from "@/tauri/types";
+import { isPrOnCurrentBranch } from "@/components/github/pr-status-icon";
 import { ReviewHeader } from "./review/review-header";
 import { ReviewChecks } from "./review/review-checks";
 import { ReviewThreads } from "./review/review-threads";
@@ -357,7 +358,15 @@ function ReviewView({
 
 export function ReviewPanel({ workspace }: Props) {
   const cwd = workspace.worktree_path ?? workspace.cwd;
-  const hasPr = workspace.pr_number != null;
+  // Strictly the checked-out branch's PR. The workspace snapshot may also
+  // carry a *badge-only* side-branch association (a PR the workspace opened
+  // from a branch it has since left — see `isPrOnCurrentBranch`), and this
+  // panel is a working surface, not a badge: honouring one here would review
+  // a branch the user is not on while hiding the "Create PR" affordance for
+  // the branch they actually are on.
+  const hasPr =
+    workspace.pr_number != null &&
+    isPrOnCurrentBranch(workspace.pr_head_branch, workspace.git_branch);
 
   const [ghStatus, setGhStatus] = useState<GhStatus | null>(getCachedGhStatus());
   const [isGithubRepo, setIsGithubRepo] = useState<boolean | null>(

--- a/src/hooks/use-active-chat-tasks.test.tsx
+++ b/src/hooks/use-active-chat-tasks.test.tsx
@@ -86,6 +86,7 @@ describe("useActiveChatTasks", () => {
       threadId: null,
       tasks: null,
       updatedAt: null,
+      streaming: false,
     });
   });
 });

--- a/src/hooks/use-active-chat-tasks.ts
+++ b/src/hooks/use-active-chat-tasks.ts
@@ -23,6 +23,11 @@ export function useActiveChatTasks(workspace: WorkspaceSnapshot | null): {
   tasks: TasksSnapshot | null;
   /** When the snapshot was last applied (ms), for the panel caption. */
   updatedAt?: number | null;
+  /** Whether that thread is mid-run. The task snapshot is durable state
+   *  that outlives the turn, so any *live* affordance driven by it (the
+   *  blinking tab dot, the composer chip's spinner) must be gated on this
+   *  rather than on an `in_progress` row alone. */
+  streaming?: boolean;
 } {
   const threadId = useMemo(() => {
     if (!workspace) return null;
@@ -40,5 +45,8 @@ export function useActiveChatTasks(workspace: WorkspaceSnapshot | null): {
   const updatedAt = useAgentChatStore((state) =>
     threadId ? (state.threads[threadId]?.tasksUpdatedAt ?? null) : null,
   );
-  return { threadId, tasks, updatedAt };
+  const streaming = useAgentChatStore((state) =>
+    threadId ? (state.threads[threadId]?.streaming ?? false) : false,
+  );
+  return { threadId, tasks, updatedAt, streaming };
 }

--- a/src/lib/agent-chat/subagents.test.ts
+++ b/src/lib/agent-chat/subagents.test.ts
@@ -94,6 +94,26 @@ describe("mergeSnapshot revive / statusAssumed (issue #153)", () => {
   const snap = (status: SubagentSnapshot["status"]): SubagentSnapshot =>
     ({ subagent_id: "s1", status }) as SubagentSnapshot;
 
+  it("stamps backgroundTask once and never unsets it from a later snapshot", () => {
+    const merged = mergeSnapshot(view({ id: "bg" }), {
+      subagent_id: "bg",
+      status: "running",
+      background_task: true,
+    } as SubagentSnapshot);
+    expect(merged.backgroundTask).toBe(true);
+    // A later snapshot that simply omits the flag must not promote the row
+    // back to "real subagent" (same additive-merge rule as every field).
+    expect(
+      mergeSnapshot(merged, { subagent_id: "bg", status: "running" } as SubagentSnapshot)
+        .backgroundTask,
+    ).toBe(true);
+    // A row that was never flagged stays shape-identical (no stray key).
+    expect(
+      "backgroundTask" in
+        mergeSnapshot(view(), { subagent_id: "s1", status: "running" } as SubagentSnapshot),
+    ).toBe(false);
+  });
+
   it("a real running snapshot revives an interrupted row and clears assumed", () => {
     const v = view({ status: "interrupted", statusAssumed: true });
     const next = mergeSnapshot(v, snap("running"));
@@ -394,6 +414,34 @@ describe("whole-thread lookups", () => {
     expect(entries.map((e) => e.subagent.id)).toEqual(["a", "c"]);
     expect(entries.every((e) => e.cardId === "run-1")).toBe(true);
     expect(entries.every((e) => e.fromLabel === null)).toBe(true);
+  });
+
+  it("drops background tasks from live activity once the thread stops streaming", () => {
+    const bgCard: SubagentRunItem = {
+      kind: "subagent_run",
+      id: "run-bg",
+      seq: 2,
+      turn_id: "t3",
+      subagents: [
+        view({ id: "bg", status: "running", backgroundTask: true }),
+        view({ id: "real", status: "running" }),
+      ],
+    };
+    const withBg: ChatViewItem[] = [bgCard];
+
+    // Mid-run both read as live.
+    expect(countRunningSubagents(withBg, true)).toBe(2);
+    expect(runningSubagentEntries(withBg, true).map((e) => e.subagent.id)).toEqual([
+      "bg",
+      "real",
+    ]);
+
+    // Run over: the never-terminating background job stops counting, so
+    // the docked bar can't spin forever after the turn settled.
+    expect(countRunningSubagents(withBg, false)).toBe(1);
+    expect(runningSubagentEntries(withBg, false).map((e) => e.subagent.id)).toEqual([
+      "real",
+    ]);
   });
 
   it("labels each running subagent with its originating card once several cards exist", () => {

--- a/src/lib/agent-chat/subagents.ts
+++ b/src/lib/agent-chat/subagents.ts
@@ -100,6 +100,11 @@ export function mergeSnapshot(
       next.statusAssumed = false;
     }
   }
+  // Sticky once set: a provider that only flags the first task event for a
+  // background job must not have a later unflagged snapshot promote it
+  // back to "real subagent" (the same additive-merge rule as every other
+  // field — a snapshot never clobbers a known value with an absent one).
+  if (snap.background_task) next.backgroundTask = true;
   if (snap.parent_item_id != null) next.parentItemId = snap.parent_item_id;
   if (snap.name != null) next.name = snap.name;
   if (snap.agent_type != null) next.agentType = snap.agent_type;
@@ -352,13 +357,36 @@ export function subagentRunItems(messages: ChatViewItem[]): SubagentRunItem[] {
   );
 }
 
+/**
+ * Whether a subagent row should read as **live activity** right now.
+ *
+ * Running/pending is necessary but not sufficient: a provider background
+ * task (a background shell command) can legitimately outlive the turn and
+ * never report a terminal status, so once the thread stops streaming it is
+ * a job that happens to still be alive — not the agent working. Counting
+ * it would keep the docked activity bar and its spinner up forever after
+ * the run ended, including across a restart (the snapshots are persisted
+ * and hydrate-replayed).
+ */
+export function isLiveActivity(
+  view: SubagentView,
+  streaming: boolean,
+): boolean {
+  if (!isRunning(view)) return false;
+  return streaming || !view.backgroundTask;
+}
+
 /** Count of currently-running subagents across the whole thread — feeds
- *  the docked {@link SubagentActivityBar}. */
-export function countRunningSubagents(messages: ChatViewItem[]): number {
+ *  the docked {@link SubagentActivityBar}. `streaming` is the thread's
+ *  live-run flag; see {@link isLiveActivity}. */
+export function countRunningSubagents(
+  messages: ChatViewItem[],
+  streaming = true,
+): number {
   let n = 0;
   for (const card of subagentRunItems(messages)) {
     for (const sub of card.subagents) {
-      if (sub.status === "running") n += 1;
+      if (sub.status === "running" && isLiveActivity(sub, streaming)) n += 1;
     }
   }
   return n;
@@ -407,15 +435,20 @@ export interface RunningSubagentEntry {
  *  the thread, no matter which reply spawned it (design "one bar for the
  *  whole thread"). Feeds the docked {@link SubagentActivityBar}: its
  *  `.length` is the bar's count, and each entry carries the "from"
- *  label + jump target for the expand list. */
+ *  label + jump target for the expand list.
+ *
+ *  `streaming` is the thread's live-run flag: with the run over, provider
+ *  background tasks drop out (see {@link isLiveActivity}) so a background
+ *  shell command can't keep the bar spinning after the turn settled. */
 export function runningSubagentEntries(
   messages: ChatViewItem[],
+  streaming = true,
 ): RunningSubagentEntry[] {
   const cards = subagentRunItems(messages);
   const entries: RunningSubagentEntry[] = [];
   cards.forEach((card, cardIdx) => {
     for (const sub of card.subagents) {
-      if (!isRunning(sub)) continue;
+      if (!isLiveActivity(sub, streaming)) continue;
       entries.push({
         subagent: sub,
         cardId: card.id,

--- a/src/lib/agent-chat/task-summary.test.ts
+++ b/src/lib/agent-chat/task-summary.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import type { TaskSnapshotItem, TasksSnapshot } from "@/tauri/events";
+
+import { taskChipSummary } from "./task-summary";
+
+function snapshot(...statuses: TaskSnapshotItem["status"][]): TasksSnapshot {
+  return {
+    tasks: statuses.map((status, index) => ({
+      task_id: `t${index}`,
+      title: `Task ${index}`,
+      status,
+      blocked_by: [],
+    })),
+  };
+}
+
+describe("taskChipSummary", () => {
+  it("renders no chip without a plan", () => {
+    expect(taskChipSummary(null, true)).toBeNull();
+    expect(taskChipSummary(undefined, true)).toBeNull();
+    expect(taskChipSummary({ tasks: [] }, true)).toBeNull();
+  });
+
+  it("reports live progress while the thread streams", () => {
+    expect(
+      taskChipSummary(snapshot("completed", "in_progress", "pending"), true),
+    ).toEqual({ completed: 1, total: 3, running: true });
+  });
+
+  it("keeps the counts but drops the spinner once the run is over", () => {
+    // The snapshot is durable — nothing rewrites the `in_progress` row when
+    // the turn ends, so only `streaming` can settle the chip.
+    expect(
+      taskChipSummary(snapshot("completed", "in_progress", "pending"), false),
+    ).toEqual({ completed: 1, total: 3, running: false });
+  });
+
+  it("still reads complete when every row is done", () => {
+    expect(taskChipSummary(snapshot("completed", "completed"), false)).toEqual({
+      completed: 2,
+      total: 2,
+      running: false,
+    });
+  });
+});

--- a/src/lib/agent-chat/task-summary.ts
+++ b/src/lib/agent-chat/task-summary.ts
@@ -1,0 +1,33 @@
+import type { TasksSnapshot } from "@/tauri/events";
+
+/** Counts + run state behind the composer's `Tasks N/M` chip. */
+export interface TaskChipSummary {
+  completed: number;
+  total: number;
+  /** Whether the chip should present as LIVE (amber + spinner). */
+  running: boolean;
+}
+
+/**
+ * Derive the composer Tasks chip's state from a thread's provider plan.
+ *
+ * The `TasksUpdated` snapshot is **durable state**: it is persisted and
+ * hydrate-replayed, and nothing ever rewrites it when a run ends. So an
+ * `in_progress` row is not evidence that work is happening — only the
+ * thread's own `streaming` flag is. Gating the spinner on `streaming`
+ * keeps a plan the provider left mid-step from spinning forever (including
+ * across a restart) while still showing the counts: the durable snapshot
+ * is by design, so the chip stays, it just stops claiming to be live.
+ */
+export function taskChipSummary(
+  tasks: TasksSnapshot | null | undefined,
+  streaming: boolean,
+): TaskChipSummary | null {
+  if (!tasks || tasks.tasks.length === 0) return null;
+  return {
+    completed: tasks.tasks.filter((task) => task.status === "completed").length,
+    total: tasks.tasks.length,
+    running:
+      streaming && tasks.tasks.some((task) => task.status === "in_progress"),
+  };
+}

--- a/src/lib/agent-chat/types.ts
+++ b/src/lib/agent-chat/types.ts
@@ -207,6 +207,12 @@ export interface SubagentView {
    *  terminal snapshot clears it; a real `running` snapshot revives an
    *  assumed/interrupted row back to `running` and clears it. */
   statusAssumed?: boolean;
+  /** True when the provider reported this row as a *background task*
+   *  (e.g. a background shell command) rather than a delegated subagent.
+   *  Such a job can outlive the turn indefinitely and never report a
+   *  terminal status, so it must not read as live activity once the
+   *  thread stops streaming (see `runningSubagentEntries`). */
+  backgroundTask?: boolean;
   /** Provider-pushed "currently doing X" line, when supplied. */
   activity?: string;
   /** Final report first surfaced on completion. */

--- a/src/tauri/events.ts
+++ b/src/tauri/events.ts
@@ -229,6 +229,12 @@ export interface SubagentSnapshot {
    *  provider's task label. `null` when no hint was found — the reducer
    *  falls back to the workflow's last planned phase title. */
   phase?: string | null;
+  /** True when this row is a provider *background task* (e.g. a
+   *  background shell command) rather than a real delegated subagent. It
+   *  can legitimately outlive the turn and never emit a terminal update,
+   *  so it never counts as live activity once the thread stops streaming.
+   *  Absent / false on every provider that has no such concept. */
+  background_task?: boolean | null;
 }
 
 // ── Workflows (Claude dynamic-workflow orchestration) ──

--- a/src/tauri/types.ts
+++ b/src/tauri/types.ts
@@ -713,6 +713,17 @@ export interface WorkspaceSnapshot {
   pr_number: number | null;
   pr_state: string | null;
   pr_url: string | null;
+  /** Head branch of the associated PR, as GitHub reports it.
+   *
+   *  Usually equal to `git_branch`. It differs when the badge came from the
+   *  backend's side-branch fallback — a PR opened from a branch this worktree
+   *  checked out recently and then left. The badge is worth showing either
+   *  way; the *inferences* drawn from a PR are not, so auto-settle requires
+   *  this to match the checked-out branch (see `isPrOnCurrentBranch`).
+   *
+   *  Optional because older persisted snapshots have no such field; `null` /
+   *  absent is read as the pre-field case and settles as before. */
+  pr_head_branch?: string | null;
   linked_issue: LinkedIssue | null;
   /** When true, agent-completion desktop notifications for this workspace's
    *  panes are suppressed. Status pills (spinner/dots) are unaffected. */


### PR DESCRIPTION
## Bug: workspace pinned at "Working" forever after a finished run

A run that ended cleanly (successful `turn_completed` persisted) stayed stuck all night showing the sidebar **Working** status, the background-browser **LIVE** chip, live activity spinners, and a spinning Tasks chip.

**Root cause (verified against the real session's persisted event stream):** the agent had run `Bash { run_in_background: true }` with `npm run dev`. The provider reports background tasks through the same `task_*` event family as subagents, so the dev server entered the run-blocking subagent set — and since a dev server never exits, its terminal notification never arrives. At `TurnCompleted` the tracker held `Working` and deferred the owed `Review` forever. Everything downstream gates on that one transition: sidebar status, the detached-browser LIVE release, and the activity affordances.

### Fix (commit 1)
- `SubagentSnapshot.background_task` (serde-defaulted): set by the Claude translator for task events that don't belong to a registered top-level `Agent`/`Task` launch. Flagged snapshots never enter the run-blocking set and can't resurrect `Working` after settle. Real subagents keep the deliberate deferred-Review flow.
- **Watchdog backstop:** an owed Review silent past the stall threshold (600s) is force-settled — status write, Review→Idle downgrade, browser release, snapshot emit — so any future missed terminal signal can't pin `Working` indefinitely.
- Frontend: Tasks chip / right-panel Tasks dot only animate while streaming; the docked activity bar drops background tasks once the run ends.

## Bug: PR opened from a side branch shows no badge (commit 2)

An agent that split work onto a fresh branch (checkout -b → commit → push → PR → checkout back) left the workspace badge-less, because association was strictly current-checkout == PR head branch.

- `get_workspace_pr`: current branch always wins; on an authoritative no-PR (never on the default branch), fall back to branches recently checked out in this worktree (parsed from `git reflog`, deduped, capped). One repo-wide `gh pr list` per origin per minute, memoized across sibling worktrees.
- `pr_head_branch` on the workspace snapshot distinguishes the association: **auto-settle, the wrapping-up tier, and the Review panel's has-PR gate all require the PR branch to match the checkout**, so a side-branch PR shows its badge but can never settle a workspace whose own work is unshipped. Hover card shows the PR branch when it differs.

## Testing
- Rust: `cargo test --lib` — 2533 passed; the 2 opencode server-spawn tests are flaky under full-suite parallelism and pass in isolation; the known `sidecar_sdk` invalid-params failure is pre-existing on `main`.
- Frontend: `vitest` — 255 files / 3899 tests passed, including new coverage for the tracker flag, watchdog helpers, reflog parsing, fallback selection, settle refusal, and hover-card rendering. `tsc` shows only the pre-existing streamdown/shiki drift.
- Docs updated: `agent-chat.md`, `browser.md`, `sidebar.md`, `review-integration.md`, `STATUS.md`.