### PR TITLE
fix: clear dispatched queued messages

### DIFF
--- a/src-tauri/src/agent_provider/claude/mod.rs
+++ b/src-tauri/src/agent_provider/claude/mod.rs
@@ -264,14 +264,14 @@ impl AgentProvider for ClaudeAgentProvider {
         &self,
         thread_id: ThreadId,
         queued_id: String,
-    ) -> Result<(), ProviderError> {
+    ) -> Result<bool, ProviderError> {
         let session = {
             let sessions = self.sessions.read().await;
             sessions.get(&thread_id).cloned()
         };
         // A missing session means nothing is queued — treat as a no-op.
         let Some(session) = session else {
-            return Ok(());
+            return Ok(false);
         };
         session.cancel_queued(&queued_id).await
     }

--- a/src-tauri/src/agent_provider/claude/session.rs
+++ b/src-tauri/src/agent_provider/claude/session.rs
@@ -518,9 +518,9 @@ impl ClaudeSession {
 
     /// Cancel a single queued turn by id (user pressed X). Emits
     /// [`ProviderRuntimeEvent::QueuedTurnCancelled`] when the item was
-    /// found. Idempotent — cancelling an unknown / already-dispatched id
-    /// is a silent no-op.
-    pub async fn cancel_queued(&self, queued_id: &str) -> Result<(), ProviderError> {
+    /// found. Returns whether the queued item was actually removed; an
+    /// unknown / already-dispatched id returns `false`.
+    pub async fn cancel_queued(&self, queued_id: &str) -> Result<bool, ProviderError> {
         let removed = {
             let mut state = self.state.lock().await;
             if let Some(pos) = state
@@ -540,7 +540,7 @@ impl ClaudeSession {
                 queued_id: queued_id.to_string(),
             });
         }
-        Ok(())
+        Ok(removed)
     }
 
     /// **Send now (steer):** promote a queued follow-up to the front of

--- a/src-tauri/src/agent_provider/codex/mod.rs
+++ b/src-tauri/src/agent_provider/codex/mod.rs
@@ -266,13 +266,13 @@ impl AgentProvider for CodexAgentProvider {
         &self,
         thread_id: ThreadId,
         queued_id: String,
-    ) -> Result<(), ProviderError> {
+    ) -> Result<bool, ProviderError> {
         let session = {
             let sessions = self.sessions.read().await;
             sessions.get(&thread_id).cloned()
         };
         let Some(session) = session else {
-            return Ok(());
+            return Ok(false);
         };
         session.cancel_queued(&queued_id).await
     }

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -604,8 +604,9 @@ impl CodexSession {
     }
 
     /// Cancel a single queued turn by id (user pressed X). Emits
-    /// [`ProviderRuntimeEvent::QueuedTurnCancelled`] when found; idempotent.
-    pub async fn cancel_queued(&self, queued_id: &str) -> Result<(), ProviderError> {
+    /// [`ProviderRuntimeEvent::QueuedTurnCancelled`] when found. Returns
+    /// whether the queued item was actually removed.
+    pub async fn cancel_queued(&self, queued_id: &str) -> Result<bool, ProviderError> {
         let removed = {
             let mut state = self.state.lock().await;
             if let Some(pos) = state
@@ -625,7 +626,7 @@ impl CodexSession {
                 queued_id: queued_id.to_string(),
             });
         }
-        Ok(())
+        Ok(removed)
     }
 
     /// **Send now (steer):** promote a queued follow-up to the front of

--- a/src-tauri/src/agent_provider/provider.rs
+++ b/src-tauri/src/agent_provider/provider.rs
@@ -59,15 +59,15 @@ pub trait AgentProvider: Send + Sync {
     ) -> Result<(), ProviderError>;
 
     /// Cancel a queued (not-yet-dispatched) follow-up turn by its queued
-    /// id. Idempotent — cancelling an unknown or already-dispatched id is
-    /// a silent success. The default implementation is a no-op for
-    /// providers without a follow-up queue (e.g. OpenCode).
+    /// id. Returns whether an item was actually removed. An unknown or
+    /// already-dispatched id returns `false`; the default implementation is
+    /// a no-op for providers without a follow-up queue (e.g. OpenCode).
     async fn cancel_queued_turn(
         &self,
         _thread_id: ThreadId,
         _queued_id: String,
-    ) -> Result<(), ProviderError> {
-        Ok(())
+    ) -> Result<bool, ProviderError> {
+        Ok(false)
     }
 
     /// **Send now (steer):** promote a queued follow-up to the front of

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -1538,17 +1538,17 @@ pub async fn agent_chat_send_turn<R: Runtime>(
     Ok(result)
 }
 
-/// Cancel a queued (not-yet-dispatched) follow-up turn. Idempotent — an
-/// unknown or already-dispatched id is a silent success. On success the
-/// provider emits a `QueuedTurnCancelled` event so the UI removes the
-/// greyed bubble.
+/// Cancel a queued (not-yet-dispatched) follow-up turn. Returns whether the
+/// provider actually removed an item. An unknown or already-dispatched id
+/// returns `false`; a real cancellation also emits `QueuedTurnCancelled` so
+/// the UI removes the greyed bubble.
 #[tauri::command]
 pub async fn agent_chat_cancel_queued_turn<R: Runtime>(
     app: AppHandle<R>,
     provider: ProviderKind,
     thread_id: ThreadId,
     queued_id: String,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let observability: State<'_, ObservabilityStore> = app.state();
     feature_flag_on(&observability)?;
     let registry: State<'_, ProviderRegistry> = app.state();

--- a/src-tauri/tests/claude_adapter.rs
+++ b/src-tauri/tests/claude_adapter.rs
@@ -1259,10 +1259,11 @@ async fn cancel_queued_turn_removes_it() {
         .queued_id
         .expect("second send queued");
 
-    provider
+    let removed = provider
         .cancel_queued_turn(ThreadId("t-cancel".into()), queued.clone())
         .await
         .unwrap();
+    assert!(removed, "the queued turn should be reported as removed");
 
     let cancelled = timeout(Duration::from_secs(3), async {
         while let Some(ev) = stream.next().await {
@@ -1278,10 +1279,14 @@ async fn cancel_queued_turn_removes_it() {
     assert_eq!(cancelled.as_deref(), Some(queued.as_str()));
 
     // Cancelling again is a silent no-op (idempotent).
-    provider
+    let removed_again = provider
         .cancel_queued_turn(ThreadId("t-cancel".into()), queued)
         .await
         .unwrap();
+    assert!(
+        !removed_again,
+        "an already-cancelled id should report false"
+    );
     provider
         .stop_session(ThreadId("t-cancel".into()))
         .await

--- a/src-tauri/tests/codex_adapter.rs
+++ b/src-tauri/tests/codex_adapter.rs
@@ -1067,10 +1067,11 @@ async fn cancel_queued_turn_removes_it_codex() {
         .queued_id
         .expect("second send queued");
 
-    provider
+    let removed = provider
         .cancel_queued_turn(ThreadId("t-cq".into()), queued.clone())
         .await
         .unwrap();
+    assert!(removed, "the queued turn should be reported as removed");
 
     let cancelled = timeout(Duration::from_secs(3), async {
         while let Some(ev) = stream.next().await {
@@ -1084,6 +1085,11 @@ async fn cancel_queued_turn_removes_it_codex() {
     .ok()
     .flatten();
     assert_eq!(cancelled.as_deref(), Some(queued.as_str()));
+    let removed_again = provider
+        .cancel_queued_turn(ThreadId("t-cq".into()), queued)
+        .await
+        .unwrap();
+    assert!(!removed_again, "an already-cancelled id should report false");
     provider.stop_session(ThreadId("t-cq".into())).await.ok();
 }
 

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -53,6 +53,7 @@ const setModelMock = vi.fn();
 const setModeMock = vi.fn();
 const setModePriorMock = vi.fn();
 const setPermissionModeMock = vi.fn();
+const setInputDraftMock = vi.fn();
 const markRequestResolvedMock = vi.fn();
 const setHasDebugActivityMock = vi.fn();
 const setDebugActivityResolvedMock = vi.fn();
@@ -93,6 +94,7 @@ vi.mock("./ChatTranscript", () => ({
     threadKey,
     onAcceptPlan,
     onEnterSubagent,
+    onCancelQueued,
     onSendQueuedNow,
   }: {
     messages: unknown[];
@@ -101,6 +103,7 @@ vi.mock("./ChatTranscript", () => ({
     threadKey?: string | null;
     onAcceptPlan: (requestId: string) => void;
     onEnterSubagent?: (subagentId: string) => void;
+    onCancelQueued?: (queuedId: string, text: string) => void;
     onSendQueuedNow?: (queuedId: string) => void;
   }) => (
     <div
@@ -130,6 +133,10 @@ vi.mock("./ChatTranscript", () => ({
       />
       {/* Dispatching a queued turn is a send, so it takes the same
           new-turn scroll contract as a composer submission. */}
+      <button
+        data-testid="cancel-queued"
+        onClick={() => onCancelQueued?.("q-1", "queued follow-up")}
+      />
       <button
         data-testid="send-queued-now"
         onClick={() => onSendQueuedNow?.("q-1")}
@@ -367,6 +374,7 @@ vi.mock("@/tauri/commands", () => ({
   // divider unless a test seeds a record.
   agentChatListSessions: vi.fn().mockResolvedValue([]),
   agentChatRespondToRequest: vi.fn().mockResolvedValue(undefined),
+  agentChatCancelQueuedTurn: vi.fn().mockResolvedValue(true),
   agentChatSendTurn: vi.fn().mockResolvedValue(undefined),
   agentChatSendQueuedTurnNow: vi.fn().mockResolvedValue(undefined),
   agentChatSetModel: vi.fn().mockResolvedValue(undefined),
@@ -533,7 +541,7 @@ vi.mock("@/stores/agent-chat-store", () => {
       const state = {
         threads: buildThreads(),
         ensureThread: vi.fn(),
-        setInputDraft: vi.fn(),
+        setInputDraft: setInputDraftMock,
         setModel: setModelMock,
         setPermissionMode: setPermissionModeMock,
         setSessionLaunchMode: vi.fn(),
@@ -761,7 +769,11 @@ describe("AgentChatPane new-turn scroll contract (send anchor)", () => {
     currentSliceOverrides = { "thread-x": { inputDraft: "hello there" } };
     workspaceIdForPaneOverride = "ws-home";
     appendUserMessageMock.mockClear();
-    const { agentChatSendTurn } = await import("@/tauri/commands");
+    setInputDraftMock.mockClear();
+    const { agentChatCancelQueuedTurn, agentChatSendTurn } = await import(
+      "@/tauri/commands"
+    );
+    vi.mocked(agentChatCancelQueuedTurn).mockClear().mockResolvedValue(true);
     vi.mocked(agentChatSendTurn).mockClear().mockResolvedValue({
       turn_id: "turn-1",
       queued_id: null,
@@ -875,6 +887,43 @@ describe("AgentChatPane new-turn scroll contract (send anchor)", () => {
       container.querySelector('[data-testid="send-queued-now"]')!,
     );
     await waitFor(() => expect(anchorClientNonce(container)).toBe(""));
+  });
+
+  it("restores a queued message only when the backend actually cancels it", async () => {
+    currentSliceOverrides = {
+      "thread-x": { inputDraft: "draft already in progress" },
+    };
+    const { container } = render(<AgentChatPane pane={pane} />);
+    fireEvent.click(container.querySelector('[data-testid="cancel-queued"]')!);
+
+    const { agentChatCancelQueuedTurn } = await import("@/tauri/commands");
+    await waitFor(() => {
+      expect(vi.mocked(agentChatCancelQueuedTurn)).toHaveBeenCalledWith(
+        expect.anything(),
+        "thread-x",
+        "q-1",
+      );
+    });
+    expect(setInputDraftMock).toHaveBeenCalledWith(
+      "thread-x",
+      "queued follow-up\ndraft already in progress",
+    );
+  });
+
+  it("does not resurrect an already-dispatched queued message in the composer", async () => {
+    const { agentChatCancelQueuedTurn } = await import("@/tauri/commands");
+    vi.mocked(agentChatCancelQueuedTurn).mockResolvedValueOnce(false);
+    const { container } = render(<AgentChatPane pane={pane} />);
+    fireEvent.click(container.querySelector('[data-testid="cancel-queued"]')!);
+
+    await waitFor(() => {
+      expect(vi.mocked(agentChatCancelQueuedTurn)).toHaveBeenCalledWith(
+        expect.anything(),
+        "thread-x",
+        "q-1",
+      );
+    });
+    expect(setInputDraftMock).not.toHaveBeenCalled();
   });
 
   it("keeps the anchor when the turn settles", async () => {

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -1989,18 +1989,31 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   // Follow-up queueing: cancel a queued (not-yet-dispatched) turn. The
   // backend emits `queued_turn_cancelled`, which the reducer uses to
   // remove the greyed bubble — so we don't optimistically remove here.
-  // On success we restore the cancelled text into the composer draft so
-  // the user can edit and resend (prepended if the composer already has
-  // content, to avoid clobbering an in-progress draft).
+  // When the provider confirms it actually removed an item, restore the
+  // cancelled text into the composer draft so the user can edit and resend
+  // (prepended if the composer already has content, to avoid clobbering an
+  // in-progress draft).
   const handleCancelQueued = useCallback(
     (queuedId: string, text: string) => {
       if (!threadId) return;
       const tid = threadId;
       void (async () => {
         try {
-          await agentChatCancelQueuedTurn(provider, tid, queuedId);
-          const current = useAgentChatStore.getState().threads[tid]?.inputDraft ?? "";
-          setInputDraft(tid, current.trim().length > 0 ? `${text}\n${current}` : text);
+          const cancelled = await agentChatCancelQueuedTurn(
+            provider,
+            tid,
+            queuedId,
+          );
+          // The provider returns false when this id already dispatched.
+          // Do not resurrect an already-sent prompt in the composer just
+          // because the UI briefly held a stale queue marker.
+          if (!cancelled) return;
+          const current =
+            useAgentChatStore.getState().threads[tid]?.inputDraft ?? "";
+          setInputDraft(
+            tid,
+            current.trim().length > 0 ? `${text}\n${current}` : text,
+          );
         } catch (err) {
           toast.error(`Failed to cancel queued message: ${err}`);
         }

--- a/src/components/chat/UserMessage.tsx
+++ b/src/components/chat/UserMessage.tsx
@@ -87,11 +87,12 @@ function useImageWithFallback(rawSrc: string): {
  * to know which form it got.
  *
  * Follow-up queueing: while `item.queued` is set the bubble renders
- * greyed-out (reduced opacity + muted foreground) with a small "Queued"
- * pill and, on hover, two actions — "Send now" (steer: soft-interrupt the
- * active turn and dispatch this message immediately, keeping all progress)
- * and an X to cancel (restores the text into the composer). Both are
- * handled by the parent. All colors are theme tokens.
+ * visually muted with a quiet "Queued" footer anchored to the bubble's
+ * right edge. On hover or keyboard focus, two compact actions appear to the
+ * footer's left without moving the status: "Send now" soft-interrupts the
+ * active turn and dispatches this message immediately (keeping all progress),
+ * while X cancels and restores the text into the composer. Both are handled
+ * by the parent. All colors are theme tokens.
  */
 export const UserMessage = memo(function UserMessage({
   item,
@@ -118,7 +119,7 @@ export const UserMessage = memo(function UserMessage({
           className={cn(
             "flex flex-col gap-2 rounded-[14px_14px_5px_14px] border px-[15px] py-[11px] text-sm leading-relaxed",
             queued
-              ? "border-dashed border-border/50 bg-muted/40 text-muted-foreground opacity-70"
+              ? "border-border/35 bg-muted/30 text-muted-foreground/75"
               : "border-border/60 bg-card text-foreground",
           )}
         >
@@ -138,33 +139,35 @@ export const UserMessage = memo(function UserMessage({
           ) : null}
         </div>
         {queued ? (
-          <div className="flex items-center gap-1.5 pr-0.5">
-            <span className="rounded-full bg-muted px-2 py-[1px] text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          <div className="relative flex h-4 items-center justify-end pr-0.5">
+            <div className="pointer-events-none absolute right-full mr-1 flex h-4 translate-x-0.5 items-center gap-px opacity-0 transition-[opacity,transform] duration-100 group-focus-within:pointer-events-auto group-focus-within:translate-x-0 group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:translate-x-0 group-hover:opacity-100">
+              {onSendQueuedNow ? (
+                <button
+                  type="button"
+                  aria-label="Send now"
+                  title="Interrupt current work and send this message now — progress so far is kept"
+                  onClick={() => onSendQueuedNow(queued.queuedId)}
+                  className="inline-flex h-4 w-4 items-center justify-center rounded-[4px] text-muted-foreground/55 transition-colors hover:bg-muted/60 hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <CornerDownLeft className="h-2.5 w-2.5" aria-hidden />
+                </button>
+              ) : null}
+              {onCancelQueued ? (
+                <button
+                  type="button"
+                  aria-label="Cancel queued message"
+                  title="Remove from queue and return to the composer"
+                  onClick={() => onCancelQueued(queued.queuedId, item.text)}
+                  className="inline-flex h-4 w-4 items-center justify-center rounded-[4px] text-muted-foreground/55 transition-colors hover:bg-destructive/10 hover:text-destructive/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <X className="h-2.5 w-2.5" aria-hidden />
+                </button>
+              ) : null}
+            </div>
+            <span className="inline-flex h-4 items-center gap-1 text-[10px] font-medium text-muted-foreground/55">
+              <span className="h-1 w-1 rounded-full bg-muted-foreground/45" aria-hidden />
               Queued
             </span>
-            {onSendQueuedNow ? (
-              <button
-                type="button"
-                aria-label="Send now"
-                title="Interrupt current work and send this message now — progress so far is kept"
-                onClick={() => onSendQueuedNow(queued.queuedId)}
-                className="flex items-center gap-0.5 rounded text-[10px] text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-              >
-                <CornerDownLeft className="h-3 w-3" aria-hidden />
-                Send now
-              </button>
-            ) : null}
-            {onCancelQueued ? (
-              <button
-                type="button"
-                aria-label="Cancel queued message"
-                onClick={() => onCancelQueued(queued.queuedId, item.text)}
-                className="flex items-center gap-0.5 rounded text-[10px] text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-              >
-                <X className="h-3 w-3" aria-hidden />
-                Cancel
-              </button>
-            ) : null}
           </div>
         ) : null}
       </div>

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -2274,10 +2274,12 @@ const handlers: Record<string, Handler> = {
       queuedId: string;
     };
     const q = chatQueues.get(threadId);
+    let removed = false;
     if (q) {
       const idx = q.findIndex((e) => e.queuedId === queuedId);
       if (idx >= 0) {
         q.splice(idx, 1);
+        removed = true;
         emitChatEvent(threadId, {
           type: "queued_turn_cancelled",
           thread_id: threadId,
@@ -2285,7 +2287,7 @@ const handlers: Record<string, Handler> = {
         });
       }
     }
-    return undefined;
+    return removed;
   },
   agent_chat_send_queued_turn_now: (a) => {
     const { threadId, queuedId } = a as {

--- a/src/lib/agent-chat/cursor-hydrate.test.ts
+++ b/src/lib/agent-chat/cursor-hydrate.test.ts
@@ -317,6 +317,46 @@ describe("cursor hydrate — path selection", () => {
     expect(transcript()).toEqual(["seed", "do the thing", "on it"]);
   });
 
+  it("promotes a queued bubble when hydrate replays its dispatched user row", async () => {
+    seedWarmSlice(10, "seed");
+    useAgentChatStore
+      .getState()
+      .appendUserMessage(THREAD, "queued follow-up", "nonce-queued");
+    useAgentChatStore.getState().applyEvent(THREAD, {
+      type: "turn_queued",
+      thread_id: THREAD,
+      queued_id: "q-1",
+      client_nonce: "nonce-queued",
+      text: "queued follow-up",
+    });
+    const before = useAgentChatStore.getState().threads[THREAD].messages.find(
+      (m) => m.kind === "user_message" && m.clientNonce === "nonce-queued",
+    );
+    expect(before?.kind === "user_message" ? before.queued : undefined).toEqual({
+      queuedId: "q-1",
+    });
+
+    // The pane was detached for dispatch, so only the durable user row and
+    // later assistant result are available; the dispatch event was lost.
+    const deps = deferredDeps(
+      [
+        userRow(11, "queued follow-up", "nonce-queued"),
+        row(12, assistantEvent("handled it", "turn-2")),
+      ],
+      12,
+    );
+    deps.release();
+    await hydrateThreadByCursor(THREAD, PROVIDER, () => false, deps.deps);
+
+    expect(transcript()).toEqual(["seed", "queued follow-up", "handled it"]);
+    const after = useAgentChatStore.getState().threads[THREAD].messages.find(
+      (m) => m.kind === "user_message" && m.clientNonce === "nonce-queued",
+    );
+    expect(
+      after?.kind === "user_message" ? after.queued : undefined,
+    ).toBeUndefined();
+  });
+
   it("applies a tail user_message that has no local bubble", async () => {
     // Same row, no optimistic bubble (another window sent it, or this
     // pane never saw the send) — it must render.

--- a/src/lib/agent-chat/reducer.test.ts
+++ b/src/lib/agent-chat/reducer.test.ts
@@ -1609,6 +1609,42 @@ describe("agent-chat reducer — follow-up queueing", () => {
     expect(list[0].created_at).toBe(5_000); // queue wait is not work time
   });
 
+  it("a persisted user row promotes a matching queued bubble after a missed dispatch event", () => {
+    let state = appendUserMessage(
+      createEmptyThreadState(),
+      "follow up",
+      () => 1_000,
+      "nonce-dispatched",
+    );
+    state = applyEvent(state, {
+      type: "turn_queued",
+      thread_id: "t1",
+      queued_id: "q-missed",
+      client_nonce: "nonce-dispatched",
+      text: "follow up",
+    });
+    const queuedSeq = users(state)[0].seq;
+
+    // `user_message` is durable at dispatch time. A remount can replay it
+    // without ever receiving the live-only `queued_turn_dispatched` event.
+    state = applyEvent(
+      state,
+      {
+        type: "user_message",
+        thread_id: "t1",
+        text: "follow up",
+        client_nonce: "nonce-dispatched",
+      },
+      () => 6_000,
+    );
+
+    const list = users(state);
+    expect(list).toHaveLength(1);
+    expect(list[0].queued).toBeUndefined();
+    expect(list[0].seq).toBeLessThan(queuedSeq);
+    expect(list[0].created_at).toBe(6_000);
+  });
+
   it("queued_turn_cancelled removes the greyed bubble", () => {
     let state = applyEvent(createEmptyThreadState(), {
       type: "turn_queued",

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -1081,6 +1081,37 @@ function findQueuedUserMessage(
   );
 }
 
+/** Promote a queued bubble into the normal transcript at dispatch time.
+ *
+ * The live `queued_turn_dispatched` event is not durable, but the
+ * `user_message` envelope written at the same boundary is. Both paths use
+ * this helper so a pane that missed the live event can still reconcile its
+ * warm queued bubble when it replays the persisted envelope. */
+function promoteQueuedUserMessage(
+  state: ChatThreadState,
+  index: number,
+  now: Clock,
+): ChatThreadState {
+  const existing = state.messages[index];
+  if (existing?.kind !== "user_message" || !existing.queued) return state;
+  const { seq, next } = takeSeq(state);
+  const { queued: _dropped, ...rest } = existing;
+  const promoted: UserMessageItem = {
+    ...rest,
+    seq,
+    // Queue wait is not agent work. Start the visible duration at the
+    // moment the follow-up actually becomes the active provider turn.
+    created_at: now(),
+  };
+  return {
+    ...next,
+    // A dispatched follow-up means a live turn is starting — clear any
+    // interrupted flag so the Continue chip / divider drop.
+    interrupted: false,
+    messages: replaceItem(next.messages, index, promoted),
+  };
+}
+
 /**
  * Local-only action: mark a permission request as "responding" so the
  * UI can render a pending state while the Tauri invoke is in flight.
@@ -1187,8 +1218,19 @@ function applyEventInner(
       // sender appended, on the greyed bubble `turn_queued` reconstructs,
       // and on this envelope — so whoever already has the turn on screen
       // skips it, and whoever does not inserts it in row order.
-      if (event.client_nonce && hasUserMessageNonce(state, event.client_nonce)) {
-        return state;
+      if (event.client_nonce) {
+        const existingIdx = state.messages.findIndex(
+          (m) =>
+            m.kind === "user_message" &&
+            m.clientNonce === event.client_nonce,
+        );
+        if (existingIdx >= 0) {
+          // A queued turn's user-message envelope is only persisted when
+          // that turn dispatches. Therefore a matching durable row is also
+          // an authoritative dispatch signal when the pane missed the
+          // live-only `queued_turn_dispatched` event while detached.
+          return promoteQueuedUserMessage(state, existingIdx, now);
+        }
       }
       // Persisted `images` carry absolute paths; the bubble's display
       // shape wants them under `src`, which `resolveAssetSrc` routes
@@ -1676,23 +1718,7 @@ function applyEventInner(
       // produced), not where it was typed.
       const idx = findQueuedUserMessage(state.messages, event.queued_id);
       if (idx < 0) return state;
-      const existing = state.messages[idx] as UserMessageItem;
-      const { seq, next } = takeSeq(state);
-      const { queued: _dropped, ...rest } = existing;
-      const promoted: UserMessageItem = {
-        ...rest,
-        seq,
-        // Queue wait is not agent work. Start the visible duration at the
-        // moment the follow-up actually becomes the active provider turn.
-        created_at: now(),
-      };
-      // A dispatched follow-up means a live turn is starting — clear any
-      // interrupted flag so the Continue chip / divider drop.
-      return {
-        ...next,
-        interrupted: false,
-        messages: replaceItem(next.messages, idx, promoted),
-      };
+      return promoteQueuedUserMessage(state, idx, now);
     }
 
     case "queued_turn_cancelled": {

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1508,15 +1508,16 @@ export const agentChatTurnActive = (
     threadId,
   });
 
-/** Cancel a queued (not-yet-dispatched) follow-up turn. On success the
- *  provider emits a `queued_turn_cancelled` event so the UI removes the
- *  greyed bubble. */
+/** Cancel a queued (not-yet-dispatched) follow-up turn. Returns whether the
+ *  provider actually removed it; a `false` result means it already
+ *  dispatched or otherwise no longer exists. A real cancellation emits a
+ *  `queued_turn_cancelled` event so the UI removes the greyed bubble. */
 export const agentChatCancelQueuedTurn = (
   provider: AgentChatProviderKind,
   threadId: string,
   queuedId: string,
 ) =>
-  invoke<void>("agent_chat_cancel_queued_turn", {
+  invoke<boolean>("agent_chat_cancel_queued_turn", {
     provider,
     threadId,
     queuedId,


### PR DESCRIPTION
## Problem

A follow-up could remain marked as queued after the provider had already dispatched and answered it when the pane missed the live dispatch event. Clicking Cancel in that stale state then restored an already-sent prompt into the composer.

## Fix

- Treat the persisted user-message row with the matching client nonce as a durable dispatch signal, clearing and repositioning the queued bubble even after a detached-pane race.
- Return whether cancellation actually removed an item across the Claude and Codex providers, and only restore the composer draft when it did.
- Align the queued state with a compact muted status and small hover/focus actions that do not shift its position.
- Cover live dispatch, cursor hydration, and stale-cancel behavior with focused frontend and adapter tests.

## Screenshots

| Before | After |
| --- | --- |
| ![Queued message before](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/fix-queued-message-indicator/before.png) | ![Queued message after](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/fix-queued-message-indicator/after.png) |

## Verification

- npm run check
- 210 focused Vitest tests across the reducer, cursor hydration, AgentChatPane, and UserMessage
- cargo check -j 2 --manifest-path src-tauri/Cargo.toml
- Focused Claude and Codex cancel-queued adapter tests
- Mocked Codemux browser reproduction before and after dispatch

Model: GPT-5.6-Sol · Harness: Codex