### PR TITLE
fix(chat): preserve composer focus after first send

### DIFF
--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -209,6 +209,7 @@ vi.mock("./Composer", () => ({
     provider,
     providerCliInstalled,
     providerAuthenticated,
+    focusOnMount,
   }: {
     zone1Override?: React.ReactNode;
     belowComposerSlot?: React.ReactNode;
@@ -223,12 +224,14 @@ vi.mock("./Composer", () => ({
     provider: "claude" | "codex" | "opencode";
     providerCliInstalled?: boolean | null;
     providerAuthenticated?: boolean | null;
+    focusOnMount?: boolean;
   }) => (
     <div
       data-testid="composer"
       data-provider={provider}
       data-provider-cli-installed={String(providerCliInstalled)}
       data-provider-authenticated={String(providerAuthenticated)}
+      data-focus-on-mount={focusOnMount ? "true" : "false"}
     >
       {/* The running-subagents strip is welded inside the real composer's
           top edge, so the mock has to render the slot for the pane's
@@ -662,6 +665,34 @@ describe("AgentChatPane empty-state branch", () => {
     expect(
       container.querySelector('[data-testid="home-landing"]'),
     ).toBeNull();
+  });
+
+  it("requests composer focus when a local first send swaps in the transcript", async () => {
+    currentMessages = [];
+    currentSliceOverrides = { "thread-x": { inputDraft: "hello" } };
+    const view = render(<AgentChatPane pane={pane} />);
+
+    fireEvent.click(
+      view.container.querySelector('[data-testid="composer-submit"]')!,
+    );
+    await waitFor(() => {
+      expect(
+        view.container.querySelector('[data-testid="composer"]'),
+      ).toHaveAttribute(
+        "data-focus-on-mount",
+        "true",
+      );
+    });
+
+    currentMessages = [{ kind: "user_message", id: "m1" }];
+    view.rerender(<AgentChatPane pane={pane} />);
+
+    expect(
+      view.container.querySelector('[data-testid="composer"]'),
+    ).toHaveAttribute(
+      "data-focus-on-mount",
+      "true",
+    );
   });
 });
 
@@ -1379,6 +1410,26 @@ describe("AgentChatPane Stage C race fix", () => {
     expect(transcript!.getAttribute("data-message-count")).toBe("1");
     // Critical: no duplicate session started.
     expect(agentChatStartSession).not.toHaveBeenCalled();
+  });
+
+  it("requests focus for the composer mounted from a promoted draft", () => {
+    currentDraftsById = {
+      "draft-1": {
+        draftId: "draft-1",
+        threadId: "draft-thread-42",
+        promotedTo: { workspaceId: "ws-home", paneId: "pane-new" },
+      },
+    };
+    currentThreadsMap = {
+      "draft-thread-42": [{ kind: "user_message", id: "m1", text: "hello" }],
+    };
+
+    const { container } = render(<AgentChatPane pane={paneNoThread} />);
+
+    expect(container.querySelector('[data-testid="composer"]')).toHaveAttribute(
+      "data-focus-on-mount",
+      "true",
+    );
   });
 
   it("starts a fresh session when pane.thread_id is null AND no promoted draft claims this workspace", () => {

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -345,6 +345,20 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     );
     return match?.threadId ?? null;
   });
+  // Promotion metadata intentionally survives for a short cleanup window,
+  // but focus handoff is a one-shot concern. Consume the signal after the
+  // replacement Composer has had its mount effect; otherwise an unrelated
+  // remount during that grace period could steal focus later.
+  const promotionFocusConsumedRef = useRef(false);
+  const focusComposerAfterPromotion =
+    promotedDraftThreadId !== null &&
+    threadId === promotedDraftThreadId &&
+    !promotionFocusConsumedRef.current;
+  useEffect(() => {
+    if (focusComposerAfterPromotion) {
+      promotionFocusConsumedRef.current = true;
+    }
+  }, [focusComposerAfterPromotion]);
   // Recovery fallback: if materialize made it past pane-creation but
   // failed during start_session / send_turn, the draft has
   // `materializedTo` set and `promotedTo` still null. The existing
@@ -2924,6 +2938,12 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       // An empty pane reads as a new chat: "Describe what you want the
       // agent to do…" until the first turn lands (design D10 copy).
       isDraft={messages.length === 0}
+      // A local first send replaces ChatHomeLanding with the transcript;
+      // a promoted lazy draft replaces DraftChatSurface with this pane.
+      // Both swaps create a new textarea, so explicitly carry keyboard
+      // focus across them. Existing-thread mounts have neither signal and
+      // therefore do not steal focus.
+      focusOnMount={isSending || focusComposerAfterPromotion}
       // In a subagent drill-in the composer stays parent-bound; only the
       // placeholder changes to make that explicit (design copy).
       placeholderOverride={

--- a/src/components/chat/Composer.test.tsx
+++ b/src/components/chat/Composer.test.tsx
@@ -76,6 +76,24 @@ function renderComposer(props: Partial<ComposerProps> = {}) {
 }
 
 describe("Composer", () => {
+  describe("focus handoff", () => {
+    it("focuses the textarea when a layout transition requests it", () => {
+      const { container } = renderComposer({ focusOnMount: true });
+      expect(document.activeElement).toBe(container.querySelector("textarea"));
+    });
+
+    it("does not steal focus on a normal mount", () => {
+      const outside = document.createElement("button");
+      document.body.appendChild(outside);
+      outside.focus();
+
+      renderComposer();
+
+      expect(document.activeElement).toBe(outside);
+      outside.remove();
+    });
+  });
+
   describe("error banner (§8)", () => {
     it("renders the banner when errorMessage is set", () => {
       const { getByRole } = renderComposer({

--- a/src/components/chat/Composer.tsx
+++ b/src/components/chat/Composer.tsx
@@ -149,6 +149,10 @@ interface Props {
    *  steer the agent…" (design D10). Mode-specific placeholders
    *  (plan/ask/debug) are unaffected. Defaults to false. */
   isDraft?: boolean;
+  /** Reclaim keyboard focus when this composer is mounted as part of a
+   *  first-send layout transition. Opt-in so opening an existing pane does
+   *  not steal focus from another control. */
+  focusOnMount?: boolean;
   /** When set, overrides the computed textarea placeholder entirely.
    *  Used by the subagent drill-in to swap in "Steering goes to the
    *  orchestrator…" while the composer stays parent-bound. */
@@ -311,6 +315,7 @@ export function Composer({
   sessionReady,
   showProviderPicker,
   isDraft = false,
+  focusOnMount = false,
   placeholderOverride,
   mode,
   errorMessage = null,
@@ -366,6 +371,16 @@ export function Composer({
   // input's onChange forwards each picked File to onAttachImage.
   // Kept hidden so the visible affordance stays the popup row.
   const imageInputRef = useRef<HTMLInputElement | null>(null);
+
+  // The first send moves the composer between distinct layout branches
+  // (empty-state -> transcript, and draft -> live pane), which replaces the
+  // textarea DOM node. Restore the caret on the replacement without allowing
+  // the browser to scroll the newly bottom-docked composer out of position.
+  // This is deliberately opt-in: a normal pane mount must not steal focus.
+  useEffect(() => {
+    if (!focusOnMount) return;
+    textareaRef.current?.focus({ preventScroll: true });
+  }, [focusOnMount]);
 
   // Auto-grow textarea from the resting min up to ~10 rows.
   useEffect(() => {

--- a/src/components/chat/DraftChatSurface.test.tsx
+++ b/src/components/chat/DraftChatSurface.test.tsx
@@ -742,6 +742,29 @@ describe("DraftChatSurface", () => {
         ).toEqual([]);
       }
     });
+
+    it("keeps the textarea focused when the first send docks the composer", async () => {
+      vi.mocked(materializeAndSend).mockImplementation(
+        () => new Promise(() => {}),
+      );
+      seedProjectDraft();
+      const { container, getByRole } = renderSurface();
+      const centeredTextarea = container.querySelector(
+        "textarea",
+      ) as HTMLTextAreaElement;
+      centeredTextarea.focus();
+
+      fireEvent.keyDown(centeredTextarea, { key: "Enter" });
+
+      await vi.waitFor(() => {
+        expect(getByRole("status", { name: "Starting the agent" })).toBeTruthy();
+      });
+      const dockedTextarea = container.querySelector(
+        "textarea",
+      ) as HTMLTextAreaElement;
+      expect(dockedTextarea).not.toBe(centeredTextarea);
+      expect(document.activeElement).toBe(dockedTextarea);
+    });
   });
 
   describe("config handlers", () => {

--- a/src/components/chat/DraftChatSurface.tsx
+++ b/src/components/chat/DraftChatSurface.tsx
@@ -277,6 +277,12 @@ function DraftChatSurfaceInner({ draft }: { draft: ChatDraft }) {
   // multi-second workspace/session bring-up. Cleared on failure (restore
   // composer); on success the surface unmounts as the live pane flips in.
   const [pending, setPending] = useState<DraftPendingState | null>(null);
+  // Once this surface has accepted a first send, every composer replacement
+  // in the handoff (centered -> docked, or docked -> retry after failure)
+  // should reclaim the caret. This state dies with the draft surface, so it
+  // cannot make an unrelated chat steal focus later.
+  const [focusComposerAfterSubmit, setFocusComposerAfterSubmit] =
+    useState(false);
 
   // Warm the MCP servers as soon as the draft mounts so the up-front
   // prime cost overlaps the user composing, instead of blocking the
@@ -350,6 +356,7 @@ function DraftChatSurfaceInner({ draft }: { draft: ChatDraft }) {
     }
 
     sendInFlightRef.current = true;
+    setFocusComposerAfterSubmit(true);
     const chat = useAgentChatStore.getState();
     // Resolve any `/skill-name` tokens in the draft text against the
     // skills registry. Same parser the live pane uses; bodies are
@@ -992,6 +999,7 @@ function DraftChatSurfaceInner({ draft }: { draft: ChatDraft }) {
       sessionReady={true}
       // No live session yet — drives the draft-variant placeholder copy.
       isDraft={true}
+      focusOnMount={focusComposerAfterSubmit}
       placeholderOverride={placeholderOverride}
       showProviderPicker={true}
       showStopButton={false}


### PR DESCRIPTION
The first prompt in a new chat replaces the centered composer with a bottom-docked composer, then may replace the draft surface with the live pane. Those DOM handoffs dropped textarea focus and forced users to click the composer before typing a follow-up.

This adds an opt-in focus handoff to the shared composer and carries that intent through the draft pending state, the empty-thread transcript transition, and the promoted live pane. The promotion signal is consumed once so ordinary pane mounts and later remounts do not steal focus.

### Before / after

- Before: after the first send, typing went nowhere until the composer was clicked again.
- After: the replacement composer retains keyboard focus and accepts the next prompt immediately.
- Visual layout and styling are unchanged, so screenshots are visually identical; the change is covered with active-element and transition regression tests.

### Verification

- `npm run test -- src/components/chat/Composer.test.tsx src/components/chat/DraftChatSurface.test.tsx src/components/chat/AgentChatPane.test.tsx` (168 passed)
- `npm run check`
- `git diff --check`

Implemented with GPT-5 using the Codex harness.