### PR TITLE
fix(chat): highlight only selected transcript text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { useSyncedSettingsStore } from "@/stores/synced-settings-store";
 import { useFeatureFlagsInit } from "@/stores/feature-flags";
 import { useProviderCapabilitiesInit } from "@/stores/provider-capabilities-store";
 import { useEnsureDraftWhenEmpty } from "@/hooks/use-ensure-draft-when-empty";
+import { useTranscriptSelectionHighlight } from "@/hooks/use-transcript-selection-highlight";
 import { getHomeDir } from "@/tauri/commands";
 
 function App() {
@@ -86,6 +87,9 @@ function App() {
   // effects (the transcript edge-fade) switch themselves off when the webview
   // is running CPU-rendered.
   useRendererModeInit();
+  // WebKitGTK otherwise paints the virtualized boxes between selected chat
+  // messages. Keep native selection semantics and paint exact text ranges.
+  useTranscriptSelectionHighlight();
   // Web remote client only: bridge backend `notification` events into the
   // browser (Web Notifications API with a toast fallback). No-op on desktop.
   useWebNotifications();

--- a/src/dev/mock-fixtures.ts
+++ b/src/dev/mock-fixtures.ts
@@ -2097,8 +2097,8 @@ function stressWorkspaces(target: number): WorkspaceSnapshot[] {
     const kept = ALL_WORKSPACES.slice(0, target);
     // The seed's active workspace must survive any cut, or the snapshot
     // points `active_workspace_id` at a workspace that isn't in the list.
-    if (!kept.some((w) => w.workspace_id === wsCodemuxMock.workspace_id)) {
-      kept[kept.length - 1] = wsCodemuxMock;
+    if (!kept.some((w) => w.workspace_id === wsCodemuxChat.workspace_id)) {
+      kept[kept.length - 1] = wsCodemuxChat;
     }
     stressWorkspacesCache = kept;
     return kept;
@@ -2149,7 +2149,9 @@ export function createSeedAppState(): AppStateSnapshot {
   const workspaces = fixture ? stressWorkspaces(fixture.workspaces) : ALL_WORKSPACES;
   return structuredClone({
     schema_version: 1,
-    active_workspace_id: wsCodemuxMock.workspace_id,
+    // Agent Chat is the default interface, so the plain-browser mock should
+    // open on its hydrated transcript instead of a legacy terminal fixture.
+    active_workspace_id: wsCodemuxChat.workspace_id,
     workspaces,
     terminal_sessions: terminalSessions,
     browser_sessions: [],

--- a/src/dev/stress-seed.test.ts
+++ b/src/dev/stress-seed.test.ts
@@ -28,7 +28,7 @@ describe("dev mock seed — stress fixture scaling", () => {
   it("leaves the curated seed untouched when no fixture is selected", async () => {
     const seed = await loadSeed(null);
     expect(seed.workspaces).toHaveLength(19);
-    expect(seed.active_workspace_id).toBe("ws-codemux-mock");
+    expect(seed.active_workspace_id).toBe("ws-codemux-chat");
   });
 
   it("grows the seed to the requested workspace count", async () => {

--- a/src/globals.css
+++ b/src/globals.css
@@ -389,6 +389,19 @@ body.pane-resizing iframe {
     user-select: text;
     cursor: auto;
     }
+  /* WebKitGTK paints the structural boxes between separately selectable
+   * transcript messages. When the custom text-node highlight is available,
+   * keep the native range for clipboard and accessibility but let the exact
+   * per-text-node ranges own the visible paint. */
+  .transcript-selection-highlight [data-slot="transcript-list"]::selection,
+  .transcript-selection-highlight [data-slot="transcript-list"] *::selection {
+    background-color: transparent;
+    color: currentColor;
+    }
+  ::highlight(codemux-transcript-selection) {
+    background-color: var(--selection-background);
+    color: var(--selection-foreground);
+    }
   /* Companion cursor for one-off `select-text` opt-ins (the utility itself
    * only sets user-select; without this the body's `cursor: default` would
    * leave selectable text without an I-beam). */

--- a/src/globals.css
+++ b/src/globals.css
@@ -392,11 +392,26 @@ body.pane-resizing iframe {
   /* WebKitGTK paints the structural boxes between separately selectable
    * transcript messages. When the custom text-node highlight is available,
    * keep the native range for clipboard and accessibility but let the exact
-   * per-text-node ranges own the visible paint. */
+   * per-text-node ranges own the visible paint. `currentColor` on purpose:
+   * it is the value that lets the custom highlight's ink through, and where
+   * an engine takes it literally instead the text merely keeps its own color
+   * over the highlight. A fixed selection ink here would read as invisible
+   * text anywhere the custom range has not landed yet (a row the virtualizer
+   * is still remounting). */
   .transcript-selection-highlight [data-slot="transcript-list"]::selection,
   .transcript-selection-highlight [data-slot="transcript-list"] *::selection {
     background-color: transparent;
     color: currentColor;
+    }
+  /* Text controls are the one place the custom highlight cannot reach: their
+   * editable text has no light-DOM text nodes for a Range to cover, so
+   * `::highlight` never paints them. Selection inheritance would otherwise
+   * carry the suppression above into every deny-reason box in the transcript
+   * and leave typing there with no visible selection at all. */
+  .transcript-selection-highlight [data-slot="transcript-list"] textarea::selection,
+  .transcript-selection-highlight [data-slot="transcript-list"] input::selection {
+    background-color: var(--selection-background);
+    color: var(--selection-foreground);
     }
   ::highlight(codemux-transcript-selection) {
     background-color: var(--selection-background);

--- a/src/hooks/use-transcript-selection-highlight.test.tsx
+++ b/src/hooks/use-transcript-selection-highlight.test.tsx
@@ -60,6 +60,31 @@ describe("collectTranscriptSelectionRanges", () => {
     expect(pieces.map((range) => range.toString())).toEqual(["pha", "ome"]);
   });
 
+  it("paints the spaces between inline elements but not markup between rows", () => {
+    document.body.innerHTML = `
+      <div data-slot="transcript-list">
+        <div style="user-select: text">
+          <p id="prose"><em id="a">alpha</em> <em id="b">omega</em></p>
+          <p id="tail">delta</p>
+        </div>
+      </div>
+    `;
+    const start = document.querySelector("#a")!.firstChild as Text;
+    const end = document.querySelector("#tail")!.firstChild as Text;
+    const selection = selectBetween(start, 0, end, 5);
+
+    const pieces = collectTranscriptSelectionRanges(selection);
+
+    // The space between the two <em>s is prose and paints; the newline the
+    // markup puts between the two block paragraphs is scaffolding and does not.
+    expect(pieces.map((range) => range.toString())).toEqual([
+      "alpha",
+      " ",
+      "omega",
+      "delta",
+    ]);
+  });
+
   it("returns no paint ranges for a collapsed caret", () => {
     const { first } = transcriptFixture();
     const selection = selectBetween(first, 2, first, 2);
@@ -96,5 +121,44 @@ describe("useTranscriptSelectionHighlight", () => {
     unmount();
     expect(registry.has(TRANSCRIPT_SELECTION_HIGHLIGHT)).toBe(false);
     expect(document.documentElement).not.toHaveClass(TRANSCRIPT_SELECTION_CLASS);
+  });
+
+  it("repaints rows the virtualizer remounts inside a live selection", async () => {
+    const { first, second } = transcriptFixture();
+    selectBetween(first, 0, second, 5);
+    const registry = new Map<string, { ranges: AbstractRange[] }>();
+
+    class MockHighlight {
+      readonly ranges: AbstractRange[];
+      constructor(...ranges: AbstractRange[]) {
+        this.ranges = ranges;
+      }
+    }
+
+    vi.stubGlobal("CSS", { highlights: registry });
+    vi.stubGlobal("Highlight", MockHighlight);
+
+    const { unmount } = renderHook(() => useTranscriptSelectionHighlight());
+
+    await waitFor(() =>
+      expect(registry.get(TRANSCRIPT_SELECTION_HIGHLIGHT)?.ranges).toHaveLength(
+        2,
+      ),
+    );
+
+    // A row scrolling back into view brings text nodes no existing range
+    // covers. Nothing touches the selection, so `selectionchange` never fires.
+    const row = document.createElement("div");
+    row.style.userSelect = "text";
+    row.textContent = "middle";
+    second.parentElement!.before(row);
+
+    await waitFor(() =>
+      expect(registry.get(TRANSCRIPT_SELECTION_HIGHLIGHT)?.ranges).toHaveLength(
+        3,
+      ),
+    );
+
+    unmount();
   });
 });

--- a/src/hooks/use-transcript-selection-highlight.test.tsx
+++ b/src/hooks/use-transcript-selection-highlight.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TRANSCRIPT_SELECTION_CLASS,
+  TRANSCRIPT_SELECTION_HIGHLIGHT,
+  collectTranscriptSelectionRanges,
+  useTranscriptSelectionHighlight,
+} from "./use-transcript-selection-highlight";
+
+function selectBetween(
+  start: Text,
+  startOffset: number,
+  end: Text,
+  endOffset: number,
+) {
+  const range = document.createRange();
+  range.setStart(start, startOffset);
+  range.setEnd(end, endOffset);
+  const selection = document.getSelection()!;
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return selection;
+}
+
+function transcriptFixture() {
+  document.body.innerHTML = `
+    <div data-slot="transcript-list">
+      <div style="user-select: text"><p id="first">alpha</p></div>
+      <div style="user-select: none">chrome</div>
+      <div style="user-select: text"><p id="second">omega</p></div>
+    </div>
+  `;
+  return {
+    first: document.querySelector("#first")!.firstChild as Text,
+    second: document.querySelector("#second")!.firstChild as Text,
+  };
+}
+
+beforeEach(() => {
+  document.getSelection()?.removeAllRanges();
+  document.documentElement.classList.remove(TRANSCRIPT_SELECTION_CLASS);
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+  document.getSelection()?.removeAllRanges();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("collectTranscriptSelectionRanges", () => {
+  it("keeps selected text but omits structural and non-selectable nodes", () => {
+    const { first, second } = transcriptFixture();
+    const selection = selectBetween(first, 2, second, 3);
+
+    const pieces = collectTranscriptSelectionRanges(selection);
+
+    expect(pieces.map((range) => range.toString())).toEqual(["pha", "ome"]);
+  });
+
+  it("returns no paint ranges for a collapsed caret", () => {
+    const { first } = transcriptFixture();
+    const selection = selectBetween(first, 2, first, 2);
+
+    expect(collectTranscriptSelectionRanges(selection)).toEqual([]);
+  });
+});
+
+describe("useTranscriptSelectionHighlight", () => {
+  it("gates native suppression on API support and preserves the native selection", async () => {
+    const { first, second } = transcriptFixture();
+    const selection = selectBetween(first, 1, second, 4);
+    const selectedText = selection.toString();
+    const registry = new Map<string, Highlight>();
+
+    class MockHighlight {
+      readonly ranges: AbstractRange[];
+      constructor(...ranges: AbstractRange[]) {
+        this.ranges = ranges;
+      }
+    }
+
+    vi.stubGlobal("CSS", { highlights: registry });
+    vi.stubGlobal("Highlight", MockHighlight);
+
+    const { unmount } = renderHook(() => useTranscriptSelectionHighlight());
+
+    await waitFor(() =>
+      expect(registry.has(TRANSCRIPT_SELECTION_HIGHLIGHT)).toBe(true),
+    );
+    expect(document.documentElement).toHaveClass(TRANSCRIPT_SELECTION_CLASS);
+    expect(document.getSelection()?.toString()).toBe(selectedText);
+
+    unmount();
+    expect(registry.has(TRANSCRIPT_SELECTION_HIGHLIGHT)).toBe(false);
+    expect(document.documentElement).not.toHaveClass(TRANSCRIPT_SELECTION_CLASS);
+  });
+});

--- a/src/hooks/use-transcript-selection-highlight.ts
+++ b/src/hooks/use-transcript-selection-highlight.ts
@@ -32,11 +32,41 @@ function isSelectableText(node: Text, transcript: Element): boolean {
   return false;
 }
 
+const INLINE_DISPLAY = /^(inline|ruby)/;
+
+/** Does this sibling share an inline formatting context with the whitespace
+ *  next to it? Text always does; elements only when they lay out inline. */
+function rendersInline(node: ChildNode | null): boolean {
+  if (!node) return false;
+  if (node.nodeType === Node.TEXT_NODE) {
+    return (node as Text).data.trim().length > 0;
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return false;
+  const display = getComputedStyle(node as Element).display;
+  // A tree with no default style sheet reports no display at all. Treat that
+  // as inline so prose spacing still paints instead of silently dropping out.
+  return display === "" || INLINE_DISPLAY.test(display);
+}
+
+/**
+ * Whitespace-only text nodes are two different things wearing one face. The
+ * newline between two block rows of rendered markup is scaffolding — painting
+ * it is what makes WebKitGTK blow the highlight up to the whole virtualized
+ * row box. The space between two inline elements (`<em>a</em> <em>b</em>`) is
+ * real prose, and dropping it punches a hole in the middle of a selection.
+ * Inline neighbours on both sides separate the two cases without needing to
+ * know anything about the surrounding row scaffolding.
+ */
+function isPaintableWhitespace(text: Text): boolean {
+  return rendersInline(text.previousSibling) && rendersInline(text.nextSibling);
+}
+
 /**
  * Split the browser's native selection into text-only ranges inside Agent
  * Chat transcripts. Structural whitespace nodes are deliberately omitted:
  * WebKitGTK expands those nodes to their virtualized row boxes when painting
- * one range across multiple messages.
+ * one range across multiple messages. Whitespace that is part of a line of
+ * prose still counts as text — see `isPaintableWhitespace`.
  */
 export function collectTranscriptSelectionRanges(
   selection: Selection,
@@ -61,7 +91,7 @@ export function collectTranscriptSelectionRanges(
       while (current) {
         const text = current as Text;
         if (
-          text.data.trim().length > 0 &&
+          (text.data.trim().length > 0 || isPaintableWhitespace(text)) &&
           rangeIntersectsNode(selectionRange, text) &&
           isSelectableText(text, transcript)
         ) {
@@ -108,12 +138,33 @@ export function useTranscriptSelectionHighlight(): void {
     const root = document.documentElement;
     let frame = 0;
 
+    // Native paint is suppressed while a selection lives, so rows the
+    // virtualizer remounts mid-selection arrive with text nodes no range
+    // covers and read as unselected until the user moves the caret. Rows come
+    // and go through the DOM, so watching for that is enough — the highlight
+    // ranges themselves are live and follow scrolling on their own. The
+    // observer only runs while something is actually selected.
+    const observer = new MutationObserver(() => schedulePaint());
+
+    const watchTranscripts = () => {
+      observer.disconnect();
+      for (const transcript of document.querySelectorAll(TRANSCRIPT_SELECTOR)) {
+        observer.observe(transcript, { childList: true, subtree: true });
+      }
+    };
+
     const paint = () => {
       frame = 0;
       const selection = document.getSelection();
       const ranges = selection
         ? collectTranscriptSelectionRanges(selection)
         : [];
+
+      if (selection && !selection.isCollapsed && selection.rangeCount > 0) {
+        watchTranscripts();
+      } else {
+        observer.disconnect();
+      }
 
       if (ranges.length === 0) {
         CSS.highlights.delete(TRANSCRIPT_SELECTION_HIGHLIGHT);
@@ -136,6 +187,7 @@ export function useTranscriptSelectionHighlight(): void {
 
     return () => {
       document.removeEventListener("selectionchange", schedulePaint);
+      observer.disconnect();
       if (frame) cancelAnimationFrame(frame);
       CSS.highlights.delete(TRANSCRIPT_SELECTION_HIGHLIGHT);
       root.classList.remove(TRANSCRIPT_SELECTION_CLASS);

--- a/src/hooks/use-transcript-selection-highlight.ts
+++ b/src/hooks/use-transcript-selection-highlight.ts
@@ -1,0 +1,144 @@
+import { useEffect } from "react";
+
+export const TRANSCRIPT_SELECTION_HIGHLIGHT =
+  "codemux-transcript-selection";
+export const TRANSCRIPT_SELECTION_CLASS =
+  "transcript-selection-highlight";
+
+const TRANSCRIPT_SELECTOR = '[data-slot="transcript-list"]';
+
+function rangeIntersectsNode(range: Range, node: Node): boolean {
+  try {
+    return range.intersectsNode(node);
+  } catch {
+    return false;
+  }
+}
+
+function isSelectableText(node: Text, transcript: Element): boolean {
+  let element = node.parentElement;
+  while (element) {
+    const style = getComputedStyle(element);
+    const values = [
+      style.userSelect,
+      (style as CSSStyleDeclaration & { webkitUserSelect?: string })
+        .webkitUserSelect,
+    ];
+    if (values.includes("none")) return false;
+    if (values.includes("text") || values.includes("all")) return true;
+    if (element === transcript) return false;
+    element = element.parentElement;
+  }
+  return false;
+}
+
+/**
+ * Split the browser's native selection into text-only ranges inside Agent
+ * Chat transcripts. Structural whitespace nodes are deliberately omitted:
+ * WebKitGTK expands those nodes to their virtualized row boxes when painting
+ * one range across multiple messages.
+ */
+export function collectTranscriptSelectionRanges(
+  selection: Selection,
+  scope: ParentNode = document,
+): Range[] {
+  if (selection.isCollapsed || selection.rangeCount === 0) return [];
+
+  const pieces: Range[] = [];
+  const transcripts = scope.querySelectorAll(TRANSCRIPT_SELECTOR);
+
+  for (let rangeIndex = 0; rangeIndex < selection.rangeCount; rangeIndex += 1) {
+    const selectionRange = selection.getRangeAt(rangeIndex);
+
+    for (const transcript of transcripts) {
+      if (!rangeIntersectsNode(selectionRange, transcript)) continue;
+
+      const walker = transcript.ownerDocument.createTreeWalker(
+        transcript,
+        NodeFilter.SHOW_TEXT,
+      );
+      let current = walker.nextNode();
+      while (current) {
+        const text = current as Text;
+        if (
+          text.data.trim().length > 0 &&
+          rangeIntersectsNode(selectionRange, text) &&
+          isSelectableText(text, transcript)
+        ) {
+          const start =
+            text === selectionRange.startContainer
+              ? selectionRange.startOffset
+              : 0;
+          const end =
+            text === selectionRange.endContainer
+              ? selectionRange.endOffset
+              : text.length;
+
+          if (start < end) {
+            const piece = transcript.ownerDocument.createRange();
+            piece.setStart(text, start);
+            piece.setEnd(text, end);
+            pieces.push(piece);
+          }
+        }
+        current = walker.nextNode();
+      }
+    }
+  }
+
+  return pieces;
+}
+
+/**
+ * Paint transcript selections from exact text-node ranges while leaving the
+ * native Selection untouched for copy, keyboard interaction, and assistive
+ * technology. Browsers without the Custom Highlight API retain their normal
+ * native selection because the CSS suppression class is never installed.
+ */
+export function useTranscriptSelectionHighlight(): void {
+  useEffect(() => {
+    if (
+      typeof CSS === "undefined" ||
+      !("highlights" in CSS) ||
+      typeof Highlight === "undefined"
+    ) {
+      return;
+    }
+
+    const root = document.documentElement;
+    let frame = 0;
+
+    const paint = () => {
+      frame = 0;
+      const selection = document.getSelection();
+      const ranges = selection
+        ? collectTranscriptSelectionRanges(selection)
+        : [];
+
+      if (ranges.length === 0) {
+        CSS.highlights.delete(TRANSCRIPT_SELECTION_HIGHLIGHT);
+        return;
+      }
+      CSS.highlights.set(
+        TRANSCRIPT_SELECTION_HIGHLIGHT,
+        new Highlight(...ranges),
+      );
+    };
+
+    const schedulePaint = () => {
+      if (frame) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(paint);
+    };
+
+    root.classList.add(TRANSCRIPT_SELECTION_CLASS);
+    document.addEventListener("selectionchange", schedulePaint);
+    schedulePaint();
+
+    return () => {
+      document.removeEventListener("selectionchange", schedulePaint);
+      if (frame) cancelAnimationFrame(frame);
+      CSS.highlights.delete(TRANSCRIPT_SELECTION_HIGHLIGHT);
+      root.classList.remove(TRANSCRIPT_SELECTION_CLASS);
+    };
+  }, []);
+}

--- a/src/lib/codemirror-theme.test.ts
+++ b/src/lib/codemirror-theme.test.ts
@@ -52,6 +52,22 @@ describe("editor selection contract", () => {
 });
 
 describe("document selection contract", () => {
+  it("replaces WebKit transcript box paint only when the text-range highlight is active", () => {
+    const nativeRule = globalsCss.match(
+      /\.transcript-selection-highlight \[data-slot="transcript-list"\] \*::selection\s*\{([^}]*)\}/,
+    )?.[1] ?? "";
+    const customRule = globalsCss.match(
+      /::highlight\(codemux-transcript-selection\)\s*\{([^}]*)\}/,
+    )?.[1] ?? "";
+
+    expect(nativeRule).toContain("background-color: transparent");
+    expect(nativeRule).toContain("color: currentColor");
+    expect(customRule).toContain(
+      "background-color: var(--selection-background)",
+    );
+    expect(customRule).toContain("color: var(--selection-foreground)");
+  });
+
   it("defines both selection channels at the root so no native fallback leaks in", () => {
     const rule = globalsCss.match(/:root::selection\s*\{([^}]*)\}/)?.[1] ?? "";
     expect(rule).toContain("background-color: var(--selection-background)");

--- a/src/lib/codemirror-theme.test.ts
+++ b/src/lib/codemirror-theme.test.ts
@@ -68,6 +68,18 @@ describe("document selection contract", () => {
     expect(customRule).toContain("color: var(--selection-foreground)");
   });
 
+  it("leaves text controls in the transcript with a visible native selection", () => {
+    // A textarea's editable text has no light-DOM text nodes, so the custom
+    // highlight can never paint it. Without this rule the suppression above
+    // inherits in and selecting a typed deny reason shows nothing at all.
+    const textareaRule = globalsCss.match(
+      /\.transcript-selection-highlight\s+\[data-slot="transcript-list"\]\s+textarea::selection[^{]*\{([^}]*)\}/,
+    )?.[1] ?? "";
+
+    expect(textareaRule).toContain("background-color: var(--selection-background)");
+    expect(textareaRule).toContain("color: var(--selection-foreground)");
+  });
+
   it("defines both selection channels at the root so no native fallback leaks in", () => {
     const rule = globalsCss.match(/:root::selection\s*\{([^}]*)\}/)?.[1] ?? "";
     expect(rule).toContain("background-color: var(--selection-background)");


### PR DESCRIPTION
## Problem

On WebKitGTK, selecting text across Agent Chat messages paints the virtualized row boxes and structural whitespace as full-width selection bands. Styling the native highlight only changes those bands from browser blue to Codemux orange; it does not constrain their geometry. The plain-browser dev mock also still opened on a legacy terminal workspace even though Agent Chat is the default interface.

## Fix

- keep the native `Selection` intact for copying, keyboard interaction, and assistive technology
- when the CSS Custom Highlight API is available, split the transcript selection into exact selectable text-node ranges and paint those ranges with Codemux's selection colors
- suppress native transcript paint only while that custom highlight path is active; unsupported browsers retain native selection
- open the dev mock on the hydrated Agent Chat fixture and preserve it in reduced stress fixtures
- add focused coverage for text-range collection, fallback gating, selection preservation, selection CSS, and the mock default

## Screenshots

Synthetic dev-mock data in WebKitGTK 2.52.5.

| Before | After |
| --- | --- |
| ![Full-width transcript row boxes painted as selected whitespace](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/fix-text-selection-whitespace/before.png) | ![Only the selected transcript text is highlighted](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/fix-text-selection-whitespace/after.png) |

## Verification

- `npm run check`
- `npm run test -- src/hooks/use-transcript-selection-highlight.test.tsx src/lib/codemirror-theme.test.ts src/dev/stress-seed.test.ts` — 14 passed
- real WebKitGTK 2.52.5 visual verification against the synthetic dev mock; the native selected string remained unchanged
- `git diff --check`

Built with GPT-5 in the Codex harness.
