### PR TITLE
fix(sidebar): recede background workspace colors

### DIFF
--- a/src/components/github/pr-status-icon.test.tsx
+++ b/src/components/github/pr-status-icon.test.tsx
@@ -1,7 +1,11 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { describe, it, expect, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/react";
-import { PrStatusIcon, prStatusSettledHoverClass } from "./pr-status-icon";
+import {
+  PrStatusIcon,
+  prStatusRecededCardHoverClass,
+  prStatusSettledHoverClass,
+} from "./pr-status-icon";
 
 afterEach(cleanup);
 
@@ -44,5 +48,22 @@ describe("PrStatusIcon", () => {
     );
     expect(prStatusSettledHoverClass("weird")).toBeNull();
     expect(prStatusSettledHoverClass(null)).toBeNull();
+  });
+
+  it("defers each state's color to a receded card's hover/focus variants", () => {
+    expect(prStatusRecededCardHoverClass("MERGED")).toContain(
+      "group-hover/card:text-accent-violet",
+    );
+    expect(prStatusRecededCardHoverClass("open")).toContain(
+      "group-focus-within/card:text-status-open",
+    );
+    expect(prStatusRecededCardHoverClass("closed")).toContain(
+      "group-hover/card:text-destructive",
+    );
+    expect(prStatusRecededCardHoverClass("draft")).toContain(
+      "group-hover/card:text-muted-foreground",
+    );
+    expect(prStatusRecededCardHoverClass("weird")).toBeNull();
+    expect(prStatusRecededCardHoverClass(null)).toBeNull();
   });
 });

--- a/src/components/github/pr-status-icon.tsx
+++ b/src/components/github/pr-status-icon.tsx
@@ -61,10 +61,33 @@ const STATE_TO_SETTLED_HOVER: Record<PrStatusState, string> = {
     "group-hover/settled:text-muted-foreground group-focus-within/settled:text-muted-foreground",
 };
 
+/** Deferred PR color for a full-size inbox card that is background work.
+ *  These variants mirror the settled-row map above, but name the card's own
+ *  group. Keeping the maps explicit lets Tailwind discover every variant and
+ *  lets a receded working / monitoring / wrapping-up card stay neutral until
+ *  the user points at it or moves keyboard focus inside it. */
+const STATE_TO_RECEDED_CARD_HOVER: Record<PrStatusState, string> = {
+  merged:
+    "group-hover/card:text-accent-violet group-focus-within/card:text-accent-violet",
+  open: "group-hover/card:text-status-open group-focus-within/card:text-status-open",
+  closed:
+    "group-hover/card:text-destructive group-focus-within/card:text-destructive",
+  draft:
+    "group-hover/card:text-muted-foreground group-focus-within/card:text-muted-foreground",
+};
+
 export function prStatusSettledHoverClass(state: string | null | undefined): string | null {
   const normalized = normalizePrState(state);
   if (!normalized) return null;
   return STATE_TO_SETTLED_HOVER[normalized];
+}
+
+export function prStatusRecededCardHoverClass(
+  state: string | null | undefined,
+): string | null {
+  const normalized = normalizePrState(state);
+  if (!normalized) return null;
+  return STATE_TO_RECEDED_CARD_HOVER[normalized];
 }
 
 export function prStatusToneClass(state: string | null | undefined): string | null {

--- a/src/components/layout/sidebar-inbox-card.test.tsx
+++ b/src/components/layout/sidebar-inbox-card.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type {
@@ -235,7 +235,7 @@ describe("SidebarInboxCard — snooze affordance", () => {
   });
 
   it("keeps the hover cluster pinned open while the snooze menu is open", async () => {
-    renderCard();
+    const { card } = renderCard();
     const trigger = screen.getByRole("button", { name: 'Snooze "Ship it"' });
     // The reveal rides the cluster the buttons share, not each button, so the
     // three actions can never half-appear.
@@ -249,6 +249,10 @@ describe("SidebarInboxCard — snooze affordance", () => {
     // the card can no longer collapse the trigger out from under it.
     expect(cluster.className).not.toContain("hidden");
     expect(cluster.className).toContain("flex");
+    // The menu portal owns pointer/focus now, but the card must stay visually
+    // restored for the duration of that interaction.
+    expect(card.className).not.toContain("opacity-70");
+    expect(within(card).getByText("M").className).not.toContain("grayscale");
   });
 
   it("snoozes to the chosen preset's instant without activating the workspace", async () => {
@@ -341,6 +345,47 @@ describe("SidebarInboxCard — background recede", () => {
     expect(card.className).toContain("focus-within:opacity-100");
   });
 
+  it("neutralizes a background card's colors until hover or focus", () => {
+    const { card } = renderCard({
+      status: "working",
+      workspace: makeWorkspace({
+        git_additions: 38,
+        git_deletions: 12,
+        pr_number: 87,
+        pr_state: "open",
+        pr_url: "https://example.test/pr/87",
+      }),
+    });
+
+    const avatar = screen.getByText("M");
+    expect(avatar.className).toContain("grayscale");
+    expect(avatar.className).toContain("group-hover/card:grayscale-0");
+
+    const title = screen.getByText("Ship it");
+    expect(title.className).toContain("text-muted-foreground/80");
+    expect(title.className).toContain("group-hover/card:text-foreground");
+
+    const workingState = screen.getByText("Working").parentElement;
+    expect(workingState?.className).toContain("text-muted-foreground/70");
+    expect(workingState?.className).toContain("group-hover/card:text-status-working");
+
+    const additions = screen.getByText("+38");
+    const deletions = screen.getByText("−12");
+    expect(additions.className).toContain("text-muted-foreground/70");
+    expect(additions.className).toContain("group-hover/card:text-status-open/80");
+    expect(deletions.className).toContain("text-muted-foreground/70");
+    expect(deletions.className).toContain(
+      "group-focus-within/card:text-status-attention/80",
+    );
+
+    const pr = screen.getByRole("button", { name: "Pull request #87 — open" });
+    expect(pr.className).toContain("text-muted-foreground/65");
+    expect(pr.className).toContain("group-hover/card:text-status-open");
+    expect(pr.className).not.toMatch(/(^|\s)text-status-open\b/);
+    expect(pr.querySelector("svg")?.getAttribute("class")).toContain("text-current");
+    expect(card.className).toContain("opacity-70");
+  });
+
   it("dims an idle background card the same way", () => {
     const { card } = renderCard({ status: null });
     expect(card.className).toContain("opacity-70");
@@ -371,6 +416,28 @@ describe("SidebarInboxCard — background recede", () => {
       expect(card.className, label).not.toContain("opacity-70");
       cleanup();
     }
+  });
+
+  it("keeps semantic colors on the workspace currently being viewed", () => {
+    renderCard({
+      isActive: true,
+      status: "working",
+      workspace: makeWorkspace({
+        git_additions: 8,
+        git_deletions: 3,
+        pr_number: 12,
+        pr_state: "open",
+        pr_url: "https://example.test/pr/12",
+      }),
+    });
+
+    expect(screen.getByText("M").className).not.toContain("grayscale");
+    expect(screen.getByText("Ship it").className).toContain("text-foreground");
+    expect(screen.getByText("+8").className).toContain("text-status-open/80");
+    expect(screen.getByText("−3").className).toContain("text-status-attention/80");
+    expect(
+      screen.getByRole("button", { name: "Pull request #12 — open" }).className,
+    ).toContain("text-status-open");
   });
 });
 
@@ -637,20 +704,26 @@ describe("SidebarInboxCard — working duration", () => {
 });
 
 describe("SidebarInboxCard — monitoring status", () => {
-  it("labels the eyebrow Monitoring in the dedicated tone", () => {
+  it("defers the Monitoring tone until the background card is engaged", () => {
     const { card } = renderCard({ status: "monitoring" as ActivePaneStatus });
-    expect(screen.getByText("Monitoring")).toBeInTheDocument();
-    expect(card.innerHTML).toContain("text-status-monitoring");
-    expect(card.innerHTML).toContain("bg-status-monitoring");
+    const label = screen.getByText("Monitoring");
+    expect(label.className).toContain("text-muted-foreground/70");
+    expect(label.className).toContain("group-hover/card:text-status-monitoring");
+    const dot = [...card.querySelectorAll("span")].find((element) =>
+      element.className.includes("group-hover/card:bg-status-monitoring"),
+    );
+    expect(dot?.className).toContain("bg-muted-foreground/60");
   });
 
   // The whole point of a separate status: monitoring is calm. A pulsing dot
   // is this app's "look at me" vocabulary and belongs to `permission` alone.
   it("renders a steady dot with no pulse", () => {
     const { card } = renderCard({ status: "monitoring" as ActivePaneStatus });
-    const dot = card.querySelector(".bg-status-monitoring") as HTMLElement;
-    expect(dot).not.toBeNull();
-    expect(dot.className).not.toContain("animate");
+    const dot = [...card.querySelectorAll("span")].find((element) =>
+      element.className.includes("group-hover/card:bg-status-monitoring"),
+    );
+    expect(dot).toBeDefined();
+    expect(dot?.className).not.toContain("animate");
   });
 
   // Settle/Snooze are guarded only against live and blocked agents. A

--- a/src/components/layout/sidebar-inbox-card.tsx
+++ b/src/components/layout/sidebar-inbox-card.tsx
@@ -22,6 +22,7 @@ import { IssueDetailPopover } from "@/components/github/issue-detail-popover";
 import {
   PrStatusIcon,
   normalizePrState,
+  prStatusRecededCardHoverClass,
   prStatusTextClass,
 } from "@/components/github/pr-status-icon";
 import { WorkspaceInboxMenu } from "./workspace-inbox-menu";
@@ -310,6 +311,11 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
   // instead — the actions stay up and the state cluster stays down until the
   // menu closes and Radix returns focus to the trigger inside the card.
   const actionsPinned = snoozeMenuOpen;
+  // The open menu is an active interaction even though its portal has taken
+  // both pointer and focus away from the card. Treat it like hover/focus for
+  // the whole visual contract, not just the root opacity, so descendants do
+  // not fall back to grayscale while the user is operating the card.
+  const visuallyReceded = receded && !actionsPinned;
 
   /** Shared shape for the eyebrow's hover-revealed actions: borderless,
    *  transparent, one muted ink that resolves to full foreground on the
@@ -339,9 +345,15 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
           (actionsPinned
             ? "hidden"
             : "group-hover/card:hidden group-focus-within/card:hidden"),
-        isWorking && "font-semibold text-status-working",
+        isWorking &&
+          (visuallyReceded
+            ? "font-medium text-muted-foreground/70 group-hover/card:text-status-working group-focus-within/card:text-status-working"
+            : "font-semibold text-status-working"),
         isNeeds && "font-semibold text-status-attention",
-        isMonitoring && "font-semibold text-status-monitoring",
+        isMonitoring &&
+          (visuallyReceded
+            ? "font-medium text-muted-foreground/70 group-hover/card:text-status-monitoring group-focus-within/card:text-status-monitoring"
+            : "font-semibold text-status-monitoring"),
         isDone && "font-semibold text-status-open",
         !status && "font-medium text-muted-foreground/70",
       )}
@@ -363,7 +375,14 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
       {/* Steady dot, deliberately not the configurable WorkingIndicator and
           deliberately not animated: monitoring is calm background presence. */}
       {isMonitoring && (
-        <span className="size-1.5 rounded-full bg-status-monitoring" />
+        <span
+          className={cn(
+            "size-1.5 rounded-full transition-colors",
+            visuallyReceded
+              ? "bg-muted-foreground/60 group-hover/card:bg-status-monitoring group-focus-within/card:bg-status-monitoring"
+              : "bg-status-monitoring",
+          )}
+        />
       )}
       {isDone && <Check className="h-3 w-3" strokeWidth={2.5} />}
       {isWorking ? (
@@ -498,8 +517,7 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                 // open menu out of this card, so the pointer has left and
                 // focus sits outside — neither restore would hold, and the
                 // card the user is actively operating on would dim mid-menu.
-                receded &&
-                  !actionsPinned &&
+                visuallyReceded &&
                   "opacity-70 hover:opacity-100 focus-within:opacity-100",
               )}
             >
@@ -530,7 +548,11 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                   cacheBust={appearance.imageVersion}
                   size="sm"
                   shape="square"
-                  className="shrink-0 font-bold"
+                  className={cn(
+                    "shrink-0 font-bold transition-[opacity,filter] duration-150",
+                    visuallyReceded &&
+                      "opacity-55 grayscale group-hover/card:opacity-100 group-hover/card:grayscale-0 group-focus-within/card:opacity-100 group-focus-within/card:grayscale-0",
+                  )}
                 />
                 <span className="min-w-0 truncate text-[11px] font-semibold tracking-[0.01em] text-muted-foreground/80">
                   {repo.name}
@@ -707,7 +729,10 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                 )}
                 <span
                   className={cn(
-                    "truncate text-[13px] leading-[1.35] text-foreground",
+                    "truncate text-[13px] leading-[1.35] transition-colors duration-150",
+                    visuallyReceded
+                      ? "text-muted-foreground/80 group-hover/card:text-foreground group-focus-within/card:text-foreground"
+                      : "text-foreground",
                     // The extra weight is what makes an unread card readable
                     // as unread at a glance down a scrolling list, where a
                     // 6px dot alone is easy to sweep past.
@@ -764,12 +789,24 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                 {hasStats && (
                   <span className="shrink-0 tabular-nums">
                     {workspace.git_additions > 0 && (
-                      <span className="text-status-open/80">
+                      <span
+                        className={cn(
+                          visuallyReceded
+                            ? "text-muted-foreground/70 transition-colors group-hover/card:text-status-open/80 group-focus-within/card:text-status-open/80"
+                            : "text-status-open/80",
+                        )}
+                      >
                         +{workspace.git_additions}
                       </span>
                     )}{" "}
                     {workspace.git_deletions > 0 && (
-                      <span className="text-status-attention/80">
+                      <span
+                        className={cn(
+                          visuallyReceded
+                            ? "text-muted-foreground/70 transition-colors group-hover/card:text-status-attention/80 group-focus-within/card:text-status-attention/80"
+                            : "text-status-attention/80",
+                        )}
+                      >
                         −{workspace.git_deletions}
                       </span>
                     )}
@@ -789,7 +826,12 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                     className={cn(
                       "inline-flex shrink-0 items-center gap-1 rounded px-1 py-px font-mono text-[10px] font-medium",
                       "transition-colors duration-150",
-                      prStatusTextClass(prState),
+                      visuallyReceded
+                        ? cn(
+                            "text-muted-foreground/65",
+                            prStatusRecededCardHoverClass(prState),
+                          )
+                        : prStatusTextClass(prState),
                       workspace.pr_url
                         ? "hover:bg-foreground/[0.055]"
                         : // `cursor-default`, not `pointer-events-none`: the
@@ -801,7 +843,14 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                           "cursor-default opacity-65",
                     )}
                   >
-                    <PrStatusIcon state={prState} size={3} className="shrink-0" />
+                    <PrStatusIcon
+                      state={prState}
+                      size={3}
+                      className={cn(
+                        "shrink-0",
+                        visuallyReceded && "text-current",
+                      )}
+                    />
                     {workspace.pr_number != null && (
                       <span>{providerRef(scProvider, workspace.pr_number)}</span>
                     )}
@@ -831,7 +880,12 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                       role="img"
                       aria-label={`Long-running process on :${runningPort}`}
                       title={`Long-running process on :${runningPort}`}
-                      className="flex shrink-0 animate-pulse items-center text-status-open"
+                      className={cn(
+                        "flex shrink-0 animate-pulse items-center transition-colors",
+                        visuallyReceded
+                          ? "text-muted-foreground/60 group-hover/card:text-status-open group-focus-within/card:text-status-open"
+                          : "text-status-open",
+                      )}
                     >
                       <Terminal className="size-3" strokeWidth={1.7} />
                     </span>
@@ -840,13 +894,23 @@ export const SidebarInboxCard = memo(function SidebarInboxCard({
                     <ProviderLogo
                       key={p}
                       provider={p}
-                      className="h-[13px] w-[13px] opacity-80"
+                      className={cn(
+                        "h-[13px] w-[13px] transition-[opacity,filter]",
+                        visuallyReceded
+                          ? "opacity-50 grayscale group-hover/card:opacity-80 group-hover/card:grayscale-0 group-focus-within/card:opacity-80 group-focus-within/card:grayscale-0"
+                          : "opacity-80",
+                      )}
                     />
                   ))}
                   {isRemote && (
                     <Cloud
                       aria-label="Runs on a remote host"
-                      className="h-[13px] w-[13px] shrink-0 text-status-remote"
+                      className={cn(
+                        "h-[13px] w-[13px] shrink-0 transition-colors",
+                        visuallyReceded
+                          ? "text-muted-foreground/60 group-hover/card:text-status-remote group-focus-within/card:text-status-remote"
+                          : "text-status-remote",
+                      )}
                     />
                   )}
                   {workspace.notification_count > 0 && (


### PR DESCRIPTION
Background workspace cards still carried saturated status, git, provider, and pull-request colors, so working and wrapping-up work competed visually with work that actually needs attention.

This derives a complete neutral-at-rest treatment from the existing receded state: titles and lifecycle labels mute, avatars and provider marks desaturate, and git/PR/process metadata gives up semantic color until hover, keyboard focus, or activation. Needs-you, unread, woken, selected, active, and done-for-review workspaces keep their prominence.

Verification:
- npm run check
- npm run test -- src/components/github/pr-status-icon.test.tsx src/components/layout/sidebar-inbox-card.test.tsx (44 tests)
- Browser-verified with mock Working, Monitoring, Wrapping up, Done/review, Needs-you, active, and Settled states

Before:
![Before: background work retains semantic colors](https://github.com/user-attachments/assets/e841c8ae-c50d-4c7f-9650-4706a480dc69)

After:
![After: background work is neutral until engagement](https://github.com/user-attachments/assets/6c2e2186-8012-4827-a660-874ff59b97ef)

Built with GPT-5 in the Codex harness.
