### PR TITLE
feat(release): deploy hosted web client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,3 +349,114 @@ jobs:
           # — Authenticode is what Windows SmartScreen checks on install,
           # Ed25519 is what the Tauri auto-updater checks before applying
           # an update.
+
+  hosted-web:
+    name: hosted web release asset
+    # Wait for both desktop matrix legs so this job never races tauri-action
+    # while it is creating or updating the GitHub release. `!cancelled()` is
+    # deliberate: Windows is best-effort, so a Windows-only failure must not
+    # prevent a successful Linux release from getting its hosted client.
+    needs: release
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Verify the Linux release is published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          assets="$(gh release view "$GITHUB_REF_NAME" --json assets --jq '.assets[].name')"
+          for pattern in '\.AppImage$' '\.deb$' '\.rpm$'; do
+            if ! grep -qE "$pattern" <<<"$assets"; then
+              echo "::error::Refusing to publish the hosted client: the Linux release is missing an asset matching $pattern"
+              exit 1
+            fi
+          done
+
+      - name: Install WASM system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends clang binaryen
+
+      - name: Setup Rust with wasm target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: iroh-wasm -> target
+          key: hosted-web-wasm32-unknown-unknown
+
+      - name: Cache wasm-bindgen CLI
+        uses: actions/cache@v4
+        with:
+          path: iroh-wasm/.tools
+          key: wasm-bindgen-cli-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('iroh-wasm/Cargo.toml') }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build hosted client
+        env:
+          CODEMUX_IROH_WASM_VERSION: ${{ github.ref_name }}
+          VITE_CODEMUX_RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          npm run build:iroh-wasm
+          npm run build
+
+      - name: Package and verify hosted client
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test -s dist/index.html
+          test -s "dist/iroh-wasm/$GITHUB_REF_NAME/iroh_wasm.js"
+          test -s "dist/iroh-wasm/$GITHUB_REF_NAME/iroh_wasm_bg.wasm"
+          test "$(od -An -tx1 -N4 "dist/iroh-wasm/$GITHUB_REF_NAME/iroh_wasm_bg.wasm" | tr -d '[:space:]')" = "0061736d"
+          wasm_loader_asset="$(grep -Rl '/iroh-wasm' dist/assets | sed -n '1p')"
+          test -n "$wasm_loader_asset"
+          grep -Fq "$GITHUB_REF_NAME" "$wasm_loader_asset"
+
+          version="${GITHUB_REF_NAME#v}"
+          archive="codemux-web-${version}.tar.gz"
+          mkdir -p release-assets
+          tar -C dist -czf "release-assets/$archive" .
+          (cd release-assets && sha256sum "$archive" > "$archive.sha256")
+
+          tar -tzf "release-assets/$archive" > release-assets/archive-contents.txt
+          grep -qE '^(\./)?index\.html$' release-assets/archive-contents.txt
+          grep -qE '^(\./)?assets/.+\.js$' release-assets/archive-contents.txt
+          grep -qE "^(\\./)?iroh-wasm/$GITHUB_REF_NAME/iroh_wasm\\.js$" release-assets/archive-contents.txt
+          grep -qE "^(\\./)?iroh-wasm/$GITHUB_REF_NAME/iroh_wasm_bg\\.wasm$" release-assets/archive-contents.txt
+
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+
+      - name: Upload hosted client to the GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARCHIVE: ${{ steps.package.outputs.archive }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release upload "$GITHUB_REF_NAME" \
+            "release-assets/$ARCHIVE" \
+            "release-assets/$ARCHIVE.sha256" \
+            --clobber

--- a/scripts/build-iroh-wasm.sh
+++ b/scripts/build-iroh-wasm.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Build the browser (WASM) iroh relay client and stage the generated web-target
 # glue + wasm into public/iroh-wasm/ so `vite build` copies it to the deploy
-# root (served at /iroh-wasm/…). The artifact is multi-MB and gitignored; the
+# root (served at /iroh-wasm/…). Release builds set CODEMUX_IROH_WASM_VERSION
+# to stage under a versioned subdirectory, keeping older browser tabs isolated
+# from later wasm-bindgen output. The artifact is multi-MB and gitignored; the
 # main build stays green without it (relay mode degrades to "build the wasm",
 # the LAN/mesh WebSocket path is the default). Mirrors how the repo treats the
 # bundled agent sidecar: a build script produces a bundled binary, not committed.
@@ -17,7 +19,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CRATE_DIR="$REPO_ROOT/iroh-wasm"
-OUT_DIR="$REPO_ROOT/public/iroh-wasm"
+OUT_ROOT="$REPO_ROOT/public/iroh-wasm"
 TOOLS_DIR="$CRATE_DIR/.tools"
 TARGET="wasm32-unknown-unknown"
 
@@ -33,6 +35,16 @@ WASM_BINDGEN_VERSION="$(
 log "wasm-bindgen version: $WASM_BINDGEN_VERSION"
 
 command -v cargo >/dev/null 2>&1 || die "cargo not found — install Rust."
+
+IROH_WASM_VERSION="${CODEMUX_IROH_WASM_VERSION:-}"
+if [ -n "$IROH_WASM_VERSION" ]; then
+  if [[ ! "$IROH_WASM_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+    die "CODEMUX_IROH_WASM_VERSION must be a v-prefixed semantic version"
+  fi
+  OUT_DIR="$OUT_ROOT/$IROH_WASM_VERSION"
+else
+  OUT_DIR="$OUT_ROOT"
+fi
 
 # ── 1. wasm target ──────────────────────────────────────────────────
 if ! rustc --print target-list 2>/dev/null | grep -qx "$TARGET"; then
@@ -71,13 +83,13 @@ fi
 # the crates' `wasm_js` features in Cargo.toml); 0.2 uses its `js` feature.
 export RUSTFLAGS="${RUSTFLAGS:-} --cfg getrandom_backend=\"wasm_js\""
 log "compiling (release, opt-level=z) for $TARGET"
-(cd "$CRATE_DIR" && cargo build --release --target "$TARGET")
+(cd "$CRATE_DIR" && cargo build --locked --release --target "$TARGET")
 
 WASM_IN="$CRATE_DIR/target/$TARGET/release/iroh_wasm.wasm"
 [ -f "$WASM_IN" ] || die "expected wasm at $WASM_IN not found"
 
 # ── 4. generate the web-target JS glue + bindings ───────────────────
-rm -rf "$OUT_DIR"
+rm -rf "$OUT_ROOT"
 mkdir -p "$OUT_DIR"
 log "running wasm-bindgen (--target web) → $OUT_DIR"
 "$WASM_BINDGEN" \
@@ -91,7 +103,8 @@ log "running wasm-bindgen (--target web) → $OUT_DIR"
 WASM_OUT="$OUT_DIR/iroh_wasm_bg.wasm"
 if command -v wasm-opt >/dev/null 2>&1; then
   log "wasm-opt -Oz"
-  wasm-opt -Oz --strip-debug "$WASM_OUT" -o "$WASM_OUT.opt" && mv "$WASM_OUT.opt" "$WASM_OUT"
+  wasm-opt --all-features -Oz --strip-debug "$WASM_OUT" -o "$WASM_OUT.opt" &&
+    mv "$WASM_OUT.opt" "$WASM_OUT"
 else
   log "wasm-opt not found — skipping (install binaryen for a smaller artifact)"
 fi

--- a/scripts/deploy-app-codemux.sh
+++ b/scripts/deploy-app-codemux.sh
@@ -13,6 +13,7 @@ LATEST_RELEASE_URL="${CODEMUX_DEPLOY_LATEST_URL:-https://github.com/Zeus-Deus/co
 DOWNLOAD_BASE_URL="${CODEMUX_DEPLOY_DOWNLOAD_BASE_URL:-https://github.com/Zeus-Deus/codemux/releases/download}"
 PUBLIC_URL="${CODEMUX_DEPLOY_PUBLIC_URL:-https://app.codemux.org}"
 API_HEALTH_URL="${CODEMUX_DEPLOY_API_HEALTH_URL:-https://api.codemux.org/health}"
+BACKUP_KEEP="${CODEMUX_DEPLOY_BACKUP_KEEP:-5}"
 DRY_RUN=false
 REQUESTED_TAG="${CODEMUX_DEPLOY_RELEASE_TAG:-}"
 
@@ -44,6 +45,8 @@ case "$APP_DIR" in
 esac
 [ "$APP_DIR" != "/" ] || { echo "ERROR: refusing to use / as the app directory" >&2; exit 1; }
 [ -d "$HTML_DIR" ] || { echo "ERROR: hosted client directory not found: $HTML_DIR" >&2; exit 1; }
+[[ "$BACKUP_KEEP" =~ ^[1-9][0-9]*$ ]] ||
+  { echo "ERROR: backup retention must be a positive integer: $BACKUP_KEEP" >&2; exit 1; }
 
 log() {
   local line
@@ -92,9 +95,7 @@ trap cleanup EXIT
 
 if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 300 \
   "$release_url/$archive" -o "$work_dir/$archive" 2>/dev/null; then
-  if $DRY_RUN; then
-    log "hosted client asset is not available for $tag yet"
-  fi
+  log "hosted client asset is not available for $tag yet"
   exit 0
 fi
 if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 30 \
@@ -178,6 +179,14 @@ backup="$BACKUP_DIR/html-before-${tag}-${timestamp}.tar.gz"
 backup_tmp="$backup.tmp"
 tar -C "$APP_DIR" -czf "$backup_tmp" html
 mv -f "$backup_tmp" "$backup"
+
+# Keep only the most recent backups; a repeatedly failing deploy would
+# otherwise write a full copy of the tree on every poll.
+while IFS= read -r stale_backup; do
+  case "$stale_backup" in
+    "$BACKUP_DIR"/html-before-*.tar.gz) rm -f -- "$stale_backup" ;;
+  esac
+done < <(ls -1t "$BACKUP_DIR"/html-before-*.tar.gz 2>/dev/null | tail -n "+$((BACKUP_KEEP + 1))")
 
 # Copy immutable/versioned files first and retain previous generations. The
 # entry point is promoted last with a same-filesystem rename, so a page load

--- a/scripts/deploy-app-codemux.sh
+++ b/scripts/deploy-app-codemux.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# Pull and deploy the hosted Codemux client from the latest GitHub release.
+# Intended for /home/work/app-codemux/deploy-pull.sh on the production VPS.
+set -euo pipefail
+
+APP_DIR="${CODEMUX_DEPLOY_APP_DIR:-/home/work/app-codemux}"
+HTML_DIR="$APP_DIR/html"
+BACKUP_DIR="$APP_DIR/backups"
+STATE_FILE="$APP_DIR/deployed-release"
+LOG_FILE="$APP_DIR/deploy.log"
+LOCK_FILE="$APP_DIR/deploy.lock"
+LATEST_RELEASE_URL="${CODEMUX_DEPLOY_LATEST_URL:-https://github.com/Zeus-Deus/codemux/releases/latest}"
+DOWNLOAD_BASE_URL="${CODEMUX_DEPLOY_DOWNLOAD_BASE_URL:-https://github.com/Zeus-Deus/codemux/releases/download}"
+PUBLIC_URL="${CODEMUX_DEPLOY_PUBLIC_URL:-https://app.codemux.org}"
+API_HEALTH_URL="${CODEMUX_DEPLOY_API_HEALTH_URL:-https://api.codemux.org/health}"
+DRY_RUN=false
+REQUESTED_TAG="${CODEMUX_DEPLOY_RELEASE_TAG:-}"
+
+usage() {
+  echo "Usage: $0 [--check] [--tag vX.Y.Z]" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --check)
+      DRY_RUN=true
+      shift
+      ;;
+    --tag)
+      [ "$#" -ge 2 ] || { usage; exit 2; }
+      REQUESTED_TAG="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$APP_DIR" in
+  /*) ;;
+  *) echo "ERROR: app directory must be absolute: $APP_DIR" >&2; exit 1 ;;
+esac
+[ "$APP_DIR" != "/" ] || { echo "ERROR: refusing to use / as the app directory" >&2; exit 1; }
+[ -d "$HTML_DIR" ] || { echo "ERROR: hosted client directory not found: $HTML_DIR" >&2; exit 1; }
+
+log() {
+  local line
+  line="$(date -u +%FT%TZ) $*"
+  echo "$line"
+  echo "$line" >> "$LOG_FILE"
+}
+
+exec 9>>"$LOCK_FILE"
+if ! flock -n 9; then
+  exit 0
+fi
+
+if [ -n "$REQUESTED_TAG" ]; then
+  tag="$REQUESTED_TAG"
+else
+  effective_url="$(
+    curl -fsSIL --retry 3 --connect-timeout 10 --max-time 30 \
+      -o /dev/null -w '%{url_effective}' "$LATEST_RELEASE_URL"
+  )"
+  tag="${effective_url%/}"
+  tag="${tag##*/}"
+fi
+
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+  log "refusing invalid release tag: $tag"
+  exit 1
+fi
+
+if [ -f "$STATE_FILE" ] && [ "$(sed -n '1p' "$STATE_FILE")" = "$tag" ]; then
+  exit 0
+fi
+
+version="${tag#v}"
+archive="codemux-web-${version}.tar.gz"
+checksum="$archive.sha256"
+release_url="$DOWNLOAD_BASE_URL/$tag"
+work_dir="$(mktemp -d "$APP_DIR/.deploy-work.XXXXXX")"
+
+cleanup() {
+  case "$work_dir" in
+    "$APP_DIR"/.deploy-work.*) rm -rf -- "$work_dir" ;;
+  esac
+}
+trap cleanup EXIT
+
+if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 300 \
+  "$release_url/$archive" -o "$work_dir/$archive" 2>/dev/null; then
+  if $DRY_RUN; then
+    log "hosted client asset is not available for $tag yet"
+  fi
+  exit 0
+fi
+if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 30 \
+  "$release_url/$checksum" -o "$work_dir/$checksum"; then
+  log "checksum is not available for hosted client $tag"
+  exit 1
+fi
+
+read -r expected_sum expected_name extra < "$work_dir/$checksum" || true
+if [[ ! "$expected_sum" =~ ^[0-9a-fA-F]{64}$ ]] ||
+  [ "$expected_name" != "$archive" ] || [ -n "${extra:-}" ]; then
+  log "invalid checksum file for hosted client $tag"
+  exit 1
+fi
+actual_sum="$(sha256sum "$work_dir/$archive" | awk '{print $1}')"
+if [ "$actual_sum" != "$expected_sum" ]; then
+  log "checksum mismatch for hosted client $tag"
+  exit 1
+fi
+
+tar -tzf "$work_dir/$archive" > "$work_dir/archive-contents.txt"
+invalid_path=false
+while IFS= read -r raw_path; do
+  path="${raw_path#./}"
+  case "$path" in
+    ""|.) ;;
+    /*|../*|*/../*|*/..) invalid_path=true ;;
+  esac
+done < "$work_dir/archive-contents.txt"
+if $invalid_path; then
+  log "archive for hosted client $tag contains an unsafe path"
+  exit 1
+fi
+if ! tar -tvzf "$work_dir/$archive" | awk '
+  { type = substr($1, 1, 1); if (type != "-" && type != "d") exit 1 }
+'; then
+  log "archive for hosted client $tag contains a link or special file"
+  exit 1
+fi
+
+stage_dir="$work_dir/stage"
+mkdir -p "$stage_dir"
+tar --no-same-owner --no-same-permissions -xzf "$work_dir/$archive" -C "$stage_dir"
+
+wasm_js="iroh-wasm/$tag/iroh_wasm.js"
+wasm_binary="iroh-wasm/$tag/iroh_wasm_bg.wasm"
+test -s "$stage_dir/index.html" || { log "hosted client $tag has no index.html"; exit 1; }
+test -s "$stage_dir/$wasm_js" || { log "hosted client $tag has no versioned WASM glue"; exit 1; }
+test -s "$stage_dir/$wasm_binary" || { log "hosted client $tag has no versioned WASM binary"; exit 1; }
+
+wasm_magic="$(od -An -tx1 -N4 "$stage_dir/$wasm_binary" | tr -d '[:space:]')"
+[ "$wasm_magic" = "0061736d" ] || { log "hosted client $tag has an invalid WASM binary"; exit 1; }
+
+entry_path="$(sed -n 's#.*src="/\([^"]*\.js\)".*#\1#p' "$stage_dir/index.html" | sed -n '1p')"
+[ -n "$entry_path" ] && test -s "$stage_dir/$entry_path" || {
+  log "hosted client $tag has a missing JavaScript entry"
+  exit 1
+}
+wasm_loader_asset="$(grep -Rl '/iroh-wasm' "$stage_dir/assets" | sed -n '1p' || true)"
+if [ -z "$wasm_loader_asset" ] || ! grep -Fq "$tag" "$wasm_loader_asset"; then
+  log "hosted client $tag does not reference its versioned WASM glue"
+  exit 1
+fi
+
+if $DRY_RUN; then
+  log "validated hosted client $tag (dry run; no files changed)"
+  exit 0
+fi
+
+if [ "${CODEMUX_DEPLOY_SKIP_LIVE_CHECKS:-0}" != "1" ]; then
+  if ! curl -fsS --connect-timeout 10 --max-time 20 "$API_HEALTH_URL" |
+    grep -qE '"status"[[:space:]]*:[[:space:]]*"ok"'; then
+    log "API health check failed; leaving hosted client unchanged"
+    exit 1
+  fi
+fi
+
+mkdir -p "$BACKUP_DIR"
+timestamp="$(date -u +%Y%m%d_%H%M%S)"
+backup="$BACKUP_DIR/html-before-${tag}-${timestamp}.tar.gz"
+backup_tmp="$backup.tmp"
+tar -C "$APP_DIR" -czf "$backup_tmp" html
+mv -f "$backup_tmp" "$backup"
+
+# Copy immutable/versioned files first and retain previous generations. The
+# entry point is promoted last with a same-filesystem rename, so a page load
+# sees either the complete old deployment or the complete new deployment.
+while IFS= read -r -d '' entry; do
+  cp -a -- "$entry" "$HTML_DIR/"
+done < <(find "$stage_dir" -mindepth 1 -maxdepth 1 ! -name index.html -print0)
+
+index_tmp="$HTML_DIR/.index.html.${tag}.new"
+install -m 0644 "$stage_dir/index.html" "$index_tmp"
+mv -f "$index_tmp" "$HTML_DIR/index.html"
+
+verify_live() {
+  [ "${CODEMUX_DEPLOY_SKIP_LIVE_CHECKS:-0}" = "1" ] && return 0
+
+  curl -fsS --connect-timeout 10 --max-time 30 \
+    "$PUBLIC_URL/index.html?release=$tag" -o "$work_dir/live-index.html" || return 1
+  cmp -s "$stage_dir/index.html" "$work_dir/live-index.html" || return 1
+
+  curl -fsS --connect-timeout 10 --max-time 60 \
+    "$PUBLIC_URL/$entry_path" -o "$work_dir/live-entry.js" || return 1
+  cmp -s "$stage_dir/$entry_path" "$work_dir/live-entry.js" || return 1
+
+  curl -fsS --connect-timeout 10 --max-time 120 \
+    -D "$work_dir/wasm-headers.txt" \
+    "$PUBLIC_URL/$wasm_binary" -o "$work_dir/live.wasm" || return 1
+  grep -qiE '^content-type:[[:space:]]*application/wasm([[:space:]]|;|$)' \
+    "$work_dir/wasm-headers.txt" || return 1
+  cmp -s "$stage_dir/$wasm_binary" "$work_dir/live.wasm" || return 1
+}
+
+if ! verify_live; then
+  tar -C "$APP_DIR" -xzf "$backup"
+  log "live verification failed for $tag; restored $backup"
+  exit 1
+fi
+
+state_tmp="$APP_DIR/.deployed-release.${tag}.new"
+echo "$tag" > "$state_tmp"
+mv -f "$state_tmp" "$STATE_FILE"
+log "deployed hosted client $tag; rollback: $backup"

--- a/scripts/deploy-app-codemux.test.sh
+++ b/scripts/deploy-app-codemux.test.sh
@@ -32,6 +32,7 @@ run_deploy() {
   CODEMUX_DEPLOY_APP_DIR="$APP_DIR" \
   CODEMUX_DEPLOY_DOWNLOAD_BASE_URL="file://$RELEASES_DIR" \
   CODEMUX_DEPLOY_SKIP_LIVE_CHECKS=1 \
+  CODEMUX_DEPLOY_BACKUP_KEEP="${DEPLOY_BACKUP_KEEP:-5}" \
     "$DEPLOY_SCRIPT" --tag "$1"
 }
 
@@ -58,5 +59,19 @@ if run_deploy v1.2.4; then
 fi
 test "$(sed -n '1p' "$APP_DIR/deployed-release")" = "v1.2.3"
 grep -q 'assets/app.js' "$APP_DIR/html/index.html"
+
+# A release without a hosted client asset must say so instead of exiting quietly.
+mkdir -p "$RELEASES_DIR/v1.2.5"
+run_deploy v1.2.5
+grep -q 'hosted client asset is not available for v1.2.5' "$APP_DIR/deploy.log"
+test "$(sed -n '1p' "$APP_DIR/deployed-release")" = "v1.2.3"
+
+# Backups are pruned to the retention limit.
+make_release v1.2.6
+make_release v1.2.7
+DEPLOY_BACKUP_KEEP=2 run_deploy v1.2.6
+DEPLOY_BACKUP_KEEP=2 run_deploy v1.2.7
+test "$(find "$APP_DIR/backups" -type f -name 'html-before-*.tar.gz' | wc -l)" -eq 2
+test "$(find "$APP_DIR/backups" -type f -name 'html-before-v1.2.3-*.tar.gz' | wc -l)" -eq 0
 
 echo "deploy-app-codemux tests passed"

--- a/scripts/deploy-app-codemux.test.sh
+++ b/scripts/deploy-app-codemux.test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/deploy-app-codemux.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+APP_DIR="$TEST_ROOT/app-codemux"
+RELEASES_DIR="$TEST_ROOT/releases/download"
+mkdir -p "$APP_DIR/html/assets" "$RELEASES_DIR"
+echo "old index" > "$APP_DIR/html/index.html"
+echo "keep me" > "$APP_DIR/html/assets/old.js"
+
+make_release() {
+  local tag="$1"
+  local version="${tag#v}"
+  local release_dir="$RELEASES_DIR/$tag"
+  local stage="$TEST_ROOT/stage-$tag"
+  local archive="codemux-web-${version}.tar.gz"
+
+  mkdir -p "$release_dir" "$stage/assets" "$stage/iroh-wasm/$tag"
+  echo '<script type="module" src="/assets/app.js"></script>' > "$stage/index.html"
+  echo "const wasm = \"/iroh-wasm/$tag/iroh_wasm.js\";" > "$stage/assets/app.js"
+  echo "wasm glue $tag" > "$stage/iroh-wasm/$tag/iroh_wasm.js"
+  printf '\0asm\1\0\0\0' > "$stage/iroh-wasm/$tag/iroh_wasm_bg.wasm"
+  tar -C "$stage" -czf "$release_dir/$archive" .
+  (cd "$release_dir" && sha256sum "$archive" > "$archive.sha256")
+}
+
+run_deploy() {
+  CODEMUX_DEPLOY_APP_DIR="$APP_DIR" \
+  CODEMUX_DEPLOY_DOWNLOAD_BASE_URL="file://$RELEASES_DIR" \
+  CODEMUX_DEPLOY_SKIP_LIVE_CHECKS=1 \
+    "$DEPLOY_SCRIPT" --tag "$1"
+}
+
+make_release v1.2.3
+run_deploy v1.2.3
+
+grep -q 'assets/app.js' "$APP_DIR/html/index.html"
+grep -q 'keep me' "$APP_DIR/html/assets/old.js"
+test -s "$APP_DIR/html/iroh-wasm/v1.2.3/iroh_wasm.js"
+test "$(sed -n '1p' "$APP_DIR/deployed-release")" = "v1.2.3"
+test "$(find "$APP_DIR/backups" -type f -name 'html-before-v1.2.3-*.tar.gz' | wc -l)" -eq 1
+
+# An idempotent poll must not create another backup.
+run_deploy v1.2.3
+test "$(find "$APP_DIR/backups" -type f -name 'html-before-v1.2.3-*.tar.gz' | wc -l)" -eq 1
+
+# A corrupt release must fail before changing the live tree or state.
+make_release v1.2.4
+echo 'not the real checksum  codemux-web-1.2.4.tar.gz' > \
+  "$RELEASES_DIR/v1.2.4/codemux-web-1.2.4.tar.gz.sha256"
+if run_deploy v1.2.4; then
+  echo "FAIL: corrupt checksum was accepted" >&2
+  exit 1
+fi
+test "$(sed -n '1p' "$APP_DIR/deployed-release")" = "v1.2.3"
+grep -q 'assets/app.js' "$APP_DIR/html/index.html"
+
+echo "deploy-app-codemux tests passed"

--- a/scripts/test-release-pipeline.sh
+++ b/scripts/test-release-pipeline.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 #
-# Dev-only: validate a Codemux release's artifacts and latest.json structure.
+# Dev-only: validate a Codemux release's desktop and hosted-web artifacts.
 #
 # This script does NOT build anything. It fetches artifacts from a completed
 # GitHub release and asserts the shape — used after a test tag build finishes
 # to verify the release.yml workflow's multi-platform latest.json merge
 # behavior actually worked.
 #
-# Intended flow for testing Windows support before merging to main:
+# Intended flow for smoke-testing release workflow changes before merging:
 #   1. Create a throwaway tag: `git tag v0.0.0-test1 && git push origin v0.0.0-test1`
 #   2. Wait for release.yml CI to complete (~15 min — Windows is the slow leg)
 #   3. Run this script against the tag: ./scripts/test-release-pipeline.sh v0.0.0-test1
@@ -32,19 +32,20 @@ HAS_WINDOWS=false
 echo "=== Release Pipeline Verification for $TAG ==="
 
 # 1. Check release exists
-echo "[1/8] Checking release exists..."
+echo "[1/9] Checking release exists..."
 gh release view "$TAG" > /dev/null || { echo "FAIL: Release $TAG not found"; exit 1; }
 echo "  OK"
 
 # 2. Check Linux artifacts
-echo "[2/8] Checking Linux artifacts..."
+echo "[2/9] Checking Linux artifacts..."
 ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name')
 echo "$ASSETS" | grep -q "\.AppImage$" || { echo "FAIL: AppImage missing"; exit 1; }
 echo "$ASSETS" | grep -q "\.deb$" || { echo "FAIL: deb missing"; exit 1; }
-echo "  OK: AppImage and deb present"
+echo "$ASSETS" | grep -q "\.rpm$" || { echo "FAIL: rpm missing"; exit 1; }
+echo "  OK: AppImage, deb, and rpm present"
 
 # 3. Check Windows artifact
-echo "[3/8] Checking Windows artifact..."
+echo "[3/9] Checking Windows artifact..."
 if echo "$ASSETS" | grep -q "x64-setup\.exe$"; then
     echo "  OK: NSIS .exe present"
     WINDOWS_EXE_PRESENT=true
@@ -55,12 +56,12 @@ else
 fi
 
 # 4. Check latest.json exists
-echo "[4/8] Checking latest.json exists..."
+echo "[4/9] Checking latest.json exists..."
 echo "$ASSETS" | grep -q "latest.json" || { echo "FAIL: latest.json missing"; exit 1; }
 echo "  OK"
 
 # 5. Download and validate latest.json structure
-echo "[5/8] Validating latest.json structure..."
+echo "[5/9] Validating latest.json structure..."
 gh release download "$TAG" --pattern "latest.json" --dir "$TMPDIR" --clobber
 
 # Check it's valid JSON
@@ -74,7 +75,7 @@ echo "  Version in latest.json: $VERSION"
 echo "  OK: valid JSON"
 
 # 6. CRITICAL: Check both platforms are present
-echo "[6/8] CRITICAL: Checking both platforms in latest.json..."
+echo "[6/9] CRITICAL: Checking both platforms in latest.json..."
 PLATFORMS=$(jq -r '.platforms | keys[]' "$TMPDIR/latest.json" 2>/dev/null || true)
 
 if [ -z "$PLATFORMS" ]; then
@@ -103,7 +104,7 @@ fi
 echo "  OK: Linux=$HAS_LINUX, Windows=$HAS_WINDOWS"
 
 # 7. Check signatures exist for each platform
-echo "[7/8] Checking update signatures..."
+echo "[7/9] Checking update signatures..."
 while IFS= read -r platform; do
     [ -z "$platform" ] && continue
     SIG=$(jq -r --arg p "$platform" '.platforms[$p].signature // empty' "$TMPDIR/latest.json")
@@ -115,7 +116,7 @@ while IFS= read -r platform; do
 done <<< "$PLATFORMS"
 
 # 8. Check download URLs are valid
-echo "[8/8] Checking update download URLs..."
+echo "[8/9] Checking update download URLs..."
 while IFS= read -r platform; do
     [ -z "$platform" ] && continue
     URL=$(jq -r --arg p "$platform" '.platforms[$p].url // empty' "$TMPDIR/latest.json")
@@ -135,6 +136,62 @@ while IFS= read -r platform; do
     fi
 done <<< "$PLATFORMS"
 
+# 9. Check the pull-based hosted-web payload, its checksum, and its
+# load-bearing iroh WASM files. The page can render without these WASM files,
+# so their absence must fail verification rather than ship a dead relay path.
+echo "[9/9] Checking hosted web release asset..."
+WEB_VERSION="${TAG#v}"
+WEB_ARCHIVE="codemux-web-${WEB_VERSION}.tar.gz"
+WEB_CHECKSUM="${WEB_ARCHIVE}.sha256"
+
+echo "$ASSETS" | grep -Fxq "$WEB_ARCHIVE" || {
+    echo "FAIL: hosted web archive missing: $WEB_ARCHIVE"
+    exit 1
+}
+echo "$ASSETS" | grep -Fxq "$WEB_CHECKSUM" || {
+    echo "FAIL: hosted web checksum missing: $WEB_CHECKSUM"
+    exit 1
+}
+
+gh release download "$TAG" \
+    --pattern "$WEB_ARCHIVE" \
+    --pattern "$WEB_CHECKSUM" \
+    --dir "$TMPDIR" \
+    --clobber
+(cd "$TMPDIR" && sha256sum -c "$WEB_CHECKSUM")
+
+tar -tzf "$TMPDIR/$WEB_ARCHIVE" > "$TMPDIR/web-archive-contents.txt"
+grep -qE '^(\./)?index\.html$' "$TMPDIR/web-archive-contents.txt" || {
+    echo "FAIL: hosted web archive has no index.html"
+    exit 1
+}
+grep -qE '^(\./)?assets/.+\.js$' "$TMPDIR/web-archive-contents.txt" || {
+    echo "FAIL: hosted web archive has no JavaScript assets"
+    exit 1
+}
+grep -qE "^(\\./)?iroh-wasm/$TAG/iroh_wasm\\.js$" "$TMPDIR/web-archive-contents.txt" || {
+    echo "FAIL: hosted web archive has no iroh WASM JavaScript glue"
+    exit 1
+}
+grep -qE "^(\\./)?iroh-wasm/$TAG/iroh_wasm_bg\\.wasm$" "$TMPDIR/web-archive-contents.txt" || {
+    echo "FAIL: hosted web archive has no iroh WASM binary"
+    exit 1
+}
+
+mkdir -p "$TMPDIR/web"
+tar --no-same-owner --no-same-permissions -xzf "$TMPDIR/$WEB_ARCHIVE" -C "$TMPDIR/web"
+WASM_MAGIC=$(od -An -tx1 -N4 "$TMPDIR/web/iroh-wasm/$TAG/iroh_wasm_bg.wasm" | tr -d '[:space:]')
+[ "$WASM_MAGIC" = "0061736d" ] || {
+    echo "FAIL: hosted web archive contains an invalid WASM binary"
+    exit 1
+}
+WASM_LOADER_ASSET=$(grep -Rl '/iroh-wasm' "$TMPDIR/web/assets" | sed -n '1p' || true)
+[ -n "$WASM_LOADER_ASSET" ] && grep -Fq "$TAG" "$WASM_LOADER_ASSET" || {
+    echo "FAIL: hosted frontend does not reference its versioned WASM glue"
+    exit 1
+}
+echo "  OK: archive checksum and hosted relay payload are valid"
+
 echo ""
 echo "=== SUMMARY ==="
 echo "Release: $TAG"
@@ -147,10 +204,11 @@ fi
 echo "latest.json: valid"
 echo "Linux in latest.json: $HAS_LINUX"
 echo "Windows in latest.json: $HAS_WINDOWS"
+echo "Hosted web artifact: present and valid"
 echo ""
 
 if $HAS_LINUX && $HAS_WINDOWS; then
-    echo "ALL CHECKS PASSED — safe to merge Windows support branch"
+    echo "ALL CHECKS PASSED"
     exit 0
 else
     echo "ISSUES FOUND — review above before merging"

--- a/src/remote/iroh-wasm-loader.test.ts
+++ b/src/remote/iroh-wasm-loader.test.ts
@@ -3,10 +3,33 @@ import {
   loadIrohDialer,
   IrohWasmUnavailableError,
   __resetIrohDialer,
+  resolveIrohWasmArtifactPaths,
   type WasmImporter,
 } from "./iroh-wasm-loader";
 
 beforeEach(() => __resetIrohDialer());
+
+describe("resolveIrohWasmArtifactPaths", () => {
+  it("keeps the unversioned path for local builds", () => {
+    expect(resolveIrohWasmArtifactPaths()).toEqual({
+      js: "/iroh-wasm/iroh_wasm.js",
+      wasm: "/iroh-wasm/iroh_wasm_bg.wasm",
+    });
+  });
+
+  it("isolates hosted artifacts by release tag", () => {
+    expect(resolveIrohWasmArtifactPaths("v0.20.0")).toEqual({
+      js: "/iroh-wasm/v0.20.0/iroh_wasm.js",
+      wasm: "/iroh-wasm/v0.20.0/iroh_wasm_bg.wasm",
+    });
+  });
+
+  it("rejects an unsafe release path", () => {
+    expect(() => resolveIrohWasmArtifactPaths("../latest")).toThrow(
+      "invalid Codemux release tag",
+    );
+  });
+});
 
 describe("loadIrohDialer graceful missing-wasm", () => {
   it("throws IrohWasmUnavailableError when the artifact import rejects", async () => {

--- a/src/remote/iroh-wasm-loader.ts
+++ b/src/remote/iroh-wasm-loader.ts
@@ -25,9 +25,39 @@ export class IrohWasmUnavailableError extends Error {
   }
 }
 
-/** Served paths of the built artifact (from `public/iroh-wasm/`). */
-const ARTIFACT_JS = "/iroh-wasm/iroh_wasm.js";
-const ARTIFACT_WASM = "/iroh-wasm/iroh_wasm_bg.wasm";
+export interface IrohWasmArtifactPaths {
+  readonly js: string;
+  readonly wasm: string;
+}
+
+/** Resolve the served artifact paths. Hosted release builds use a versioned
+ *  directory so a tab running an older frontend can never fetch a newer,
+ *  incompatible wasm-bindgen pair through the stable filenames. Local and
+ *  embedded builds retain the unversioned development path. */
+export function resolveIrohWasmArtifactPaths(
+  releaseTag?: string,
+): IrohWasmArtifactPaths {
+  const normalizedTag = releaseTag?.trim();
+  if (
+    normalizedTag &&
+    !/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+      normalizedTag,
+    )
+  ) {
+    throw new Error(`invalid Codemux release tag: ${normalizedTag}`);
+  }
+  const versionPath = normalizedTag
+    ? `/${encodeURIComponent(normalizedTag)}`
+    : "";
+  return {
+    js: `/iroh-wasm${versionPath}/iroh_wasm.js`,
+    wasm: `/iroh-wasm${versionPath}/iroh_wasm_bg.wasm`,
+  };
+}
+
+const ARTIFACT_PATHS = resolveIrohWasmArtifactPaths(
+  import.meta.env.VITE_CODEMUX_RELEASE_TAG,
+);
 
 /** One open stream as exposed by the wasm-bindgen glue. `read` resolves to the
  *  next chunk, or `null`/`undefined` at EOF. */
@@ -85,7 +115,7 @@ export function __resetIrohDialer(): void {
 async function buildDialer(importer: WasmImporter): Promise<IrohDialer> {
   let mod: WasmModule;
   try {
-    mod = (await importer(ARTIFACT_JS)) as WasmModule;
+    mod = (await importer(ARTIFACT_PATHS.js)) as WasmModule;
   } catch (err) {
     throw new IrohWasmUnavailableError(err);
   }
@@ -94,7 +124,7 @@ async function buildDialer(importer: WasmImporter): Promise<IrohDialer> {
       new Error("iroh wasm module missing expected exports"),
     );
   }
-  await mod.default({ module_or_path: ARTIFACT_WASM });
+  await mod.default({ module_or_path: ARTIFACT_PATHS.wasm });
   return {
     async dial(target): Promise<IrohByteStream> {
       const handle = await mod.connect(

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_CODEMUX_RELEASE_TAG?: string;
+}


### PR DESCRIPTION
## Problem

Desktop releases did not publish or deploy the separately hosted app.codemux.org frontend, so the managed-relay client could remain stale across releases. Replacing the stable iroh WASM files could also mix an older open tab with newer wasm-bindgen output.

## Fix

- build a versioned hosted frontend and iroh WASM artifact in the release workflow
- publish the archive and SHA-256 checksum on the GitHub release
- add a pull-only VPS deployer with validation, locking, backups, index-last promotion, live verification, and rollback
- retain older immutable assets and WASM generations for already-open tabs
- extend release verification and add focused deployer and loader tests

## Verification

- npm run check
- npm run test -- src/remote/iroh-wasm-loader.test.ts
- scripts/deploy-app-codemux.test.sh
- bash syntax checks for affected scripts
- actionlint
- real optimized Rust/WASM build and isolated end-to-end archive deployment
- production puller dry run; no hosted files replaced and no container restart

Model: GPT-5.6-sol via the Codex harness in T3 Code.