### PR TITLE
fix(sidebar): align settled PR details

### DIFF
--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -1552,13 +1552,27 @@ describe("SidebarInbox — settle / un-settle", () => {
       .getByText("Implement sidebar v2")
       .closest("[data-settled-row]") as HTMLElement;
     expect(row).not.toBeNull();
+    // The grid tracks are the row's only column widths — 56px fits a 4-digit
+    // ref like `#1234`, 64px fits the hover-revealed Un-settle button. The
+    // slots themselves must not restate either number, or the two copies drift.
     expect(row.className).toContain(
-      "grid-cols-[auto_minmax(0,1fr)_52px_48px]",
+      "grid-cols-[auto_minmax(0,1fr)_56px_64px]",
     );
-    expect(row.querySelector("[data-settled-pr-slot]")).toHaveClass(
-      "w-[52px]",
-    );
-    expect(row.querySelector("[data-settled-meta-slot]")).toHaveClass("w-12");
+    const prSlot = row.querySelector("[data-settled-pr-slot]") as HTMLElement;
+    const metaSlot = row.querySelector(
+      "[data-settled-meta-slot]",
+    ) as HTMLElement;
+    expect(prSlot.className).not.toMatch(/(^|\s)w-/);
+    expect(metaSlot.className).not.toMatch(/(^|\s)w-/);
+    // The hover-revealed Un-settle button is bounded by that meta column —
+    // it fills the slot and the slot clips — so it can never sit on top of the
+    // PR badge and take clicks meant for it.
+    const unsettle = within(row).getByRole("button", {
+      name: 'Un-settle "Implement sidebar v2"',
+    });
+    expect(unsettle.parentElement).toBe(metaSlot);
+    expect(unsettle).toHaveClass("absolute", "inset-0");
+    expect(metaSlot).toHaveClass("overflow-hidden");
     // In a slim settled-history row, the PR remains visible and directly
     // reachable instead of degrading to an unlabeled merge glyph. Its fixed
     // slot makes the PR and age columns line up across the whole shelf.

--- a/src/components/layout/sidebar-inbox.test.tsx
+++ b/src/components/layout/sidebar-inbox.test.tsx
@@ -1552,8 +1552,16 @@ describe("SidebarInbox — settle / un-settle", () => {
       .getByText("Implement sidebar v2")
       .closest("[data-settled-row]") as HTMLElement;
     expect(row).not.toBeNull();
+    expect(row.className).toContain(
+      "grid-cols-[auto_minmax(0,1fr)_52px_48px]",
+    );
+    expect(row.querySelector("[data-settled-pr-slot]")).toHaveClass(
+      "w-[52px]",
+    );
+    expect(row.querySelector("[data-settled-meta-slot]")).toHaveClass("w-12");
     // In a slim settled-history row, the PR remains visible and directly
-    // reachable instead of degrading to an unlabeled merge glyph.
+    // reachable instead of degrading to an unlabeled merge glyph. Its fixed
+    // slot makes the PR and age columns line up across the whole shelf.
     const pr = within(row).getByRole("button", {
       name: "Open PR #203 on GitHub — merged",
     });

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -572,7 +572,16 @@ const SettledRow = memo(function SettledRow({
         activateFromSidebar(workspace.workspace_id);
       }}
       className={cn(
-        "group/settled grid h-[30px] cursor-pointer grid-cols-[auto_minmax(0,1fr)_52px_48px] items-center gap-2 rounded-lg px-2",
+        // The four tracks are the single source of truth for this row's
+        // columns — avatar, title, PR, meta — and the slots below deliberately
+        // carry no widths of their own. Both fixed tracks are measured, not
+        // guessed: the PR badge is `px-1` (8px) + a 12px icon + a 4px gap + a
+        // 10px JetBrains Mono ref, which is 6px per glyph, so `#1234` needs
+        // 54px and 56px leaves it a hair of slack. The meta track holds the
+        // hover-revealed Un-settle button (62.7px at 10.5px DM Sans semibold
+        // with its 10px glyph and gap), so 64px keeps that control inside its
+        // own column instead of reaching left across the PR badge's hit area.
+        "group/settled grid h-[30px] cursor-pointer grid-cols-[auto_minmax(0,1fr)_56px_64px] items-center gap-2 rounded-lg px-2",
         // Same off-screen containment as the cards (see `SidebarInboxCard`):
         // the Settled shelf is the list that actually grows without bound, and
         // paging only limits what is *rendered*, not what the forced-visible
@@ -601,7 +610,7 @@ const SettledRow = memo(function SettledRow({
       />
       <span
         className={cn(
-          "min-w-0 flex-1 truncate text-xs font-medium transition-colors duration-150",
+          "min-w-0 truncate text-xs font-medium transition-colors duration-150",
           dimmed
             ? "text-muted-foreground/60 group-hover/settled:text-foreground group-focus-within/settled:text-foreground"
             : "text-foreground",
@@ -612,11 +621,10 @@ const SettledRow = memo(function SettledRow({
       {/* Every settled row reserves the same PR column, including rows without
           one. Together with the fixed age/action column below, this keeps the
           historical shelf on one quiet vertical rhythm instead of letting
-          variable title, PR-number and elapsed-label widths nudge each other. */}
-      <div
-        data-settled-pr-slot
-        className="flex h-5 w-[52px] min-w-0 items-center"
-      >
+          variable title, PR-number and elapsed-label widths nudge each other.
+          The slot takes its width from the grid track above and states none of
+          its own — two places to edit is how a column drifts. */}
+      <div data-settled-pr-slot className="flex h-5 min-w-0 items-center">
         {prState && (
           <button
             type="button"
@@ -670,9 +678,15 @@ const SettledRow = memo(function SettledRow({
           </button>
         )}
       </div>
+      {/* Age and Un-settle share one cell: the age is what the row says at
+          rest, the button is what it says under the cursor, and stacking them
+          means the swap costs no reflow. `overflow-hidden` is the guarantee
+          that goes with that — whatever the label measures, it is clipped at
+          this column's edge rather than allowed to reach left and swallow
+          clicks meant for the PR badge. Width comes from the grid track. */}
       <div
         data-settled-meta-slot
-        className="relative h-5 w-12 justify-self-end whitespace-nowrap"
+        className="relative h-5 overflow-hidden whitespace-nowrap"
       >
         {time && (
           <span className="absolute inset-y-0 right-0 flex items-center font-mono text-[11px] tabular-nums text-muted-foreground/70 group-hover/settled:hidden group-focus-within/settled:hidden">
@@ -693,7 +707,10 @@ const SettledRow = memo(function SettledRow({
             // row's own affordance. The word stays — this is the one control on
             // the shelf that changes a lifecycle, and an undo arrow alone is too
             // close to "go back" to be trusted with it.
-            "absolute inset-y-0 right-0 hidden items-center gap-1 border-none bg-transparent p-0",
+            // Filling the slot (`inset-0`, right-aligned content) makes the
+            // control's hit area exactly its own column — never a pixel of it
+            // over the PR badge next door.
+            "absolute inset-0 hidden items-center justify-end gap-1 border-none bg-transparent p-0",
             "text-[10.5px] font-semibold text-muted-foreground transition-colors duration-150",
             "hover:text-foreground",
             "group-hover/settled:inline-flex group-focus-within/settled:inline-flex",
@@ -810,9 +827,13 @@ const SnoozeRow = memo(function SnoozeRow({
         <span className="min-w-0 flex-1 truncate text-xs font-medium text-muted-foreground">
           {workspace.title}
         </span>
+        {/* Same face as a settled row's age (`font-mono tabular-nums`): the two
+            shelves sit directly on top of each other, and a proportional "3h"
+            beside a mono one is exactly the kind of half-match the eye reads as
+            a mistake. */}
         <span
           aria-label={`Wakes in ${timeUntil}`}
-          className="shrink-0 text-[11px] tabular-nums text-muted-foreground/70 group-hover/snoozed:hidden group-focus-within/snoozed:hidden"
+          className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground/70 group-hover/snoozed:hidden group-focus-within/snoozed:hidden"
         >
           {timeUntil}
         </span>

--- a/src/components/layout/sidebar-inbox.tsx
+++ b/src/components/layout/sidebar-inbox.tsx
@@ -572,7 +572,7 @@ const SettledRow = memo(function SettledRow({
         activateFromSidebar(workspace.workspace_id);
       }}
       className={cn(
-        "group/settled flex h-[30px] cursor-pointer items-center gap-2 rounded-lg px-2",
+        "group/settled grid h-[30px] cursor-pointer grid-cols-[auto_minmax(0,1fr)_52px_48px] items-center gap-2 rounded-lg px-2",
         // Same off-screen containment as the cards (see `SidebarInboxCard`):
         // the Settled shelf is the list that actually grows without bound, and
         // paging only limits what is *rendered*, not what the forced-visible
@@ -609,77 +609,100 @@ const SettledRow = memo(function SettledRow({
       >
         {workspace.title}
       </span>
-      {prState && (
+      {/* Every settled row reserves the same PR column, including rows without
+          one. Together with the fixed age/action column below, this keeps the
+          historical shelf on one quiet vertical rhythm instead of letting
+          variable title, PR-number and elapsed-label widths nudge each other. */}
+      <div
+        data-settled-pr-slot
+        className="flex h-5 w-[52px] min-w-0 items-center"
+      >
+        {prState && (
+          <button
+            type="button"
+            onClick={handlePrClick}
+            disabled={!workspace.pr_url}
+            aria-label={
+              workspace.pr_number
+                ? workspace.pr_url
+                  ? `Open ${providerRefLabel(provider, workspace.pr_number)} on ${provider.name} — ${prState}`
+                  : `${providerRefLabel(provider, workspace.pr_number)} — ${prState}`
+                : `${provider.nounTitle} — ${prState}`
+            }
+            className={cn(
+              "inline-flex h-5 min-w-0 items-center gap-1 whitespace-nowrap rounded px-1 font-mono text-[10px] font-medium",
+              "transition-colors duration-150",
+              // Held one step brighter than the avatar's /40: `#87` is this
+              // control's only label, so the badge has to stay legible at rest
+              // even though it has given its state color up. The row still
+              // reads as one grey block — the difference is a shade, not a
+              // second focal point.
+              dimmed
+                ? cn(
+                    "text-muted-foreground/55",
+                    prStatusSettledHoverClass(prState),
+                  )
+                : prStatusTextClass(prState),
+              workspace.pr_url
+                ? "hover:bg-foreground/[0.055]"
+                : "cursor-default opacity-65",
+            )}
+          >
+            {/* `text-current` hands the icon's color to the button above, so
+                the badge's icon and number light up together on hover instead
+                of the icon staying colored while the number is grey. It works
+                because `PrStatusIcon` runs its own `STATE_TO_ICON` color through
+                `cn()` *before* this className: tailwind-merge is caller-wins
+                within a conflicting group, so the later `text-current` drops the
+                built-in `text-status-open`/etc. Swap that argument order inside
+                the icon and this badge silently goes back to a colored glyph on
+                a grey number — there is a test pinning it. */}
+            <PrStatusIcon
+              state={prState}
+              size={3}
+              className="shrink-0 text-current"
+            />
+            {workspace.pr_number != null && (
+              <span className="truncate">
+                {providerRef(provider, workspace.pr_number)}
+              </span>
+            )}
+          </button>
+        )}
+      </div>
+      <div
+        data-settled-meta-slot
+        className="relative h-5 w-12 justify-self-end whitespace-nowrap"
+      >
+        {time && (
+          <span className="absolute inset-y-0 right-0 flex items-center font-mono text-[11px] tabular-nums text-muted-foreground/70 group-hover/settled:hidden group-focus-within/settled:hidden">
+            {time}
+          </span>
+        )}
         <button
           type="button"
-          onClick={handlePrClick}
-          disabled={!workspace.pr_url}
-          aria-label={
-            workspace.pr_number
-              ? workspace.pr_url
-                ? `Open ${providerRefLabel(provider, workspace.pr_number)} on ${provider.name} — ${prState}`
-                : `${providerRefLabel(provider, workspace.pr_number)} — ${prState}`
-              : `${provider.nounTitle} — ${prState}`
-          }
+          onClick={(e) => {
+            e.stopPropagation();
+            onUnsettle(workspace.workspace_id);
+          }}
+          aria-label={`Un-settle "${workspace.title}"`}
           className={cn(
-            "inline-flex h-5 shrink-0 items-center gap-1 rounded px-1 font-mono text-[10px] font-medium",
-            "transition-colors duration-150",
-            // Held one step brighter than the avatar's /40: `#87` is this
-            // control's only label, so the badge has to stay legible at rest
-            // even though it has given its state color up. The row still
-            // reads as one grey block — the difference is a shade, not a
-            // second focal point.
-            dimmed
-              ? cn("text-muted-foreground/55", prStatusSettledHoverClass(prState))
-              : prStatusTextClass(prState),
-            workspace.pr_url
-              ? "hover:bg-foreground/[0.055]"
-              : "cursor-default opacity-65",
+            // Borderless, matching the cards' action cluster: a settled row is
+            // 30px tall and mostly negative space, and a bordered pill inside it
+            // read as a second object competing with the row rather than as the
+            // row's own affordance. The word stays — this is the one control on
+            // the shelf that changes a lifecycle, and an undo arrow alone is too
+            // close to "go back" to be trusted with it.
+            "absolute inset-y-0 right-0 hidden items-center gap-1 border-none bg-transparent p-0",
+            "text-[10.5px] font-semibold text-muted-foreground transition-colors duration-150",
+            "hover:text-foreground",
+            "group-hover/settled:inline-flex group-focus-within/settled:inline-flex",
           )}
         >
-          {/* `text-current` hands the icon's color to the button above, so
-              the badge's icon and number light up together on hover instead
-              of the icon staying colored while the number is grey. It works
-              because `PrStatusIcon` runs its own `STATE_TO_ICON` color through
-              `cn()` *before* this className: tailwind-merge is caller-wins
-              within a conflicting group, so the later `text-current` drops the
-              built-in `text-status-open`/etc. Swap that argument order inside
-              the icon and this badge silently goes back to a colored glyph on
-              a grey number — there is a test pinning it. */}
-          <PrStatusIcon state={prState} size={3} className="shrink-0 text-current" />
-          {workspace.pr_number != null && (
-            <span>{providerRef(provider, workspace.pr_number)}</span>
-          )}
+          <Undo2 className="size-2.5" strokeWidth={1.7} />
+          Un-settle
         </button>
-      )}
-      {time && (
-        <span className="shrink-0 text-[11px] text-muted-foreground/70 group-hover/settled:hidden group-focus-within/settled:hidden">
-          {time}
-        </span>
-      )}
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onUnsettle(workspace.workspace_id);
-        }}
-        aria-label={`Un-settle "${workspace.title}"`}
-        className={cn(
-          // Borderless, matching the cards' action cluster: a settled row is
-          // 30px tall and mostly negative space, and a bordered pill inside it
-          // read as a second object competing with the row rather than as the
-          // row's own affordance. The word stays — this is the one control on
-          // the shelf that changes a lifecycle, and an undo arrow alone is too
-          // close to "go back" to be trusted with it.
-          "hidden shrink-0 items-center gap-1 border-none bg-transparent p-0",
-          "text-[10.5px] font-semibold text-muted-foreground transition-colors duration-150",
-          "hover:text-foreground",
-          "group-hover/settled:inline-flex group-focus-within/settled:inline-flex",
-        )}
-      >
-        <Undo2 className="size-2.5" strokeWidth={1.7} />
-        Un-settle
-      </button>
+      </div>
     </div>
     </WorkspaceHoverCard>
     </div>


### PR DESCRIPTION
Settled workspace rows let each title, pull-request reference, and elapsed label size itself independently, so PR details drift horizontally and the history shelf is harder to scan.

This gives settled rows stable title, PR, and elapsed-time columns. Long titles truncate within the available space, GitHub and GitLab references stay directly actionable, timestamps remain right-aligned without moving the PR column, and the hover-revealed Un-settle action uses the same trailing slot without causing layout shift.

## Visual comparison

| Before | After |
| --- | --- |
| ![Before: settled PR references drift across rows](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/sidebar-pr-single-line/before.png) | ![After: settled PR references and timestamps align in stable columns](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/sidebar-pr-single-line/after.png) |

## Verification

- `npm run check`
- `npm run test -- src/components/layout/sidebar-inbox.test.tsx` (118 tests)
- Browser-verified at the standard sidebar width with varied title lengths, GitHub/GitLab references, missing PRs, and elapsed labels through `30d23h`

Model: GPT-5.6-Sol · Harness: Codex
