### PR TITLE
fix(chat): preserve thread across session restarts

### DIFF
--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -574,6 +574,29 @@ pub async fn agent_chat_start_session<R: Runtime>(
         permission_mode: Some(input.permission_mode.clone()),
         fast_mode: Some(input.fast_mode),
     };
+    // A restart of an existing durable CodeMux thread must not depend solely
+    // on the frontend's in-memory cursor. That slice can be cold after sleep,
+    // remount, or event-stream recovery even though the authoritative session
+    // row already has the provider-native id. Recover it here when the caller
+    // kept the same thread/provider. New Chat uses a new thread id, and a
+    // provider handoff has a different provider, so neither can accidentally
+    // inherit an old provider's cursor through this fallback.
+    if input.resume_cursor.is_none() {
+        let provider_name = match provider {
+            ProviderKind::Claude => "claude",
+            ProviderKind::Codex => "codex",
+            ProviderKind::OpenCode => "opencode",
+        };
+        let persisted_sdk_session_id = {
+            let db: State<'_, DatabaseStore> = app.state();
+            db.get_agent_chat_session(&input.thread_id.0)
+                .filter(|record| record.provider == provider_name)
+                .and_then(|record| record.sdk_session_id)
+        };
+        if let Some(sdk_session_id) = persisted_sdk_session_id {
+            input.resume_cursor = Some(serde_json::json!({ "resume": sdk_session_id }));
+        }
+    }
     // Trace the resume wire so the dev console shows whether a
     // resume_cursor actually reached the provider, and with what
     // shape. Helps distinguish "frontend didn't send it" from

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -200,6 +200,7 @@ vi.mock("./Composer", () => ({
     belowComposerSlot,
     topStripSlot,
     onSubmit,
+    onStop,
     onContinueRun,
     onModeRemove,
     onModeActivate,
@@ -215,6 +216,7 @@ vi.mock("./Composer", () => ({
     belowComposerSlot?: React.ReactNode;
     topStripSlot?: React.ReactNode;
     onSubmit: () => void;
+    onStop: () => void;
     onContinueRun?: () => void;
     onModeRemove: () => void;
     onModeActivate: (mode: "plan" | "ask" | "debug") => void;
@@ -240,6 +242,7 @@ vi.mock("./Composer", () => ({
       <div data-testid="zone1">{zone1Override}</div>
       <div data-testid="below-composer">{belowComposerSlot}</div>
       <button data-testid="composer-submit" onClick={() => onSubmit()} />
+      <button data-testid="composer-stop" onClick={() => onStop()} />
       <button
         data-testid="composer-continue"
         onClick={() => onContinueRun?.()}
@@ -616,6 +619,7 @@ vi.mock("@/stores/agent-chat-store", () => {
 import { AgentChatPane } from "./AgentChatPane";
 import {
   agentChatGetSession,
+  agentChatInterruptTurn,
   agentChatListMessages,
   agentChatListMessagesAfter,
   agentChatThreadHeadId,
@@ -2052,6 +2056,48 @@ describe("AgentChatPane picker-config persistence (design G)", () => {
   });
 });
 
+describe("AgentChatPane Stop preserves its durable thread", () => {
+  beforeEach(() => {
+    currentMessages = [{ kind: "user_message", id: "m1" }];
+    currentThreadsMap = {};
+    currentDraftsById = {};
+    currentSliceOverrides = {
+      "thread-x": { streaming: true },
+    };
+    workspaceIdForPaneOverride = "ws-home";
+    vi.mocked(agentChatInterruptTurn).mockClear().mockResolvedValue(undefined);
+    vi.mocked(agentChatStartSession).mockClear();
+    vi.mocked(agentChatStopSession).mockClear().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => cleanup());
+
+  it.each(["claude", "codex", "opencode"] as const)(
+    "interrupts %s without stopping, restarting, or replacing the thread",
+    async (provider) => {
+      const { getByTestId } = render(
+        <AgentChatPane pane={{ ...pane, provider }} />,
+      );
+
+      fireEvent.click(getByTestId("composer-stop"));
+
+      await waitFor(() =>
+        expect(agentChatInterruptTurn).toHaveBeenCalledWith(
+          provider,
+          "thread-x",
+          null,
+        ),
+      );
+      expect(agentChatStopSession).not.toHaveBeenCalled();
+      expect(agentChatStartSession).not.toHaveBeenCalled();
+      expect(getByTestId("transcript")).toHaveAttribute(
+        "data-thread-key",
+        "thread-x",
+      );
+    },
+  );
+});
+
 describe("AgentChatPane provider handoff", () => {
   beforeEach(() => {
     currentMessages = [{ kind: "user_message", id: "m1" }];
@@ -2168,7 +2214,7 @@ describe("AgentChatPane handleModeRemove silent-restart", () => {
     setPermissionModeMock.mockClear();
     setModelMock.mockClear();
     markRequestResolvedMock.mockClear();
-    vi.mocked(agentChatStartSession).mockClear().mockResolvedValue("thread-restarted");
+    vi.mocked(agentChatStartSession).mockClear().mockResolvedValue("thread-x");
     vi.mocked(agentChatStopSession).mockClear().mockResolvedValue(undefined);
     vi.mocked(agentChatSetPermissionMode).mockClear().mockResolvedValue(undefined);
   });
@@ -2202,6 +2248,7 @@ describe("AgentChatPane handleModeRemove silent-restart", () => {
     // so the SDK re-applies `--dangerously-skip-permissions`.
     expect(agentChatStartSession).toHaveBeenCalled();
     const startInput = vi.mocked(agentChatStartSession).mock.calls[0][2];
+    expect(startInput.thread_id).toBe("thread-x");
     expect(startInput.permission_mode).toBe("bypassPermissions");
     // UI snap: slice.permissionMode flips immediately, slice.mode
     // returns to "default", priorPermissionMode is cleared.

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -2076,76 +2076,24 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     }
   }, [isSending, streaming, activeTurnId]);
 
-  // Interrupt mechanic: the SDK's `query.interrupt()` causes its
-  // async iterator to exit, so the underlying SDK query is dead after
-  // an interrupt. The sidecar now recovers from that transparently —
-  // like the reference multi-provider client, its next `send-turn`
-  // rebuilds a resumed SDK query for the (surviving) session, so a bare
-  // interrupt already lets subsequent turns land on a live query.
-  // The Stop button still performs a deliberate hard reset: interrupt
-  // for the immediate turn abort, then stop + start the session (fresh
-  // thread id, resume cursor) so subsequent turns land on a known-good
-  // SDK query and any wedged sidecar state is cleared. Transcript and
-  // picker state persist via `migrateThreadId`.
+  // Stop is turn-scoped, not conversation-scoped. Every provider recovers
+  // its query/stream after an interrupt, and a dead provider process is
+  // rebuilt by the backend on the next send. Keep the durable CodeMux thread
+  // id untouched here: minting another id made an ordinary Stop look like a
+  // new conversation whenever the in-memory resume cursor was missing.
   const handleStop = useCallback(() => {
     if (!threadId) return;
     if (restarting) return;
-    const currentSlice = useAgentChatStore.getState().threads[threadId];
-    if (!currentSlice) return;
     setRestarting(true);
     void (async () => {
-      // Await the interrupt BEFORE tearing the session down. The provider
-      // settles a user stop with a persisted `turn_completed{interrupted}`
-      // (Claude via the sidecar's `session-ended`, Codex via the app-server's
-      // `turn/completed`) that flows asynchronously. If we fired the interrupt
-      // and immediately killed the child, that settlement could lose the race
-      // and the stopped turn would hydrate as an unsettled — i.e. "Run
-      // interrupted" — turn after a restart. Awaiting orders the interrupt
-      // ahead of `stop_session`, whose graceful shutdown (EOF → grace → kill)
-      // then gives the settlement time to reach the event bridge (which
-      // persists from the broadcast independent of the child's liveness). An
-      // interrupt failure is safe to swallow — the stop below tears down anyway.
       try {
         await agentChatInterruptTurn(provider, threadId, null);
-      } catch {
-        // Non-fatal: the teardown below still restarts the session.
-      }
-      try {
-        await agentChatStopSession(provider, threadId);
       } catch (err) {
-        console.warn("[agent-chat] stop_session during Stop failed", err);
-      }
-      if (!cwd) {
-        setRestarting(false);
-        return;
-      }
-      try {
-        const newLocalThreadId = `chat-${pane.pane_id}-${Date.now()}`;
-        const newId = await agentChatStartSession(pane.pane_id, provider, {
-            thread_id: newLocalThreadId,
-            cwd,
-            model: currentSlice.model,
-            resume_cursor: currentSlice.resumeCursor,
-            permission_mode:
-              provider === "opencode" ? null : currentSlice.permissionMode,
-            effort: currentSlice.effort,
-            context_window: currentSlice.contextWindow,
-            fast_mode: currentSlice.fastMode,
-            additional_directories: [],
-            env: null,
-        });
-        migrateThreadId(threadId, newId);
-        setThreadId(newId);
-        setSessionLaunchMode(
-          newId,
-          provider === "opencode" ? null : currentSlice.permissionMode,
-        );
-      } catch (err) {
-        toast.error(`Failed to restart session after stop: ${err}`);
+        toast.error(`Failed to stop turn: ${err}`);
       } finally {
         setRestarting(false);
-        // Belt-and-braces: restart cleared any in-flight state, so
-        // drop the local send guard.
+        // The provider's interrupted settlement clears the durable turn state;
+        // release the pane-local guard even if that event is still in flight.
         sendInFlightRef.current = false;
         setIsSending(false);
       }
@@ -2153,11 +2101,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   }, [
     threadId,
     provider,
-    cwd,
-    pane.pane_id,
     restarting,
-    migrateThreadId,
-    setSessionLaunchMode,
   ]);
 
   // Follow-up queueing: cancel a queued (not-yet-dispatched) turn. The
@@ -2259,10 +2203,12 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   /**
    * Shared silent-restart helper. Permission-mode, effort, and
    * context-window all trigger the same flow on Claude: stop the
-   * current session, start a new one with the updated launch params,
-   * migrate the thread id. Transcript + model + draft survive via
-   * `migrateThreadId`; resume cursor carries session state when
-   * available. Codex-side callers don't route through here.
+   * current provider process, then rebuild it under the SAME durable
+   * CodeMux thread id with the updated launch params. The resume cursor
+   * carries provider-native state when available; the stable thread id
+   * keeps the visible transcript authoritative even if native resume
+   * ultimately has to fall back. Codex-side callers only route through
+   * here for launch-scoped features such as Fast mode.
    *
    * Declared above the mode handlers so `handleModeRemove` can use
    * it for the silent-restart restore path (the SDK rejects live
@@ -2283,7 +2229,6 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       if (restarting) return;
       setRestarting(true);
       const resumeCursor = currentSlice.resumeCursor;
-      const newLocalThreadId = `chat-${pane.pane_id}-${Date.now()}`;
       const nextMode =
         provider === "opencode"
           ? null
@@ -2308,7 +2253,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         }
         try {
           const newId = await agentChatStartSession(pane.pane_id, provider, {
-            thread_id: newLocalThreadId,
+            thread_id: threadId,
             cwd: cwd ?? "",
             model: nextModel,
             resume_cursor: resumeCursor,
@@ -2319,8 +2264,11 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
             additional_directories: [],
             env: null,
           });
-          migrateThreadId(threadId, newId);
-          setThreadId(newId);
+          if (newId !== threadId) {
+            throw new Error(
+              `Provider restart changed durable thread id from ${threadId} to ${newId}`,
+            );
+          }
           setSessionLaunchMode(newId, nextMode);
         } catch (err) {
           toast.error(`Failed to restart session: ${err}`);
@@ -2335,7 +2283,6 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       cwd,
       pane.pane_id,
       restarting,
-      migrateThreadId,
       setSessionLaunchMode,
     ],
   );


### PR DESCRIPTION
The Stop flow could turn an ordinary interruption into a new conversation. It stopped the provider, minted a new CodeMux thread ID, and relied on an in-memory resume cursor; if that cursor was cold after sleep or remount, the pane could silently continue in a blank provider session while the original transcript remained under the old ID.

This keeps the CodeMux thread durable across provider lifecycle changes. Stop now interrupts only the active turn, launch-setting restarts rebuild the provider under the same thread ID, and the backend recovers a persisted resume cursor when a same-provider restart arrives without the frontend cursor. Explicit New Chat behavior is unchanged.

Regression coverage verifies that Stop neither stops, restarts, nor replaces the mounted thread for Claude, Codex, and OpenCode. There is no visual delta, so screenshots are not applicable.

Verification:
- `npm run test -- src/components/chat/AgentChatPane.test.tsx` (79 passed)
- `npm run check`
- `cargo check -j 2 --manifest-path src-tauri/Cargo.toml`
- `cargo test -j 2 --manifest-path src-tauri/Cargo.toml send_after_dead_session_auto_resumes_with_persisted_config -- --test-threads=2`

Model and harness: GPT-5.6-Sol (High) via CodeMux/Codex.
