### PR TITLE
Restore review status when marking workspaces unread

### DIFF
--- a/docs/features/sidebar.md
+++ b/docs/features/sidebar.md
@@ -684,9 +684,12 @@ snoozing; parking is visual only — nothing is archived, closed, or deleted.
   claim from "Done · review", and it must survive the hover swap. The focused
   workspace is never unread whatever the stamps say. A **"Mark unread"** context
   entry adds a session-only override (there is no read flag to flip), offered
-  only on cards that don't already read as unread; a real visit — which moves
-  `last_visited_at` — is what clears it, so the override can't outlive the truth
-  it overrides.
+  only on cards that don't already read as unread. When opening the workspace
+  had acknowledged and cleared a `review` status, this inverse gesture also
+  restores **Done · review** alongside the unread dot; any later working,
+  permission, monitoring, or fresh review status supersedes that remembered
+  completion. A real visit — which moves `last_visited_at` — clears the manual
+  override, so it can't outlive the truth it overrides.
 - **Multi-select and bulk parking**: Cmd/Ctrl-click toggles a row into the
   selection; Shift-click selects the range **over rendered rows only**
   (`selectRange` walks the visible id list — active cards in rendered order,

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -2848,6 +2848,64 @@ describe("SidebarInbox — unread + woke markers", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("restores Done · review when a completed workspace is marked unread", async () => {
+    workspaces = [
+      makeWorkspace({
+        title: "Completed result",
+        surfaces: surfaceWithPane("p1"),
+      }),
+      makeWorkspace({ title: "Current work" }),
+    ];
+    activeWorkspaceId = "ws-2";
+    paneStatuses = { p1: "review" };
+    const { container, rerender } = await flushRender();
+
+    const completedCard = () =>
+      container.querySelector('[data-inbox-card="ws-1"]') as HTMLElement;
+    expect(
+      within(completedCard()).getByText("Done · review"),
+    ).toBeInTheDocument();
+
+    // Visiting the result acknowledges it, so the backend drops `review`.
+    activeWorkspaceId = "ws-1";
+    paneStatuses = {};
+    await rerenderInbox(rerender);
+    expect(
+      within(completedCard()).queryByText("Done · review"),
+    ).not.toBeInTheDocument();
+
+    // Once we move away, the explicit inverse gesture restores both claims:
+    // the orange unread dot and the green review-ready state.
+    activeWorkspaceId = "ws-2";
+    await rerenderInbox(rerender);
+    fireEvent.contextMenu(completedCard());
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Mark unread" }),
+    );
+
+    expect(
+      within(completedCard()).getByLabelText('Unread — "Completed result"'),
+    ).toBeInTheDocument();
+    expect(
+      within(completedCard()).getByText("Done · review"),
+    ).toBeInTheDocument();
+
+    // Genuine new work supersedes the restored completion, and once that
+    // work clears the stale review must not return.
+    paneStatuses = { p1: "working" };
+    await rerenderInbox(rerender);
+    expect(within(completedCard()).getByText("Working")).toBeInTheDocument();
+    expect(
+      within(completedCard()).queryByText("Done · review"),
+    ).not.toBeInTheDocument();
+
+    paneStatuses = {};
+    await rerenderInbox(rerender);
+    expect(
+      within(completedCard()).queryByText("Done · review"),
+    ).not.toBeInTheDocument();
+  });
+
   it("badges a card that woke from its snooze and clears it on visit", async () => {
     const base = Date.now();
     persistInbox({ snoozed: [{ id: "ws-1", at: base - 1000, until: base - 1 }] });

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -878,6 +878,31 @@ export function SidebarInbox() {
   // `last_visited_at`) is what clears it, so the override can never outlive
   // the truth it is overriding.
   const [manualUnread, setManualUnread] = useState<ReadonlySet<string>>(new Set());
+  // Opening a finished workspace clears its backend `review` status because
+  // the result has been seen. Keep just enough session-local history to make
+  // the inverse gesture honest: if the user later chooses "Mark unread", the
+  // green Done · review claim returns with the unread dot. Any new live status
+  // retires that history, so an old completion can never mask fresh work.
+  const restorableReviewIdsRef = useRef(new Set<string>());
+  useEffect(() => {
+    if (!paneStatuses) return;
+    const presentIds = new Set<string>();
+    for (const ws of allWorkspaces) {
+      const id = ws.workspace_id;
+      presentIds.add(id);
+      const status = getWorkspaceStatus(ws.surfaces, paneStatuses);
+      if (status === "review") {
+        restorableReviewIdsRef.current.add(id);
+      } else if (status !== null) {
+        restorableReviewIdsRef.current.delete(id);
+      }
+      // A null status deliberately retains the last review: that is the
+      // transition produced by reading a completed workspace.
+    }
+    for (const id of restorableReviewIdsRef.current) {
+      if (!presentIds.has(id)) restorableReviewIdsRef.current.delete(id);
+    }
+  }, [allWorkspaces, paneStatuses]);
   // Last status observed by the activity effect. A keep-active pin is cleared
   // only by a NEW non-idle status edge, matching the server-side
   // "real activity clears the override" lifecycle. Re-reading an existing
@@ -1005,8 +1030,20 @@ export function SidebarInbox() {
   const matchesFilter = (ws: WorkspaceSnapshot) =>
     !filter || repoByWorkspace.get(ws.workspace_id)?.path === filter;
 
-  const statusOf = (ws: WorkspaceSnapshot) =>
-    paneStatuses ? getWorkspaceStatus(ws.surfaces, paneStatuses) : null;
+  /** Status presented by inbox surfaces. Backend state always wins; the only
+   *  synthetic state is the review the user explicitly restores by marking a
+   *  previously completed workspace unread. Lifecycle effects below continue
+   *  to read the backend status directly. */
+  const statusOf = (ws: WorkspaceSnapshot): ActivePaneStatus | null => {
+    const status = paneStatuses
+      ? getWorkspaceStatus(ws.surfaces, paneStatuses)
+      : null;
+    if (status !== null) return status;
+    return manualUnread.has(ws.workspace_id) &&
+      restorableReviewIdsRef.current.has(ws.workspace_id)
+      ? "review"
+      : null;
+  };
 
   // A pin overrides both parking lifecycles without erasing either persisted
   // shelf entry. Unpinning therefore returns the workspace to the exact shelf
@@ -1904,11 +1941,7 @@ export function SidebarInbox() {
                   repo={repo}
                   isActive={workspace.workspace_id === activeWorkspaceId}
                   selected={selectedIds.has(workspace.workspace_id)}
-                  status={
-                    paneStatuses
-                      ? getWorkspaceStatus(workspace.surfaces, paneStatuses)
-                      : null
-                  }
+                  status={statusOf(workspace)}
                   timeUntil={formatTimeUntil(entry.until - now)}
                   onWake={handleWake}
                   onSelect={handleSelect}
@@ -1938,11 +1971,7 @@ export function SidebarInbox() {
                   repo={repo}
                   isActive={workspace.workspace_id === activeWorkspaceId}
                   selected={selectedIds.has(workspace.workspace_id)}
-                  status={
-                    paneStatuses
-                      ? getWorkspaceStatus(workspace.surfaces, paneStatuses)
-                      : null
-                  }
+                  status={statusOf(workspace)}
                   time={formatElapsed(now - resolveSettledTimestamp(entry))}
                   unread={isUnread(workspace)}
                   justSettled={justSettledId === workspace.workspace_id}


### PR DESCRIPTION
## Summary

- remember a workspace's review-ready state when opening it acknowledges and clears the backend status
- restore `Done · review` together with the unread dot when `Mark unread` is selected
- let fresh working, permission, monitoring, or review states supersede the remembered completion
- cover the read → mark unread flow and update the canonical sidebar behavior docs

## Verification

- `npm run check`
- `npm run test` — 4,211 passed
- `npm run test -- --run src/components/layout/sidebar-inbox.test.tsx` — 114 passed
- `CARGO_BUILD_JOBS=2 cargo check --manifest-path src-tauri/Cargo.toml`
- Rust main suite — 2,707 passed; the full verifier was stopped after the unrelated `pty_daemon_persistence::set_flow_paused_stops_and_resumes_output` integration test hung