### PR TITLE
fix(pull-requests): stop the page exhausting GitHub's API budget

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -249,6 +249,20 @@ pub async fn list_prs_overview_stats(
     .map_err(|e| format!("list_prs_overview_stats task join failed: {e}"))?
 }
 
+/// What is left of the GitHub budget, and when it refills.
+///
+/// The Pull Requests page asks this only after a call has come back
+/// refused for exceeding the limit — never speculatively. GitHub does
+/// not charge for the endpoint, so it is the one request that is still
+/// safe to make when there is nothing left to spend, and it is what lets
+/// the page say "resumes at 10:49" instead of retrying into a wall.
+#[tauri::command]
+pub async fn github_rate_limit(path: String) -> Result<crate::github::GhRateLimit, String> {
+    tokio::task::spawn_blocking(move || crate::github::rate_limit(Path::new(&path)))
+        .await
+        .map_err(|e| format!("github_rate_limit task join failed: {e}"))?
+}
+
 #[tauri::command]
 pub async fn merge_pull_request(
     path: String,

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -1863,6 +1863,69 @@ pub fn list_prs_overview_stats(repo_path: &Path) -> Result<Vec<PrOverviewStats>,
     Ok(arr.iter().map(parse_overview_stats_json).collect())
 }
 
+/// What is left of the GitHub API budget, and when it refills.
+///
+/// Asked only when a call has just been refused for exceeding it, which
+/// is exactly the moment a normal request would be wasted. `rate_limit`
+/// is the one endpoint GitHub does not charge for — checking it costs
+/// nothing when there is nothing left to spend — so the page can find
+/// out *when* it will work again rather than guessing, and say so.
+///
+/// Both buckets are reported because the two halves of this file spend
+/// from different ones: `gh pr list` is GraphQL, while the REST reads
+/// elsewhere are core. The page gates on `graphql`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GhRateLimit {
+    pub graphql_remaining: i64,
+    /// Unix seconds. Zero means the host did not say.
+    pub graphql_reset: i64,
+    pub core_remaining: i64,
+    pub core_reset: i64,
+}
+
+/// Short on purpose: this call exists to end a stall, so waiting a long
+/// time for it defeats the point. A timeout here just leaves the caller
+/// with its own default back-off.
+const RATE_LIMIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn rate_limit(repo_path: &Path) -> Result<GhRateLimit, String> {
+    let output = run_gh_timed(repo_path, &["api", "rate_limit"], RATE_LIMIT_TIMEOUT)?;
+    parse_rate_limit(&output)
+}
+
+/// Split out from the shell-out so the shape can be tested without one.
+///
+/// A missing `resources` object is an error rather than a zeroed answer:
+/// the caller's fallback is a fixed back-off, which is a better thing to
+/// do with a reply we cannot read than to invent "exhausted, refills at
+/// the epoch" from it.
+fn parse_rate_limit(output: &str) -> Result<GhRateLimit, String> {
+    let v: serde_json::Value =
+        serde_json::from_str(output).map_err(|e| format!("Failed to parse gh JSON: {e}"))?;
+    let resources = v.get("resources").filter(|r| r.is_object()).ok_or_else(|| {
+        "Expected a resources object from gh api rate_limit".to_string()
+    })?;
+    // A bucket the host did not report reads as exhausted-with-no-reset,
+    // which the caller turns into its minimum back-off. Guessing a
+    // generous "plenty remaining" would keep it hammering a host that
+    // has already said no.
+    let bucket = |name: &str| -> (i64, i64) {
+        let b = &resources[name];
+        (
+            b["remaining"].as_i64().unwrap_or(0),
+            b["reset"].as_i64().unwrap_or(0),
+        )
+    };
+    let (graphql_remaining, graphql_reset) = bucket("graphql");
+    let (core_remaining, core_reset) = bucket("core");
+    Ok(GhRateLimit {
+        graphql_remaining,
+        graphql_reset,
+        core_remaining,
+        core_reset,
+    })
+}
+
 /// `passing` / `failing` / `pending` / `none` — the four states a row
 /// can be drawn in, decided here so both products answer in the same
 /// vocabulary and the frontend never sees a raw check array.
@@ -4898,5 +4961,73 @@ build\tcompile\t2026-08-16T09:00:03.000Z done";
         // An unrelated failure keeps its own words; replacing them would
         // send the reviewer re-anchoring notes that are fine.
         assert!(!is_stale_anchor_error("HTTP 403: Resource not accessible"));
+    }
+
+    // ── The budget the page gates on ──────────────────────────────────
+
+    #[test]
+    fn the_graphql_bucket_is_read_off_a_real_reply() {
+        // Trimmed from an actual `gh api rate_limit` response taken
+        // while the page was locked out: core untouched, GraphQL over.
+        let limit = parse_rate_limit(
+            r#"{"resources":{
+                 "core":{"limit":5000,"used":1,"remaining":4999,"reset":1787478026},
+                 "graphql":{"limit":5000,"used":5011,"remaining":0,"reset":1787474964},
+                 "search":{"limit":30,"used":0,"remaining":30,"reset":1787474853}},
+               "rate":{"limit":5000,"remaining":4999,"reset":1787478026}}"#,
+        )
+        .expect("a well-formed reply parses");
+
+        assert_eq!(limit.graphql_remaining, 0);
+        assert_eq!(limit.graphql_reset, 1787474964);
+        // The two buckets are genuinely independent, and reading the
+        // wrong one is how "the app is broken" gets diagnosed as "the
+        // app is fine": core had 4999 left the whole time.
+        assert_eq!(limit.core_remaining, 4999);
+        assert_eq!(limit.core_reset, 1787478026);
+    }
+
+    #[test]
+    fn a_bucket_the_host_did_not_report_reads_as_spent() {
+        let limit = parse_rate_limit(r#"{"resources":{"core":{"remaining":10,"reset":5}}}"#)
+            .expect("a partial reply still parses");
+        // Not "plenty left": the caller is asking because a request was
+        // already refused, and inventing headroom would send it back.
+        assert_eq!(limit.graphql_remaining, 0);
+        assert_eq!(limit.graphql_reset, 0);
+    }
+
+    /// The live path, end to end: spawn a real `gh`, against the real
+    /// host, and read the real reply.
+    ///
+    /// Ignored by default because it needs a signed-in `gh` and the
+    /// network. Run it with
+    /// `cargo test rate_limit_reads_the_live_host -- --ignored --nocapture`
+    /// — the endpoint is not metered, so running it costs nothing even
+    /// when the budget it reports is already spent.
+    #[test]
+    #[ignore]
+    fn rate_limit_reads_the_live_host() {
+        let repo = std::env::current_dir().expect("a working directory");
+        let limit = rate_limit(&repo).expect("gh answered");
+        eprintln!(
+            "graphql {} left, resets at {} · core {} left, resets at {}",
+            limit.graphql_remaining, limit.graphql_reset, limit.core_remaining, limit.core_reset
+        );
+        // Not asserting a particular budget — that is the host's
+        // business and changes by the minute. What must hold is that the
+        // reply was understood: a real reset is a plausible epoch, not
+        // the zero a silently-misparsed field would leave behind.
+        assert!(limit.graphql_reset > 1_700_000_000, "graphql reset looks unparsed");
+        assert!(limit.core_reset > 1_700_000_000, "core reset looks unparsed");
+        assert!(limit.core_remaining >= 0);
+    }
+
+    #[test]
+    fn an_unreadable_reply_is_an_error_not_a_zeroed_answer() {
+        // Both of these must fall through to the caller's own back-off
+        // rather than being read as "exhausted until the epoch".
+        assert!(parse_rate_limit("not json at all").is_err());
+        assert!(parse_rate_limit(r#"{"message":"Bad credentials"}"#).is_err());
     }
 }

--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -1888,6 +1888,11 @@ pub struct GhRateLimit {
 /// with its own default back-off.
 const RATE_LIMIT_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// `repo_path` is only a working directory for `gh`. `gh api` does not
+/// pick a host from the checkout it runs in — it reads whichever host
+/// `gh` treats as its default — so the answer is that account's budget
+/// wherever this is asked from, and the page treats it as one budget
+/// for every root `gh` serves.
 pub fn rate_limit(repo_path: &Path) -> Result<GhRateLimit, String> {
     let output = run_gh_timed(repo_path, &["api", "rate_limit"], RATE_LIMIT_TIMEOUT)?;
     parse_rate_limit(&output)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2207,6 +2207,7 @@ fn build_core_app<R: tauri::Runtime>(
             commands::list_incoming_prs,
             commands::list_prs_overview,
             commands::list_prs_overview_stats,
+            commands::github_rate_limit,
             commands::merge_pull_request,
             commands::close_pull_request,
             commands::reopen_pull_request,

--- a/src/components/pull-requests/pr-detail-column.test.ts
+++ b/src/components/pull-requests/pr-detail-column.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { checksAreSettled } from "./pr-detail-column";
+import { EMPTY_CHECKS_GRACE_MS, checksAreSettled, newestRefusalAt } from "./pr-detail-column";
 import type { CheckInfo } from "@/tauri/types";
 
 function check(over: Partial<CheckInfo> = {}): CheckInfo {
@@ -16,16 +16,28 @@ function check(over: Partial<CheckInfo> = {}): CheckInfo {
   };
 }
 
+/** An open row the stats have not coloured yet. */
+const OPEN = { checks: null, state: "OPEN" } as const;
+
 describe("checksAreSettled", () => {
   it("is not settled before the first answer arrives", () => {
     // The fast cadence is what gets that answer on screen.
-    expect(checksAreSettled(undefined, false, null)).toBe(false);
+    expect(checksAreSettled(undefined, false, OPEN, 0)).toBe(false);
+    // However long the column has been open, and whatever the row is.
+    expect(checksAreSettled(undefined, false, { checks: null, state: "MERGED" }, 600_000)).toBe(
+      false,
+    );
   });
 
   it("is not settled while anything is still running", () => {
-    expect(checksAreSettled([check(), check({ status: "in_progress", conclusion: null })], false, "pending")).toBe(
-      false,
-    );
+    expect(
+      checksAreSettled(
+        [check(), check({ status: "in_progress", conclusion: null })],
+        false,
+        { checks: "pending", state: "OPEN" },
+        0,
+      ),
+    ).toBe(false);
   });
 
   it("keeps the fast cadence for statuses it does not recognise", () => {
@@ -33,7 +45,7 @@ describe("checksAreSettled", () => {
     // and this relies on that: an unfamiliar status must never be the
     // reason the column goes quiet.
     for (const status of ["queued", "waiting", "action_required", "pending", ""]) {
-      expect(checksAreSettled([check({ status, conclusion: null })], false, null)).toBe(false);
+      expect(checksAreSettled([check({ status, conclusion: null })], false, OPEN, 0)).toBe(false);
     }
   });
 
@@ -42,23 +54,79 @@ describe("checksAreSettled", () => {
       checksAreSettled(
         [check({ conclusion: "success" }), check({ conclusion: "failure" })],
         false,
-        "failing",
+        { checks: "failing", state: "OPEN" },
+        0,
       ),
     ).toBe(true);
   });
 
-  it("settles on an empty list only when the host said there is no CI", () => {
-    // `"none"` is the host having looked. Anything else is a pull
-    // request whose first check has not registered yet — the seconds
-    // right after a push, which is precisely when someone is watching.
-    expect(checksAreSettled([], false, "none")).toBe(true);
-    expect(checksAreSettled([], false, null)).toBe(false);
-    expect(checksAreSettled([], false, "pending")).toBe(false);
+  it("settles on an empty list when the host said there is no CI", () => {
+    // `"none"` is the host having looked.
+    expect(checksAreSettled([], false, { checks: "none", state: "OPEN" }, 0)).toBe(true);
+    expect(checksAreSettled([], false, { checks: "none" }, 0)).toBe(true);
+  });
+
+  it("keeps an open pull request fast while its first check may still register", () => {
+    // The seconds right after a push, which is precisely when someone is
+    // watching. `null` is nobody having asked; `"pending"` is the row
+    // still expecting something.
+    expect(checksAreSettled([], false, OPEN, 0)).toBe(false);
+    expect(checksAreSettled([], false, { checks: null }, EMPTY_CHECKS_GRACE_MS - 1)).toBe(false);
+    expect(checksAreSettled([], false, { checks: "pending", state: "OPEN" }, 0)).toBe(false);
+  });
+
+  it("settles an open pull request once the grace has passed with nothing registered", () => {
+    // The history list never fills `checks` in, and the stats that do
+    // can take a cycle or fail outright — so a row that still says
+    // `null` after a minute on the fast clock is a repository with no
+    // CI, not one about to report. Left to the row alone, a selected
+    // pull request in such a repository polled twice every 2.5s for as
+    // long as it was selected.
+    expect(checksAreSettled([], false, OPEN, EMPTY_CHECKS_GRACE_MS)).toBe(true);
+    expect(checksAreSettled([], false, { checks: "pending" }, EMPTY_CHECKS_GRACE_MS)).toBe(true);
+  });
+
+  it("settles a closed or merged pull request on an empty list straight away", () => {
+    // Nothing is going to register against a pull request that is done,
+    // and the history rows these come from never carry `"none"` — they
+    // never asked — so waiting on the row's word would mean waiting
+    // forever at the fast cadence.
+    for (const state of ["MERGED", "CLOSED", "merged", "closed"]) {
+      expect(checksAreSettled([], false, { checks: null, state }, 0)).toBe(true);
+      expect(checksAreSettled([], false, { checks: "pending", state }, 0)).toBe(true);
+    }
   });
 
   it("settles when the checks call itself is failing", () => {
     // Re-asking a host that just said no, twice every five seconds, is
     // the behaviour the budget gate exists to prevent.
-    expect(checksAreSettled(undefined, true, null)).toBe(true);
+    expect(checksAreSettled(undefined, true, OPEN, 0)).toBe(true);
+  });
+});
+
+describe("newestRefusalAt", () => {
+  const REFUSAL = "GraphQL: API rate limit already exceeded for user ID 1.";
+
+  it("is nothing when no query has been refused for spending", () => {
+    expect(newestRefusalAt([])).toBe(0);
+    expect(newestRefusalAt([{ error: null, errorUpdatedAt: 0 }])).toBe(0);
+    // A failure that is not a refusal is left to the ordinary error
+    // handling: one unreachable repository must not pause the rest.
+    expect(
+      newestRefusalAt([{ error: "could not resolve host github.com", errorUpdatedAt: 500 }]),
+    ).toBe(0);
+  });
+
+  it("reports the newest refusal among the queries it is given", () => {
+    // Both of the column's live queries can be refused, and either one
+    // is enough to raise the gate — but the gate is told once, with the
+    // time it can use to tell this refusal from the one before it.
+    expect(
+      newestRefusalAt([
+        { error: REFUSAL, errorUpdatedAt: 100 },
+        { error: REFUSAL, errorUpdatedAt: 105 },
+        { error: "gh: command not found", errorUpdatedAt: 900 },
+      ]),
+    ).toBe(105);
   });
 });

--- a/src/components/pull-requests/pr-detail-column.test.ts
+++ b/src/components/pull-requests/pr-detail-column.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+
+import { checksAreSettled } from "./pr-detail-column";
+import type { CheckInfo } from "@/tauri/types";
+
+function check(over: Partial<CheckInfo> = {}): CheckInfo {
+  return {
+    name: "build",
+    status: "completed",
+    conclusion: "success",
+    elapsed_time: null,
+    detail_url: null,
+    started_at: null,
+    completed_at: null,
+    ...over,
+  };
+}
+
+describe("checksAreSettled", () => {
+  it("is not settled before the first answer arrives", () => {
+    // The fast cadence is what gets that answer on screen.
+    expect(checksAreSettled(undefined, false, null)).toBe(false);
+  });
+
+  it("is not settled while anything is still running", () => {
+    expect(checksAreSettled([check(), check({ status: "in_progress", conclusion: null })], false, "pending")).toBe(
+      false,
+    );
+  });
+
+  it("keeps the fast cadence for statuses it does not recognise", () => {
+    // `checkState` treats anything outside pass/fail/neutral as running,
+    // and this relies on that: an unfamiliar status must never be the
+    // reason the column goes quiet.
+    for (const status of ["queued", "waiting", "action_required", "pending", ""]) {
+      expect(checksAreSettled([check({ status, conclusion: null })], false, null)).toBe(false);
+    }
+  });
+
+  it("settles once every check has reported", () => {
+    expect(
+      checksAreSettled(
+        [check({ conclusion: "success" }), check({ conclusion: "failure" })],
+        false,
+        "failing",
+      ),
+    ).toBe(true);
+  });
+
+  it("settles on an empty list only when the host said there is no CI", () => {
+    // `"none"` is the host having looked. Anything else is a pull
+    // request whose first check has not registered yet — the seconds
+    // right after a push, which is precisely when someone is watching.
+    expect(checksAreSettled([], false, "none")).toBe(true);
+    expect(checksAreSettled([], false, null)).toBe(false);
+    expect(checksAreSettled([], false, "pending")).toBe(false);
+  });
+
+  it("settles when the checks call itself is failing", () => {
+    // Re-asking a host that just said no, twice every five seconds, is
+    // the behaviour the budget gate exists to prevent.
+    expect(checksAreSettled(undefined, true, null)).toBe(true);
+  });
+});

--- a/src/components/pull-requests/pr-detail-column.tsx
+++ b/src/components/pull-requests/pr-detail-column.tsx
@@ -168,8 +168,9 @@ export function PrDetailColumn({
   // rather than from a value worked out during render: a render-time
   // value would be assigned after the checks query had already
   // registered its options for that render, and take effect one render
-  // late. React Query re-evaluates the callback form whenever the query
-  // updates, and only resets a timer when the answer actually changes.
+  // late. React Query re-evaluates the callback form on every render
+  // and on every update of the query it belongs to, so a checks answer
+  // that changes the cadence reaches the detail query within a render.
   const pollMsFor = (state: { data?: CheckInfo[]; status: QueryStatus } | undefined) =>
     checksAreSettled(state?.data, state?.status === "error", row, Date.now() - watchingSince)
       ? SETTLED_POLL_MS
@@ -188,6 +189,10 @@ export function PrDetailColumn({
     enabled: !paused,
     staleTime: DETAIL_POLL_MS,
     refetchInterval: (query) => pollMsFor(query.state),
+    // One retry, and none for a refusal — the same rule as the list. The
+    // default retry would spend a second refused request per query and
+    // hold the refusal back from the gate below until it had.
+    retry: (count: number, error: unknown) => !isRateLimitError(error) && count < 1,
   });
 
   const detailQuery = useQuery({
@@ -196,6 +201,7 @@ export function PrDetailColumn({
     enabled: !paused,
     staleTime: DETAIL_POLL_MS,
     refetchInterval: () => pollMsFor(queryClient.getQueryState<CheckInfo[]>(checksKey)),
+    retry: (count: number, error: unknown) => !isRateLimitError(error) && count < 1,
   });
 
   // And the gate hears about refusals from here, not only from the
@@ -214,6 +220,7 @@ export function PrDetailColumn({
     enabled: !paused,
     staleTime: CONVERSATION_POLL_MS,
     refetchInterval: CONVERSATION_POLL_MS,
+    retry: (count: number, error: unknown) => !isRateLimitError(error) && count < 1,
   });
 
   /**
@@ -236,6 +243,7 @@ export function PrDetailColumn({
     enabled: !paused,
     staleTime: CONVERSATION_POLL_MS,
     refetchInterval: CONVERSATION_POLL_MS,
+    retry: (count: number, error: unknown) => !isRateLimitError(error) && count < 1,
   });
 
   const refresh = useCallback(() => {

--- a/src/components/pull-requests/pr-detail-column.tsx
+++ b/src/components/pull-requests/pr-detail-column.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useRef } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo } from "react";
+import { useQuery, useQueryClient, type QueryStatus } from "@tanstack/react-query";
 
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -15,7 +15,13 @@ import type { CheckInfo } from "@/tauri/types";
 import { ReviewDetail } from "@/components/workspace/review/review-detail";
 import { RepoUnreachableState } from "@/components/workspace/review/review-empty-states";
 import { checkState } from "@/components/workspace/review/review-ui";
-import { budgetApplies, clearRateLimitPause, useRateLimitPause } from "@/lib/pr-rate-limit";
+import {
+  budgetApplies,
+  clearRateLimitPause,
+  isRateLimitError,
+  noteRateLimited,
+  useRateLimitPause,
+} from "@/lib/pr-rate-limit";
 
 /**
  * How often the open pull request re-reads itself while its checks are
@@ -53,6 +59,16 @@ export interface PrDetailColumnProps {
 }
 
 /**
+ * How long an open pull request may sit with an empty check list on the
+ * fast cadence before the column concludes nothing is coming.
+ *
+ * A check that is going to register does so within seconds of the push.
+ * A minute of nothing is a repository with no CI, whatever the row says
+ * — and the row may well say nothing: see `checksAreSettled`.
+ */
+export const EMPTY_CHECKS_GRACE_MS = 60_000;
+
+/**
  * Nothing is still running, so nothing is still changing — and the fast
  * cadence has nothing left to buy.
  *
@@ -68,24 +84,60 @@ export interface PrDetailColumnProps {
  * situations wearing the same shape: a repository with no CI at all, and
  * a pull request whose first check has not registered yet — the seconds
  * right after a push, which is exactly when someone opens the column to
- * watch. Only the row can tell them apart. `"none"` is the host having
- * looked and found nothing; `null` is nobody having asked. So an empty
- * list settles on the host's own word and on nothing else, and a
- * just-pushed pull request keeps the fast cadence until its checks show
- * up rather than going quiet for the twenty seconds that matter most.
+ * watch. The row can sometimes tell them apart: `"none"` is the host
+ * having looked and found nothing, and a closed or merged pull request
+ * is not about to grow a check. But the row's `null` only means nobody
+ * has asked — the history list never does, and the stats that fill it
+ * in for open rows take up to a cycle to land, or never land at all —
+ * so it cannot be read as "keep asking", or a merged pull request with
+ * no CI would hold the fast cadence for as long as it stayed selected.
+ * An empty list therefore settles on the host's word, on the row being
+ * closed, or on `watchedForMs`: the column having sat on the fast clock
+ * for the whole grace window and seen nothing register. A just-pushed
+ * pull request still gets its first minute at full speed.
  */
 export function checksAreSettled(
   checks: CheckInfo[] | undefined,
   checksFailed: boolean,
-  rowChecks: string | null,
+  row: Pick<PrRow, "checks" | "state">,
+  watchedForMs: number,
 ): boolean {
   if (checksFailed) return true;
   if (!checks) return false;
-  if (checks.length === 0) return rowChecks === "none";
+  if (checks.length === 0) {
+    if (row.checks === "none") return true;
+    // An absent state is open: the overview only lists open pull
+    // requests, and only the history list stamps a state on its rows.
+    if (row.state != null && row.state.toUpperCase() !== "OPEN") return true;
+    return watchedForMs >= EMPTY_CHECKS_GRACE_MS;
+  }
   // `checkState` returns "running" for anything it does not recognise —
   // queued, in_progress, waiting, action_required — so an unfamiliar
   // status keeps the fast cadence rather than silencing the column.
   return !checks.some((check) => checkState(check.conclusion, check.status) === "running");
+}
+
+/**
+ * When the newest refusal-for-spending among these queries landed, or 0
+ * when none of them is refused.
+ *
+ * The column's own calls are GraphQL too, and the most frequent in the
+ * app, so this is the surface most likely to be refused first. A refusal
+ * it sees is the same fact about the account that a refusal on the list
+ * is, and it has to reach the same gate — otherwise the list would stop
+ * asking and the column would carry on spending on its behalf until the
+ * list happened to be refused as well.
+ */
+export function newestRefusalAt(
+  queries: readonly { error: unknown; errorUpdatedAt: number }[],
+): number {
+  let newest = 0;
+  for (const query of queries) {
+    if (isRateLimitError(query.error) && query.errorUpdatedAt > newest) {
+      newest = query.errorUpdatedAt;
+    }
+  }
+  return newest;
 }
 
 /**
@@ -105,12 +157,23 @@ export function PrDetailColumn({
   const queryClient = useQueryClient();
   const path = row.projectRoot;
   const number = row.number;
+  const checksKey = ["pr", "page-checks", path, number] as const;
 
-  // The cadence both live queries read, through a ref so that changing
-  // it never tears down and re-creates their timers: React Query calls
-  // the callback form each time a timer fires, which is exactly when a
-  // new value should take effect.
-  const pollMsRef = useRef(DETAIL_POLL_MS);
+  // When the column started watching this pull request — the clock the
+  // empty-list grace in `checksAreSettled` runs against.
+  const watchingSince = useMemo(() => Date.now(), [path, number]);
+
+  // The cadence both live queries read. It is derived from the checks
+  // query's *cached* state inside each query's own interval callback,
+  // rather than from a value worked out during render: a render-time
+  // value would be assigned after the checks query had already
+  // registered its options for that render, and take effect one render
+  // late. React Query re-evaluates the callback form whenever the query
+  // updates, and only resets a timer when the answer actually changes.
+  const pollMsFor = (state: { data?: CheckInfo[]; status: QueryStatus } | undefined) =>
+    checksAreSettled(state?.data, state?.status === "error", row, Date.now() - watchingSince)
+      ? SETTLED_POLL_MS
+      : DETAIL_POLL_MS;
 
   // The same budget gate the list obeys. An open pull request polling
   // twice every couple of seconds is the most expensive surface in the
@@ -120,24 +183,30 @@ export function PrDetailColumn({
   const paused = useRateLimitPause() > 0 && budgetApplies(row.providerKind);
 
   const checksQuery = useQuery({
-    queryKey: ["pr", "page-checks", path, number] as const,
+    queryKey: checksKey,
     queryFn: () => getPullRequestChecks(path, number),
     enabled: !paused,
     staleTime: DETAIL_POLL_MS,
-    refetchInterval: () => pollMsRef.current,
+    refetchInterval: (query) => pollMsFor(query.state),
   });
-
-  pollMsRef.current = checksAreSettled(checksQuery.data, checksQuery.isError, row.checks)
-    ? SETTLED_POLL_MS
-    : DETAIL_POLL_MS;
 
   const detailQuery = useQuery({
     queryKey: ["pr", "page-detail", path, number] as const,
     queryFn: () => getGithubPrByPath(path, number),
     enabled: !paused,
     staleTime: DETAIL_POLL_MS,
-    refetchInterval: () => pollMsRef.current,
+    refetchInterval: () => pollMsFor(queryClient.getQueryState<CheckInfo[]>(checksKey)),
   });
+
+  // And the gate hears about refusals from here, not only from the
+  // list. The gate remembers what it has already acted on, so the
+  // refusal a query keeps wearing while its refetch is in flight cannot
+  // raise it a second time after it lifts.
+  const refusedAt = newestRefusalAt([checksQuery, detailQuery]);
+  useEffect(() => {
+    if (refusedAt === 0 || !budgetApplies(row.providerKind)) return;
+    void noteRateLimited(path, refusedAt);
+  }, [refusedAt, path, row.providerKind]);
 
   const reviewsQuery = useQuery({
     queryKey: ["pr", "page-reviews", path, number] as const,

--- a/src/components/pull-requests/pr-detail-column.tsx
+++ b/src/components/pull-requests/pr-detail-column.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Skeleton } from "@/components/ui/skeleton";
@@ -11,12 +11,38 @@ import {
 import { resolveProvider } from "@/lib/source-control";
 import { fetchProviderAuth } from "@/lib/provider-auth";
 import type { PrRow } from "@/lib/pr-overview";
+import type { CheckInfo } from "@/tauri/types";
 import { ReviewDetail } from "@/components/workspace/review/review-detail";
 import { RepoUnreachableState } from "@/components/workspace/review/review-empty-states";
+import { checkState } from "@/components/workspace/review/review-ui";
+import { budgetApplies, clearRateLimitPause, useRateLimitPause } from "@/lib/pr-rate-limit";
 
-/** Same cadence as the panel: a check going green is the one thing you
- *  wait for, and 2.5s is fast enough that you never reach for refresh. */
+/**
+ * How often the open pull request re-reads itself while its checks are
+ * still running.
+ *
+ * Fast on purpose: a build going green under the cursor is most of what
+ * the column is for, and two and a half seconds is what makes that feel
+ * like watching rather than refreshing.
+ */
 const DETAIL_POLL_MS = 2_500;
+
+/**
+ * And how often once every check has reported.
+ *
+ * A settled pull request has nothing left to watch at the fast cadence,
+ * and the cost of pretending otherwise is not theoretical: two calls
+ * every 2.5s is roughly three thousand requests an hour, spent re-asking
+ * a question whose answer has stopped changing, against an hourly budget
+ * of five thousand for the whole account. A pull request left open on a
+ * second monitor was quietly the most expensive thing in the app.
+ *
+ * Twenty seconds is still well inside "I looked away and it updated",
+ * and it is already the cadence the conversation below it polls at — so
+ * a settled column now refreshes as one surface rather than in two
+ * tiers.
+ */
+const SETTLED_POLL_MS = 20_000;
 const CONVERSATION_POLL_MS = 30_000;
 
 export interface PrDetailColumnProps {
@@ -24,6 +50,42 @@ export interface PrDetailColumnProps {
   /** Workspace standing on this PR's branch, when there is one. */
   existingWorkspaceId: string | null;
   viewerLogin: string | null;
+}
+
+/**
+ * Nothing is still running, so nothing is still changing — and the fast
+ * cadence has nothing left to buy.
+ *
+ * `checks` undefined is "not asked yet", which is not settled: the first
+ * answer should arrive on the fast clock.
+ *
+ * A failing checks call *is* settled. Re-asking a host that just said no
+ * every two and a half seconds is the behaviour the budget gate exists
+ * to prevent, and doing it here would be doing it in the one place that
+ * asks most often.
+ *
+ * The empty list is the case worth naming, because it is two different
+ * situations wearing the same shape: a repository with no CI at all, and
+ * a pull request whose first check has not registered yet — the seconds
+ * right after a push, which is exactly when someone opens the column to
+ * watch. Only the row can tell them apart. `"none"` is the host having
+ * looked and found nothing; `null` is nobody having asked. So an empty
+ * list settles on the host's own word and on nothing else, and a
+ * just-pushed pull request keeps the fast cadence until its checks show
+ * up rather than going quiet for the twenty seconds that matter most.
+ */
+export function checksAreSettled(
+  checks: CheckInfo[] | undefined,
+  checksFailed: boolean,
+  rowChecks: string | null,
+): boolean {
+  if (checksFailed) return true;
+  if (!checks) return false;
+  if (checks.length === 0) return rowChecks === "none";
+  // `checkState` returns "running" for anything it does not recognise —
+  // queued, in_progress, waiting, action_required — so an unfamiliar
+  // status keeps the fast cadence rather than silencing the column.
+  return !checks.some((check) => checkState(check.conclusion, check.status) === "running");
 }
 
 /**
@@ -44,23 +106,43 @@ export function PrDetailColumn({
   const path = row.projectRoot;
   const number = row.number;
 
-  const detailQuery = useQuery({
-    queryKey: ["pr", "page-detail", path, number] as const,
-    queryFn: () => getGithubPrByPath(path, number),
-    staleTime: DETAIL_POLL_MS,
-    refetchInterval: DETAIL_POLL_MS,
-  });
+  // The cadence both live queries read, through a ref so that changing
+  // it never tears down and re-creates their timers: React Query calls
+  // the callback form each time a timer fires, which is exactly when a
+  // new value should take effect.
+  const pollMsRef = useRef(DETAIL_POLL_MS);
+
+  // The same budget gate the list obeys. An open pull request polling
+  // twice every couple of seconds is the most expensive surface in the
+  // app, so leaving it outside the gate would mean the page stopped
+  // asking and the column carried on spending on its behalf — and every
+  // one of those calls is refused anyway while the budget is gone.
+  const paused = useRateLimitPause() > 0 && budgetApplies(row.providerKind);
 
   const checksQuery = useQuery({
     queryKey: ["pr", "page-checks", path, number] as const,
     queryFn: () => getPullRequestChecks(path, number),
+    enabled: !paused,
     staleTime: DETAIL_POLL_MS,
-    refetchInterval: DETAIL_POLL_MS,
+    refetchInterval: () => pollMsRef.current,
+  });
+
+  pollMsRef.current = checksAreSettled(checksQuery.data, checksQuery.isError, row.checks)
+    ? SETTLED_POLL_MS
+    : DETAIL_POLL_MS;
+
+  const detailQuery = useQuery({
+    queryKey: ["pr", "page-detail", path, number] as const,
+    queryFn: () => getGithubPrByPath(path, number),
+    enabled: !paused,
+    staleTime: DETAIL_POLL_MS,
+    refetchInterval: () => pollMsRef.current,
   });
 
   const reviewsQuery = useQuery({
     queryKey: ["pr", "page-reviews", path, number] as const,
     queryFn: () => getPrReviewComments(path, number),
+    enabled: !paused,
     staleTime: CONVERSATION_POLL_MS,
     refetchInterval: CONVERSATION_POLL_MS,
   });
@@ -82,11 +164,17 @@ export function PrDetailColumn({
   const inlineQuery = useQuery({
     queryKey: ["pr", "page-inline", path, number] as const,
     queryFn: () => getPrInlineComments(path, number),
+    enabled: !paused,
     staleTime: CONVERSATION_POLL_MS,
     refetchInterval: CONVERSATION_POLL_MS,
   });
 
   const refresh = useCallback(() => {
+    // Same meaning as the list's Retry: asking by hand lifts the gate,
+    // because otherwise this invalidates a set of queries that are
+    // disabled — marking them stale and refreshing nothing, which is a
+    // control that quietly does not do what it says.
+    clearRateLimitPause();
     queryClient.invalidateQueries({
       predicate: (q) =>
         q.queryKey[0] === "pr" &&

--- a/src/components/pull-requests/pr-list.test.tsx
+++ b/src/components/pull-requests/pr-list.test.tsx
@@ -12,7 +12,7 @@ vi.mock("@/lib/toast", () => ({
   toast: { info: vi.fn(), success: vi.fn(), warning: vi.fn(), error: vi.fn() },
 }));
 
-import { PrList } from "./pr-list";
+import { PrList, clockTime } from "./pr-list";
 import { rowKey, type PrRow } from "@/lib/pr-overview";
 
 const ROOT = "/home/dev/projects/codemux";
@@ -492,6 +492,57 @@ describe("PrList — carried rows and the stale strip", () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
+  it("says the budget is spent, and when it refills, rather than 'it failed'", async () => {
+    // The one failure with a different answer to "what do I do about
+    // this": not Retry, but wait — so the strip says which, and how
+    // long, instead of inviting the retry that spends the recovery.
+    const onRefresh = vi.fn();
+    const resumesAt = Date.now() + 15 * 60_000;
+    renderList({
+      rows: carriedRows,
+      carried: true,
+      carriedAt: Date.now() - TWO_HOURS,
+      rateLimitedUntil: resumesAt,
+      allRootsFailed: true,
+      refreshFailed: true,
+      onRefresh,
+    });
+
+    const strip = screen.getByTestId("pr-stale-strip");
+    expect(strip).toHaveTextContent("Rate limit reached");
+    // A clock time, not a countdown: nothing is polling while the gate
+    // is up, so nothing re-renders, and "in 15m" would sit frozen at
+    // whatever it said when the strip first painted.
+    expect(strip).toHaveTextContent(`resuming at ${clockTime(resumesAt)}`);
+    // Still the age of what is on screen: the rows did not become less
+    // readable because the reason for their age changed.
+    expect(strip).toHaveTextContent("showing the list from 2h ago");
+    expect(strip).not.toHaveTextContent("The latest refresh failed");
+
+    // And the rows are still there, exactly as in the ordinary case.
+    expect(screen.getByTestId(`pr-row-${ROOT}-41`)).toBeInTheDocument();
+
+    // Retry stays offered: a user who thinks we are wrong is entitled to
+    // find out for the price of one request.
+    await userEvent.click(screen.getByTestId("pr-stale-retry"));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("raises the strip on a spent budget before every root has been refused", () => {
+    // The polling is already paused at that point. A page that had
+    // quietly stopped refreshing while looking perfectly current is the
+    // one outcome worse than saying so.
+    renderList({
+      rows: carriedRows,
+      updatedAt: Date.now() - 60_000,
+      rateLimitedUntil: Date.now() + 5 * 60_000,
+      allRootsFailed: false,
+      refreshFailed: false,
+    });
+
+    expect(screen.getByTestId("pr-stale-strip")).toHaveTextContent("Rate limit reached");
+  });
+
   it("leaves a partial failure to the footer", () => {
     renderList({
       rows: [row({ number: 41 })],
@@ -575,3 +626,63 @@ describe("PrList — rows whose checks have not landed", () => {
   });
 });
 
+
+describe("PrList — nothing to show, and why", () => {
+  it("does not claim the list is empty when it never got an answer", () => {
+    // "No open pull requests" is an answer. Refused-for-budget means we
+    // do not have one, and on a cold start there are no rows to fall
+    // back on either — so the page has to say which of the two it is.
+    renderList({
+      rows: [],
+      updatedAt: null,
+      rateLimitedUntil: Date.now() + 10 * 60_000,
+      allRootsFailed: true,
+      refreshFailed: true,
+    });
+
+    expect(screen.queryByText("No open pull requests.")).not.toBeInTheDocument();
+    expect(screen.getByTestId("pr-list-unanswered")).toBeInTheDocument();
+    // And the strip still explains itself, with no rows above it.
+    expect(screen.getByTestId("pr-stale-strip")).toHaveTextContent("Rate limit reached");
+  });
+
+  it("still says the list is empty when the host actually said so", () => {
+    renderList({ rows: [], updatedAt: Date.now() });
+    expect(screen.getByText("No open pull requests.")).toBeInTheDocument();
+    expect(screen.queryByTestId("pr-stale-strip")).not.toBeInTheDocument();
+  });
+
+  it("does not claim ignorance when other repositories answered", () => {
+    // One root over budget while twenty answered "nothing open" is an
+    // answer. Refusing to give it would be the same lie in the other
+    // direction, and this page has more repositories than budgets.
+    renderList({
+      rows: [],
+      updatedAt: Date.now(),
+      rateLimitedUntil: Date.now() + 10 * 60_000,
+      allRootsFailed: false,
+    });
+
+    expect(screen.getByText("No open pull requests.")).toBeInTheDocument();
+    expect(screen.queryByTestId("pr-list-unanswered")).not.toBeInTheDocument();
+  });
+
+  it("does not say it is showing a list when there is no list", () => {
+    // A cold start that was refused has nothing behind the strip, so the
+    // clause about what you are looking at has to go — it would sit
+    // directly above an empty state saying the opposite.
+    renderList({
+      rows: [],
+      updatedAt: null,
+      rateLimitedUntil: Date.now() + 10 * 60_000,
+      allRootsFailed: true,
+      refreshFailed: true,
+    });
+
+    const strip = screen.getByTestId("pr-stale-strip");
+    expect(strip).toHaveTextContent("Rate limit reached");
+    expect(strip).toHaveTextContent("resuming at");
+    expect(strip).not.toHaveTextContent("showing the last list loaded");
+    expect(strip).not.toHaveTextContent("showing the list from");
+  });
+});

--- a/src/components/pull-requests/pr-list.tsx
+++ b/src/components/pull-requests/pr-list.tsx
@@ -46,6 +46,15 @@ const MAX_RENDERED = 200;
 
 const EMPTY_MOVED: Set<string> = new Set();
 
+/** `14:12` — the user's own clock, because the only question it answers
+ *  is "when can I look again". */
+export function clockTime(epochMs: number): string {
+  return new Date(epochMs).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
 const STATE_LABEL: Record<PrStateFilter, string> = {
   open: "Open",
   closed: "Closed",
@@ -70,6 +79,11 @@ export interface PrListProps {
   allRootsFailed?: boolean;
   /** The refresh cycle settled with nothing to show for itself. */
   refreshFailed?: boolean;
+  /** Epoch ms the host's budget refills at, when a refusal for exceeding
+   *  it has paused the polling; 0 when nothing is paused. It gets its
+   *  own sentence because it is the one failure with an answer to "what
+   *  do I do about it" that isn't "press the button again". */
+  rateLimitedUntil?: number;
   isLoading: boolean;
   selectedKey: string | null;
   stateFilter: PrStateFilter;
@@ -91,6 +105,7 @@ export function PrList({
   carriedAt = null,
   allRootsFailed = false,
   refreshFailed = false,
+  rateLimitedUntil = 0,
   isLoading,
   selectedKey,
   stateFilter,
@@ -227,7 +242,13 @@ export function PrList({
   // you are reading is carried and the refresh behind it didn't land.
   // Partial failure keeps the quieter footer treatment: the other
   // repositories are current, and one line saying so is proportionate.
-  const showStaleStrip = total > 0 && (allRootsFailed || (carried && refreshFailed));
+  // A budget that is spent raises the strip on its own, without waiting
+  // for every root to have been refused individually: the polling is
+  // already paused at that point, and a page that has quietly stopped
+  // refreshing while looking perfectly normal is the one outcome worse
+  // than saying so.
+  const showStaleStrip =
+    rateLimitedUntil > 0 || (total > 0 && (allRootsFailed || (carried && refreshFailed)));
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col" data-testid="pr-list">
@@ -295,7 +316,14 @@ export function PrList({
         </DropdownMenu>
       </div>
 
-      {showStaleStrip && <StaleStrip age={age} onRetry={onRefresh} />}
+      {showStaleStrip && (
+        <StaleStrip
+          age={age}
+          hasRows={total > 0}
+          resumesAt={rateLimitedUntil > 0 ? rateLimitedUntil : null}
+          onRetry={onRefresh}
+        />
+      )}
 
       <div
         role="listbox"
@@ -315,6 +343,7 @@ export function PrList({
             hasRows={rows.length > 0}
             hasHosts={hostCount > 0}
             isLoading={isLoading}
+            unanswered={rateLimitedUntil > 0 && allRootsFailed}
             query={query}
             onClearQuery={() => setQuery("")}
           />
@@ -415,8 +444,47 @@ export function PrList({
  * It is a strip and not a dialog, and it appears above the list rather
  * than over it, so nothing that was readable a moment ago stops being
  * readable.
+ *
+ * `resumesAt` swaps the sentence for the one case where "it failed"
+ * would be a lie by omission: the host refused because the account's
+ * hourly API budget is spent, and the page has stopped asking until it
+ * refills. That is not a broken repository and pressing Retry is not
+ * what fixes it — waiting is — so the strip says which, and until when.
+ * Retry stays offered anyway, because a user who thinks we are wrong
+ * should be able to find out for the price of one request.
+ *
+ * A clock time rather than "in 15m", and the reason is specific to this
+ * state: while the gate is up nothing is polling, so nothing re-renders,
+ * so a countdown would sit frozen at whatever it read when the strip
+ * first painted. "14:12" is still true an hour later.
  */
-function StaleStrip({ age, onRetry }: { age: string | null; onRetry: () => void }) {
+function StaleStrip({
+  age,
+  hasRows,
+  resumesAt,
+  onRetry,
+}: {
+  age: string | null;
+  /** Whether there is in fact a list underneath. On a cold start that
+   *  was refused there isn't one, and the clause about what you are
+   *  looking at has to go — it would sit directly above an empty state
+   *  saying the opposite. */
+  hasRows: boolean;
+  resumesAt: number | null;
+  onRetry: () => void;
+}) {
+  // Three facts, and the sentence names only the ones that are true:
+  // what happened, what you are looking at instead (nothing, on a cold
+  // start), and when it will right itself (only the budget knows that).
+  const headline = resumesAt == null ? "The latest refresh failed" : "Rate limit reached";
+  const showing = !hasRows
+    ? null
+    : age
+      ? `showing the list from ${age} ago`
+      : "showing the last list loaded";
+  const resuming = resumesAt == null ? null : `resuming at ${clockTime(resumesAt)}`;
+  const rest = [showing, resuming].filter(Boolean).join(", ");
+  const sentence = rest ? `${headline} · ${rest}` : headline;
   return (
     <div
       role="status"
@@ -425,7 +493,7 @@ function StaleStrip({ age, onRetry }: { age: string | null; onRetry: () => void 
     >
       <span aria-hidden className="size-2 shrink-0 rounded-full bg-status-working" />
       <span className={cn("min-w-[11rem] flex-1 leading-snug text-foreground/80", tzBody)}>
-        The latest refresh failed{age ? ` · showing the list from ${age} ago` : " · showing the last list loaded"}
+        {sentence}
       </span>
       <button
         type="button"
@@ -470,12 +538,19 @@ function EmptyList({
   hasRows,
   hasHosts,
   isLoading,
+  unanswered,
   query,
   onClearQuery,
 }: {
   hasRows: boolean;
   hasHosts: boolean;
   isLoading: boolean;
+  /** *Every* root refused and the page has stopped asking, so it has no
+   *  answer to give — as opposed to having one that happens to be
+   *  empty. One root being over budget while twenty others answered
+   *  "nothing open" is an answer, and saying otherwise would be the same
+   *  lie in the other direction. */
+  unanswered: boolean;
   query: string;
   onClearQuery: () => void;
 }) {
@@ -509,6 +584,21 @@ function EmptyList({
         <p className={cn("leading-relaxed text-muted-foreground", tzBody)}>
           This page lists pull requests across the projects you have open. Open one and
           its repository shows up here.
+        </p>
+      </div>
+    );
+  }
+
+  // Asked, and refused. The same rule as the loading case immediately
+  // below, for the same reason: "no open pull requests" is an answer,
+  // and we do not have one. The strip above this says when we will.
+  if (unanswered) {
+    return (
+      <div className="flex flex-col items-start gap-2 px-3 py-8" data-testid="pr-list-unanswered">
+        <p className="text-xs text-foreground">Nothing to show yet.</p>
+        <p className={cn("leading-relaxed text-muted-foreground", tzBody)}>
+          The host is not answering requests right now, so this page has not been able to
+          ask what is open. It tries again on its own.
         </p>
       </div>
     );

--- a/src/components/pull-requests/pr-list.tsx
+++ b/src/components/pull-requests/pr-list.tsx
@@ -597,8 +597,8 @@ function EmptyList({
       <div className="flex flex-col items-start gap-2 px-3 py-8" data-testid="pr-list-unanswered">
         <p className="text-xs text-foreground">Nothing to show yet.</p>
         <p className={cn("leading-relaxed text-muted-foreground", tzBody)}>
-          The host is not answering requests right now, so this page has not been able to
-          ask what is open. It tries again on its own.
+          The host is refusing requests until the account&apos;s API budget refills, so this
+          page has not been able to ask what is open. It tries again on its own.
         </p>
       </div>
     );

--- a/src/components/pull-requests/pull-requests-view.tsx
+++ b/src/components/pull-requests/pull-requests-view.tsx
@@ -79,9 +79,14 @@ export function PullRequestsView() {
     carriedAt,
     allRootsFailed,
     refreshFailed,
+    rateLimitedUntil,
     isLoading,
     refresh,
-  } = usePrOverview(true, stateFilter);
+    // "page": this is the surface someone is actually looking at, and
+    // the only one that earns the fast cadence. Everything else sharing
+    // these rows — the badge, the toasts, the palette — runs in the
+    // slower `watch` mode by default.
+  } = usePrOverview(true, stateFilter, "page");
 
   // Escape closes, matching the other full-screen destinations — but
   // only when nothing nearer to the user wanted the key first.
@@ -271,6 +276,7 @@ export function PullRequestsView() {
             viewerByRoot={viewerByRoot}
             workspaceByBranch={workspaceByBranch}
             failures={failures}
+            rateLimitedUntil={rateLimitedUntil}
             hostCount={roots.length}
             updatedAt={updatedAt}
             carried={carried}

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -331,6 +331,21 @@ let PR_STATS_DELAY_MS = storedDelay("pr-stats-delay", 800);
  *  the slow half of it. Flipped from the console, not seeded. */
 let prOverviewOutage = false;
 let prStatsOutage = false;
+/**
+ * The host is reachable and refusing: the account's hourly API budget is
+ * spent.
+ *
+ * Its own switch rather than a flavour of the outage above, because the
+ * page treats it as its own thing — it stops polling instead of
+ * retrying, and says when it will resume rather than offering a button
+ * as the answer. Being able to see that state is the point of having it
+ * here.
+ */
+let prBudgetSpent = false;
+
+/** Verbatim what `gh pr list` prints when the GraphQL budget is gone. */
+const RATE_LIMIT_REFUSAL =
+  "GraphQL: API rate limit already exceeded for user ID 100132710.";
 
 /**
  * The expensive half of one row.
@@ -3675,6 +3690,10 @@ const handlers: Record<string, Handler> = {
     }
     const refused = undeclaredRefusal(path, "list_read", "list or read pull requests");
     if (refused) return Promise.reject(refused);
+    // Before the delay: a refusal for spending comes straight back, and
+    // it is the fact that it comes back *fast* that makes a retrying
+    // client so expensive.
+    if (prBudgetSpent) return Promise.reject(RATE_LIMIT_REFUSAL);
     await new Promise((resolve) => setTimeout(resolve, PR_LIST_DELAY_MS));
     if (prOverviewOutage) {
       return Promise.reject("could not resolve host: api.github.com");
@@ -3690,6 +3709,20 @@ const handlers: Record<string, Handler> = {
   },
 
   /**
+   * What is left of the budget, and when it refills.
+   *
+   * Asked only after a refusal, and never metered by the host — so the
+   * mock answers instantly and without a delay knob. The reset it
+   * reports is what the strip counts down to.
+   */
+  github_rate_limit: async () => ({
+    graphql_remaining: prBudgetSpent ? 0 : 4_140,
+    graphql_reset: Math.floor(Date.now() / 1000) + 15 * 60,
+    core_remaining: 5_000,
+    core_reset: Math.floor(Date.now() / 1000) + 42 * 60,
+  }),
+
+  /**
    * The slow half, deliberately slow.
    *
    * 800ms is not a guess at gh's latency — it is long enough that the
@@ -3699,6 +3732,7 @@ const handlers: Record<string, Handler> = {
    */
   list_prs_overview_stats: async (a) => {
     const path = String(a.path ?? "");
+    if (prBudgetSpent) return Promise.reject(RATE_LIMIT_REFUSAL);
     if (path === MOCK_UNREACHABLE_ROOT || prOverviewOutage) {
       return Promise.reject("could not resolve host: api.github.com");
     }
@@ -5360,18 +5394,23 @@ function kickPrOverview(): void {
 
 // Dev affordance: take the host away, and watch the rows stay.
 //
-//   __codemuxMockPrOutage()             // everything fails
-//   __codemuxMockPrOutage(true, "stats") // only the slow half fails
-//   __codemuxMockPrOutage(false)        // back to normal
+//   __codemuxMockPrOutage()              // everything fails
+//   __codemuxMockPrOutage(true, "stats")  // only the slow half fails
+//   __codemuxMockPrOutage(true, "budget") // the host refuses: budget spent
+//   __codemuxMockPrOutage(false)         // back to normal
 (
   window as unknown as {
-    __codemuxMockPrOutage: (down?: boolean, which?: "all" | "stats") => string;
+    __codemuxMockPrOutage: (down?: boolean, which?: "all" | "stats" | "budget") => string;
   }
 ).__codemuxMockPrOutage = (down = true, which = "all") => {
-  prStatsOutage = down;
+  prBudgetSpent = down && which === "budget";
+  prStatsOutage = down && which !== "budget";
   prOverviewOutage = down && which === "all";
   kickPrOverview();
   if (!down) return "pull-request host reachable again";
+  if (which === "budget") {
+    return "the host now refuses for spending — the page stops polling and says until when";
+  }
   return which === "stats"
     ? "the stats half now fails — rows keep the checks they had"
     : "every root now fails — the list keeps its rows and says how old they are";

--- a/src/lib/pr-overview-query.test.tsx
+++ b/src/lib/pr-overview-query.test.tsx
@@ -840,4 +840,60 @@ describe("usePrOverview — the gate can be raised more than once", () => {
     await waitFor(() => expect(mockGithubRateLimit).toHaveBeenCalledTimes(2));
     expect(result.current.rateLimitedUntil).toBeGreaterThan(0);
   });
+
+  it("does not raise the gate again on a refusal from before the pause", async () => {
+    // Two roots with rows are both refused, and the newer refusal is
+    // the one that raised the gate. When the pause lifts both refetch,
+    // and a root with rows keeps its error — and its old timestamp —
+    // while its refetch is in flight. If the *other* root answers
+    // first, the newest refusal on the page is suddenly the older one,
+    // the effect sees a change, and a refusal that the pause already
+    // answered for would put the gate straight back up. The gate has
+    // to remember what it has already acted on.
+    const RESET_SEC = Math.floor(Date.now() / 1000) + 900;
+    setRoots(ROOT, OTHER);
+    const calls = new Map<string, number>();
+    const rootRefetch = deferred<unknown>();
+    mockListPrsOverview.mockImplementation((path: string) => {
+      const n = (calls.get(path) ?? 0) + 1;
+      calls.set(path, n);
+      if (n === 1) return Promise.resolve({ viewer: "mock-dev", items: [item({ number: n })] });
+      if (n === 2) return Promise.reject("GraphQL: API rate limit already exceeded for user ID 1.");
+      return path === ROOT
+        ? rootRefetch.promise
+        : Promise.resolve({ viewer: "mock-dev", items: [item({ number: 7 })] });
+    });
+    mockListPrsOverviewStats.mockResolvedValue([]);
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: RESET_SEC,
+      core_remaining: 1,
+      core_reset: RESET_SEC,
+    });
+
+    const { client, wrapper } = clientWrapper();
+    const { result } = renderHook(() => usePrOverview(true), { wrapper });
+    await waitFor(() => expect(result.current.rows).toHaveLength(2));
+
+    await act(async () => {
+      await client.refetchQueries({ predicate: (q) => q.queryKey[1] === "overview" });
+    });
+    await waitFor(() => expect(result.current.rateLimitedUntil).toBeGreaterThan(0));
+    expect(result.current.failures).toHaveLength(2);
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
+
+    act(() => clearRateLimitPause());
+
+    // The second root has answered; the first is still asking, and
+    // still wearing the refusal from before the pause.
+    await waitFor(() => expect(result.current.rows.map((r) => r.number)).toContain(7));
+    expect(result.current.failures.map((f) => f.root.path)).toEqual([ROOT]);
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
+    expect(result.current.rateLimitedUntil).toBe(0);
+
+    rootRefetch.resolve({ viewer: "mock-dev", items: [item({ number: 8 })] });
+    await waitFor(() => expect(result.current.failures).toHaveLength(0));
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
+    expect(result.current.rateLimitedUntil).toBe(0);
+  });
 });

--- a/src/lib/pr-overview-query.test.tsx
+++ b/src/lib/pr-overview-query.test.tsx
@@ -1,16 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { act, renderHook, waitFor, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
 const mockListPrsOverview = vi.fn();
 const mockListPrsOverviewStats = vi.fn();
 const mockListPullRequests = vi.fn().mockResolvedValue([]);
+const mockGithubRateLimit = vi.fn();
 
 vi.mock("@/tauri/commands", () => ({
   listPrsOverview: (...a: unknown[]) => mockListPrsOverview(...a),
   listPrsOverviewStats: (...a: unknown[]) => mockListPrsOverviewStats(...a),
   listPullRequests: (...a: unknown[]) => mockListPullRequests(...a),
+  githubRateLimit: (...a: unknown[]) => mockGithubRateLimit(...a),
 }));
 
 const mockWorkspaces: {
@@ -28,8 +30,11 @@ vi.mock("@/stores/app-store", () => ({
 import {
   usePrOverview,
   mergeStats,
+  prOverviewKey,
+  prOverviewStatsKey,
   _resetSnapshotWriteGuard,
 } from "./pr-overview-query";
+import { _resetRateLimitGate, clearRateLimitPause } from "./pr-rate-limit";
 import {
   PR_SNAPSHOT_VERSION,
   prSnapshotKey,
@@ -117,6 +122,8 @@ function setRoots(...paths: string[]) {
 beforeEach(() => {
   localStorage.clear();
   _resetSnapshotWriteGuard();
+  _resetRateLimitGate();
+  mockGithubRateLimit.mockReset();
   mockListPrsOverview.mockReset();
   mockListPrsOverviewStats.mockReset();
   setRoots(ROOT);
@@ -523,5 +530,314 @@ describe("usePrOverview — failure shape", () => {
     await waitFor(() => expect(result.current.failures).toHaveLength(1));
     expect(result.current.allRootsFailed).toBe(false);
     expect(result.current.rows).toHaveLength(1);
+  });
+});
+
+// ── Cadence ──────────────────────────────────────────────────────────
+//
+// The fan-out is one `gh` call per repository root, so what it costs is
+// the root count times the rate — and the watcher that feeds the sidebar
+// badge runs for the whole session whether or not anyone is looking. At
+// the page's own cadence that came to more requests per hour than the
+// host grants in an hour, and the page then found the budget already
+// spent. These two tests are the split that fixed it; they assert the
+// interval each mode actually registers rather than waiting for timers.
+
+function clientWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retryDelay: 0, gcTime: 0 } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, wrapper: Wrapper };
+}
+
+function intervalOf(client: QueryClient, key: readonly unknown[]): unknown {
+  const query = client.getQueryCache().find({ queryKey: key });
+  return query?.observers[0]?.options.refetchInterval;
+}
+
+describe("usePrOverview — cadence", () => {
+  it("gives the page the cadence a person notices", async () => {
+    mockListPrsOverview.mockResolvedValue({ viewer: "mock-dev", items: [item({ number: 1 })] });
+    mockListPrsOverviewStats.mockResolvedValue([]);
+
+    const { client, wrapper } = clientWrapper();
+    const { result } = renderHook(() => usePrOverview(true, "open", "page"), { wrapper });
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    expect(intervalOf(client, prOverviewKey(ROOT))).toBe(30_000);
+    // The expensive half is slower even on the page: it is a second call
+    // per root, and a check rollup ticking over on a row nobody has
+    // opened yet is not what the page is for.
+    await waitFor(() =>
+      expect(intervalOf(client, prOverviewStatsKey(ROOT))).toBe(90_000),
+    );
+  });
+
+  it("lets the unwatched watcher run slowly", async () => {
+    mockListPrsOverview.mockResolvedValue({ viewer: "mock-dev", items: [item({ number: 1 })] });
+    mockListPrsOverviewStats.mockResolvedValue([]);
+
+    const { client, wrapper } = clientWrapper();
+    // No third argument: the badge, the toasts and the palette all take
+    // the default, and the default is the cheap one.
+    const { result } = renderHook(() => usePrOverview(true), { wrapper });
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    expect(intervalOf(client, prOverviewKey(ROOT))).toBe(120_000);
+    await waitFor(() =>
+      expect(intervalOf(client, prOverviewStatsKey(ROOT))).toBe(240_000),
+    );
+  });
+});
+
+// ── The budget gate ──────────────────────────────────────────────────
+
+describe("usePrOverview — the budget gate", () => {
+  const RESET_SEC = Math.floor(Date.now() / 1000) + 900;
+
+  it("stops polling when the account's budget is spent, and says until when", async () => {
+    setRoots(ROOT, OTHER);
+    mockListPrsOverview.mockRejectedValue(
+      "GraphQL: API rate limit already exceeded for user ID 100132710.",
+    );
+    mockListPrsOverviewStats.mockResolvedValue([]);
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: RESET_SEC,
+      core_remaining: 4999,
+      core_reset: RESET_SEC,
+    });
+
+    const { client, wrapper } = clientWrapper();
+    const { result } = renderHook(() => usePrOverview(true), { wrapper });
+
+    await waitFor(() => expect(result.current.rateLimitedUntil).toBe(RESET_SEC * 1000));
+
+    // The budget belongs to the account, not to the repository whose
+    // call happened to carry the refusal — so both roots are gated and
+    // only one of them paid for the lookup.
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
+    const query = client.getQueryCache().find({ queryKey: prOverviewKey(ROOT) });
+    expect(query?.observers[0]?.options.enabled).toBe(false);
+  });
+
+  it("does not pause a repository metered by a different host", async () => {
+    // The gate holds GitHub's hourly budget. A GitLab root draws on an
+    // entirely separate one and has nothing to wait for — freezing its
+    // badge, its toasts and its rows on GitHub's word would be a new
+    // silent outage traded for the old one.
+    mockWorkspaces.length = 0;
+    mockWorkspaces.push({
+      workspace_id: "ws-gh",
+      project_root: ROOT,
+      cwd: ROOT,
+      provider_kind: "github",
+    });
+    mockWorkspaces.push({
+      workspace_id: "ws-gl",
+      project_root: OTHER,
+      cwd: OTHER,
+      provider_kind: "gitlab",
+    });
+    mockListPrsOverview.mockImplementation((path: string) =>
+      path === ROOT
+        ? Promise.reject("GraphQL: API rate limit already exceeded for user ID 1.")
+        : Promise.resolve({ viewer: "mock-dev", items: [item({ number: 4 })] }),
+    );
+    mockListPrsOverviewStats.mockResolvedValue([]);
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: Math.floor(Date.now() / 1000) + 900,
+      core_remaining: 1,
+      core_reset: Math.floor(Date.now() / 1000) + 900,
+    });
+
+    const { client, wrapper } = clientWrapper();
+    const { result } = renderHook(() => usePrOverview(true), { wrapper });
+    await waitFor(() => expect(result.current.rateLimitedUntil).toBeGreaterThan(0));
+
+    const gh = client.getQueryCache().find({ queryKey: prOverviewKey(ROOT) });
+    const gl = client.getQueryCache().find({ queryKey: prOverviewKey(OTHER) });
+    expect(gh?.observers[0]?.options.enabled).toBe(false);
+    expect(gl?.observers[0]?.options.enabled).toBe(true);
+    expect(result.current.rows.map((r) => r.number)).toEqual([4]);
+  });
+
+  it("does not raise the gate on a host it cannot speak for", async () => {
+    // A GitLab root saying "rate limit" is reporting a budget this gate
+    // does not hold and `gh api rate_limit` cannot read.
+    mockWorkspaces.length = 0;
+    mockWorkspaces.push({
+      workspace_id: "ws-gl",
+      project_root: OTHER,
+      cwd: OTHER,
+      provider_kind: "gitlab",
+    });
+    mockListPrsOverview.mockRejectedValue("429: API rate limit exceeded for this project");
+    mockListPrsOverviewStats.mockResolvedValue([]);
+
+    const { result } = renderHook(() => usePrOverview(true), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.failures).toHaveLength(1));
+
+    expect(result.current.rateLimitedUntil).toBe(0);
+    expect(mockGithubRateLimit).not.toHaveBeenCalled();
+  });
+
+  it("leaves an unreachable repository to the footer", async () => {
+    // The narrowness of the match is what keeps one dead remote from
+    // pausing every other repository along with it.
+    setRoots(ROOT, OTHER);
+    mockListPrsOverview.mockImplementation((path: string) =>
+      path === ROOT
+        ? Promise.resolve({ viewer: "mock-dev", items: [item({ number: 1 })] })
+        : Promise.reject("could not resolve host github.com"),
+    );
+    mockListPrsOverviewStats.mockResolvedValue([]);
+
+    const { result } = renderHook(() => usePrOverview(true), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.failures).toHaveLength(1));
+    expect(result.current.rateLimitedUntil).toBe(0);
+    expect(mockGithubRateLimit).not.toHaveBeenCalled();
+    expect(result.current.rows).toHaveLength(1);
+  });
+
+  it("keeps the rows it already had while it waits", async () => {
+    // The gate stops fetching, never rendering: a page that emptied
+    // itself because the budget ran out would be strictly worse than the
+    // stale list it is replacing.
+    mockListPrsOverview
+      .mockResolvedValueOnce({ viewer: "mock-dev", items: [item({ number: 1 })] })
+      .mockRejectedValue("GraphQL: API rate limit already exceeded for user ID 1.");
+    mockListPrsOverviewStats.mockResolvedValue([]);
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: RESET_SEC,
+      core_remaining: 1,
+      core_reset: RESET_SEC,
+    });
+
+    const { client, wrapper } = clientWrapper();
+    const { result } = renderHook(() => usePrOverview(true), { wrapper });
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    await act(async () => {
+      await client.refetchQueries({ queryKey: prOverviewKey(ROOT) });
+    });
+    await waitFor(() => expect(result.current.rateLimitedUntil).toBeGreaterThan(0));
+
+    expect(result.current.rows).toHaveLength(1);
+    expect(result.current.rows[0]?.number).toBe(1);
+  });
+
+  it("lifts the gate when the user presses Retry, and recovers", async () => {
+    mockListPrsOverview.mockRejectedValue(
+      "GraphQL: API rate limit already exceeded for user ID 1.",
+    );
+    mockListPrsOverviewStats.mockResolvedValue([]);
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: RESET_SEC,
+      core_remaining: 1,
+      core_reset: RESET_SEC,
+    });
+
+    const { result } = renderHook(() => usePrOverview(true), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.rateLimitedUntil).toBeGreaterThan(0));
+
+    // The budget refilled early, or the user simply disbelieves us.
+    // Retry is allowed to find out, for the price of one request.
+    mockListPrsOverview.mockResolvedValue({
+      viewer: "mock-dev",
+      items: [item({ number: 9 })],
+    });
+    act(() => result.current.refresh());
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+    expect(result.current.rows[0]?.number).toBe(9);
+    expect(result.current.rateLimitedUntil).toBe(0);
+  });
+});
+
+describe("usePrOverview — the gate can be raised more than once", () => {
+  it("goes back up when the budget is still spent after the pause lifts", async () => {
+    // The failure this guards against is subtle and total: if the effect
+    // that raises the gate keys off something that does not change
+    // between two refusals, the gate goes up exactly once per session.
+    // Every pause after the first one then lifts into a page that
+    // resumes hammering a host still refusing it — which is the original
+    // bug, with a fifteen-minute pause in front of it.
+    const RESET_SEC = Math.floor(Date.now() / 1000) + 900;
+    mockListPrsOverview.mockRejectedValue(
+      "GraphQL: API rate limit already exceeded for user ID 1.",
+    );
+    mockListPrsOverviewStats.mockResolvedValue([]);
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: RESET_SEC,
+      core_remaining: 1,
+      core_reset: RESET_SEC,
+    });
+
+    const { result } = renderHook(() => usePrOverview(true), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.rateLimitedUntil).toBeGreaterThan(0));
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
+
+    // The pause lifting is what Retry does by hand, so this is the same
+    // path the timer takes when it fires.
+    act(() => result.current.refresh());
+
+    await waitFor(() => expect(mockGithubRateLimit).toHaveBeenCalledTimes(2));
+    expect(result.current.rateLimitedUntil).toBeGreaterThan(0);
+  });
+
+  it("goes back up when the timer lifts the pause, on a root that already has rows", async () => {
+    // Two things at once, and the second is why the first is written
+    // this way.
+    //
+    // The timer path: Retry also invalidates the queries, while the
+    // timer only lifts the gate and leaves the re-fetch to the observers
+    // re-enabling. That is the path that actually runs in production —
+    // nobody is watching at 03:00 to press the button.
+    //
+    // And the root *succeeds first*, which is what makes this a real
+    // test of the dependency. A query that has never held data has its
+    // error cleared on every refetch, so the offending path goes null
+    // and back and the effect re-fires on the path alone — the shape
+    // every other test here has, and the shape the bug hides behind. A
+    // root with rows keeps its error across refetches, so the timestamp
+    // is genuinely the only thing that changes between two refusals.
+    const RESET_SEC = Math.floor(Date.now() / 1000) + 900;
+    mockListPrsOverview
+      .mockResolvedValueOnce({ viewer: "mock-dev", items: [item({ number: 3 })] })
+      .mockRejectedValue("GraphQL: API rate limit already exceeded for user ID 1.");
+    mockListPrsOverviewStats.mockResolvedValue([]);
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: RESET_SEC,
+      core_remaining: 1,
+      core_reset: RESET_SEC,
+    });
+
+    const { client, wrapper } = clientWrapper();
+    const { result } = renderHook(() => usePrOverview(true), { wrapper });
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+
+    await act(async () => {
+      await client.refetchQueries({ queryKey: prOverviewKey(ROOT) });
+    });
+    await waitFor(() => expect(result.current.rateLimitedUntil).toBeGreaterThan(0));
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
+    // The row survived the refusal, which is the state that makes the
+    // second refusal indistinguishable from the first by path alone.
+    expect(result.current.rows).toHaveLength(1);
+
+    act(() => clearRateLimitPause());
+
+    await waitFor(() => expect(mockGithubRateLimit).toHaveBeenCalledTimes(2));
+    expect(result.current.rateLimitedUntil).toBeGreaterThan(0);
   });
 });

--- a/src/lib/pr-overview-query.ts
+++ b/src/lib/pr-overview-query.ts
@@ -23,6 +23,13 @@ import { useEffect, useMemo } from "react";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 
 import { listPrsOverview, listPrsOverviewStats, listPullRequests } from "@/tauri/commands";
+import {
+  budgetApplies,
+  clearRateLimitPause,
+  isRateLimitError,
+  noteRateLimited,
+  useRateLimitPause,
+} from "@/lib/pr-rate-limit";
 import { useAppStore } from "@/stores/app-store";
 import { repoSlugFromUrl } from "@/lib/source-control";
 import type { PrRow } from "@/lib/pr-overview";
@@ -34,9 +41,73 @@ import {
 } from "@/lib/pr-overview-snapshot";
 import type { PrOverviewStats, PullRequestInfo } from "@/tauri/types";
 
-/** 30s: PRs across every open project change on a human cadence, and
- *  each root is a CLI shell-out. The detail column polls far faster. */
+/**
+ * Who is asking, which is the same question as how often to ask.
+ *
+ * `page` is the Pull Requests page: on screen, being read, and open for
+ * as long as someone is triaging. `watch` is everything that wants these
+ * rows without anyone looking at them — the sidebar badge, the toast
+ * watcher, the palette's `pr ` mode — and it runs for the whole session.
+ */
+export type PrOverviewMode = "page" | "watch";
+
+/**
+ * 30s: PRs across every open project change on a human cadence, and each
+ * root is a CLI shell-out. The detail column polls far faster.
+ */
 export const PR_OVERVIEW_REFETCH_MS = 30_000;
+
+/**
+ * How often the listing re-runs, by mode.
+ *
+ * The fan-out is one `gh` call *per repository root*, so its cost is not
+ * a constant — it is the root count times the rate. On a machine with
+ * twenty-odd projects open, polling every root every thirty seconds is
+ * more GraphQL requests per hour than GitHub grants in an hour, and the
+ * budget is per account rather than per surface. What that bought was
+ * the watcher spending the page's quota all day and the page finding
+ * none left the moment it was opened: every root refused at once, and a
+ * page of "the latest refresh failed" over rows from twenty minutes ago.
+ *
+ * So the two cadences are split by what is actually being served. The
+ * page keeps 30s, because that is the number a person watching a list
+ * notices. The watcher — which nobody is watching — moves to two
+ * minutes, which is the same information at a fifth of the price.
+ *
+ * Two things already in the query layer keep the slower cadence from
+ * costing the badge its freshness, and they are why this is a cadence
+ * change rather than a trade:
+ *
+ * - `refetchOnWindowFocus` (on globally) refreshes the watcher when you
+ *   return to Codemux, so the badge is current exactly when you are in
+ *   front of it.
+ * - Opening the page mounts an observer with the 30s staleness, which
+ *   refetches on mount — so the page never opens onto watcher-aged rows.
+ */
+const LIST_REFETCH_MS: Record<PrOverviewMode, number> = {
+  page: PR_OVERVIEW_REFETCH_MS,
+  watch: 120_000,
+};
+
+/**
+ * How often the expensive half re-runs, by mode.
+ *
+ * Slower than the listing in both modes, because it is a second call per
+ * root and it answers a slower question. A pull request appearing, or
+ * appearing in *your* group, is news; its check rollup ticking from
+ * pending to green is a detail of a row you are not looking at yet — and
+ * the moment you do look at one, the detail column watches its checks
+ * properly, on a cadence this page has no business trying to match.
+ *
+ * This is also the half that never stops asking: the fast listing leaves
+ * `checks` null by design, so `needsStats` is true on essentially every
+ * root, forever. At the listing's own rate that quietly doubled the
+ * price of every cycle.
+ */
+const STATS_REFETCH_MS: Record<PrOverviewMode, number> = {
+  page: 90_000,
+  watch: 240_000,
+};
 
 export const prOverviewKey = (projectRoot: string) =>
   ["prs", "overview", projectRoot] as const;
@@ -189,6 +260,14 @@ export interface PrOverviewResult {
    *  later, and announcing a failed refresh in that gap would be both
    *  alarming and wrong. */
   refreshFailed: boolean;
+  /** Epoch ms at which the host's budget refills, when a refusal for
+   *  exceeding it has paused the polling; 0 when nothing is paused.
+   *
+   *  Distinct from `refreshFailed` on purpose. "It broke" and "you are
+   *  out of budget until 10:49" want different sentences: the first is a
+   *  thing to retry, the second is a thing to wait out, and the strip
+   *  can only say which if it is told. */
+  rateLimitedUntil: number;
   isLoading: boolean;
   refresh: () => void;
 }
@@ -218,20 +297,42 @@ export function _resetSnapshotWriteGuard(): void {
 export function usePrOverview(
   enabled = true,
   stateFilter: PrStateFilter = "open",
+  mode: PrOverviewMode = "watch",
 ): PrOverviewResult {
   const roots = useProjectRoots();
   const queryClient = useQueryClient();
+
+  // The host has refused for exceeding its budget and told us when it
+  // refills. Everything below stops asking until then — the rows already
+  // on screen stay exactly as they are, which is the same rule that
+  // governs an ordinary failed refresh; only the retrying stops.
+  const rateLimitedUntil = useRateLimitPause();
+  // Per root, not globally: the gate holds *one host's* budget, and a
+  // repository metered somewhere else has nothing to wait for. Pausing
+  // it too would trade one silent freeze for another.
+  const canFetch = (root: ProjectRoot) =>
+    enabled && (rateLimitedUntil === 0 || !budgetApplies(root.providerKind));
+
+  const listRefetchMs = LIST_REFETCH_MS[mode];
+  const statsRefetchMs = STATS_REFETCH_MS[mode];
 
   const results = useQueries({
     queries: roots.map((root) => ({
       queryKey: prOverviewKey(root.path),
       queryFn: () => listPrsOverview(root.path),
-      enabled,
-      staleTime: PR_OVERVIEW_REFETCH_MS,
-      refetchInterval: PR_OVERVIEW_REFETCH_MS,
+      enabled: canFetch(root),
+      // Staleness tracks the cadence rather than being pinned to the
+      // page's, so returning to the window doesn't refetch every root
+      // on every focus — `refetchOnWindowFocus` is on globally, and with
+      // twenty roots a stale-on-arrival watcher made alt-tab expensive.
+      staleTime: listRefetchMs,
+      refetchInterval: listRefetchMs,
       // One retry, then the footer says so. Retrying a repository that
-      // isn't there just delays the sentence that explains it.
-      retry: 1,
+      // isn't there just delays the sentence that explains it — and a
+      // refusal for exceeding the budget is not retried at all, because
+      // the retry is refused too and spends the recovery it is waiting
+      // for. The gate above is what handles that case.
+      retry: (count: number, error: unknown) => !isRateLimitError(error) && count < 1,
     })),
   });
 
@@ -249,12 +350,12 @@ export function usePrOverview(
     queries: roots.map((root, i) => ({
       queryKey: prOverviewStatsKey(root.path),
       queryFn: () => listPrsOverviewStats(root.path),
-      enabled: enabled && needsStats[i],
-      staleTime: PR_OVERVIEW_REFETCH_MS,
-      refetchInterval: PR_OVERVIEW_REFETCH_MS,
+      enabled: canFetch(root) && needsStats[i],
+      staleTime: statsRefetchMs,
+      refetchInterval: statsRefetchMs,
       // No retry. The row keeps whatever it has and the next poll tries
-      // again in thirty seconds; a second attempt at a slow call is the
-      // one thing that would make the slow half slower.
+      // again on the cadence above; a second attempt at a slow call is
+      // the one thing that would make the slow half slower.
       retry: false,
     })),
   });
@@ -268,9 +369,9 @@ export function usePrOverview(
     queries: roots.map((root) => ({
       queryKey: prHistoryKey(root.path, stateFilter),
       queryFn: () => listPullRequests(root.path, stateFilter === "closed" ? "closed" : "all"),
-      enabled: enabled && wantsHistory,
-      staleTime: PR_OVERVIEW_REFETCH_MS,
-      retry: 1,
+      enabled: canFetch(root) && wantsHistory,
+      staleTime: listRefetchMs,
+      retry: (count: number, error: unknown) => !isRateLimitError(error) && count < 1,
     })),
   });
 
@@ -299,6 +400,15 @@ export function usePrOverview(
   let carried = false;
   let statsPending = false;
   let anyRootFresh = false;
+  // The newest refusal-for-spending seen this render, and when it
+  // landed. Both halves matter: the path points `gh` at the right host,
+  // and the timestamp is what tells a *second* refusal apart from the
+  // first one still sitting in the query's error state. Without it the
+  // gate would raise once per session and every pause after the first
+  // would lift into a page that resumed hammering a host still saying
+  // no — the original bug with a fifteen-minute delay in front of it.
+  let rateLimitedRoot: string | null = null;
+  let rateLimitedAt = 0;
 
   results.forEach((result, i) => {
     const root = roots[i];
@@ -362,6 +472,19 @@ export function usePrOverview(
     // failing refresh keeps its rows and still reports the failure.
     if (result.isError) {
       failures.push({ root, message: String(result.error) });
+      // Only a host the gate can actually speak for. A GitLab root that
+      // says "rate limit" is telling us about a budget this gate does
+      // not hold and `gh api rate_limit` cannot read — raising it from
+      // there would pause every GitHub repository on someone else's
+      // word, and look up the wrong host's reset to decide for how long.
+      if (
+        budgetApplies(root.providerKind) &&
+        isRateLimitError(result.error) &&
+        result.errorUpdatedAt >= rateLimitedAt
+      ) {
+        rateLimitedRoot = root.path;
+        rateLimitedAt = result.errorUpdatedAt;
+      }
     }
   });
 
@@ -424,7 +547,25 @@ export function usePrOverview(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [writeToken]);
 
+  // ── Raising the gate ──
+  //
+  // Being refused for exceeding the budget is not a fact about the
+  // repository whose call happened to carry the refusal — it is a fact
+  // about the account, and every other root is about to be told the same
+  // thing. So one refusal speaks for all of them.
+  useEffect(() => {
+    if (!rateLimitedRoot) return;
+    void noteRateLimited(rateLimitedRoot);
+    // `rateLimitedAt` is deliberately a dependency: it is the only thing
+    // that changes when the same root is refused a second time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rateLimitedRoot, rateLimitedAt]);
+
   const refresh = () => {
+    // Retry means "try now", gate or no gate: the user is entitled to
+    // disbelieve us, and the cost of being wrong is a single request
+    // that puts the gate straight back up.
+    clearRateLimitPause();
     queryClient.invalidateQueries({ predicate: (q) => q.queryKey[0] === "prs" });
   };
 
@@ -438,6 +579,7 @@ export function usePrOverview(
     carriedAt: carried ? (snapshot?.savedAt ?? null) : null,
     allRootsFailed: roots.length > 0 && failures.length === roots.length,
     refreshFailed: failures.length > 0 && !anyRootFresh && !isLoading,
+    rateLimitedUntil,
     isLoading,
     refresh,
   };

--- a/src/lib/pr-overview-query.ts
+++ b/src/lib/pr-overview-query.ts
@@ -401,7 +401,7 @@ export function usePrOverview(
   let statsPending = false;
   let anyRootFresh = false;
   // The newest refusal-for-spending seen this render, and when it
-  // landed. Both halves matter: the path points `gh` at the right host,
+  // landed. Both halves matter: the path gives `gh` somewhere to run,
   // and the timestamp is what tells a *second* refusal apart from the
   // first one still sitting in the query's error state. Without it the
   // gate would raise once per session and every pause after the first
@@ -553,12 +553,15 @@ export function usePrOverview(
   // repository whose call happened to carry the refusal — it is a fact
   // about the account, and every other root is about to be told the same
   // thing. So one refusal speaks for all of them.
+  //
+  // The timestamp goes with it. "Newest on screen" is not "new": a root
+  // with rows keeps its error while it refetches, so once the pause
+  // lifts and the other roots recover, the newest refusal left on the
+  // page is one from before the pause — and the gate, not this hook, is
+  // what remembers it has already been paused for.
   useEffect(() => {
     if (!rateLimitedRoot) return;
-    void noteRateLimited(rateLimitedRoot);
-    // `rateLimitedAt` is deliberately a dependency: it is the only thing
-    // that changes when the same root is refused a second time.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    void noteRateLimited(rateLimitedRoot, rateLimitedAt);
   }, [rateLimitedRoot, rateLimitedAt]);
 
   const refresh = () => {

--- a/src/lib/pr-rate-limit.test.ts
+++ b/src/lib/pr-rate-limit.test.ts
@@ -16,8 +16,7 @@ import {
   isRateLimitError,
   noteRateLimited,
   pauseUntil,
-  publishForTest,
-  subscribeRateLimit,
+  subscribe,
 } from "./pr-rate-limit";
 
 const ROOT = "/home/dev/projects/codemux";
@@ -150,16 +149,70 @@ describe("noteRateLimited", () => {
     expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
   });
 
-  it("wakes its subscribers when the gate is reset", () => {
+  it("wakes its subscribers when the gate lifts", async () => {
     // Assigning the module value without publishing would leave a
     // mounted subscriber holding the old snapshot forever — the one way
     // to produce a gate that never lifts.
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: Math.floor(NOW / 1000) + 600,
+    });
     const seen: number[] = [];
-    const stop = subscribeRateLimit(() => seen.push(getPausedUntil()));
-    publishForTest(Date.now() + 60_000);
-    _resetRateLimitGate();
+    const stop = subscribe(() => seen.push(getPausedUntil()));
+    await noteRateLimited(ROOT, NOW);
+    expect(seen[seen.length - 1]).toBeGreaterThan(0);
+    clearRateLimitPause();
     stop();
     expect(seen[seen.length - 1]).toBe(0);
+  });
+
+  it("ignores a refusal no newer than the last one it acted on", async () => {
+    // A query that already holds rows keeps its error, and the error's
+    // timestamp, for as long as its refetch is in flight — so after the
+    // gate lifts, the page is briefly still showing refusals from before
+    // it went up, and any of them can be handed back here as the other
+    // roots recover. The pause that just ended already answered for
+    // them; raising the gate again on one would pause the page on news
+    // from before the pause, and again on every lift after.
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: Math.floor(NOW / 1000) + 600,
+    });
+
+    await noteRateLimited("/home/dev/projects/site", NOW + 5);
+    clearRateLimitPause();
+    expect(getPausedUntil()).toBe(0);
+
+    // Older than the one acted on: not news.
+    await noteRateLimited(ROOT, NOW);
+    expect(getPausedUntil()).toBe(0);
+    // The same one again: not news either.
+    await noteRateLimited("/home/dev/projects/site", NOW + 5);
+    expect(getPausedUntil()).toBe(0);
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
+
+    // Newer: the host has refused *since* the lift, and that is news.
+    await noteRateLimited(ROOT, NOW + 6);
+    expect(getPausedUntil()).toBeGreaterThan(0);
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(2);
+  });
+
+  it("remembers a refusal it declined to act on", async () => {
+    // A refusal seen *during* a pause does not pay for a lookup, but it
+    // is still a refusal the pause answered for: replayed after the
+    // lift, it must not raise the gate a second time.
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: Math.floor(NOW / 1000) + 600,
+    });
+
+    await noteRateLimited(ROOT, NOW);
+    await noteRateLimited("/home/dev/projects/site", NOW + 5);
+    clearRateLimitPause();
+
+    await noteRateLimited("/home/dev/projects/site", NOW + 5);
+    expect(getPausedUntil()).toBe(0);
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the default when the host will not say", async () => {
@@ -177,7 +230,10 @@ describe("noteRateLimited", () => {
     clearRateLimitPause();
     expect(getPausedUntil()).toBe(0);
 
-    await noteRateLimited(ROOT, NOW);
+    // A second refusal is one that landed after the lift, so it is
+    // newer than the first by construction.
+    await noteRateLimited(ROOT, NOW + MIN_PAUSE_MS);
     expect(mockGithubRateLimit).toHaveBeenCalledTimes(2);
+    expect(getPausedUntil()).toBeGreaterThan(0);
   });
 });

--- a/src/lib/pr-rate-limit.test.ts
+++ b/src/lib/pr-rate-limit.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGithubRateLimit = vi.fn();
+
+vi.mock("@/tauri/commands", () => ({
+  githubRateLimit: (...a: unknown[]) => mockGithubRateLimit(...a),
+}));
+
+import {
+  DEFAULT_PAUSE_MS,
+  MAX_PAUSE_MS,
+  MIN_PAUSE_MS,
+  _resetRateLimitGate,
+  clearRateLimitPause,
+  getPausedUntil,
+  isRateLimitError,
+  noteRateLimited,
+  pauseUntil,
+  publishForTest,
+  subscribeRateLimit,
+} from "./pr-rate-limit";
+
+const ROOT = "/home/dev/projects/codemux";
+const NOW = 1_787_474_000_000;
+
+beforeEach(() => {
+  _resetRateLimitGate();
+  mockGithubRateLimit.mockReset();
+});
+
+describe("isRateLimitError", () => {
+  it("recognises every wording the host actually sends", () => {
+    // The first of these is verbatim what `gh pr list` printed while the
+    // page was locked out; the rest are GitHub's other two phrasings.
+    expect(
+      isRateLimitError("GraphQL: API rate limit already exceeded for user ID 100132710."),
+    ).toBe(true);
+    expect(isRateLimitError("HTTP 403: API rate limit exceeded for user ID 1.")).toBe(true);
+    expect(isRateLimitError("You have exceeded a secondary rate limit")).toBe(true);
+  });
+
+  it("leaves every other failure alone", () => {
+    // The narrowness is the point: these are failures retrying *would*
+    // fix, and one unreachable repository must never pause the rest.
+    expect(isRateLimitError("could not resolve host github.com")).toBe(false);
+    expect(isRateLimitError("gh: command not found")).toBe(false);
+    expect(isRateLimitError("no pull requests match your search")).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+  });
+});
+
+describe("pauseUntil", () => {
+  it("waits until the host says the budget refills", () => {
+    const reset = Math.floor(NOW / 1000) + 900;
+    expect(pauseUntil(reset, NOW)).toBe(reset * 1000);
+  });
+
+  it("never resumes instantly on a reset that has already passed", () => {
+    // Clock skew, or a reply that sat in a queue. Resuming on this
+    // reading is how a gate turns back into a retry loop.
+    const past = Math.floor(NOW / 1000) - 300;
+    expect(pauseUntil(past, NOW)).toBe(NOW + MIN_PAUSE_MS);
+  });
+
+  it("falls back to the default when the host said nothing", () => {
+    expect(pauseUntil(0, NOW)).toBe(NOW + DEFAULT_PAUSE_MS);
+  });
+
+  it("never waits longer than the host's own window", () => {
+    // GitHub's budget is hourly, so a reset a day out is a misread
+    // reply — and the cost of testing that reading is one request.
+    const absurd = Math.floor(NOW / 1000) + 86_400;
+    expect(pauseUntil(absurd, NOW)).toBe(NOW + MAX_PAUSE_MS);
+  });
+});
+
+describe("noteRateLimited", () => {
+  it("raises the gate before it asks how long for", async () => {
+    // The asking is itself a request. A gate that stayed open until the
+    // answer arrived would leave a window for exactly the polls it
+    // exists to stop — one per root, on the cycle that just failed.
+    let release!: (value: unknown) => void;
+    mockGithubRateLimit.mockReturnValue(
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+    );
+
+    const pending = noteRateLimited(ROOT, NOW);
+    expect(getPausedUntil()).toBe(NOW + DEFAULT_PAUSE_MS);
+
+    // A real reset, because the refinement below is measured from the
+    // clock at the moment it lands rather than from the moment the
+    // refusal was seen — the lookup is a shell-out with a budget of its
+    // own, and a floor is only a floor if it is measured from where it
+    // is applied.
+    const reset = Math.floor(Date.now() / 1000) + 600;
+    release({ graphql_remaining: 0, graphql_reset: reset });
+    await pending;
+    expect(getPausedUntil()).toBe(reset * 1000);
+  });
+
+  it("waits the minimum, not the hour, when the budget still has headroom", async () => {
+    // A secondary limit — the short block GitHub applies for asking too
+    // fast — says "rate limit" in the same words as an exhausted hourly
+    // budget, but arrives with the hourly budget largely unspent. The
+    // reset the host reports is the hourly window's rollover either way,
+    // so trusting it here would answer a sixty-second block with most of
+    // an hour of dark page.
+    const now = Date.now();
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 4_140,
+      graphql_reset: Math.floor(now / 1000) + 3_000,
+      core_remaining: 5_000,
+      core_reset: Math.floor(now / 1000) + 3_000,
+    });
+
+    await noteRateLimited(ROOT);
+
+    const paused = getPausedUntil();
+    expect(paused).toBeGreaterThanOrEqual(now + MIN_PAUSE_MS);
+    expect(paused).toBeLessThan(now + MIN_PAUSE_MS + 5_000);
+  });
+
+  it("does wait for the rollover when the hourly budget is the thing that ran out", async () => {
+    const now = Date.now();
+    const reset = Math.floor(now / 1000) + 1_800;
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: reset,
+      core_remaining: 5_000,
+      core_reset: reset,
+    });
+
+    await noteRateLimited(ROOT);
+    expect(getPausedUntil()).toBe(reset * 1000);
+  });
+
+  it("asks once however many roots were refused", async () => {
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: Math.floor(NOW / 1000) + 600,
+    });
+
+    await noteRateLimited(ROOT, NOW);
+    await noteRateLimited("/home/dev/projects/site", NOW);
+    await noteRateLimited("/home/dev/projects/docs", NOW);
+
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it("wakes its subscribers when the gate is reset", () => {
+    // Assigning the module value without publishing would leave a
+    // mounted subscriber holding the old snapshot forever — the one way
+    // to produce a gate that never lifts.
+    const seen: number[] = [];
+    const stop = subscribeRateLimit(() => seen.push(getPausedUntil()));
+    publishForTest(Date.now() + 60_000);
+    _resetRateLimitGate();
+    stop();
+    expect(seen[seen.length - 1]).toBe(0);
+  });
+
+  it("keeps the default when the host will not say", async () => {
+    mockGithubRateLimit.mockRejectedValue("gh exited 1");
+    await noteRateLimited(ROOT, NOW);
+    expect(getPausedUntil()).toBe(NOW + DEFAULT_PAUSE_MS);
+  });
+
+  it("can be asked again once the gate has lifted", async () => {
+    mockGithubRateLimit.mockResolvedValue({
+      graphql_remaining: 0,
+      graphql_reset: Math.floor(NOW / 1000) + 600,
+    });
+    await noteRateLimited(ROOT, NOW);
+    clearRateLimitPause();
+    expect(getPausedUntil()).toBe(0);
+
+    await noteRateLimited(ROOT, NOW);
+    expect(mockGithubRateLimit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/pr-rate-limit.ts
+++ b/src/lib/pr-rate-limit.ts
@@ -1,0 +1,232 @@
+/**
+ * The GitHub budget gate: stop asking when the host has said no.
+ *
+ * GitHub meters the GraphQL API — the one `gh pr list` spends from — at
+ * five thousand points an hour. Every request past that is refused for
+ * the rest of the hour, and the refusal is *cheaper for the host than
+ * for us*: it arrives fast, it looks exactly like a normal failure, and
+ * the ordinary reaction to a failure is to try again. A page that fans
+ * out across twenty repositories and retries each one therefore spends
+ * its entire recovery window making the wall it just hit taller.
+ *
+ * So the gate. The first refusal pauses every pull-request query, at
+ * once and globally — one gate for the page, the sidebar badge and the
+ * toast watcher together, because they all draw from one budget and a
+ * gate any of them could route around is not a gate. It then asks the
+ * host when the budget refills and waits exactly that long.
+ *
+ * Three properties this file exists to guarantee:
+ *
+ * - **Pause first, ask second.** The pause is set to a default the
+ *   instant a refusal is seen, before the call that refines it. The
+ *   refining call is itself a request, and a gate that opened a window
+ *   for one more request per failure would have nothing to say for
+ *   itself.
+ * - **Nothing on screen goes away.** The gate only stops *fetching*.
+ *   The rows already loaded stay loaded, and the strip above them says
+ *   what happened and when it will lift — the same "stale and labelled
+ *   beats blank" rule the rest of the page is built on.
+ * - **It lifts by itself.** A timer fires at the reset, the queries
+ *   re-enable, and the page refreshes without the user having done
+ *   anything. Retry is offered, not required.
+ */
+
+import { useEffect, useSyncExternalStore } from "react";
+
+import { githubRateLimit } from "@/tauri/commands";
+
+/**
+ * Never pause for less than this, even if the host says the budget has
+ * already refilled.
+ *
+ * A reset in the past means the clocks disagree or the reply was stale,
+ * and resuming instantly on that reading is how a gate turns into a
+ * retry loop with extra steps.
+ */
+export const MIN_PAUSE_MS = 60_000;
+
+/**
+ * Never pause for longer than this. GitHub's window is an hour, so an
+ * hour is the longest honest answer; anything beyond it is a misread
+ * reply, and the cost of testing that reading is one request.
+ */
+export const MAX_PAUSE_MS = 60 * 60_000;
+
+/**
+ * What we wait when the host won't say. Long enough to be a real
+ * back-off, short enough that a transient refusal doesn't cost the rest
+ * of the hour.
+ */
+export const DEFAULT_PAUSE_MS = 5 * 60_000;
+
+/**
+ * A refusal for spending too much, as opposed to any other failure.
+ *
+ * Matched on wording because that is what the host gives us: `gh` exits
+ * non-zero with the API's own sentence, and the two GitHub uses are
+ * "API rate limit exceeded" and "API rate limit already exceeded". The
+ * secondary-limit wording ("exceeded a secondary rate limit") is caught
+ * too — it is the same instruction to back off, on a shorter clock.
+ *
+ * Narrow by intent rather than by construction: this is a substring
+ * match on prose, so it recognises the refusals the host actually sends
+ * and nothing that merely fails. What it cannot do is tell a primary
+ * budget from a secondary block — both say "rate limit" — which is why
+ * `noteRateLimited` re-reads the remaining budget before deciding how
+ * long to wait rather than trusting this to have classified it.
+ *
+ * An unreachable repository must stay a footer line rather than pausing
+ * every other repository with it, and it does: "could not resolve host"
+ * says nothing about limits.
+ */
+export function isRateLimitError(error: unknown): boolean {
+  return /\b(rate limit|ratelimit)\b/i.test(String(error ?? ""));
+}
+
+/**
+ * Whether this repository draws on the budget the gate is holding.
+ *
+ * The gate is GitHub's hourly GraphQL budget. A GitLab root is metered
+ * by an entirely different host and must keep polling while GitHub is
+ * refusing — one over-budget GitHub account silently freezing the badge,
+ * the toasts and the page for a GitLab repository would be a new bug
+ * traded for the old one.
+ *
+ * `null` is GitHub, per the wire's back-compat rule (`resolveProvider`):
+ * an unnamed host is the one the app started with, and flattening it to
+ * "some other host" here would exempt most repositories from the gate.
+ */
+export function budgetApplies(providerKind: string | null | undefined): boolean {
+  return (providerKind ?? "github") === "github";
+}
+
+/**
+ * When to resume, given what the host said about the refill.
+ *
+ * `resetEpochSec` of zero or less means it said nothing, which is the
+ * default's case rather than an instruction to resume now.
+ */
+export function pauseUntil(resetEpochSec: number, now: number): number {
+  const raw = resetEpochSec > 0 ? resetEpochSec * 1000 : now + DEFAULT_PAUSE_MS;
+  return Math.min(Math.max(raw, now + MIN_PAUSE_MS), now + MAX_PAUSE_MS);
+}
+
+// ── The gate itself ──────────────────────────────────────────────────
+//
+// Module scope, for the same reason the snapshot write guard is: these
+// are three components sharing one query cache and, underneath it, one
+// account's budget. A per-component gate would let the badge keep
+// spending while the page waits.
+
+let pausedUntil = 0;
+const listeners = new Set<() => void>();
+
+function publish(value: number): void {
+  if (value === pausedUntil) return;
+  pausedUntil = value;
+  for (const listener of listeners) listener();
+}
+
+export function subscribeRateLimit(listener: () => void): () => void {
+  return subscribe(listener);
+}
+
+/** Test seam: raise the gate without a refusal to raise it from. */
+export function publishForTest(until: number): void {
+  publish(until);
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Epoch ms the gate lifts at, or 0 when nothing is paused. */
+export function getPausedUntil(): number {
+  return pausedUntil;
+}
+
+/** Lift the gate — what Retry means, and what the timer does. */
+export function clearRateLimitPause(): void {
+  publish(0);
+}
+
+/** Test seam: a fresh gate without reloading the module.
+ *
+ *  Goes through `publish` rather than assigning: a subscriber that is
+ *  still mounted would otherwise keep the old snapshot and never
+ *  re-render, which is the one way to produce the permanently-stuck gate
+ *  this file is written to avoid. */
+export function _resetRateLimitGate(): void {
+  publish(0);
+}
+
+/**
+ * Record a refusal and work out how long to wait.
+ *
+ * `path` is the repository whose call was refused, and is only there to
+ * give `gh` a working directory that resolves the right host — an
+ * enterprise root and a github.com root have separate budgets.
+ *
+ * Idempotent while a pause is in force: many roots fail in the same
+ * cycle and each will call this, but only the first one pays for the
+ * lookup.
+ */
+export async function noteRateLimited(path: string, now = Date.now()): Promise<void> {
+  if (pausedUntil > now) return;
+  // Pause on the default *first*. Everything below this line is a
+  // request, and until the gate is up the polls it is meant to stop are
+  // still firing.
+  publish(now + DEFAULT_PAUSE_MS);
+  try {
+    const limit = await githubRateLimit(path);
+    // `now` again, not the one captured above: the lookup is a shell-out
+    // with a ten-second budget of its own, and the floor below is only a
+    // floor if it is measured from when it is applied.
+    const settled = Date.now();
+    // The reset the host reports is the *primary* hourly window's, and
+    // it reports it whether or not that window is the one that refused
+    // us. A secondary limit — the short block GitHub applies for asking
+    // too fast, which `isRateLimitError` deliberately also catches — can
+    // arrive with three-quarters of the hourly budget still unspent, and
+    // waiting for an hourly rollover that was never the problem would
+    // turn a sixty-second block into fifty-nine minutes of dark page.
+    // Headroom remaining means it was not the hourly budget: wait the
+    // minimum and find out.
+    publish(
+      limit.graphql_remaining > 0
+        ? settled + MIN_PAUSE_MS
+        : pauseUntil(limit.graphql_reset, settled),
+    );
+  } catch {
+    // The host wouldn't say. The default stands, which is the whole
+    // reason it is set before the asking rather than after it.
+  }
+}
+
+/**
+ * The gate, as a React value: epoch ms to resume at, or 0 when open.
+ *
+ * Also owns the timer that lifts it, so the queries re-enable and the
+ * page refreshes on its own the moment the budget refills.
+ */
+export function useRateLimitPause(): number {
+  const until = useSyncExternalStore(subscribe, getPausedUntil, getPausedUntil);
+
+  useEffect(() => {
+    if (until === 0) return;
+    const delay = until - Date.now();
+    if (delay <= 0) {
+      clearRateLimitPause();
+      return;
+    }
+    const timer = setTimeout(clearRateLimitPause, delay);
+    return () => clearTimeout(timer);
+  }, [until]);
+
+  // A pause whose moment has passed is already open, even if the timer
+  // above has not run yet — so a render never gates on a stale value.
+  return until > Date.now() ? until : 0;
+}

--- a/src/lib/pr-rate-limit.ts
+++ b/src/lib/pr-rate-limit.ts
@@ -119,6 +119,22 @@ export function pauseUntil(resetEpochSec: number, now: number): number {
 // spending while the page waits.
 
 let pausedUntil = 0;
+/**
+ * When the newest refusal this gate has acted on landed, epoch ms.
+ *
+ * A refusal outlives the pause it raised. A query that already holds
+ * rows keeps its error — and the error's timestamp — for as long as its
+ * refetch is in flight, so for a moment after the gate lifts the page
+ * is still showing refusals from before it went up, and as the other
+ * roots recover any one of them can become the "newest" on screen and
+ * be handed back here. The pause that just ended already answered for
+ * them; re-raising the gate on one would pause the page on news from
+ * before the pause, and do it again on every lift.
+ *
+ * Deliberately *not* cleared when the gate lifts, for that reason. A
+ * refusal that is genuinely new is newer than this by construction.
+ */
+let lastRefusalAt = 0;
 const listeners = new Set<() => void>();
 
 function publish(value: number): void {
@@ -127,16 +143,7 @@ function publish(value: number): void {
   for (const listener of listeners) listener();
 }
 
-export function subscribeRateLimit(listener: () => void): () => void {
-  return subscribe(listener);
-}
-
-/** Test seam: raise the gate without a refusal to raise it from. */
-export function publishForTest(until: number): void {
-  publish(until);
-}
-
-function subscribe(listener: () => void): () => void {
+export function subscribe(listener: () => void): () => void {
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
@@ -148,38 +155,52 @@ export function getPausedUntil(): number {
   return pausedUntil;
 }
 
-/** Lift the gate — what Retry means, and what the timer does. */
+/** Lift the gate — what Retry means, and what the timer does.
+ *
+ *  Leaves `lastRefusalAt` alone: the refusals still on screen were
+ *  answered for by the pause this is ending, and forgetting that is how
+ *  the gate would go straight back up on one of them. */
 export function clearRateLimitPause(): void {
   publish(0);
 }
 
-/** Test seam: a fresh gate without reloading the module.
+/** Test seam: a fresh gate without reloading the module — the pause
+ *  lifted *and* the refusal memory cleared, which is the one thing
+ *  `clearRateLimitPause` must not do.
  *
  *  Goes through `publish` rather than assigning: a subscriber that is
  *  still mounted would otherwise keep the old snapshot and never
  *  re-render, which is the one way to produce the permanently-stuck gate
  *  this file is written to avoid. */
 export function _resetRateLimitGate(): void {
+  lastRefusalAt = 0;
   publish(0);
 }
 
 /**
  * Record a refusal and work out how long to wait.
  *
- * `path` is the repository whose call was refused, and is only there to
- * give `gh` a working directory that resolves the right host — an
- * enterprise root and a github.com root have separate budgets.
+ * `path` is the repository whose call was refused. It only gives `gh` a
+ * working directory to run in: `gh api rate_limit` reads the budget of
+ * whichever host `gh` treats as its default, wherever it is invoked
+ * from, and the gate pauses every root `gh` serves. This is one gate
+ * for the account `gh` is signed in to, not one per host.
  *
- * Idempotent while a pause is in force: many roots fail in the same
- * cycle and each will call this, but only the first one pays for the
- * lookup.
+ * `refusedAt` is when the refusal landed — the query's `errorUpdatedAt`
+ * rather than the clock now — and is what tells a refusal that is news
+ * from one the page has already been paused for. Idempotent on both
+ * counts: many roots fail in the same cycle and each will call this,
+ * but only the first one pays for the lookup, and a refusal no newer
+ * than the last one acted on is not acted on again.
  */
-export async function noteRateLimited(path: string, now = Date.now()): Promise<void> {
-  if (pausedUntil > now) return;
+export async function noteRateLimited(path: string, refusedAt = Date.now()): Promise<void> {
+  if (refusedAt <= lastRefusalAt) return;
+  lastRefusalAt = refusedAt;
+  if (pausedUntil > refusedAt) return;
   // Pause on the default *first*. Everything below this line is a
   // request, and until the gate is up the polls it is meant to stop are
   // still firing.
-  publish(now + DEFAULT_PAUSE_MS);
+  publish(refusedAt + DEFAULT_PAUSE_MS);
   try {
     const limit = await githubRateLimit(path);
     // `now` again, not the one captured above: the lookup is a shell-out

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -668,8 +668,10 @@ export const listPrsOverviewStats = (path: string) =>
  *
  *  Asked only after a call has come back refused for exceeding it —
  *  GitHub does not charge for this endpoint, so it is the one request
- *  still safe to make when there is nothing left to spend. `path` picks
- *  the host: an enterprise root and a github.com root meter separately. */
+ *  still safe to make when there is nothing left to spend. `path` is
+ *  only a working directory for `gh`: the reply is the budget of the
+ *  host `gh` treats as its default, and the gate it feeds is one gate
+ *  for every root `gh` serves. */
 export const githubRateLimit = (path: string) =>
   invoke<GhRateLimit>("github_rate_limit", { path });
 

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -49,6 +49,7 @@ import type {
   IncomingPrItem,
   PrOverviewStats,
   PrsOverview,
+  GhRateLimit,
   ReviewComment,
   InlineReviewComment,
   PrReviewThread,
@@ -662,6 +663,15 @@ export const listPrsOverview = (path: string) =>
  *  with `checks: null`. */
 export const listPrsOverviewStats = (path: string) =>
   invoke<PrOverviewStats[]>("list_prs_overview_stats", { path });
+
+/** What is left of the GitHub budget, and when it refills.
+ *
+ *  Asked only after a call has come back refused for exceeding it —
+ *  GitHub does not charge for this endpoint, so it is the one request
+ *  still safe to make when there is nothing left to spend. `path` picks
+ *  the host: an enterprise root and a github.com root meter separately. */
+export const githubRateLimit = (path: string) =>
+  invoke<GhRateLimit>("github_rate_limit", { path });
 
 /** Merge a PR. `deleteBranch` defaults to true on the backend, matching
  *  the behaviour before the merge sheet made it a question. */

--- a/src/tauri/types.ts
+++ b/src/tauri/types.ts
@@ -712,6 +712,20 @@ export interface PrOverviewStats {
   deletions: number | null;
 }
 
+/** What is left of the GitHub API budget, and when it refills.
+ *
+ *  `graphql_*` is the bucket the pull-request listing spends from and the
+ *  one the page gates on; `core_*` is the REST bucket the detail reads
+ *  use. They are metered separately, which is why both are reported —
+ *  reading the wrong one turns "locked out" into "looks fine". */
+export interface GhRateLimit {
+  graphql_remaining: number;
+  /** Unix seconds. Zero means the host did not say. */
+  graphql_reset: number;
+  core_remaining: number;
+  core_reset: number;
+}
+
 /** One repository root's open pull requests, plus who is asking — the
  *  grouping is meaningless without the viewer. */
 export interface PrsOverview {


### PR DESCRIPTION
The Pull Requests page fans out one `gh pr list` per open repository root, twice over, every thirty seconds — and the hook doing it is mounted by four surfaces at once: the page, the sidebar badge, the command palette and the toast watcher. So the cost scales with how many projects you have open rather than with what anyone is looking at, and on a machine with twenty-odd roots it comes to more GraphQL requests per hour than GitHub grants in an hour. The budget was spent before the page was ever opened, every root was refused at once, and the page sat on "The latest refresh failed" over rows from twenty minutes ago — retrying into the wall, which made the lockout last longer.

Measured on the machine that reported it: `graphql: {used: 5011, limit: 5000, remaining: 0}`, refilling and re-exhausting every hour, while the REST bucket sat untouched at 1/5000.

## What changed

**Cadence by who is asking.** A new `mode: "page" | "watch"`. The page keeps thirty seconds. The watcher nobody is looking at moves to two minutes — and loses nothing, because `refetchOnWindowFocus` refreshes it when you return to the window and opening the page mounts a thirty-second observer that refetches on mount. The badge is current exactly when it is read.

**The expensive half gets its own clock.** `list_prs_overview_stats` re-fired every cycle forever, because the fast listing leaves `checks` null by design and `needsStats` is therefore true on essentially every root. It now runs at 90s on the page and 240s behind it.

**A gate for the refusal itself.** One host saying the budget is spent pauses that host's queries, asks it when the budget refills (`rate_limit` is the one endpoint GitHub does not meter, so it is still safe to call when there is nothing left to spend), waits exactly that long and lifts itself. Rows already on screen never go away — only the asking stops. A secondary rate limit is told apart from an exhausted hourly budget by re-reading the remaining headroom, so a sixty-second block does not get a fifty-nine-minute pause. A repository metered by a different host keeps polling throughout.

**Open pull requests stop being the most expensive surface in the app.** The detail column polled twice every 2.5s regardless of whether anything could still change — about three thousand requests an hour to re-read a settled result. It now drops to 20s once every check has reported, and stays fast for anything still running, anything unrecognised, and a pull request whose first check has not registered yet.

## Verified

- Page open, ~50s window: 7 listing calls. Page closed, same window: **0**. Gated, 44s: **0**.
- On `main`, while every root was being refused: **10 further calls in 26 seconds**. On this branch: none.
- Both observers live on one query key: `[120000, 30000]`.
- Budget: idle ~5,520/hr → ~1,035/hr; page open ~5,520/hr → ~4,715/hr (the watcher's 120s timer keeps firing alongside the page's 30s one; only in-flight fetches dedupe).
- 5,034 frontend tests across 329 files, 132 Rust `github` tests, plus a network test (ignored by default) that exercises the new command against the real host.

## Before

Every root refused, and the page can only say "it failed" — then keeps asking.

![before](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/fix-pr-tab-error/before.png)

## After

The same refusal, named, with the time it rights itself — and the polling stopped until then.

![after](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/fix-pr-tab-error/after.png)

Built with Claude Opus 5 in Codemux.