### PR TITLE
fix(settings): show themes first from appearance

### DIFF
--- a/src/components/overlays/command-palette.test.tsx
+++ b/src/components/overlays/command-palette.test.tsx
@@ -225,12 +225,54 @@ describe("command palette — theme picker", () => {
     expect(mocks.ui.openThemeStudio).toHaveBeenCalledWith({ mode: "import" });
   });
 
-  it("opens on the seed query handed to it by Settings' Change button", async () => {
+  it("keeps the seeded Change flow anchored on Themes through crowded results", async () => {
+    const workspaces = Array.from({ length: 30 }, (_, index) => ({
+      workspace_id: `ws-theme-${index}`,
+      title: `Theme investigation ${index}`,
+      cwd: `/repo-${index}`,
+      git_branch: `feature/theme-investigation-${index}`,
+      project_root: `/repo-${index}`,
+      surfaces: [],
+      active_surface_id: "",
+    }));
+    mocks.app.appState = {
+      active_workspace_id: "ws-theme-0",
+      pane_statuses: {},
+      workspaces,
+    };
+    mocks.backend.agentChatSearch.mockResolvedValue([
+      {
+        message_id: 91,
+        thread_id: "thread-theme",
+        workspace_id: "ws-theme-0",
+        cwd: "/repo-0",
+        provider: "codex",
+        session_title: "Theme notes from an older conversation",
+        role: "assistant",
+        turn_id: "turn-theme",
+        snippet: "The theme keyword also appears in this conversation.",
+        created_at: "2026-08-14 00:00:00",
+      },
+    ]);
     mocks.ui.takeCommandPaletteQuery.mockReturnValue("theme");
     renderPalette();
 
     expect(screen.getByRole("combobox")).toHaveValue("theme");
+    expect(screen.getByText("Workspaces")).toBeInTheDocument();
+    expect(screen.getByText("24 of 30")).toBeInTheDocument();
     await waitFor(() => expect(screen.getByText("Ember")).toBeInTheDocument());
+    const themesHeader = document.querySelector('[data-palette-group="Themes"]');
+    const workspacesHeader = document.querySelector('[data-palette-group="Workspaces"]');
+    expect(themesHeader?.compareDocumentPosition(workspacesHeader!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+
+    // Conversation hits arrive later, but the deep link keeps Themes first
+    // instead of allowing that asynchronous result to shift the target away.
+    const conversation = await screen.findByText("Theme notes from an older conversation");
+    expect(themesHeader?.compareDocumentPosition(conversation)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
 });
 

--- a/src/components/overlays/command-palette.tsx
+++ b/src/components/overlays/command-palette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { Command as CommandPrimitive } from "cmdk";
 import {
   ArrowLeft,
@@ -291,16 +291,14 @@ function PaletteBody({ onOpenChange }: { onOpenChange: (open: boolean) => void }
   );
   const query = useMemo(() => parsePaletteQuery(rawQuery), [rawQuery]);
   const listRef = useRef<HTMLDivElement>(null);
+  // A seeded `theme` query is a deep link from Settings ▸ Appearance, not
+  // an ordinary palette search. Remember that distinction after the store's
+  // one-shot seed has been consumed so only that entry point puts Themes
+  // ahead of otherwise valid workspace/project/conversation matches.
+  const openedForThemesRef = useRef(rawQuery === "theme");
   const searchRequestRef = useRef(0);
   const [conversationRows, setConversationRows] = useState<AgentChatSearchResult[]>([]);
   const [conversationSearching, setConversationSearching] = useState(false);
-
-  // Every keystroke re-ranks the list and cmdk re-selects the top row, but it
-  // only scrolls on arrow navigation — so without this the user can be left
-  // staring at the middle of a list whose selection is far above.
-  useEffect(() => {
-    listRef.current?.scrollTo({ top: 0 });
-  }, [rawQuery]);
 
   const appState = useAppStore((s) => s.appState);
   const homeDir = useHomeDir();
@@ -570,6 +568,17 @@ function PaletteBody({ onOpenChange }: { onOpenChange: (open: boolean) => void }
     0,
     searching ? PROJECT_CAP_SEARCH : PROJECT_CAP_RESTING,
   );
+  const themeResultsFirst =
+    openedForThemesRef.current &&
+    rawQuery === "theme" &&
+    matchedThemes.length + matchedThemeStudio.length > 0;
+
+  // Every keystroke re-ranks the list and cmdk re-selects the first row, but
+  // it only scrolls on arrow navigation. Resetting here keeps ordinary search
+  // results (and the seeded Themes-first ordering) aligned with that row.
+  useEffect(() => {
+    listRef.current?.scrollTo({ top: 0 });
+  }, [rawQuery]);
   const totalShown =
     shownWorkspaces.length +
     shownProjects.length +
@@ -676,6 +685,34 @@ function PaletteBody({ onOpenChange }: { onOpenChange: (open: boolean) => void }
     row.open();
   };
 
+  const themeResults = (
+    <Fragment>
+      {matchedThemes.length + matchedThemeStudio.length > 0 && (
+        <GroupHeader
+          label="Themes"
+          count={`${matchedThemes.length}`}
+          first={
+            themeResultsFirst ||
+            (shownWorkspaces.length === 0 &&
+              shownProjects.length === 0 &&
+              conversationRows.length === 0)
+          }
+        />
+      )}
+      {matchedThemes.map((row) => (
+        <ThemeItemRow
+          key={row.key}
+          row={row}
+          applied={row.theme.id === appliedTheme.id}
+          onSelect={() => keepTheme(row.theme)}
+        />
+      ))}
+      {matchedThemeStudio.map((row) => (
+        <ThemeStudioItemRow key={row.key} row={row} onSelect={() => openStudio(row)} />
+      ))}
+    </Fragment>
+  );
+
   return (
     <CommandPrimitive
       shouldFilter={false}
@@ -744,11 +781,13 @@ function PaletteBody({ onOpenChange }: { onOpenChange: (open: boolean) => void }
             </div>
           )}
 
+          {themeResultsFirst && themeResults}
+
           {shownWorkspaces.length > 0 && (
             <GroupHeader
               label="Workspaces"
               count={groupCountLabel(shownWorkspaces.length, matchedWorkspaces.length)}
-              first
+              first={!themeResultsFirst}
             />
           )}
           {shownWorkspaces.map((row) => (
@@ -764,7 +803,7 @@ function PaletteBody({ onOpenChange }: { onOpenChange: (open: boolean) => void }
             <GroupHeader
               label="Projects"
               count={groupCountLabel(shownProjects.length, matchedProjects.length)}
-              first={shownWorkspaces.length === 0}
+              first={!themeResultsFirst && shownWorkspaces.length === 0}
             />
           )}
           {shownProjects.map((row) => (
@@ -775,7 +814,9 @@ function PaletteBody({ onOpenChange }: { onOpenChange: (open: boolean) => void }
             <GroupHeader
               label="Conversations"
               count={`${conversationRows.length}`}
-              first={shownWorkspaces.length === 0 && shownProjects.length === 0}
+              first={
+                !themeResultsFirst && shownWorkspaces.length === 0 && shownProjects.length === 0
+              }
             />
           )}
           {conversationRows.map((row) => (
@@ -788,28 +829,7 @@ function PaletteBody({ onOpenChange }: { onOpenChange: (open: boolean) => void }
             />
           ))}
 
-          {matchedThemes.length + matchedThemeStudio.length > 0 && (
-            <GroupHeader
-              label="Themes"
-              count={`${matchedThemes.length}`}
-              first={
-                shownWorkspaces.length === 0 &&
-                shownProjects.length === 0 &&
-                conversationRows.length === 0
-              }
-            />
-          )}
-          {matchedThemes.map((row) => (
-            <ThemeItemRow
-              key={row.key}
-              row={row}
-              applied={row.theme.id === appliedTheme.id}
-              onSelect={() => keepTheme(row.theme)}
-            />
-          ))}
-          {matchedThemeStudio.map((row) => (
-            <ThemeStudioItemRow key={row.key} row={row} onSelect={() => openStudio(row)} />
-          ))}
+          {!themeResultsFirst && themeResults}
 
           {matchedCommands.length > 0 && (
             <GroupHeader
@@ -873,6 +893,7 @@ function GroupHeader({
 }) {
   return (
     <div
+      data-palette-group={label}
       className={cn(
         "sticky top-0 z-10 flex h-7 items-center gap-2.5 bg-popover px-2.5",
         !first && "mt-2",


### PR DESCRIPTION
Appearance's Change button seeds the global palette with `theme`, so matching workspaces and conversations could fill the viewport and force users to scroll before reaching the theme picker.

Treat the seeded Appearance query as a theme deep link and render the Themes group first for that entry point. Matching workspace, project, conversation, and command results remain available below it, while manually typing `theme` into the global palette keeps the normal global result ordering. The crowded regression covers 30 matching workspaces plus a delayed conversation result.

## Visual comparison

| Before | After |
| --- | --- |
| ![Before: matching workspaces fill the theme palette](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/scroll-to-theme-section/before.png) | ![After: theme choices appear first and workspace matches remain below](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/scroll-to-theme-section/after.png) |

## Verification

- `npm run check`
- `npm run test -- src/components/overlays/command-palette.test.tsx` (12 tests passed)
- Browser-verified with the Tauri mock's large fixture and 41 workspace matches for `theme`

Model: GPT-5 via the Codex harness.
