### PR TITLE
fix: improve chat image previews

### DIFF
--- a/src/components/chat/ImageLightbox.test.tsx
+++ b/src/components/chat/ImageLightbox.test.tsx
@@ -1,0 +1,42 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  ImageLightbox,
+  IMAGE_LIGHTBOX_MEDIA_CLASS,
+} from "./ImageLightbox";
+
+describe("ImageLightbox", () => {
+  it("shrink-wraps the image and exposes clear dismissal controls", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <ImageLightbox
+        open
+        onOpenChange={onOpenChange}
+        title="Screenshot"
+      >
+        <img
+          src="data:image/png;base64,AQID"
+          alt="Screenshot"
+          className={IMAGE_LIGHTBOX_MEDIA_CLASS}
+        />
+      </ImageLightbox>,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveClass("w-fit");
+    expect(dialog).not.toHaveClass("w-full");
+    expect(document.querySelector('[data-slot="dialog-overlay"]')).toHaveClass(
+      "bg-black/75",
+    );
+    expect(
+      screen.getByRole("button", { name: "Close image preview" }),
+    ).toBeVisible();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Close expanded image" }),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/chat/ImageLightbox.tsx
+++ b/src/components/chat/ImageLightbox.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import { X } from "lucide-react";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * Shared image viewer for every image source in chat. The dialog shrink-wraps
+ * the rendered media instead of occupying most of the viewport, so every
+ * visible area around the image remains a clickable dismiss target.
+ */
+export function ImageLightbox({
+  open,
+  onOpenChange,
+  title,
+  description = `Expanded preview of ${title}`,
+  children,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="bg-black/75 supports-backdrop-filter:backdrop-blur-sm"
+        className="w-fit max-w-[calc(100vw-2rem)] gap-0 border-0 bg-transparent p-0 ring-0 shadow-none sm:max-w-[calc(100vw-2rem)]"
+        data-image-lightbox
+      >
+        <DialogTitle className="sr-only">{title}</DialogTitle>
+        <DialogDescription className="sr-only">
+          {description}
+        </DialogDescription>
+
+        <div className="relative w-fit max-w-full">
+          <DialogClose asChild>
+            <button
+              type="button"
+              aria-label="Close expanded image"
+              title="Click the image to close"
+              className="block w-fit max-w-full cursor-zoom-out overflow-hidden rounded-xl bg-[#090909] shadow-2xl ring-1 ring-white/15 outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            >
+              {children}
+            </button>
+          </DialogClose>
+
+          <DialogClose asChild>
+            <button
+              type="button"
+              aria-label="Close image preview"
+              title="Close image preview (Esc)"
+              className="absolute top-2.5 right-2.5 z-10 flex size-9 items-center justify-center rounded-full bg-black/70 text-white shadow-lg ring-1 ring-white/25 backdrop-blur-md transition-[background-color,transform] hover:bg-black/90 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            >
+              <X className="size-4.5" aria-hidden />
+            </button>
+          </DialogClose>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Viewport-safe sizing shared by all full-size chat images. */
+export const IMAGE_LIGHTBOX_MEDIA_CLASS =
+  "block h-auto w-auto max-h-[calc(100vh-2rem)] max-w-[calc(100vw-2rem)] object-contain select-none";
+
+/** Stable dimensions for the error state when there is no image to size to. */
+export const IMAGE_LIGHTBOX_FALLBACK_CLASS =
+  "flex h-[min(60vh,28rem)] w-[calc(100vw-2rem)] max-w-xl flex-col items-center justify-center gap-2 bg-muted text-muted-foreground";

--- a/src/components/chat/MarkdownLocalImage.tsx
+++ b/src/components/chat/MarkdownLocalImage.tsx
@@ -2,11 +2,10 @@ import { useCallback, useRef, useState, type ReactNode } from "react";
 import { ImageIcon, ImageOff, Maximize2 } from "lucide-react";
 
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  ImageLightbox,
+  IMAGE_LIGHTBOX_FALLBACK_CLASS,
+  IMAGE_LIGHTBOX_MEDIA_CLASS,
+} from "@/components/chat/ImageLightbox";
 import { resolveAssetSrc } from "@/lib/asset-url";
 import { readLocalChatImage } from "@/tauri/commands";
 
@@ -166,15 +165,14 @@ export function MarkdownLocalImage({
         </span>
       </button>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="w-fit max-w-[94vw] border-none bg-transparent p-0 shadow-none sm:max-w-[94vw]">
-          <DialogTitle className="sr-only">{caption}</DialogTitle>
-          <DialogDescription className="sr-only">
-            Full-size preview of {caption}
-          </DialogDescription>
-          <ExpandedImage path={path} caption={caption} />
-        </DialogContent>
-      </Dialog>
+      <ImageLightbox
+        open={open}
+        onOpenChange={setOpen}
+        title={caption}
+        description={`Full-size preview of ${caption}`}
+      >
+        <ExpandedImage path={path} caption={caption} />
+      </ImageLightbox>
     </span>
   );
 }
@@ -184,7 +182,7 @@ function ExpandedImage({ path, caption }: { path: string; caption: string }) {
 
   if (image.failed || !image.src) {
     return (
-      <span className="flex h-[60vh] w-full flex-col items-center justify-center gap-2 rounded-xl bg-muted text-muted-foreground">
+      <span className={IMAGE_LIGHTBOX_FALLBACK_CLASS}>
         <ImageOff className="size-8 opacity-50" aria-hidden />
         <span className="text-sm">Failed to load {caption}</span>
       </span>
@@ -195,7 +193,7 @@ function ExpandedImage({ path, caption }: { path: string; caption: string }) {
     <img
       src={image.src}
       alt={caption}
-      className="mx-auto max-h-[90vh] w-auto max-w-full rounded-lg object-contain shadow-2xl"
+      className={IMAGE_LIGHTBOX_MEDIA_CLASS}
       onError={image.onError}
     />
   );

--- a/src/components/chat/ToolResultImages.tsx
+++ b/src/components/chat/ToolResultImages.tsx
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import { ImageOff } from "lucide-react";
 
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  ImageLightbox,
+  IMAGE_LIGHTBOX_FALLBACK_CLASS,
+  IMAGE_LIGHTBOX_MEDIA_CLASS,
+} from "@/components/chat/ImageLightbox";
 import type { ToolResultImage } from "@/lib/agent-chat/tool-result-images";
 
 /**
@@ -30,19 +34,15 @@ export function ToolResultImages({ images }: { images: ToolResultImage[] }) {
         />
       ))}
 
-      <Dialog
+      <ImageLightbox
         open={lightboxImage !== undefined}
         onOpenChange={(open) => {
           if (!open) setLightboxIndex(null);
         }}
+        title="Tool result image"
       >
-        <DialogContent className="max-w-[92vw] border-none bg-transparent p-0 shadow-none sm:max-w-[92vw]">
-          <DialogTitle className="sr-only">Tool result image</DialogTitle>
-          {lightboxImage ? (
-            <LightboxImage image={lightboxImage} />
-          ) : null}
-        </DialogContent>
-      </Dialog>
+        {lightboxImage ? <LightboxImage image={lightboxImage} /> : null}
+      </ImageLightbox>
     </div>
   );
 }
@@ -94,7 +94,7 @@ function LightboxImage({ image }: { image: ToolResultImage }) {
 
   if (failed) {
     return (
-      <div className="flex h-[60vh] w-full flex-col items-center justify-center gap-2 rounded-lg bg-muted/40 text-muted-foreground">
+      <div className={IMAGE_LIGHTBOX_FALLBACK_CLASS}>
         <ImageOff className="h-8 w-8 opacity-40" aria-hidden />
         <span className="text-xs">Failed to load image</span>
       </div>
@@ -105,7 +105,7 @@ function LightboxImage({ image }: { image: ToolResultImage }) {
     <img
       src={image.src}
       alt={image.mediaType ?? "tool result image"}
-      className="mx-auto max-h-[88vh] w-auto max-w-full rounded-lg object-contain"
+      className={IMAGE_LIGHTBOX_MEDIA_CLASS}
       onError={() => setFailed(true)}
     />
   );

--- a/src/components/chat/UserMessage.tsx
+++ b/src/components/chat/UserMessage.tsx
@@ -2,10 +2,10 @@ import { memo, useCallback, useState } from "react";
 import { CornerDownLeft, ImageOff, X } from "lucide-react";
 
 import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  ImageLightbox,
+  IMAGE_LIGHTBOX_FALLBACK_CLASS,
+  IMAGE_LIGHTBOX_MEDIA_CLASS,
+} from "@/components/chat/ImageLightbox";
 import { isAbsoluteFsPath, resolveAssetSrc } from "@/lib/asset-url";
 import { readChatImage } from "@/tauri/commands";
 import type { UserMessageImage, UserMessageItem } from "@/lib/agent-chat/types";
@@ -169,22 +169,15 @@ export const UserMessage = memo(function UserMessage({
         ) : null}
       </div>
 
-      {/* Lightbox — reuses the shared Dialog so Esc / click-outside close
-          for free (matches project-image-dialog). Near-fullscreen,
-          object-contain so no image is cropped. */}
-      <Dialog
+      <ImageLightbox
         open={lightboxImage !== undefined}
         onOpenChange={(open) => {
           if (!open) setLightboxIndex(null);
         }}
+        title="Attached image"
       >
-        <DialogContent className="max-w-[92vw] border-none bg-transparent p-0 shadow-none sm:max-w-[92vw]">
-          <DialogTitle className="sr-only">Attached image</DialogTitle>
-          {lightboxImage ? (
-            <LightboxImage image={lightboxImage} />
-          ) : null}
-        </DialogContent>
-      </Dialog>
+        {lightboxImage ? <LightboxImage image={lightboxImage} /> : null}
+      </ImageLightbox>
     </div>
   );
 });
@@ -237,7 +230,7 @@ function LightboxImage({ image }: { image: UserMessageImage }) {
 
   if (failed || !src) {
     return (
-      <div className="flex h-[60vh] w-full flex-col items-center justify-center gap-2 rounded-lg bg-muted/40 text-muted-foreground">
+      <div className={IMAGE_LIGHTBOX_FALLBACK_CLASS}>
         <ImageOff className="h-8 w-8 opacity-40" aria-hidden />
         <span className="text-xs">Failed to load image</span>
       </div>
@@ -248,7 +241,7 @@ function LightboxImage({ image }: { image: UserMessageImage }) {
     <img
       src={src}
       alt={image.mediaType ?? "attached image"}
-      className="mx-auto max-h-[88vh] w-auto max-w-full rounded-lg object-contain"
+      className={IMAGE_LIGHTBOX_MEDIA_CLASS}
       onError={onError}
     />
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -74,13 +74,15 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  overlayClassName,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  overlayClassName?: string
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(


### PR DESCRIPTION
## Problem

Chat image previews inherited a near-full-width dialog surface even when the image was much narrower. That transparent surface produced visible ghost borders, intercepted backdrop clicks, and left the close control stranded at the edge of the window.

## Fix

- Add a shared, shrink-wrapped image lightbox for sent attachments, tool-result images, and local Markdown screenshots.
- Clamp images to the viewport without cropping and keep the dialog surface aligned to the rendered image.
- Add a deliberate dark backdrop, a high-contrast close control, and click-the-image dismissal while preserving backdrop and Escape dismissal.
- Add focused regression coverage for sizing and dismissal behavior.

## Visual verification

| Before | After |
| --- | --- |
| ![Before: transparent dialog spans most of the viewport](https://gist.githubusercontent.com/Zeus-Deus/e539f992da84c98dc9d0b49904b23a6e/raw/50301ed9ea8f2ba160e4aca4b94af6b4066beedf/before.png) | ![After: lightbox shrink-wraps the image with a visible close control](https://gist.githubusercontent.com/Zeus-Deus/e539f992da84c98dc9d0b49904b23a6e/raw/50301ed9ea8f2ba160e4aca4b94af6b4066beedf/after.png) |

## Verification

- `npm run check`
- `npm run test -- src/components/chat/ImageLightbox.test.tsx src/components/chat/MarkdownLocalImage.test.tsx src/components/chat/UserMessage.test.tsx` (9 tests)
- Codemux Browser visual check at 1280×633, including image-click dismissal

Model: GPT-5 · Harness: Codex