### PR TITLE
Restrict text selection to content, not UI chrome

### DIFF
--- a/docs/reference/DESIGN-SYSTEM.md
+++ b/docs/reference/DESIGN-SYSTEM.md
@@ -95,6 +95,43 @@ overview):
 
 ## Text Selection
 
+### Selectability: chrome is not selectable, content is
+
+Codemux follows the desktop-app convention: drag-selection only ever grabs
+real content, never UI chrome. Selectable-everything is a website default —
+being able to rubber-band sidebar cards, settings labels, buttons, and layout
+whitespace makes the app read as a web page. The document therefore opts out
+once at the root (`body { user-select: none; cursor: default }` in
+`src/globals.css` `@layer base`, with the `-webkit-` prefix WebKitGTK
+requires) and content opts back in.
+
+Two opt-in tiers, both in the same `@layer base` block:
+
+1. **Automatic element/root selectors** — `input`, `textarea`,
+   `[contenteditable]`, `pre`, `code`, `kbd`, `samp`, `.cm-content`,
+   `.chat-markdown`, `.markdown-rendered`, and sonner toast title/description.
+   Because `user-select` inherits, a rule on a content root re-enables its
+   whole subtree, so most new content stays selectable without remembering a
+   class.
+2. **The `select-text` utility** for one-off prose/mono blocks that have no
+   shared root (user message text, reasoning text, tool-output divs, diff pane
+   content, review-thread comments). A base-layer companion rule gives
+   `.select-text` elements `cursor: auto` so re-enabled text gets its I-beam
+   back.
+
+Rules of thumb:
+
+- New chrome needs no class — it is unselectable by default.
+- New content surfaces should either render under an existing content root or
+  carry `select-text`.
+- Chrome *inside* a content root (a code-block header bar, a copy button)
+  opts out again with `select-none`; Tailwind utilities beat the base-layer
+  opt-ins, so precedence works in both directions.
+- Never re-disable selection on error text, paths, IDs, or anything a user
+  might legitimately copy.
+
+### Highlight colors
+
 Selectable Codemux-owned DOM text inherits one document-level highlight
 contract from `:root::selection`: solid `--selection-background` with
 `--selection-foreground`. Keep the selector root-scoped rather than using a

--- a/docs/reference/DESIGN-SYSTEM.md
+++ b/docs/reference/DESIGN-SYSTEM.md
@@ -128,7 +128,11 @@ Rules of thumb:
   opts out again with `select-none`; Tailwind utilities beat the base-layer
   opt-ins, so precedence works in both directions.
 - Never re-disable selection on error text, paths, IDs, or anything a user
-  might legitimately copy.
+  might legitimately copy. Rendered diffs, file-path headers, grep matches,
+  ssh targets, and inline error/notice lines all count as content.
+- `cursor` inherits from the body opt-out too, so a base-layer `a { cursor:
+  pointer }` keeps links clickable-looking; any other custom cursor still
+  needs its own rule or utility.
 
 ### Highlight colors
 

--- a/src/components/automations/automations-section.tsx
+++ b/src/components/automations/automations-section.tsx
@@ -638,7 +638,7 @@ function AutomationDetail({
         <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/60">
           Prompt
         </p>
-        <div className="rounded-lg border border-border/60 bg-muted/30 p-3 text-[13px] text-foreground/90 leading-relaxed whitespace-pre-wrap max-h-40 overflow-y-auto">
+        <div className="select-text rounded-lg border border-border/60 bg-muted/30 p-3 text-[13px] text-foreground/90 leading-relaxed whitespace-pre-wrap max-h-40 overflow-y-auto">
           {automation.prompt}
         </div>
       </div>

--- a/src/components/chat/ActivityBlock.tsx
+++ b/src/components/chat/ActivityBlock.tsx
@@ -221,7 +221,7 @@ function StepRow({
 function StepDetail({ step }: { step: ActivityStep }) {
   if (step.kind === "reasoning") {
     return (
-      <p className="whitespace-pre-wrap break-words text-[13px] italic leading-[1.6] text-muted-foreground">
+      <p className="select-text whitespace-pre-wrap break-words text-[13px] italic leading-[1.6] text-muted-foreground">
         {step.text}
       </p>
     );

--- a/src/components/chat/DiffView.tsx
+++ b/src/components/chat/DiffView.tsx
@@ -47,7 +47,7 @@ export function DiffView({
           <CopyButton text={copyText} />
         </span>
       </div>
-      <div className="overflow-x-auto py-[9px] font-mono text-[12px] leading-[1.75]">
+      <div className="select-text overflow-x-auto py-[9px] font-mono text-[12px] leading-[1.75]">
         {rows.map((row, i) => {
           if (row.type === "context" || row.type === "add") lineNo += 1;
           const gutter =

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1508,7 +1508,7 @@ function renderAssistantBody(
           }
           if (item.resolution.state === "failed") {
             return (
-              <div className="py-0.5 text-xs text-muted-foreground">
+              <div className="select-text py-0.5 text-xs text-muted-foreground">
                 {item.resolution.message}
               </div>
             );
@@ -1532,7 +1532,7 @@ function renderAssistantBody(
     case "turn_ended":
       if (item.status.kind !== "error") return null;
       return (
-        <div className="py-0.5 text-xs text-muted-foreground">
+        <div className="select-text py-0.5 text-xs text-muted-foreground">
           Turn ended: {item.status.subtype}
           {item.status.message ? ` — ${item.status.message}` : ""}
         </div>
@@ -1542,7 +1542,7 @@ function renderAssistantBody(
       // enumerated assistant error) — a left-bordered line in the
       // assistant gutter. Tokens only (design-system no-hardcoded-color).
       return (
-        <div className="border-l-2 border-status-working/40 bg-status-working/10 px-3 py-1.5 text-[12px] text-status-working">
+        <div className="select-text border-l-2 border-status-working/40 bg-status-working/10 px-3 py-1.5 text-[12px] text-status-working">
           {item.message}
         </div>
       );

--- a/src/components/chat/ReasoningBlock.tsx
+++ b/src/components/chat/ReasoningBlock.tsx
@@ -70,7 +70,7 @@ export const ReasoningBlock = memo(function ReasoningBlock({
         />
       </button>
       {open && item.text.length > 0 && (
-        <div className="whitespace-pre-wrap break-words border-t border-border/60 py-[11px] pl-[33px] pr-3.5 text-[13px] italic leading-[1.65] text-muted-foreground">
+        <div className="select-text whitespace-pre-wrap break-words border-t border-border/60 py-[11px] pl-[33px] pr-3.5 text-[13px] italic leading-[1.65] text-muted-foreground">
           {item.text}
         </div>
       )}

--- a/src/components/chat/ToolCallBlock.tsx
+++ b/src/components/chat/ToolCallBlock.tsx
@@ -33,7 +33,7 @@ export function ToolCallBlock({ content, error, text }: Props) {
   return (
     <div
       className={cn(
-        "rounded-md bg-muted/40 font-mono text-[12px] leading-5",
+        "select-text rounded-md bg-muted/40 font-mono text-[12px] leading-5",
         "text-foreground whitespace-pre-wrap break-words",
         error && "text-foreground",
       )}

--- a/src/components/chat/ToolCallBodies.tsx
+++ b/src/components/chat/ToolCallBodies.tsx
@@ -94,7 +94,7 @@ export function BashToolBody({ item, input }: BodyProps) {
   return (
     <div className="space-y-2">
       {command && (
-        <div className="rounded-md bg-muted/40 px-3 py-2 font-mono text-[12px] leading-5 text-foreground whitespace-pre-wrap break-words">
+        <div className="select-text rounded-md bg-muted/40 px-3 py-2 font-mono text-[12px] leading-5 text-foreground whitespace-pre-wrap break-words">
           <span className="text-muted-foreground/70">$ </span>
           {command}
           {description && (
@@ -388,7 +388,7 @@ function LazyToolResultBody({ stub }: { stub: LazyToolResultStub }) {
   const hidden = Math.max(stub.line_count - previewLineCount(stub.preview), 0);
 
   return (
-    <div className="rounded-md bg-muted/40 font-mono text-[12px] leading-5 text-foreground whitespace-pre-wrap break-words">
+    <div className="select-text rounded-md bg-muted/40 font-mono text-[12px] leading-5 text-foreground whitespace-pre-wrap break-words">
       <div className="px-3 py-2">
         {stub.preview}
         <span className="text-muted-foreground/60">{"\n"}…</span>

--- a/src/components/chat/ToolCallBodies.tsx
+++ b/src/components/chat/ToolCallBodies.tsx
@@ -146,7 +146,7 @@ export function ReadToolBody({ item, input }: BodyProps) {
   return (
     <div className="space-y-2">
       {path && (
-        <div className="font-mono text-[12px] text-foreground">
+        <div className="select-text font-mono text-[12px] text-foreground">
           {path}
           {(offset != null || limit != null) && (
             <span className="ml-2 text-muted-foreground/70">
@@ -182,7 +182,7 @@ export function GrepToolBody({ item, input }: BodyProps) {
   return (
     <div className="space-y-2">
       {(pattern || path) && (
-        <div className="font-mono text-[12px] text-foreground">
+        <div className="select-text font-mono text-[12px] text-foreground">
           {pattern && <span>{pattern}</span>}
           {path && (
             <span className="ml-2 text-muted-foreground/70">in {path}</span>
@@ -190,7 +190,7 @@ export function GrepToolBody({ item, input }: BodyProps) {
         </div>
       )}
       {matches.length > 0 ? (
-        <div className="rounded-md bg-muted/40 px-3 py-2 space-y-1">
+        <div className="select-text rounded-md bg-muted/40 px-3 py-2 space-y-1">
           <p className="text-[11px] text-muted-foreground/80">
             {matches.length} match{matches.length === 1 ? "" : "es"}
           </p>
@@ -246,10 +246,10 @@ export function WebFetchToolBody({ item, input }: BodyProps) {
         )
       )}
       {title && (
-        <p className="text-[12px] text-muted-foreground">{title}</p>
+        <p className="select-text text-[12px] text-muted-foreground">{title}</p>
       )}
       {prompt && (
-        <p className="rounded-md bg-muted/40 px-3 py-2 text-[12px] text-foreground">
+        <p className="select-text rounded-md bg-muted/40 px-3 py-2 text-[12px] text-foreground">
           {prompt}
         </p>
       )}
@@ -295,7 +295,7 @@ export function EditToolBody({ item, input }: BodyProps) {
   return (
     <div className="space-y-1">
       {path && (
-        <div className="font-mono text-[12px] text-foreground">{path}</div>
+        <div className="select-text font-mono text-[12px] text-foreground">{path}</div>
       )}
       {result && <ToolCallBlock content={result} />}
     </div>

--- a/src/components/chat/ToolCallCard.tsx
+++ b/src/components/chat/ToolCallCard.tsx
@@ -193,7 +193,7 @@ export const ToolCallCard = memo(function ToolCallCard({
       )}
 
       {isRequestFailed && resolution?.state === "failed" && (
-        <div className="border-t border-border/60 px-3 py-2 text-xs text-muted-foreground">
+        <div className="select-text border-t border-border/60 px-3 py-2 text-xs text-muted-foreground">
           {resolution.message}
         </div>
       )}

--- a/src/components/chat/UserInputAnswer.tsx
+++ b/src/components/chat/UserInputAnswer.tsx
@@ -50,7 +50,7 @@ export const UserInputAnswer = memo(function UserInputAnswer({
                   {line.header}
                 </div>
               ) : null}
-              <div className="whitespace-pre-wrap break-words">
+              <div className="select-text whitespace-pre-wrap break-words">
                 {line.value}
               </div>
             </div>

--- a/src/components/chat/UserMessage.tsx
+++ b/src/components/chat/UserMessage.tsx
@@ -134,7 +134,7 @@ export const UserMessage = memo(function UserMessage({
             </div>
           ) : null}
           {item.text ? (
-            <div className="whitespace-pre-wrap break-words">{item.text}</div>
+            <div className="select-text whitespace-pre-wrap break-words">{item.text}</div>
           ) : null}
         </div>
         {queued ? (

--- a/src/components/diff/DiffSplitView.tsx
+++ b/src/components/diff/DiffSplitView.tsx
@@ -146,7 +146,7 @@ export const DiffSplitView = forwardRef<DiffViewHandle, Props>(
       };
 
     return (
-      <div className="flex-1 grid grid-cols-[1fr_1px_1fr] min-h-0 overflow-hidden font-mono text-xs leading-[18px]">
+      <div className="select-text flex-1 grid grid-cols-[1fr_1px_1fr] min-h-0 overflow-hidden font-mono text-xs leading-[18px]">
         {/* Left — deletions / old */}
         <div
           ref={leftRef}

--- a/src/components/diff/DiffUnifiedView.tsx
+++ b/src/components/diff/DiffUnifiedView.tsx
@@ -50,7 +50,7 @@ export const DiffUnifiedView = forwardRef<DiffViewHandle, Props>(
     return (
       <div
         ref={containerRef}
-        className="flex-1 overflow-auto bg-card font-mono text-xs leading-[18px]"
+        className="select-text flex-1 overflow-auto bg-card font-mono text-xs leading-[18px]"
       >
         <div className="py-0.5">
           {lines.map((line, i) => {

--- a/src/components/github/issue-detail-popover.tsx
+++ b/src/components/github/issue-detail-popover.tsx
@@ -151,7 +151,7 @@ export function IssueDetailPopover({
               {/* Body */}
               {fullIssue.body ? (
                 <div className="max-h-[300px] overflow-y-auto">
-                  <p className="text-xs text-muted-foreground whitespace-pre-wrap break-words leading-relaxed">
+                  <p className="select-text text-xs text-muted-foreground whitespace-pre-wrap break-words leading-relaxed">
                     {fullIssue.body}
                   </p>
                 </div>

--- a/src/components/settings/hosts-section.tsx
+++ b/src/components/settings/hosts-section.tsx
@@ -604,7 +604,7 @@ export function HostsSection() {
                   </span>
                 )}
               </div>
-              <p className="font-mono text-[12px] text-muted-foreground/85">
+              <p className="select-text font-mono text-[12px] text-muted-foreground/85">
                 {selected.ssh_target}
               </p>
             </div>

--- a/src/components/settings/settings-view.tsx
+++ b/src/components/settings/settings-view.tsx
@@ -1631,11 +1631,11 @@ export function SettingsView() {
               {authUser ? (
                 <>
                   <SettingRow label="Email" description="Your sign-in email address.">
-                    <span className="font-mono text-[13px] text-muted-foreground">{authUser.email}</span>
+                    <span className="select-text font-mono text-[13px] text-muted-foreground">{authUser.email}</span>
                   </SettingRow>
                   <Separator />
                   <SettingRow label="Name" description="Your display name.">
-                    <span className="text-sm text-muted-foreground">{authUser.name ?? "—"}</span>
+                    <span className="select-text text-sm text-muted-foreground">{authUser.name ?? "—"}</span>
                   </SettingRow>
                   {isDevBypass && (
                     <>

--- a/src/components/workspace/changes-panel.tsx
+++ b/src/components/workspace/changes-panel.tsx
@@ -735,7 +735,7 @@ export function ChangesPanel({ workspace }: Props) {
           <div className="rounded-md border border-border/60 bg-background overflow-hidden">
             <div className="flex items-start gap-2 px-2.5 py-2 border-l-2 border-l-primary/70">
               <Sparkles className="size-3 text-primary/80 mt-0.5 shrink-0" />
-              <p className="flex-1 text-[11px] leading-snug text-foreground whitespace-pre-wrap break-words">
+              <p className="select-text flex-1 text-[11px] leading-snug text-foreground whitespace-pre-wrap break-words">
                 {generatedMsg}
               </p>
             </div>

--- a/src/components/workspace/review/review-threads.tsx
+++ b/src/components/workspace/review/review-threads.tsx
@@ -168,7 +168,7 @@ export function ReviewThreads({ reviews, inlineComments, isLoading = false }: Pr
             {/* Review body */}
             {g.review.body && (
               <div className="group/comment flex items-start gap-1 pl-7 pr-1">
-                <p className="text-xs text-muted-foreground flex-1 whitespace-pre-wrap break-words">
+                <p className="select-text text-xs text-muted-foreground flex-1 whitespace-pre-wrap break-words">
                   {g.review.body}
                 </p>
                 <CopyButton text={g.review.body} />
@@ -193,7 +193,7 @@ export function ReviewThreads({ reviews, inlineComments, isLoading = false }: Pr
                   </span>
                   <CopyButton text={ic.body} />
                 </div>
-                <p className="text-xs text-muted-foreground whitespace-pre-wrap break-words">
+                <p className="select-text text-xs text-muted-foreground whitespace-pre-wrap break-words">
                   {ic.body}
                 </p>
               </div>

--- a/src/globals.css
+++ b/src/globals.css
@@ -341,6 +341,47 @@ body.pane-resizing iframe {
     }
   body {
     @apply bg-background text-foreground;
+    /* Desktop-app selection model: UI chrome (sidebar cards, settings rows,
+     * buttons, panel labels, layout whitespace) is NOT selectable — only real
+     * content is. Selectable-everything is a website default; native apps
+     * restrict selection to content, so the document opts out once here and
+     * content surfaces opt back in below (or via the `select-text` utility,
+     * which wins over these base-layer rules). The -webkit- prefix is
+     * required by WebKitGTK. `cursor: default` keeps the I-beam off
+     * non-selectable chrome text. */
+    -webkit-user-select: none;
+    user-select: none;
+    cursor: default;
+    }
+  /* Content opt-ins. `user-select` inherits, so a rule on a content root
+   * (e.g. `.chat-markdown`) re-enables its whole subtree. Element-level
+   * entries (pre/code/kbd, form fields, CodeMirror's contenteditable) cover
+   * most surfaces automatically so new content stays selectable without
+   * remembering a class. Chrome inside these (a code-block header, a kbd hint
+   * in a menu) can opt out again with `select-none`. `cursor: auto` restores
+   * the I-beam over the re-enabled text. */
+  input,
+  textarea,
+  [contenteditable="true"],
+  [contenteditable="plaintext-only"],
+  pre,
+  code,
+  kbd,
+  samp,
+  .cm-content,
+  .chat-markdown,
+  .markdown-rendered,
+  [data-sonner-toast] [data-title],
+  [data-sonner-toast] [data-description] {
+    -webkit-user-select: text;
+    user-select: text;
+    cursor: auto;
+    }
+  /* Companion cursor for one-off `select-text` opt-ins (the utility itself
+   * only sets user-select; without this the body's `cursor: default` would
+   * leave selectable text without an I-beam). */
+  .select-text {
+    cursor: auto;
     }
   html {
     @apply font-sans;

--- a/src/globals.css
+++ b/src/globals.css
@@ -383,6 +383,12 @@ body.pane-resizing iframe {
   .select-text {
     cursor: auto;
     }
+  /* Links keep their pointer. The body's `cursor: default` would otherwise
+   * inherit down into anchors that carry no explicit cursor utility, making
+   * chrome links (docs links in settings, review headers) read as dead text. */
+  a {
+    cursor: pointer;
+    }
   html {
     @apply font-sans;
     }


### PR DESCRIPTION
## Summary

Rubber-band-selecting sidebar cards, settings labels, and layout whitespace made the app read as a web page. This adopts the desktop-app selection model: drag-selection only ever grabs real content, never UI chrome.

- `body` opts out once (`user-select: none`, `cursor: default`, with the `-webkit-` prefix WebKitGTK requires) in `globals.css` `@layer base`
- Content opts back in through two tiers:
  1. **Automatic roots/elements** — form fields, `contenteditable`, `pre`/`code`/`kbd`/`samp`, CodeMirror content, chat markdown, toast text. Since `user-select` inherits, a content root re-enables its whole subtree, so most new content stays selectable with no class.
  2. **`select-text` utility** for one-off prose/mono blocks with no shared root: user messages, reasoning text, tool commands/output, diff panes, review-thread comments, issue bodies, settings account email/name. A base-layer companion rule restores the I-beam cursor on those.
- Chrome inside a content root (code-block headers, copy buttons) can opt out again with `select-none`; Tailwind utilities beat the base-layer rules, so precedence works in both directions.
- New "Selectability" section in `docs/reference/DESIGN-SYSTEM.md` documenting the convention and rules of thumb.

## Testing

- `npm run check` — clean
- `npm run test` — 259 files, 3985 tests pass
- Manually verified in the app: chrome no longer selectable, content surfaces (chat, diffs, tool output, settings values) still are

## Post-review fixes

103e924d: opt-in extended to the chat Edit/Write diff card, chat error/notice text, Read/Grep/WebFetch tool body text (paths, match lines, title/prompt), and the selected host's ssh_target; base-layer anchor rule restores the pointer cursor on chrome links. Design-system Selectability section updated.
