### PR TITLE
fix: clear stale Claude auth banner after re-login

### DIFF
--- a/sidecar/claude-agent/src/auth-probe.ts
+++ b/sidecar/claude-agent/src/auth-probe.ts
@@ -17,6 +17,12 @@ const UNAUTHENTICATED_PATTERNS = [
   "not logged in",
   "run claude login",
   "not authenticated",
+  // Must be listed (and therefore matched) BEFORE the positive
+  // heuristic below, which looks for the substring "authenticated" —
+  // that substring also sits inside "unauthenticated", so a CLI that
+  // reports `Status: unauthenticated` would otherwise be read as
+  // logged in and no banner would ever appear.
+  "unauthenticated",
   "please log in",
   "login required",
 ];
@@ -92,9 +98,82 @@ export async function probeInstalled(
   return { installed: true, version: token };
 }
 
+/** Newer CLIs print `auth status` as a JSON object with a `loggedIn`
+ *  boolean. The legacy substring matcher below never sees the phrase
+ *  "logged in" in that form (the key is `loggedIn`), so without this
+ *  step a fully logged-in user is reported as `unknown` forever and
+ *  the chat surface shows a "could not verify" banner that no amount
+ *  of re-login clears. Returns `null` when the output is not JSON or
+ *  lacks the field, so the text heuristics still apply. */
+function classifyJsonAuthOutput(
+  output: string,
+): ProbeAuthenticatedResult | null {
+  for (const candidate of jsonObjectCandidates(output)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const loggedIn = (parsed as Record<string, unknown>)["loggedIn"];
+    if (typeof loggedIn !== "boolean") continue;
+    return loggedIn
+      ? { status: "authenticated" }
+      : {
+          status: "unauthenticated",
+          message:
+            "Claude CLI is not authenticated. Run `claude login` and retry.",
+        };
+  }
+  return null;
+}
+
+/** Every balanced top-level `{...}` region in `output`, in order.
+ *
+ *  Scanning for balanced regions rather than slicing first-`{` to
+ *  last-`}` matters because the classified text is stdout AND stderr
+ *  concatenated: one brace-bearing extra line (an update notice, a
+ *  second JSON object, a runtime warning) would make the single wide
+ *  slice unparseable and silently drop the whole probe back to
+ *  `unknown` — reinstating the very "could not verify" banner this
+ *  parsing exists to prevent. Quoted strings are tracked so braces
+ *  inside values (an org name, say) do not unbalance the scan. */
+function* jsonObjectCandidates(output: string): Generator<string> {
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < output.length; i += 1) {
+    const ch = output[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      if (depth === 0) start = i;
+      depth += 1;
+    } else if (ch === "}") {
+      // A stray closer outside any object is noise, not an underflow.
+      if (depth === 0) continue;
+      depth -= 1;
+      if (depth === 0 && start !== -1) {
+        yield output.slice(start, i + 1);
+        start = -1;
+      }
+    }
+  }
+}
+
 /** Classify combined stdout+stderr into an auth status. Split out
  *  so it is pure and unit-testable. */
 export function classifyAuthOutput(output: string): ProbeAuthenticatedResult {
+  const structured = classifyJsonAuthOutput(output);
+  if (structured) return structured;
   const lower = output.toLowerCase();
   for (const pattern of UNAUTHENTICATED_PATTERNS) {
     if (lower.includes(pattern)) {

--- a/sidecar/claude-agent/test/auth-probe.test.ts
+++ b/sidecar/claude-agent/test/auth-probe.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { classifyAuthOutput } from "../src/auth-probe";
+
+describe("classifyAuthOutput", () => {
+  test("JSON loggedIn:true is authenticated", () => {
+    const out = JSON.stringify({
+      loggedIn: true,
+      authMethod: "claude.ai",
+      subscriptionType: "max",
+    });
+    expect(classifyAuthOutput(out).status).toBe("authenticated");
+  });
+
+  test("JSON loggedIn:false is unauthenticated", () => {
+    const out = `${JSON.stringify({ loggedIn: false })}\n`;
+    expect(classifyAuthOutput(out).status).toBe("unauthenticated");
+  });
+
+  test("JSON with stderr noise around it still parses", () => {
+    const out = `warning: something\n{"loggedIn":true}\n`;
+    expect(classifyAuthOutput(out).status).toBe("authenticated");
+  });
+
+  test("legacy text output still classifies", () => {
+    expect(classifyAuthOutput("Logged in as x@y.z").status).toBe(
+      "authenticated",
+    );
+    expect(classifyAuthOutput("You are not logged in").status).toBe(
+      "unauthenticated",
+    );
+  });
+
+  test("unparseable output is unknown", () => {
+    expect(classifyAuthOutput("{ garbage").status).toBe("unknown");
+    expect(classifyAuthOutput("").status).toBe("unknown");
+  });
+
+  test("the CLI's real pretty-printed payload is authenticated", () => {
+    // Verbatim shape of `claude auth status` on a logged-in machine.
+    const out = [
+      "{",
+      '  "loggedIn": true,',
+      '  "authMethod": "claude.ai",',
+      '  "apiProvider": "firstParty",',
+      '  "email": "user@example.com",',
+      '  "subscriptionType": "max"',
+      "}",
+      "",
+    ].join("\n");
+    expect(classifyAuthOutput(out).status).toBe("authenticated");
+  });
+
+  test("brace-bearing noise AFTER the payload does not defeat parsing", () => {
+    // The classified text is stdout+stderr concatenated, so anything the
+    // CLI adds on stderr lands after the JSON. Slicing first-`{` to
+    // last-`}` would swallow it and fall back to `unknown`, which is the
+    // stale "could not verify" banner all over again.
+    const out = `{"loggedIn":true}\n(node:1) Warning: legacy config {a}\n`;
+    expect(classifyAuthOutput(out).status).toBe("authenticated");
+  });
+
+  test("a second JSON object does not defeat parsing", () => {
+    const out = `{"loggedIn":false}\n{"update":"available"}\n`;
+    expect(classifyAuthOutput(out).status).toBe("unauthenticated");
+  });
+
+  test("braces inside string values do not unbalance the scan", () => {
+    const out = JSON.stringify({ orgName: "Acme {Labs}", loggedIn: true });
+    expect(classifyAuthOutput(out).status).toBe("authenticated");
+  });
+
+  test("`unauthenticated` is not read as `authenticated`", () => {
+    // "authenticated" is a substring of "unauthenticated"; matching it
+    // positively would hide the banner from a logged-OUT user.
+    expect(classifyAuthOutput("Status: unauthenticated").status).toBe(
+      "unauthenticated",
+    );
+  });
+
+  test("a JSON object without `loggedIn` falls through to the text rules", () => {
+    expect(classifyAuthOutput(`{"other":1}\nnot logged in`).status).toBe(
+      "unauthenticated",
+    );
+    expect(classifyAuthOutput(`{"other":1}`).status).toBe("unknown");
+  });
+
+  test("non-boolean `loggedIn` does not fabricate an answer", () => {
+    // A string/null value is an unrecognized schema, not a "yes".
+    expect(classifyAuthOutput(`{"loggedIn":"true"}`).status).toBe("unknown");
+    expect(classifyAuthOutput(`{"loggedIn":null}`).status).toBe("unknown");
+  });
+});

--- a/src/stores/provider-health-store.test.ts
+++ b/src/stores/provider-health-store.test.ts
@@ -185,6 +185,58 @@ describe("provider-health-store", () => {
     ).toBe("Claude CLI is not installed.");
   });
 
+  it("noteProviderSuccess keeps a dismissal when the same warning returns", async () => {
+    // A dismissed advisory must not come back on every successful send
+    // just because the re-probe is still inconclusive.
+    seed(report("warning", "Could not verify Claude authentication status."));
+    useProviderHealth.getState().dismiss("claude");
+    mockProbe.mockResolvedValue(
+      report("warning", "Could not verify Claude authentication status."),
+    );
+
+    await useProviderHealth.getState().noteProviderSuccess("claude");
+
+    expect(mockProbe).toHaveBeenCalledTimes(1);
+    expect(
+      selectVisibleHealthReport(useProviderHealth.getState(), "claude"),
+    ).toBeNull();
+  });
+
+  it("keeps a dismissal narrow: a different failure still banners", async () => {
+    // The counterweight to the test above — the dismissal survives a
+    // successful send, but it must stay scoped to the failure the user
+    // actually closed, or a real new problem goes unreported.
+    seed(report("warning", "Could not verify Claude authentication status."));
+    useProviderHealth.getState().dismiss("claude");
+    mockProbe.mockResolvedValue(report("error", "Claude CLI is not installed."));
+
+    await useProviderHealth.getState().noteProviderSuccess("claude");
+
+    expect(
+      selectVisibleHealthReport(useProviderHealth.getState(), "claude")
+        ?.message,
+    ).toBe("Claude CLI is not installed.");
+  });
+
+  it("retires a dismissal on recovery so the same failure banners again", async () => {
+    // Recovery is the ONLY thing that clears a dismissal now, so pin it:
+    // fail → dismiss → recover → fail identically → visible again.
+    const failure = report("warning", "Could not verify Claude auth.");
+    seed(failure);
+    useProviderHealth.getState().dismiss("claude");
+
+    mockProbe.mockResolvedValueOnce(report("ready"));
+    await useProviderHealth.getState().refresh("claude", { force: true });
+    expect(useProviderHealth.getState().slots.claude.dismissedKey).toBeNull();
+
+    mockProbe.mockResolvedValueOnce(failure);
+    await useProviderHealth.getState().refresh("claude", { force: true });
+    expect(
+      selectVisibleHealthReport(useProviderHealth.getState(), "claude")
+        ?.message,
+    ).toBe("Could not verify Claude auth.");
+  });
+
   it("noteProviderSuccess costs nothing on the healthy path", async () => {
     seed(report("ready"));
     await useProviderHealth.getState().noteProviderSuccess("claude");

--- a/src/stores/provider-health-store.ts
+++ b/src/stores/provider-health-store.ts
@@ -192,6 +192,13 @@ export const useProviderHealth = create<ProviderHealthStore>((set, get) => ({
     // `ready` report would break the banner's probe-backed contract, so
     // the forced re-probe below re-establishes ground truth (and puts
     // the banner back if the provider really is still degraded).
+    //
+    // The user's dismissal is deliberately KEPT. Successful turns are
+    // the common case, so wiping it here would resurrect a dismissed
+    // banner on every send whenever the re-probe returns the same
+    // inconclusive answer (a probe that can't classify the CLI's
+    // output, say). `refresh` already clears the dismissal on a
+    // genuine recovery, and a DIFFERENT failure has a different key.
     set((state) => ({
       slots: {
         ...state.slots,
@@ -199,7 +206,6 @@ export const useProviderHealth = create<ProviderHealthStore>((set, get) => ({
           ...state.slots[provider],
           report: null,
           fetchedAt: 0,
-          dismissedKey: null,
         },
       },
     }));


### PR DESCRIPTION
## Problem

The chat pane showed an amber "Claude · Could not verify Claude authentication status." banner that never cleared after re-logging in, and reappeared immediately after dismissing it.

Two causes:

1. `claude auth status` now prints JSON (`{"loggedIn": true, ...}`). The sidecar classifier only matched the substrings `"logged in"` / `"authenticated"`, so every probe returned `unknown` regardless of login state — re-login genuinely had no effect. The 5-minute recovery poll just kept getting the same wrong answer.
2. `noteProviderSuccess` (fired after every successful session start) wiped the user's dismissal before force-reprobing. The identical warning came back and the banner popped up again.

## Fix

- **Sidecar** (`auth-probe.ts`): parse the JSON `loggedIn` boolean first, scanning balanced top-level `{...}` objects so stderr noise (e.g. a Node warning containing a brace) can't knock it back to `unknown`. Legacy text heuristics remain as fallback. Also adds `"unauthenticated"` to the negative patterns — previously it matched the `"authenticated"` positive check and a logged-out CLI could be reported as ready.
- **Store** (`provider-health-store.ts`): keep `dismissedKey` across a success-triggered reprobe. A genuine `ready` report still clears it; a different failure still banners.

## Testing

- Rebuilt sidecar against a real logged-in CLI: `authenticated` (was `unknown`). Fake logged-out CLI with brace noise on stderr: `unauthenticated`.
- Sidecar `bun test`: 105 pass, 0 fail (12 new classifier cases).
- `npm run test` store + ProviderStatusNotice: 18 pass (3 new store cases: dismissal survives a send; a different failure still banners; fail → dismiss → recover → fail banners again).
- `npm run check`, sidecar typecheck, ToS boundary check: pass.

Note: the sidecar is bundled, so the banner itself goes away in a rebuilt app; the store fix alone makes dismiss stick.

Implemented with Claude Fable 5 in Codemux, with an Opus subagent doing review and hardening.
