### PR TITLE
feat: show running processes in workspace hover card

### DIFF
--- a/src/components/layout/workspace-hover-card.test.tsx
+++ b/src/components/layout/workspace-hover-card.test.tsx
@@ -338,6 +338,40 @@ describe("WorkspaceHoverCardBody — PR, issue, ports", () => {
     );
   });
 
+  it("uses the singular label for a lone process", () => {
+    detectedPorts = [makePort({ port: 3000, pid: 10 })];
+    renderBody(makeWorkspace());
+
+    expect(valueFor("Process")).toBe("1 running");
+    expect(screen.getByLabelText("1 running process")).toBeInTheDocument();
+    expect(screen.queryByText("Processes")).not.toBeInTheDocument();
+  });
+
+  it("counts each Docker-published port, which all share the pid-0 sentinel", () => {
+    detectedPorts = [
+      makePort({ port: 3000, pid: 0, source: "docker", label: "app-web-1" }),
+      makePort({ port: 5432, pid: 0, source: "docker", label: "app-db-1" }),
+      makePort({ port: 6379, pid: 0, source: "docker", label: "app-cache-1" }),
+    ];
+    renderBody(makeWorkspace());
+
+    expect(valueFor("Processes")).toBe("3 running");
+  });
+
+  it("makes no running claim for statically configured ports", () => {
+    // `.codemux/ports.json` entries also arrive with pid 0, but they only
+    // declare which ports the workspace uses — nothing proves one is live.
+    detectedPorts = [
+      makePort({ port: 3000, pid: 0, source: null, process_name: "" }),
+      makePort({ port: 8080, pid: 0, source: null, process_name: "" }),
+    ];
+    renderBody(makeWorkspace());
+
+    expect(valueFor("Ports")).toBe(":3000 :8080");
+    expect(screen.queryByText("Process")).not.toBeInTheDocument();
+    expect(screen.queryByText("Processes")).not.toBeInTheDocument();
+  });
+
   it("omits the ports row when none are detected", () => {
     renderBody(makeWorkspace());
     expect(screen.queryByText("Port")).not.toBeInTheDocument();

--- a/src/components/layout/workspace-hover-card.test.tsx
+++ b/src/components/layout/workspace-hover-card.test.tsx
@@ -320,10 +320,30 @@ describe("WorkspaceHoverCardBody — PR, issue, ports", () => {
     expect(valueFor("Ports")).toBe(":3000 :3001 :3002 +2");
   });
 
+  it("shows the matching running-process indicator as the final detail row", () => {
+    detectedPorts = [
+      makePort({ port: 3000, pid: 10 }),
+      makePort({ port: 3001, pid: 10 }),
+      makePort({ port: 5173, pid: 20 }),
+    ];
+    const { container } = renderBody(makeWorkspace());
+
+    expect(valueFor("Processes")).toBe("2 running");
+    expect(screen.getByLabelText("2 running processes")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-terminal")).toBeInTheDocument();
+
+    const detailRows = container.querySelectorAll(".flex.flex-col > div");
+    expect(detailRows.item(detailRows.length - 1)).toHaveTextContent(
+      "Processes2 running",
+    );
+  });
+
   it("omits the ports row when none are detected", () => {
     renderBody(makeWorkspace());
     expect(screen.queryByText("Port")).not.toBeInTheDocument();
     expect(screen.queryByText("Ports")).not.toBeInTheDocument();
+    expect(screen.queryByText("Process")).not.toBeInTheDocument();
+    expect(screen.queryByText("Processes")).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/layout/workspace-hover-card.tsx
+++ b/src/components/layout/workspace-hover-card.tsx
@@ -179,10 +179,26 @@ export function WorkspaceHoverCardBody({
       ),
     [detectedPorts, workspace.workspace_id],
   );
-  const runningProcessCount = useMemo(
-    () => new Set(ports.map((port) => port.pid)).size,
-    [ports],
-  );
+  // `pid: 0` is a sentinel, not a process id. The backend stamps it on
+  // Docker-published container ports (one row per published host port) and on
+  // static `.codemux/ports.json` entries, so counting raw pids collapsed a
+  // whole compose stack into "1 running" and claimed a live process for a
+  // workspace that had only *declared* its ports in config.
+  //
+  // Count evidence instead of rows: one per distinct real pid, plus one per
+  // distinct Docker-published port — each of those is a container the daemon
+  // reports as up. Static entries count for nothing; they say the workspace
+  // uses a port, not that anything is listening on it, and the Ports row above
+  // already lists them either way.
+  const runningProcessCount = useMemo(() => {
+    const pids = new Set<number>();
+    const dockerPorts = new Set<number>();
+    for (const p of ports) {
+      if (p.pid !== 0) pids.add(p.pid);
+      else if (p.source === "docker") dockerPorts.add(p.port);
+    }
+    return pids.size + dockerPorts.size;
+  }, [ports]);
   const statusSince = useSidebarDensityStore(
     (s) => s.statusSince[workspace.workspace_id],
   );
@@ -382,9 +398,13 @@ export function WorkspaceHoverCardBody({
           <DetailRow
             label={runningProcessCount === 1 ? "Process" : "Processes"}
             value={
+              // `role="img"` collapses the glyph and its count into one
+              // labelled node, the same way the sidebar indicator does — an
+              // `aria-label` on a bare span is ignored by screen readers.
               <span
+                role="img"
                 aria-label={`${runningProcessCount} running ${runningProcessCount === 1 ? "process" : "processes"}`}
-                className="inline-flex items-center justify-end gap-1.5 text-status-open"
+                className="inline-flex items-center gap-1.5 text-status-open"
               >
                 <Terminal
                   aria-hidden="true"

--- a/src/components/layout/workspace-hover-card.tsx
+++ b/src/components/layout/workspace-hover-card.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Terminal } from "lucide-react";
 import {
   HoverCard,
   HoverCardContent,
@@ -177,6 +178,10 @@ export function WorkspaceHoverCardBody({
         (p) => p.workspace_id === workspace.workspace_id,
       ),
     [detectedPorts, workspace.workspace_id],
+  );
+  const runningProcessCount = useMemo(
+    () => new Set(ports.map((port) => port.pid)).size,
+    [ports],
   );
   const statusSince = useSidebarDensityStore(
     (s) => s.statusSince[workspace.workspace_id],
@@ -373,6 +378,24 @@ export function WorkspaceHoverCardBody({
         {workspace.notifications_muted && (
           <DetailRow label="Notifications" value="muted" muted />
         )}
+        {runningProcessCount > 0 && (
+          <DetailRow
+            label={runningProcessCount === 1 ? "Process" : "Processes"}
+            value={
+              <span
+                aria-label={`${runningProcessCount} running ${runningProcessCount === 1 ? "process" : "processes"}`}
+                className="inline-flex items-center justify-end gap-1.5 text-status-open"
+              >
+                <Terminal
+                  aria-hidden="true"
+                  className="size-3 shrink-0 animate-pulse"
+                  strokeWidth={1.7}
+                />
+                <span>{runningProcessCount} running</span>
+              </span>
+            }
+          />
+        )}
       </div>
 
       {/* Real path on disk, last: the least-scannable line, and the one users
@@ -408,7 +431,7 @@ function DetailRow({
   muted,
 }: {
   label: string;
-  value: string;
+  value: React.ReactNode;
   /** Explicit tone class for the value (warning/success/PR-state).
    *  Falls back to `muted` when omitted. */
   valueClassName?: string;


### PR DESCRIPTION
The sidebar terminal glyph shows that a workspace still owns a long-running process, but the hover card did not explain that state.

This adds a final Process/Processes row to the workspace hover card, using the same pulsing terminal glyph and live tone as the sidebar indicator. It counts unique PIDs so one process listening on multiple ports is reported once, and stays hidden when nothing is running. Focused tests cover the count, icon, placement, and empty state.

## Screenshots

| Before | After |
| --- | --- |
| The card ended after Location. | A matching Process row explains the indicator and shows the running count. |
| ![Workspace hover card before](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/running-process-icon-hover/before.png) | ![Workspace hover card after](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/running-process-icon-hover/after.png) |

## Verification

- `npm run check`
- `npm run test -- src/components/layout/workspace-hover-card.test.tsx` (39 passed)
- Visual verification in the Codemux browser

Implemented with OpenAI Codex (GPT-5).