### PR TITLE
fix(chat): stop clipping descenders in composer footer pills

### DIFF
--- a/src/components/chat/pickers/footer-trigger.ts
+++ b/src/components/chat/pickers/footer-trigger.ts
@@ -3,6 +3,12 @@
  *  text on the card surface — separation between controls comes from
  *  the hairline pipes interleaved in the footer, not from per-pill
  *  borders, so the row reads as one calm strip instead of a bank of
- *  chips. */
+ *  chips.
+ *
+ *  Line height is `leading-5`, not `leading-none`: the labels inside are
+ *  `truncate` spans (overflow hidden), and a line box the same height as
+ *  the font size clips descenders — "High · 1M" lost the tail of its "g".
+ *  The button's fixed `h-8` + `items-center` keeps the row geometry
+ *  identical either way. */
 export const FOOTER_TRIGGER =
-  "inline-flex h-8 shrink-0 items-center gap-2 rounded-lg px-2.5 text-sm font-medium leading-none text-muted-foreground transition-colors outline-none hover:bg-foreground/[0.06] hover:text-foreground disabled:opacity-50";
+  "inline-flex h-8 shrink-0 items-center gap-2 rounded-lg px-2.5 text-sm font-medium leading-5 text-muted-foreground transition-colors outline-none hover:bg-foreground/[0.06] hover:text-foreground disabled:opacity-50";


### PR DESCRIPTION
The composer footer's pills (model, reasoning, permission) cut the tails off descenders — "High · 1M" lost the bottom of its **g**, "gpt-5.4" lost its **g** and **p**.

`FOOTER_TRIGGER` used `leading-none`, so each label got a 14px line box while the 14px font needs 16px (13px ascent + 3px descent). The labels are `truncate` spans, i.e. `overflow: hidden`, so the pixel that spilled top and bottom was clipped away. Switched to `leading-5`; the buttons are fixed-height (`h-8`) flex rows, so the row geometry is unchanged.

### Before / after

Reasoning pill, 8× zoom (before on top, after below):

![reasoning pill before and after](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets-footer-descender-clip/zoom-high-1m.png)

Model pill, 8× zoom — both **g** and **p**:

![model pill before and after](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets-footer-descender-clip/zoom-model-pill.png)

Full footer strip, before:

![footer before](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets-footer-descender-clip/footer-before.png)

…and after:

![footer after](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets-footer-descender-clip/footer-after.png)

Screenshots come from `npm run dev` with the Tauri mock, no personal data.

---

Model: Claude Fable 5 · Harness: Claude Code
