### PR TITLE
fix: keep terminal browser controls aligned

### DIFF
--- a/src/components/browser/background-browser-indicator.tsx
+++ b/src/components/browser/background-browser-indicator.tsx
@@ -1,6 +1,5 @@
 import { Globe } from "lucide-react";
 import { useGuiChrome } from "@/hooks/use-gui-chrome";
-import { cn } from "@/lib/utils";
 import { useActiveWorkspaceId, useAppStore } from "@/stores/app-store";
 import { useBrowserPeekStore } from "@/stores/browser-peek-store";
 import type { AgentBrowserSession, AppStateSnapshot } from "@/tauri/types";
@@ -57,29 +56,32 @@ export function BackgroundBrowserIndicator({
   variant?: "chip" | "pane-header";
 }) {
   const openPeek = useBrowserPeekStore((s) => s.open);
+
+  if (variant === "pane-header") {
+    return (
+      <button
+        type="button"
+        onClick={() => openPeek(workspaceId)}
+        aria-label="Browser running in background — view"
+        title="View background browser"
+        className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-status-remote transition-colors hover:bg-status-remote/15 hover:text-status-remote focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-status-remote/50"
+      >
+        <Globe className="size-3.5" aria-hidden />
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
       onClick={() => openPeek(workspaceId)}
       aria-label="Browser running in background — view"
-      title={variant === "pane-header" ? "View background browser" : undefined}
-      className={cn(
-        "inline-flex shrink-0 items-center rounded-md border border-status-remote/30 bg-status-remote/10 font-semibold text-status-remote transition-colors hover:bg-status-remote/16 hover:text-foreground",
-        variant === "pane-header"
-          ? "h-5 gap-1 px-1.5 text-[10px]"
-          : "h-[26px] gap-1.5 px-2.5 text-[11px]",
-      )}
+      className="inline-flex h-[26px] shrink-0 items-center gap-1.5 rounded-md border border-status-remote/30 bg-status-remote/10 px-2.5 text-[11px] font-semibold text-status-remote transition-colors hover:bg-status-remote/16 hover:text-foreground"
     >
-      <Globe
-        className={variant === "pane-header" ? "size-2.5" : "size-3"}
-        aria-hidden
-      />
+      <Globe className="size-3" aria-hidden />
       Browser
       <span
-        className={cn(
-          "cm-blink rounded-full bg-status-working",
-          variant === "pane-header" ? "size-1" : "size-1.5",
-        )}
+        className="cm-blink size-1.5 rounded-full bg-status-working"
         aria-hidden
       />
     </button>

--- a/src/components/layout/PaneNode.tsx
+++ b/src/components/layout/PaneNode.tsx
@@ -342,6 +342,7 @@ function PaneNodeImpl({ node, activePaneId, visible, isSurfaceRoot = false }: Pr
             )}
             data-terminal-pane-actions
           >
+            <TerminalBackgroundBrowserIndicator active={isActive} />
             <Button variant="ghost" size="icon-xs" className="text-muted-foreground hover:text-foreground" onClick={() => handleSplit("horizontal")} aria-label="Split right" title="Split right">
               <SplitSquareHorizontal />
             </Button>
@@ -352,7 +353,6 @@ function PaneNodeImpl({ node, activePaneId, visible, isSurfaceRoot = false }: Pr
               <X />
             </Button>
           </div>
-          <TerminalBackgroundBrowserIndicator active={isActive} />
         </header>
         <div className="flex-1 min-h-0 overflow-hidden">
           <TerminalPane

--- a/src/components/layout/pane-header-cwd.test.tsx
+++ b/src/components/layout/pane-header-cwd.test.tsx
@@ -273,9 +273,15 @@ describe("terminal pane header background browser", () => {
     const button = screen.getByRole("button", {
       name: /Browser running in background/,
     });
+    const actions = document.querySelector("[data-terminal-pane-actions]");
     const closePane = screen.getByRole("button", { name: "Close pane" });
     expect(button).toBeInTheDocument();
-    expect(button.previousElementSibling).toContainElement(closePane);
+    expect(button).not.toHaveTextContent("Browser");
+    expect(actions).toContainElement(button);
+    expect(actions?.lastElementChild).toBe(closePane);
+    expect(button.nextElementSibling).toBe(
+      screen.getByRole("button", { name: "Split right" }),
+    );
     expect(useBrowserPeekStore.getState().isOpen("ws-1")).toBe(false);
 
     await userEvent.click(button);


### PR DESCRIPTION
The terminal background-browser pill occupied the rightmost toolbar position, shifting the existing split and close controls left whenever an agent browser was running.

This replaces the terminal-only pill with a compact blue globe and places it at the left edge of the existing pane-action cluster, preserving the controls’ right alignment and the click-to-peek behavior. The fuller Agent Chat browser chip is unchanged.

## Before

![Browser pill shifting terminal actions](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-screenshots-fix-terminal-browser-visibility/.github/pr-assets/fix-terminal-browser-visibility/before.png)

## After

![Compact browser globe before aligned terminal actions](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-screenshots-fix-terminal-browser-visibility/.github/pr-assets/fix-terminal-browser-visibility/after.png)

## Verification

- `npm run check`
- `npm run test -- src/components/layout/pane-header-cwd.test.tsx` (13 tests)
- Visual inspection with the Codemux browser against the Tauri mock

Built with GPT-5.4 via Codex.