### PR TITLE
fix: align right panel titlebar controls

### DIFF
--- a/src/components/layout/right-panel.test.tsx
+++ b/src/components/layout/right-panel.test.tsx
@@ -250,8 +250,8 @@ describe("RightPanel titlebar band", () => {
     expect(header).not.toHaveClass("mt-10");
     expect(header).toHaveClass("h-10");
     expect(header).toHaveAttribute("data-in-titlebar", "true");
-    // Clears the fixed panel cluster (56 + 6) and the window buttons (104).
-    expect(header.style.paddingRight).toBe("166px");
+    // Clears the fixed panel cluster (64 + 6) and the window buttons (104).
+    expect(header.style.paddingRight).toBe("174px");
   });
 
   // The titlebar is frameless: no cluster paints a surface of its own, and
@@ -299,7 +299,7 @@ describe("RightPanel titlebar band", () => {
     renderDeck();
     expect(
       screen.getByTestId("right-panel-tabs-header").style.paddingRight,
-    ).toBe("68px");
+    ).toBe("76px");
   });
 
   // With the GUI flag off the in-flow legacy `h-9` bar already occupies the

--- a/src/components/layout/right-panel/pane-actions.tsx
+++ b/src/components/layout/right-panel/pane-actions.tsx
@@ -27,6 +27,7 @@ export function PaneActionButton({
   active = false,
   disabled = false,
   testId,
+  size = "pane",
 }: {
   label: string;
   icon: LucideIcon;
@@ -34,6 +35,8 @@ export function PaneActionButton({
   active?: boolean;
   disabled?: boolean;
   testId?: string;
+  /** Titlebar controls match its 28px sidebar toggle; pane chrome stays dense. */
+  size?: "pane" | "titlebar";
 }) {
   return (
     <Tooltip>
@@ -46,15 +49,23 @@ export function PaneActionButton({
           data-testid={testId}
           onClick={onClick}
           className={cn(
-            "flex size-6 shrink-0 items-center justify-center rounded-md",
+            "flex shrink-0 items-center justify-center",
+            size === "titlebar"
+              ? "size-7 rounded-[min(var(--radius-md),12px)]"
+              : "size-6 rounded-md",
             "transition-colors duration-[120ms]",
             "disabled:pointer-events-none disabled:opacity-40",
             active
               ? "bg-foreground/10 text-foreground"
-              : "text-foreground/42 hover:bg-foreground/8 hover:text-foreground/80",
+              : size === "titlebar"
+                ? "text-muted-foreground hover:bg-muted hover:text-foreground dark:hover:bg-muted/50"
+                : "text-foreground/42 hover:bg-foreground/8 hover:text-foreground/80",
           )}
         >
-          <Icon className="size-[13px]" strokeWidth={1.6} />
+          <Icon
+            className={size === "titlebar" ? "size-3.5" : "size-[13px]"}
+            strokeWidth={size === "titlebar" ? 2 : 1.6}
+          />
         </button>
       </TooltipTrigger>
       <TooltipContent side="bottom" sideOffset={4}>

--- a/src/components/layout/right-panel/pane-tab-strip.tsx
+++ b/src/components/layout/right-panel/pane-tab-strip.tsx
@@ -247,7 +247,7 @@ export const PaneTabStrip = memo(function PaneTabStrip({
         inTitlebar
           ? // Clear the fixed panel cluster and, on desktop, the native
             // window buttons sitting above this row's right end.
-            { paddingRight: `${topRightReserve(remoteClient)}px` }
+            { paddingRight: `${topRightReserve(remoteClient, true)}px` }
           : undefined
       }
     >

--- a/src/components/layout/title-bar.test.tsx
+++ b/src/components/layout/title-bar.test.tsx
@@ -347,16 +347,20 @@ describe("TitleBar chrome gating", () => {
     state.enableAgentChat = true;
     const { getByRole } = renderBar();
 
-    expect(
-      getByRole("button", { name: "Toggle sidebar" }).querySelector(
-        ".lucide-panel-left",
-      ),
-    ).toBeInTheDocument();
-    expect(
-      getByRole("button", { name: "Open panel" }).querySelector(
-        ".lucide-panel-right",
-      ),
-    ).toBeInTheDocument();
+    const sidebarToggle = getByRole("button", { name: "Toggle sidebar" });
+    const panelToggle = getByRole("button", { name: "Open panel" });
+    const sidebarIcon = sidebarToggle.querySelector(".lucide-panel-left");
+    const panelIcon = panelToggle.querySelector(".lucide-panel-right");
+    expect(sidebarIcon).toBeInTheDocument();
+    expect(panelIcon).toBeInTheDocument();
+    expect(sidebarToggle).toHaveClass("size-7");
+    expect(panelToggle).toHaveClass("size-7");
+    expect(sidebarToggle).toHaveClass("text-muted-foreground");
+    expect(panelToggle).toHaveClass("text-muted-foreground");
+    expect(sidebarIcon).toHaveClass("h-3.5", "w-3.5");
+    expect(panelIcon).toHaveClass("size-3.5");
+    expect(sidebarIcon).toHaveAttribute("stroke-width", "2");
+    expect(panelIcon).toHaveAttribute("stroke-width", "2");
   });
 
   it("keeps the open right-panel toggle frameless", () => {
@@ -534,9 +538,11 @@ describe("TitleBar GUI chrome — floating placement", () => {
     // `useSidebarGapWidth` stays on its fallback — which matches
     // `SidebarProvider`'s own default width (256px). The floating band
     // begins six pixels beyond that edge and stops before the fixed panel
-    // cluster (56 + 6) plus the window controls (104).
+    // cluster (one 28px button + 6px) plus the window controls (104). The
+    // hidden expand control must not leave an empty slot while the panel is
+    // closed.
     expect(band.style.left).toBe("262px");
-    expect(band.style.right).toBe("166px");
+    expect(band.style.right).toBe("138px");
   });
 
   it("moves the workspace actions left of an open right panel", () => {

--- a/src/components/layout/title-bar.tsx
+++ b/src/components/layout/title-bar.tsx
@@ -300,6 +300,7 @@ function RightPanelChromeCluster({ workspaceId }: { workspaceId: string }) {
           icon={maximized ? Minimize2 : Maximize2}
           active={maximized}
           testId="right-panel-maximize"
+          size="titlebar"
           onClick={() => toggleMaximized(workspaceId)}
         />
       )}
@@ -308,6 +309,7 @@ function RightPanelChromeCluster({ workspaceId }: { workspaceId: string }) {
         icon={PanelRight}
         active={open}
         testId="right-panel-toggle"
+        size="titlebar"
         onClick={togglePanel}
       />
     </div>
@@ -729,7 +731,7 @@ export function TitleBar({ sidebarOpen, onToggleSidebar }: TitleBarProps) {
             ? `${panelBandWidth + 8}px`
             : // The workspace branch stops before the fixed panel cluster;
               // a draft has no panel cluster to clear, only window buttons.
-              `${guiChrome ? topRightReserve(remoteClient) : remoteClient ? 6 : 104}px`,
+              `${guiChrome ? topRightReserve(remoteClient, false) : remoteClient ? 6 : 104}px`,
         }}
       >
         <div

--- a/src/lib/right-panel-width.ts
+++ b/src/lib/right-panel-width.ts
@@ -26,7 +26,7 @@
  * It used to be 240, back when the panel's tab row had the panel's full
  * width to itself. That row is now the window's titlebar band, so its right
  * end is spoken for by the fixed panel cluster and the native window buttons
- * drawn above it — `topRightReserve()` in `@/lib/titlebar-geometry`, 166px on
+ * drawn above it — `topRightReserve()` in `@/lib/titlebar-geometry`, 174px on
  * desktop. At 240 that left about 60px for the tabs *and* the active pane's
  * actions, i.e. no visible tab at all. 360 leaves roughly one full tab plus
  * stubs beside a pane's controls, which is the least this row can do and

--- a/src/lib/titlebar-geometry.ts
+++ b/src/lib/titlebar-geometry.ts
@@ -12,7 +12,9 @@
  * panel-level controls sit at the window's top-right corner and stay there
  * whether the panel is open, closed, narrow or wide. Everything else — the
  * workspace island's right edge, the panel tab row's right padding — is
- * derived from that fixed corner, never the other way round. The band used
+ * derived from that fixed corner, never the other way round. Only the
+ * cluster's occupied width changes: a closed panel has no expand button, so
+ * the workspace band must not reserve an empty slot for one. The band used
  * to work the opposite way (the action island tracked the panel's left
  * edge, so opening the panel teleported the panel toggle across the
  * window and left a dead 40px strip above the panel's tabs).
@@ -29,12 +31,14 @@ export const TITLEBAR_BAND_HEIGHT = 40;
  */
 export const WINDOW_CONTROLS_RESERVE = 104;
 
+/** Width of one titlebar-sized `PaneActionButton` in the fixed cluster. */
+export const PANEL_CONTROL_WIDTH = 28;
+
 /**
- * The fixed panel-control cluster: two 24px `PaneActionButton`s (full
- * expand + panel toggle) with a 2px gap, plus a little breathing room so
- * the hover fills don't touch the window buttons.
+ * Reserved width for the open panel's two 28px controls. This includes its
+ * internal 2px gap and the existing 6px breathing room around the cluster.
  */
-export const PANEL_CLUSTER_WIDTH = 56;
+export const PANEL_CLUSTER_WIDTH = 64;
 
 /** Gap between the cluster and whatever sits beside it. */
 export const PANEL_CLUSTER_GAP = 6;
@@ -48,11 +52,15 @@ export function panelClusterRight(remoteClient: boolean): number {
  * Everything pinned to the top-right corner, as one number.
  *
  * Two consumers, one meaning — "content in the band must stop here":
- *   - the workspace island's `right` when the panel is closed, and
+ *   - the workspace island's `right`, based on the controls actually shown,
  *   - the right panel's tab-row padding when the panel owns the band
  *     (its tab row runs to the physical window edge, so it has to clear
  *     both the cluster and the window buttons above it).
  */
-export function topRightReserve(remoteClient: boolean): number {
-  return panelClusterRight(remoteClient) + PANEL_CLUSTER_WIDTH + PANEL_CLUSTER_GAP;
+export function topRightReserve(
+  remoteClient: boolean,
+  panelOpen: boolean,
+): number {
+  const clusterWidth = panelOpen ? PANEL_CLUSTER_WIDTH : PANEL_CONTROL_WIDTH;
+  return panelClusterRight(remoteClient) + clusterWidth + PANEL_CLUSTER_GAP;
 }


### PR DESCRIPTION
## Problem

When the right panel was collapsed, the title bar still reserved space for the hidden expand control. This left a conspicuous dead gap beside the panel toggle, whose smaller and lighter styling also made it inconsistent with the matching sidebar toggle.

## Fix

The title-bar geometry now reserves only the controls that are actually visible while keeping the panel toggle anchored in place. Title-bar panel actions use the same 28px control, 14px icon, stroke weight, resting color, and hover treatment as the left sidebar toggle; dense actions inside the panel retain their compact sizing. Regression coverage checks the closed/open reservations and the mirrored control styling.

## Screenshots

### Before

<img src="https://raw.githubusercontent.com/Zeus-Deus/codemux/7c45cd0ea34b24d2fc35563a21bd76b66330d993/.github/pr-assets/fix-sidebar-whitespace-gap/before.png" alt="Before: empty reserved slot and undersized right panel toggle" width="1280">

### After

<img src="https://raw.githubusercontent.com/Zeus-Deus/codemux/7c45cd0ea34b24d2fc35563a21bd76b66330d993/.github/pr-assets/fix-sidebar-whitespace-gap/after.png" alt="After: compact spacing and matched sidebar toggles" width="1280">

## Verification

- `npm run test -- src/components/layout/title-bar.test.tsx src/components/layout/right-panel.test.tsx` — 72 tests passed
- `npm run check` — passed
- Mock UI inspected with the panel open and closed

Model: GPT-5.6-Sol · Harness: Codex
