### PR TITLE
fix: hide git init for home chats

### DIFF
--- a/src/components/chat/WorkspaceStatusCluster.test.tsx
+++ b/src/components/chat/WorkspaceStatusCluster.test.tsx
@@ -13,6 +13,7 @@ import type {
 // close over lives in `vi.hoisted`. ──
 const mocks = vi.hoisted(() => ({
   workspace: null as WorkspaceSnapshot | null,
+  homeDir: "/home/dev" as string | null,
   hosts: [] as Array<{ id: number; name: string }>,
   openUrl: vi.fn().mockResolvedValue(undefined),
   getGithubPrByPath: vi.fn().mockResolvedValue(null as PullRequestInfo | null),
@@ -23,6 +24,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/stores/app-store", () => ({
   useActiveWorkspace: () => mocks.workspace,
+  useHomeDir: () => mocks.homeDir,
   // `useBackgroundBrowserSession` (shared with the terminal header) reads
   // `agent_browser_sessions` off the app state via `useAppStore`.
   useAppStore: (sel: (s: Record<string, unknown>) => unknown) =>
@@ -100,6 +102,7 @@ function makeBackgroundSession(
 
 beforeEach(() => {
   mocks.workspace = null;
+  mocks.homeDir = "/home/dev";
   mocks.hosts = [];
   mocks.openUrl.mockClear();
   mocks.getGithubPrByPath.mockReset().mockResolvedValue(null);
@@ -120,6 +123,33 @@ describe("WorkspaceStatusCluster", () => {
 
   it("renders nothing when the workspace has no git branch (and no background browser)", () => {
     mocks.workspace = makeWorkspace({ git_branch: null });
+    const { container } = render(<WorkspaceStatusCluster />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("offers Git initialization for a non-git project folder", () => {
+    mocks.workspace = makeWorkspace({ git_branch: null, is_git: false });
+    render(<WorkspaceStatusCluster />);
+    expect(
+      screen.getByRole("button", { name: /Initialize a git repository/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not offer Git initialization for a home-rooted workspace", () => {
+    mocks.workspace = makeWorkspace({
+      git_branch: null,
+      is_git: false,
+      cwd: "/home/dev",
+      project_root: "/home/dev",
+      worktree_path: null,
+    });
+    const { container } = render(<WorkspaceStatusCluster />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("waits for the home directory before offering Git initialization", () => {
+    mocks.homeDir = null;
+    mocks.workspace = makeWorkspace({ git_branch: null, is_git: false });
     const { container } = render(<WorkspaceStatusCluster />);
     expect(container).toBeEmptyDOMElement();
   });

--- a/src/components/chat/WorkspaceStatusCluster.tsx
+++ b/src/components/chat/WorkspaceStatusCluster.tsx
@@ -4,7 +4,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { cn } from "@/lib/utils";
 import { basename } from "@/lib/path";
 import { toast } from "@/lib/toast";
-import { useActiveWorkspace } from "@/stores/app-store";
+import { useActiveWorkspace, useHomeDir } from "@/stores/app-store";
 import { useHosts } from "@/stores/hosts-store";
 import {
   Popover,
@@ -73,6 +73,7 @@ import {
  */
 export function WorkspaceStatusCluster() {
   const workspace = useActiveWorkspace();
+  const homeDir = useHomeDir();
   const hosts = useHosts();
   const backgroundBrowserSession = useBackgroundBrowserSession(
     workspace?.workspace_id,
@@ -109,7 +110,7 @@ export function WorkspaceStatusCluster() {
 
   if (!workspace) return null;
   const gitBranch = workspace.git_branch;
-  const showNoGit = !gitBranch && showNoGitState(workspace);
+  const showNoGit = !gitBranch && showNoGitState(workspace, homeDir);
   if (
     !gitBranch &&
     !showNoGit &&

--- a/src/components/workspace/changes-panel.tsx
+++ b/src/components/workspace/changes-panel.tsx
@@ -67,7 +67,7 @@ import { toast } from "@/lib/toast";
 import { keepIfUnchanged } from "@/lib/poll-equality";
 import { useQueryClient } from "@tanstack/react-query";
 import { useDiffStore } from "@/stores/diff-store";
-import { useAppStore } from "@/stores/app-store";
+import { useAppStore, useHomeDir } from "@/stores/app-store";
 import { useAiCommitStore } from "@/stores/ai-commit-store";
 import { showNoGitState, useInitializeGit } from "@/hooks/use-initialize-git";
 import { cn } from "@/lib/utils";
@@ -316,6 +316,7 @@ export function ChangesPanel({
   const refreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const config = useAppStore((s) => s.appState?.config);
+  const homeDir = useHomeDir();
   const aiEnabled = config?.ai_commit_message_enabled ?? true;
   const generation = useAiCommitStore((s) => s.getGeneration(workspace.workspace_id));
   const requestGeneration = useAiCommitStore((s) => s.requestGeneration);
@@ -334,7 +335,7 @@ export function ChangesPanel({
   // Non-git project folder: `getGitStatus` errors (swallowed to `[]`), so
   // without this flag the panel would render a false "Working tree clean".
   // Instead we name the state and offer the explicit, opt-in `git init`.
-  const showNoGit = showNoGitState(workspace);
+  const showNoGit = showNoGitState(workspace, homeDir);
   const { initialize, initializing } = useInitializeGit(workspace);
 
   const refresh = useCallback(() => {

--- a/src/hooks/use-initialize-git.test.ts
+++ b/src/hooks/use-initialize-git.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceSnapshot } from "@/tauri/types";
+import { showNoGitState } from "./use-initialize-git";
+
+function makeWorkspace(
+  overrides: Partial<WorkspaceSnapshot> = {},
+): WorkspaceSnapshot {
+  return {
+    workspace_id: "ws-1",
+    title: "scratch",
+    workspace_type: "standard",
+    cwd: "/home/dev/projects/scratch",
+    is_git: false,
+    git_branch: null,
+    git_ahead: 0,
+    git_behind: 0,
+    git_additions: 0,
+    git_deletions: 0,
+    git_changed_files: 0,
+    notification_count: 0,
+    latest_agent_state: null,
+    worktree_path: null,
+    project_root: "/home/dev/projects/scratch",
+    pr_number: null,
+    pr_state: null,
+    pr_url: null,
+    linked_issue: null,
+    notifications_muted: false,
+    tabs: [],
+    active_tab_id: "",
+    active_surface_id: "",
+    surfaces: [],
+    ...overrides,
+  };
+}
+
+describe("showNoGitState", () => {
+  it("shows the affordance for a local non-git project", () => {
+    expect(showNoGitState(makeWorkspace(), "/home/dev")).toBe(true);
+  });
+
+  it("excludes a standard workspace rooted at home", () => {
+    const workspace = makeWorkspace({
+      cwd: "/home/dev",
+      project_root: "/home/dev",
+    });
+
+    expect(showNoGitState(workspace, "/home/dev")).toBe(false);
+  });
+
+  it("uses cwd when an older snapshot has no project root", () => {
+    const workspace = makeWorkspace({
+      cwd: "/home/dev",
+      project_root: null,
+    });
+
+    expect(showNoGitState(workspace, "/home/dev")).toBe(false);
+  });
+
+  it("fails closed while the home directory is unresolved", () => {
+    expect(showNoGitState(makeWorkspace(), null)).toBe(false);
+  });
+
+  it.each([
+    ["git workspace", { is_git: true }],
+    ["legacy Home workspace", { workspace_type: "home" as const }],
+    ["attach-only workspace", { attach_only: true }],
+    ["remote workspace", { host_id: 7 }],
+  ])("excludes a %s", (_label, overrides) => {
+    expect(showNoGitState(makeWorkspace(overrides), "/home/dev")).toBe(false);
+  });
+});

--- a/src/hooks/use-initialize-git.ts
+++ b/src/hooks/use-initialize-git.ts
@@ -27,10 +27,20 @@ import type { WorkspaceSnapshot } from "@/tauri/types";
 export function showNoGitState(
   workspace: Pick<
     WorkspaceSnapshot,
-    "is_git" | "workspace_type" | "attach_only" | "host_id"
+    | "is_git"
+    | "workspace_type"
+    | "attach_only"
+    | "host_id"
+    | "project_root"
+    | "cwd"
   >,
+  homeDir: string | null,
 ): boolean {
+  const projectRoot = workspace.project_root ?? workspace.cwd;
+
   return (
+    homeDir !== null &&
+    projectRoot !== homeDir &&
     workspace.is_git === false &&
     workspace.workspace_type === "standard" &&
     !workspace.attach_only &&


### PR DESCRIPTION
Home-rooted agent chats are represented as standard workspaces, so the non-Git affordance incorrectly offered to initialize `$HOME` as a repository. This contradicted the existing Home behavior and could also appear in the Changes panel.

Pass the cached home directory into the shared non-Git predicate and compare it with `project_root ?? cwd`, withholding the affordance until Home is known. Both the chat status cluster and Changes panel now share this path-aware guard, with regression coverage for Home, ordinary non-Git projects, unresolved Home state, legacy Home workspaces, attach-only workspaces, and remote workspaces.

Verification:
- `npm run test -- src/hooks/use-initialize-git.test.ts src/components/chat/WorkspaceStatusCluster.test.tsx` (38 tests passed)
- `npm run check`
- Browser inspection of the Home draft state at `http://localhost:1420`

Model: GPT-5 via Codex harness