### PR TITLE
docs: drop the ports section from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,6 @@ Make Codemux performant, reliable, and easy to use. Do not preserve complexity j
 
 When `$CODEMUX` is set, use `codemux browser` instead of a system browser. For UI changes, run `npm run dev`, inspect `http://localhost:1420`, and capture visual evidence with `codemux browser screenshot`. The development server uses the Tauri mock; use `npm run tauri:dev` when real IPC is required. Stop the development server when finished. Run `codemux browser --help` to discover commands.
 
-## Ports
-
-Several worktrees of one project share the host network, so bringing up a stack on its default ports collides with whatever another worktree is already running. When you hit that, reach for `codemux ports allocate <name>` — it prints a free port reserved for this worktree, and the same name always returns the same port, so an ephemeral compose file or `.env` you write against it keeps working across restarts. No other worktree is ever handed that port. Use `codemux ports list` to see what this worktree owns and `codemux ports release <name>` when you are done with it. Reach for this instead of asking to stop another worktree's stack, and only put allocated ports in ephemeral files you created yourself — never rewrite the project's own compose or config files.
-
 ## Process Safety
 
 - Never kill processes by name or pattern; stop only processes you started.


### PR DESCRIPTION
## Problem

The `## Ports` section added with #273 documents `codemux ports` for agents that bring up docker stacks in parallel worktrees. Codemux has no compose stack of its own — development runs the vite dev server on 1420/1421 — so agents reading this file never encounter the collision it describes. At ~130 words it was the longest section in AGENTS.md, for the one scenario that cannot arise in this repo.

## Fix

Remove the section. The `codemux ports` CLI from #273 is unchanged and still available; the guidance for it belongs in the AGENTS.md of projects that actually run the stacks, where an agent would read it at the moment it matters.

Docs-only change; no code touched.