### PR TITLE
feat(usage): replace stacked bars with hoverable area chart

### DIFF
--- a/src/components/settings/usage-area-chart.test.ts
+++ b/src/components/settings/usage-area-chart.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { monotonePath, tickIndices } from "./usage-area-chart";
+
+describe("monotonePath", () => {
+  it("handles the degenerate sizes", () => {
+    expect(monotonePath([])).toBe("");
+    expect(monotonePath([{ x: 5, y: 7 }])).toBe("M5,7");
+  });
+
+  it("keeps a flat run on the baseline instead of overshooting", () => {
+    // A spike followed by zeros: a Catmull-Rom curve would dip below the
+    // baseline (y > 100 here) on the way down; a monotone one must not.
+    const pts = [
+      { x: 0, y: 100 },
+      { x: 10, y: 0 },
+      { x: 20, y: 100 },
+      { x: 30, y: 100 },
+      { x: 40, y: 100 },
+    ];
+    const d = monotonePath(pts);
+    const ys = [...d.matchAll(/[\d.]+,([\d.]+)/g)].map((m) => Number(m[1]));
+    expect(Math.max(...ys)).toBeLessThanOrEqual(100);
+    expect(Math.min(...ys)).toBeGreaterThanOrEqual(0);
+    expect(d.startsWith("M0,100 C")).toBe(true);
+    expect(d.endsWith("40,100")).toBe(true);
+  });
+});
+
+describe("tickIndices", () => {
+  it("labels every bucket when there is room", () => {
+    expect(tickIndices(7, 640)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it("thins dense axes but always keeps the first and last bucket", () => {
+    const ticks = tickIndices(90, 640);
+    expect(ticks[0]).toBe(0);
+    expect(ticks[ticks.length - 1]).toBe(89);
+    expect(ticks.length).toBeLessThanOrEqual(Math.floor(640 / 72));
+    // Evenly stepped apart from the final tick.
+    const steps = new Set(ticks.slice(1, -1).map((t, i) => t - ticks[i]));
+    expect(steps.size).toBe(1);
+  });
+
+  it("never crowds the final tick", () => {
+    for (const n of [2, 3, 8, 9, 24, 30, 31, 90]) {
+      const ticks = tickIndices(n, 500);
+      const gaps = ticks.slice(1).map((t, i) => t - ticks[i]);
+      const step = gaps[0];
+      expect(gaps.every((g) => g >= step / 2)).toBe(true);
+    }
+  });
+
+  it("handles empty and single-bucket inputs", () => {
+    expect(tickIndices(0, 640)).toEqual([]);
+    expect(tickIndices(1, 640)).toEqual([0]);
+  });
+});

--- a/src/components/settings/usage-area-chart.tsx
+++ b/src/components/settings/usage-area-chart.tsx
@@ -1,0 +1,459 @@
+import { useId, useLayoutEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** One line on the chart: a provider's per-bucket values under the
+ *  active metric. `color` is any CSS color the SVG can paint with —
+ *  theme variables included — so the series match the legend. */
+export interface AreaSeries {
+  key: string;
+  label: string;
+  color: string;
+  /** Stroke/fill opacity multiplier, for series drawn in a neutral tone
+   *  that should sit behind the accent colors rather than compete. */
+  opacity?: number;
+  values: number[];
+}
+
+export interface AreaPoint {
+  /** Short axis label. */
+  label: string;
+  /** Full label for the tooltip. */
+  subLabel: string;
+}
+
+/** Plot margins. No y-axis labels — the tooltip carries the exact
+ *  figures, and the hero stat above carries the total — so the plot
+ *  can run edge to edge and only the tick row below needs room. */
+const PAD_TOP = 10;
+const PAD_BOTTOM = 22;
+const PAD_X = 4;
+const GRIDLINES = 3;
+const TICK_LABEL_PX = 10;
+/** Minimum horizontal room per axis label before ticks are thinned. */
+const TICK_MIN_SPACING_PX = 72;
+/** Longest full label that still fits the tick spacing above; "Aug 19"
+ *  does, "Yesterday 13:00" does not. */
+const TICK_FULL_LABEL_MAX_CHARS = 8;
+/** Fallback before the first measurement — wide enough that a server
+ *  or jsdom render still lays the points out sensibly. */
+const FALLBACK_WIDTH_PX = 640;
+
+/** Smooth `points` with a monotone cubic curve (Fritsch–Carlson
+ *  tangents). Unlike a Catmull-Rom spline it never overshoots, so a
+ *  run of zeros stays flat on the baseline instead of dipping below
+ *  it — a chart of spend must not draw negative money. */
+export function monotonePath(points: { x: number; y: number }[]): string {
+  const n = points.length;
+  if (n === 0) return "";
+  if (n === 1) return `M${points[0].x},${points[0].y}`;
+  const dx: number[] = [];
+  const slope: number[] = [];
+  for (let i = 0; i < n - 1; i++) {
+    const d = points[i + 1].x - points[i].x;
+    dx.push(d);
+    slope.push(d === 0 ? 0 : (points[i + 1].y - points[i].y) / d);
+  }
+  const tangent: number[] = [slope[0]];
+  for (let i = 1; i < n - 1; i++) {
+    const a = slope[i - 1];
+    const b = slope[i];
+    tangent.push(a * b <= 0 ? 0 : (a + b) / 2);
+  }
+  tangent.push(slope[n - 2]);
+  // Clamp tangents so the curve stays monotone between samples.
+  for (let i = 0; i < n - 1; i++) {
+    if (slope[i] === 0) {
+      tangent[i] = 0;
+      tangent[i + 1] = 0;
+      continue;
+    }
+    const a = tangent[i] / slope[i];
+    const b = tangent[i + 1] / slope[i];
+    const s = a * a + b * b;
+    if (s > 9) {
+      const t = 3 / Math.sqrt(s);
+      tangent[i] = t * a * slope[i];
+      tangent[i + 1] = t * b * slope[i];
+    }
+  }
+  let d = `M${fmt(points[0].x)},${fmt(points[0].y)}`;
+  for (let i = 0; i < n - 1; i++) {
+    const p0 = points[i];
+    const p1 = points[i + 1];
+    const h = dx[i] / 3;
+    d += ` C${fmt(p0.x + h)},${fmt(p0.y + tangent[i] * h)} ${fmt(p1.x - h)},${fmt(
+      p1.y - tangent[i + 1] * h,
+    )} ${fmt(p1.x)},${fmt(p1.y)}`;
+  }
+  return d;
+}
+
+function fmt(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(2);
+}
+
+/** Evenly spaced tick indices that always include the first and last
+ *  bucket, thinned so labels never collide at 24 hours or 90 days. */
+export function tickIndices(count: number, width: number): number[] {
+  if (count <= 0) return [];
+  if (count === 1) return [0];
+  const maxTicks = Math.max(2, Math.floor(width / TICK_MIN_SPACING_PX));
+  if (count <= maxTicks) return Array.from({ length: count }, (_, i) => i);
+  const step = Math.ceil((count - 1) / (maxTicks - 1));
+  const ticks: number[] = [];
+  for (let i = 0; i < count - 1; i += step) {
+    // Drop a tick that would crowd the final one.
+    if (count - 1 - i < step / 2) break;
+    ticks.push(i);
+  }
+  ticks.push(count - 1);
+  return ticks;
+}
+
+function useMeasuredWidth<T extends HTMLElement>(): [
+  React.RefObject<T | null>,
+  number,
+] {
+  const ref = useRef<T | null>(null);
+  const [width, setWidth] = useState(FALLBACK_WIDTH_PX);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => {
+      const w = el.getBoundingClientRect().width;
+      if (w > 0) setWidth(w);
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, width];
+}
+
+export function UsageAreaChart({
+  series,
+  points,
+  height,
+  hovered,
+  onHover,
+  formatValue,
+  totalLabel = "Total",
+  ariaLabel,
+  className,
+}: {
+  series: AreaSeries[];
+  points: AreaPoint[];
+  height: number;
+  hovered: number | null;
+  onHover: (index: number | null) => void;
+  formatValue: (value: number) => string;
+  totalLabel?: string;
+  ariaLabel: string;
+  className?: string;
+}) {
+  const [ref, width] = useMeasuredWidth<HTMLDivElement>();
+  const gradientId = useId();
+  const count = points.length;
+
+  const plotLeft = PAD_X;
+  const plotRight = Math.max(plotLeft + 1, width - PAD_X);
+  const plotTop = PAD_TOP;
+  const plotBottom = Math.max(plotTop + 1, height - PAD_BOTTOM);
+  const plotWidth = plotRight - plotLeft;
+  const plotHeight = plotBottom - plotTop;
+
+  const max =
+    Math.max(0, ...series.flatMap((s) => s.values.map((v) => (Number.isFinite(v) ? v : 0)))) ||
+    1;
+
+  const xAt = (i: number) =>
+    count <= 1 ? plotLeft + plotWidth / 2 : plotLeft + (i / (count - 1)) * plotWidth;
+  const yAt = (v: number) => plotBottom - (Math.max(0, v) / max) * plotHeight;
+
+  const paths = series.map((s) => {
+    const pts = Array.from({ length: count }, (_, i) => ({
+      x: xAt(i),
+      y: yAt(s.values[i] ?? 0),
+    }));
+    const line = monotonePath(pts);
+    const area =
+      count >= 2 && line
+        ? `${line} L${fmt(pts[count - 1].x)},${fmt(plotBottom)} L${fmt(pts[0].x)},${fmt(
+            plotBottom,
+          )} Z`
+        : "";
+    return { series: s, pts, line, area };
+  });
+
+  const ticks = tickIndices(count, plotWidth);
+  // Prefer the full "Aug 19" over a bare "19" — a day number alone is
+  // ambiguous once a 90-day axis spans months. Hourly "Today 13:00"
+  // labels are too long and fall back to the compact "13:00" form.
+  const fullTicks = ticks.every(
+    (i) => (points[i]?.subLabel.length ?? 0) <= TICK_FULL_LABEL_MAX_CHARS,
+  );
+  const tickLabel = (i: number) =>
+    fullTicks ? points[i]?.subLabel : points[i]?.label;
+
+  const indexFromClientX = (clientX: number): number | null => {
+    const el = ref.current;
+    if (!el || count === 0) return null;
+    const rect = el.getBoundingClientRect();
+    const x = clientX - rect.left;
+    if (count === 1) return 0;
+    const i = Math.round(((x - plotLeft) / plotWidth) * (count - 1));
+    return Math.min(count - 1, Math.max(0, i));
+  };
+
+  const hoveredPoint = hovered === null ? null : (points[hovered] ?? null);
+  const hoverX = hovered === null ? null : xAt(hovered);
+  const total =
+    hovered === null ? 0 : series.reduce((sum, s) => sum + (s.values[hovered] ?? 0), 0);
+  // Flip the tooltip to the left of the crosshair past the midpoint so it
+  // never runs off the card's right edge.
+  const tooltipLeft = hoverX !== null && hoverX > width / 2;
+
+  return (
+    <div
+      ref={ref}
+      className={cn("relative w-full select-none", className)}
+      style={{ height }}
+      onPointerMove={(e) => onHover(indexFromClientX(e.clientX))}
+      onPointerLeave={() => onHover(null)}
+    >
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={ariaLabel}
+        className="block overflow-visible"
+      >
+        <defs>
+          {series.map((s) => (
+            <linearGradient
+              key={s.key}
+              id={`${gradientId}-${s.key}`}
+              x1="0"
+              y1="0"
+              x2="0"
+              y2="1"
+            >
+              <stop offset="0%" stopColor={s.color} stopOpacity={0.32 * (s.opacity ?? 1)} />
+              <stop offset="70%" stopColor={s.color} stopOpacity={0.06 * (s.opacity ?? 1)} />
+              <stop offset="100%" stopColor={s.color} stopOpacity={0} />
+            </linearGradient>
+          ))}
+        </defs>
+
+        {/* Gridlines: quiet horizontal guides plus the baseline. */}
+        {Array.from({ length: GRIDLINES + 1 }, (_, i) => {
+          const y = plotBottom - (i / GRIDLINES) * plotHeight;
+          return (
+            <line
+              key={i}
+              x1={plotLeft}
+              x2={plotRight}
+              y1={y}
+              y2={y}
+              stroke="var(--border)"
+              strokeOpacity={i === 0 ? 1 : 0.5}
+              strokeWidth={1}
+              strokeDasharray={i === 0 ? undefined : "2 4"}
+              shapeRendering="crispEdges"
+            />
+          );
+        })}
+
+        {/* Larger series first so the smaller ones draw on top and stay
+            visible where the lines overlap. */}
+        {paths.map(({ series: s, area, line }) => (
+          <g key={s.key} opacity={s.opacity ?? 1}>
+            {area && <path d={area} fill={`url(#${gradientId}-${s.key})`} />}
+            {line && (
+              <path
+                d={line}
+                fill="none"
+                stroke={s.color}
+                strokeWidth={1.75}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                vectorEffect="non-scaling-stroke"
+              />
+            )}
+          </g>
+        ))}
+
+        {/* Crosshair and the points it passes through. */}
+        {hoverX !== null && (
+          <g>
+            <line
+              x1={hoverX}
+              x2={hoverX}
+              y1={plotTop}
+              y2={plotBottom}
+              stroke="var(--foreground)"
+              strokeOpacity={0.35}
+              strokeWidth={1}
+              strokeDasharray="3 3"
+            />
+            {paths.map(({ series: s, pts }) => {
+              const p = pts[hovered as number];
+              if (!p) return null;
+              return (
+                <g key={s.key} opacity={s.opacity ?? 1}>
+                  <circle cx={p.x} cy={p.y} r={6} fill={s.color} fillOpacity={0.2} />
+                  <circle
+                    cx={p.x}
+                    cy={p.y}
+                    r={3}
+                    fill={s.color}
+                    stroke="var(--background)"
+                    strokeWidth={1.5}
+                  />
+                </g>
+              );
+            })}
+          </g>
+        )}
+
+        {ticks.map((i) => {
+          const x = xAt(i);
+          const anchor = i === 0 ? "start" : i === count - 1 ? "end" : "middle";
+          return (
+            <text
+              key={i}
+              x={x}
+              y={height - 6}
+              textAnchor={anchor}
+              fontSize={TICK_LABEL_PX}
+              className={cn(
+                "font-mono uppercase tracking-[0.06em] transition-[fill]",
+              )}
+              fill={hovered === i ? "var(--foreground)" : "var(--muted-foreground)"}
+              fillOpacity={hovered === i ? 1 : 0.75}
+            >
+              {tickLabel(i)}
+            </text>
+          );
+        })}
+      </svg>
+
+      {hoveredPoint && hoverX !== null && (
+        <div
+          role="tooltip"
+          className={cn(
+            "pointer-events-none absolute top-1 z-10 min-w-[168px] rounded-md border border-border/70 bg-popover/95 px-3 py-2 shadow-lg backdrop-blur-sm",
+          )}
+          style={
+            tooltipLeft
+              ? { right: Math.max(0, width - hoverX + 12) }
+              : { left: Math.min(hoverX + 12, Math.max(0, width - 180)) }
+          }
+        >
+          <p className="mb-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.09em] text-muted-foreground">
+            {hoveredPoint.subLabel}
+          </p>
+          <ul className="flex flex-col gap-1">
+            {series.map((s) => (
+              <li
+                key={s.key}
+                className="flex items-center justify-between gap-4 text-[11px]"
+              >
+                <span className="inline-flex items-center gap-2 text-foreground/85">
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-[2px]"
+                    style={{ background: s.color, opacity: s.opacity ?? 1 }}
+                    aria-hidden
+                  />
+                  {s.label}
+                </span>
+                <span className="font-mono tabular-nums text-foreground">
+                  {formatValue(s.values[hovered as number] ?? 0)}
+                </span>
+              </li>
+            ))}
+          </ul>
+          {series.length > 1 && (
+            <p className="mt-1.5 flex items-center justify-between gap-4 border-t border-border/50 pt-1.5 text-[11px]">
+              <span className="text-muted-foreground">{totalLabel}</span>
+              <span className="font-mono font-semibold tabular-nums">
+                {formatValue(total)}
+              </span>
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A bare, unlabelled version of the same curve for the provider lanes —
+ *  one series, no hover, no axis. */
+export function UsageSparkline({
+  values,
+  color,
+  opacity = 1,
+  height,
+  className,
+}: {
+  values: number[];
+  color: string;
+  opacity?: number;
+  height: number;
+  className?: string;
+}) {
+  const [ref, width] = useMeasuredWidth<HTMLSpanElement>();
+  const gradientId = useId();
+  const count = values.length;
+  const max = Math.max(0, ...values) || 1;
+  const top = 2;
+  const bottom = height - 1;
+  const pts = values.map((v, i) => ({
+    x: count <= 1 ? width / 2 : (i / (count - 1)) * width,
+    y: bottom - (Math.max(0, v) / max) * (bottom - top),
+  }));
+  const line = monotonePath(pts);
+  const area =
+    count >= 2 ? `${line} L${fmt(width)},${bottom} L0,${bottom} Z` : "";
+  return (
+    <span
+      ref={ref}
+      className={cn("block w-full", className)}
+      style={{ height }}
+      aria-hidden
+    >
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        className="block overflow-visible"
+        opacity={opacity}
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.28} />
+            <stop offset="100%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        {area && <path d={area} fill={`url(#${gradientId})`} />}
+        {line && (
+          <path
+            d={line}
+            fill="none"
+            stroke={color}
+            strokeWidth={1.5}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        )}
+      </svg>
+    </span>
+  );
+}

--- a/src/components/settings/usage-section.test.tsx
+++ b/src/components/settings/usage-section.test.tsx
@@ -240,16 +240,41 @@ describe("UsageSection", () => {
     });
   });
 
-  it("switches the readout between cost and tokens", async () => {
+  it("shows a tooltip with per-provider figures for the hovered bucket", async () => {
     render(<UsageSection />);
     await waitFor(() => {
-      expect(screen.getByText("Total for period")).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: /Estimated cost per bucket/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    // jsdom has no layout, so the chart measures at its fallback width and
+    // the far-left pointer lands on the first bucket.
+    const chart = screen.getByRole("img", { name: /Estimated cost per bucket/ })
+      .parentElement as HTMLElement;
+    await userEvent.pointer({ target: chart, coords: { clientX: 0, clientY: 10 } });
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Aug 1");
+    expect(tooltip).toHaveTextContent("Claude Code$9.40");
+    expect(tooltip).toHaveTextContent("OpenCode$0.92");
+    expect(tooltip).toHaveTextContent("Total$10.32");
+
+    await userEvent.unhover(chart);
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("switches the chart between cost and tokens", async () => {
+    render(<UsageSection />);
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /Estimated cost per bucket/ })).toBeInTheDocument();
     });
     expect(screen.getAllByText("API/list-price equivalent").length).toBeGreaterThan(0);
 
     await userEvent.click(screen.getByRole("radio", { name: "Tokens" }));
     await waitFor(() => {
-      expect(screen.getByText("Tokens for period")).toBeInTheDocument();
+      expect(screen.getByRole("img", { name: /Tokens per bucket/ })).toBeInTheDocument();
     });
     expect(
       screen.getAllByText("input + output + cache read + cache write").length,
@@ -527,7 +552,8 @@ describe("composition, breakdown and cost confidence", () => {
       expect(screen.queryByText("gpt-5-codex")).not.toBeInTheDocument();
     });
     // Day rows come from the same buckets the chart uses, newest first.
-    expect(screen.getByText("Aug 7")).toBeInTheDocument();
+    // The chart's axis also labels that bucket, hence "all".
+    expect(screen.getAllByText("Aug 7").length).toBeGreaterThan(1);
 
     await userEvent.click(screen.getByRole("radio", { name: "Model" }));
     await waitFor(() => {

--- a/src/components/settings/usage-section.tsx
+++ b/src/components/settings/usage-section.tsx
@@ -5,6 +5,7 @@ import { ChevronDown, ChevronUp, Loader2, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ProviderLogo } from "@/components/chat/provider-logo";
 import { SegmentedControl } from "./settings-primitives";
+import { UsageAreaChart, UsageSparkline } from "./usage-area-chart";
 import {
   usageExportCsv,
   usageScanProviderHistory,
@@ -55,6 +56,22 @@ const SERIES_FILL: Record<string, string> = {
   cursor: "bg-accent-violet",
   opencode: "bg-status-open",
 };
+
+/** The same series tones as CSS colors, for the SVG chart. Codex's
+ *  neutral tint is expressed as foreground at reduced opacity so it
+ *  follows the palette the way the `bg-foreground/45` swatch does. */
+const SERIES_COLOR: Record<string, { color: string; opacity: number }> = {
+  claude: { color: "var(--accent-ember)", opacity: 1 },
+  codex: { color: "var(--foreground)", opacity: 0.55 },
+  cursor: { color: "var(--accent-violet)", opacity: 1 },
+  opencode: { color: "var(--status-open)", opacity: 1 },
+};
+
+const UNKNOWN_COLOR = { color: "var(--muted-foreground)", opacity: 0.5 };
+
+function seriesColor(provider: string): { color: string; opacity: number } {
+  return SERIES_COLOR[provider] ?? UNKNOWN_COLOR;
+}
 
 const SERIES_LABEL: Record<string, string> = {
   claude: "Claude Code",
@@ -387,7 +404,7 @@ function rangeLabel(summary: UsageSummary): string {
 }
 
 /** The value one bucket contributes for one provider, under the active
- *  metric. Shared by the chart and the readout so a hovered bar and its
+ *  metric. Shared by the chart and its tooltip so a hovered point and its
  *  numbers can never disagree. */
 function bucketValue(
   bucket: UsageBucket,
@@ -407,7 +424,7 @@ function formatMetric(value: number, metric: Metric): string {
 
 /** Design canvas value. The chart flexes horizontally on its own; only
  *  the height needs stating. */
-const CHART_HEIGHT_PX = 150;
+const CHART_HEIGHT_PX = 200;
 
 function OverviewCard({
   summary,
@@ -427,37 +444,20 @@ function OverviewCard({
   // readout — so the eye can track one provider across all three.
   const order = useMemo(() => providers.map((p) => p.provider), [providers]);
 
-  const max = useMemo(() => {
-    const totalsPerBucket = buckets.map((bucket) =>
-      order.reduce((sum, p) => sum + bucketValue(bucket, p, metric), 0),
-    );
-    return Math.max(...totalsPerBucket, 0) || 1;
-  }, [buckets, order, metric]);
-
-  const hoveredBucket = hovered === null ? null : (buckets[hovered] ?? null);
-
-  const readoutValue = hoveredBucket
-    ? formatMetric(
-        order.reduce((sum, p) => sum + bucketValue(hoveredBucket, p, metric), 0),
-        metric,
-      )
-    : metric === "cost"
-      ? formatMoney(totals.estimated_cost_usd)
-      : formatTokens(totals.total_tokens);
-
-  const readoutBreakdown = hoveredBucket
-    ? order
-        .map(
-          (p) =>
-            `${seriesLabel(p).split(" ")[0]} ${formatMetric(
-              bucketValue(hoveredBucket, p, metric),
-              metric,
-            )}`,
-        )
-        .join("   ")
-    : metric === "cost"
-      ? "API/list-price equivalent"
-      : "input + output + cache read + cache write";
+  const series = useMemo(
+    () =>
+      order.map((p) => ({
+        key: p,
+        label: seriesLabel(p),
+        ...seriesColor(p),
+        values: buckets.map((bucket) => bucketValue(bucket, p, metric)),
+      })),
+    [buckets, order, metric],
+  );
+  const points = useMemo(
+    () => buckets.map((b) => ({ label: b.label, subLabel: b.sub_label })),
+    [buckets],
+  );
 
   return (
     <div className="rounded-lg border border-border/60 bg-muted/30 p-4">
@@ -494,59 +494,20 @@ function OverviewCard({
         </div>
       </div>
 
-      <div className="mt-4 flex flex-wrap items-baseline gap-x-3 gap-y-1 border-t border-border/40 pt-3">
-        <span className="text-[12px] text-muted-foreground">
-          {hoveredBucket
-            ? hoveredBucket.sub_label
-            : metric === "cost"
-              ? "Total for period"
-              : "Tokens for period"}
-        </span>
-        <span className="select-text font-mono text-[14px] font-semibold tabular-nums tracking-tight">
-          {readoutValue}
-        </span>
-        <span className="select-text font-mono text-[11px] tabular-nums text-muted-foreground">
-          {readoutBreakdown}
-        </span>
-      </div>
-
-      <div
-        className="mt-4 flex items-end gap-[3px]"
-        style={{ height: CHART_HEIGHT_PX }}
-        onMouseLeave={() => onHover(null)}
-      >
-        {buckets.map((bucket, index) => (
-          <div
-            key={bucket.start_ms}
-            role="presentation"
-            onMouseEnter={() => onHover(index)}
-            title={`${bucket.sub_label} — ${formatMetric(
-              order.reduce((sum, p) => sum + bucketValue(bucket, p, metric), 0),
-              metric,
-            )}`}
-            className={cn(
-              "flex h-full min-w-0 flex-1 flex-col justify-end gap-[2px] transition-opacity",
-              hovered !== null && hovered !== index && "opacity-40",
-            )}
-          >
-            {/* Reversed so the first lane (largest provider) stacks on
-                top, matching the legend's reading order. */}
-            {[...order].reverse().map((provider) => {
-              const value = bucketValue(bucket, provider, metric);
-              if (value <= 0) return null;
-              return (
-                <div
-                  key={provider}
-                  className={cn("w-full rounded-[2px]", seriesFill(provider))}
-                  style={{
-                    height: Math.max(2, (value / max) * (CHART_HEIGHT_PX - 8)),
-                  }}
-                />
-              );
-            })}
-          </div>
-        ))}
-      </div>
+      <UsageAreaChart
+        className="mt-5"
+        series={series}
+        points={points}
+        height={CHART_HEIGHT_PX}
+        hovered={hovered}
+        onHover={onHover}
+        formatValue={(v) => formatMetric(v, metric)}
+        ariaLabel={
+          metric === "cost"
+            ? "Estimated cost per bucket by provider"
+            : "Tokens per bucket by provider"
+        }
+      />
 
       <div className="mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 xl:gap-x-6">
@@ -946,12 +907,8 @@ function ProviderLane({
 }) {
   const bars = quota ? meterWindows(quota.windows) : [];
   const note = quota ? meterNote(quota) : "";
-  const laneMax = useMemo(
-    () =>
-      Math.max(
-        ...buckets.map((b) => b.providers[provider.provider]?.tokens ?? 0),
-        0,
-      ) || 1,
+  const laneValues = useMemo(
+    () => buckets.map((b) => b.providers[provider.provider]?.tokens ?? 0),
     [buckets, provider.provider],
   );
 
@@ -1010,26 +967,12 @@ function ProviderLane({
             )}
           </span>
         ) : null}
-        <span
-          className="flex min-w-0 flex-1 items-end gap-[2px]"
-          style={{ height: SPARK_HEIGHT_PX }}
-          aria-hidden
-        >
-          {buckets.map((bucket) => {
-            const tokens = bucket.providers[provider.provider]?.tokens ?? 0;
-            return (
-              <span
-                key={bucket.start_ms}
-                className={cn(
-                  "min-w-0 flex-1 rounded-[1px]",
-                  seriesFill(provider.provider),
-                )}
-                style={{
-                  height: Math.max(2, (tokens / laneMax) * SPARK_HEIGHT_PX),
-                }}
-              />
-            );
-          })}
+        <span className="min-w-0 flex-1 self-center">
+          <UsageSparkline
+            values={laneValues}
+            height={SPARK_HEIGHT_PX}
+            {...seriesColor(provider.provider)}
+          />
         </span>
 
         <span className="flex w-[76px] shrink-0 flex-col gap-0.5 text-right">


### PR DESCRIPTION
## Problem

The usage overview in Settings drew per-day stacked bars. They read as blocks, hid the shape of spend over time, and the only per-bucket detail was a readout row above the chart.

## Fix

Replace the bars with an SVG area chart (no new dependency): one smooth line per provider with a gradient fill, faint gridlines, date ticks that thin out automatically for the 24-hour and 90-day views, and a crosshair tooltip on hover with the bucket's date, per-provider figures, and total. The tooltip flips near the right edge so it never clips. The old readout row is gone since the tooltip replaces it. Curves use monotone cubic interpolation so a spike next to quiet days never draws below zero. The lane sparklines use the same curve so the card and lanes match.

Tests: the readout test became a tooltip-hover test, plus unit tests for the curve and tick thinning. `npm run check` and the settings suites pass.

## Before

![before](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/settings-usage-area-chart/before.png)

## After

![after](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/settings-usage-area-chart/after.png)

![lanes](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/settings-usage-area-chart/lanes.png)

Built with Claude Fable 5 in Codemux.
