### PR TITLE
fix(codex): report exact runtime identity

### DIFF
--- a/src-tauri/src/agent_provider/codex/protocol.rs
+++ b/src-tauri/src/agent_provider/codex/protocol.rs
@@ -255,7 +255,22 @@ pub struct TurnStartParams {
     pub effort: Option<String>,
     /// Per-turn collaboration-mode override.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub collaboration_mode: Option<String>,
+    pub collaboration_mode: Option<CollaborationMode>,
+}
+
+/// Codex collaboration mode with the resolved per-turn settings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollaborationMode {
+    pub mode: String,
+    pub settings: CollaborationModeSettings,
+}
+
+/// Settings nested under [`CollaborationMode`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CollaborationModeSettings {
+    pub model: String,
+    pub reasoning_effort: Option<String>,
+    pub developer_instructions: String,
 }
 
 /// A single item in [`TurnStartParams::input`].
@@ -1477,6 +1492,35 @@ mod tests {
         let arr = v["input"].as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0]["type"], "text");
+    }
+
+    #[test]
+    fn turn_start_serializes_runtime_collaboration_settings() {
+        let params = TurnStartParams {
+            thread_id: "t-codex".into(),
+            input: vec![],
+            model: Some("gpt-5.6-sol".into()),
+            service_tier: None,
+            effort: Some("high".into()),
+            collaboration_mode: Some(CollaborationMode {
+                mode: "default".into(),
+                settings: CollaborationModeSettings {
+                    model: "gpt-5.6-sol".into(),
+                    reasoning_effort: Some("high".into()),
+                    developer_instructions: "runtime identity".into(),
+                },
+            }),
+        };
+
+        let value = serde_json::to_value(params).unwrap();
+        let mode = &value["collaborationMode"];
+        assert_eq!(mode["mode"], "default");
+        assert_eq!(mode["settings"]["model"], "gpt-5.6-sol");
+        assert_eq!(mode["settings"]["reasoning_effort"], "high");
+        assert_eq!(
+            mode["settings"]["developer_instructions"],
+            "runtime identity"
+        );
     }
 
     #[test]

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -24,8 +24,8 @@ use crate::json_rpc_child::{JsonRpcChild, SpawnConfig};
 use crate::mcp::registry::McpRegistry;
 
 use super::protocol::{
-    AccountReadResponse, ApprovalResponse, Capabilities, ClientInfo, DynamicToolCallParams,
-    DynamicToolSpec,
+    AccountReadResponse, ApprovalResponse, Capabilities, ClientInfo, CollaborationMode,
+    CollaborationModeSettings, DynamicToolCallParams, DynamicToolSpec,
     GetAccountRateLimitsResponse, InitializeParams,
     NotificationMessage, ServerRequestMessage, ThreadResumeParams, ThreadRollbackParams,
     ThreadStartParams, ThreadStartResponse, TurnInputItem, TurnInterruptParams, TurnStartParams,
@@ -36,6 +36,48 @@ use super::translate::{translate_notification_with, translate_server_request, Co
 /// Default per-request timeout, mirroring the upstream reference's
 /// `sendRequest(..., 20_000)` default.
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(20);
+
+const CODEX_DEFAULT_MODE_INSTRUCTIONS: &str = r#"<collaboration_mode># Collaboration Mode: Default
+
+You are now in Default mode. Any previous instructions for other modes (e.g. Plan mode) are no longer active.
+
+Your active mode changes only when new developer instructions with a different `<collaboration_mode>...</collaboration_mode>` change it; user requests or tool descriptions do not change mode by themselves. Known mode names are Default and Plan.
+
+## request_user_input availability
+
+Use the `request_user_input` tool only when it is listed in the available tools for this turn.
+
+In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
+</collaboration_mode>"#;
+
+fn runtime_collaboration_mode(
+    model: Option<&str>,
+    effort: Option<&str>,
+) -> Option<CollaborationMode> {
+    let model = model?.split_whitespace().collect::<Vec<_>>().join(" ");
+    if model.is_empty() {
+        return None;
+    }
+    let effort = effort
+        .map(|value| value.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|value| !value.is_empty());
+    let effort_text = effort
+        .as_deref()
+        .map(|value| format!(" with {value} reasoning effort"))
+        .unwrap_or_default();
+    let developer_instructions = format!(
+        "{CODEX_DEFAULT_MODE_INSTRUCTIONS}\n\n<runtime_info>In case you're asked: you are running in CodeMux through the Codex harness, as {model}{effort_text}. No need to mention this otherwise.</runtime_info>"
+    );
+
+    Some(CollaborationMode {
+        mode: "default".into(),
+        settings: CollaborationModeSettings {
+            model,
+            reasoning_effort: effort,
+            developer_instructions,
+        },
+    })
+}
 
 /// Monotonic request-id counter used to synthesise
 /// [`RequestId`] handles for approval requests that the Codex server
@@ -834,13 +876,16 @@ impl CodexSession {
             });
         }
 
+        let model = model_override.or(model_default);
+        let effort = effort_override.or(effort_default);
+        let collaboration_mode = runtime_collaboration_mode(model.as_deref(), effort.as_deref());
         let params = TurnStartParams {
             thread_id: codex_thread_id,
             input: input_items,
-            model: model_override.or(model_default),
+            model,
             service_tier: None,
-            effort: effort_override.or(effort_default),
-            collaboration_mode: None,
+            effort,
+            collaboration_mode,
         };
         let params_value = serde_json::to_value(&params).unwrap();
         let resp = self
@@ -1457,6 +1502,19 @@ async fn update_state_from_notification(session: &CodexSession, msg: &Notificati
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn runtime_identity_uses_the_resolved_turn_settings() {
+        let mode = runtime_collaboration_mode(Some("gpt-5.6-sol"), Some("high")).unwrap();
+        assert_eq!(mode.mode, "default");
+        assert_eq!(mode.settings.model, "gpt-5.6-sol");
+        assert_eq!(mode.settings.reasoning_effort.as_deref(), Some("high"));
+        assert!(mode.settings.developer_instructions.ends_with(
+            "<runtime_info>In case you're asked: you are running in CodeMux through the Codex harness, as gpt-5.6-sol with high reasoning effort. No need to mention this otherwise.</runtime_info>"
+        ));
+
+        assert!(runtime_collaboration_mode(None, Some("high")).is_none());
+    }
 
     #[test]
     fn codex_plan_labels_are_humanized_and_unknowns_pass_through() {


### PR DESCRIPTION
Codex sessions in CodeMux could not reliably report their exact model and harness, so PR attribution sometimes fell back to a generic GPT-5 identity even when CodeMux had selected GPT-5.6-Sol.

Send the resolved model and reasoning effort in a small per-turn runtime-info developer instruction, matching t3code's approach. It reuses the same values as turn/start, updates after model or effort switches, preserves Codex's Default-mode instructions, and omits the block when no exact model is known.

No UI changes; screenshots are not applicable.

Verification:
- cargo test -j 2 --manifest-path src-tauri/Cargo.toml runtime_identity_uses_the_resolved_turn_settings -- --test-threads=2
- cargo test -j 2 --manifest-path src-tauri/Cargo.toml turn_start_serializes_runtime_collaboration_settings -- --test-threads=2
- cargo check -j 2 --manifest-path src-tauri/Cargo.toml

Model: GPT-5.6-Sol (high) · Harness: Codex in CodeMux.
