### PR TITLE
fix: reopen right panel on the tab it was collapsed from

### DIFF
--- a/src/stores/ui-store.test.ts
+++ b/src/stores/ui-store.test.ts
@@ -21,6 +21,7 @@ beforeEach(() => {
   // non-default snapshot across tests.
   useUIStore.setState({
     rightPanelTabs: {},
+    rightPanelLastTabs: {},
     rightPanelWidth: 320,
     rightPanelMaximized: false,
     showNewWorkspaceDialog: false,
@@ -355,6 +356,29 @@ describe("ui-store — the empty-panel sentinel", () => {
       RIGHT_PANEL_EMPTY,
     );
     expect(useUIStore.getState().getRightPanelPanes("ws-1")).toEqual(["files"]);
+  });
+
+  it("reopens on the pane the panel was collapsed from", () => {
+    useUIStore.setState({ rightPanelPanes: { "ws-1": ["files", "diff", "review"] } });
+    useUIStore.getState().setRightPanelTab("ws-1", "review");
+    useUIStore.getState().collapseRightPanel("ws-1");
+
+    useUIStore.getState().setRightPanelTab("ws-1", RIGHT_PANEL_EMPTY);
+
+    expect(useUIStore.getState().getRightPanelTab("ws-1")).toBe("review");
+  });
+
+  it("falls back to the picker when the remembered pane left the deck", () => {
+    useUIStore.setState({ rightPanelPanes: { "ws-1": ["files", "review"] } });
+    useUIStore.getState().setRightPanelTab("ws-1", "review");
+    useUIStore.getState().collapseRightPanel("ws-1");
+    useUIStore.getState().closeRightPanelPane("ws-1", "review");
+
+    useUIStore.getState().setRightPanelTab("ws-1", RIGHT_PANEL_EMPTY);
+
+    expect(useUIStore.getState().getRightPanelTab("ws-1")).toBe(
+      RIGHT_PANEL_EMPTY,
+    );
   });
 
   it("catches the last closed pane instead of collapsing the panel", () => {

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -76,6 +76,10 @@ function isBrowserDocked(workspaceId: string): boolean {
 
 interface UIStore {
   rightPanelTabs: Record<string, RightPanelTab | null>;
+  /** The pane each workspace was showing when its panel was last collapsed.
+   *  Opening on {@link RIGHT_PANEL_EMPTY} comes back here (if the pane is
+   *  still in the deck) instead of landing on the first tab. */
+  rightPanelLastTabs: Record<string, RightPanelTab>;
   /** Ordered open panes per workspace. Absent ⇒ {@link DEFAULT_RIGHT_PANEL_PANES}. */
   rightPanelPanes: Record<string, RightPanelTab[]>;
   /** Availability-gated panes (tasks, orchestration, subagents) auto-open
@@ -252,6 +256,7 @@ export const useUIStore = create<UIStore>()(
   persist(
     (set, get) => ({
       rightPanelTabs: {},
+      rightPanelLastTabs: {},
       rightPanelPanes: {},
       rightPanelDismissedPanes: {},
       rightPanelWidth: 320,
@@ -296,11 +301,20 @@ export const useUIStore = create<UIStore>()(
           return;
         }
         set((s) => {
-          const tabs = { ...s.rightPanelTabs, [workspaceId]: tab };
-          // The picker sentinel is a view state, not a pane — it must never
-          // join the deck or clear a dismissal.
-          if (tab === RIGHT_PANEL_EMPTY) return { rightPanelTabs: tabs };
           const list = s.rightPanelPanes[workspaceId] ?? DEFAULT_RIGHT_PANEL_PANES;
+          // The picker sentinel is "open to whatever it was showing": a
+          // collapsed panel comes back on the pane it was collapsed from,
+          // provided that pane is still in the deck. It is a view state,
+          // not a pane — it must never join the deck or clear a dismissal.
+          if (tab === RIGHT_PANEL_EMPTY) {
+            const last = s.rightPanelLastTabs[workspaceId];
+            const restored =
+              s.rightPanelTabs[workspaceId] == null && last && list.includes(last)
+                ? last
+                : tab;
+            return { rightPanelTabs: { ...s.rightPanelTabs, [workspaceId]: restored } };
+          }
+          const tabs = { ...s.rightPanelTabs, [workspaceId]: tab };
           const dismissed = s.rightPanelDismissedPanes[workspaceId] ?? [];
           return {
             rightPanelTabs: tabs,
@@ -328,13 +342,20 @@ export const useUIStore = create<UIStore>()(
         if (isBrowserDocked(workspaceId)) {
           undockBrowserFromRightPanel(workspaceId, false).catch(console.error);
         }
-        set((s) => ({
-          rightPanelTabs: { ...s.rightPanelTabs, [workspaceId]: null },
+        set((s) => {
+          const active = s.rightPanelTabs[workspaceId] ?? null;
+          return {
+            rightPanelTabs: { ...s.rightPanelTabs, [workspaceId]: null },
+            rightPanelLastTabs:
+              active === null || active === RIGHT_PANEL_EMPTY
+                ? s.rightPanelLastTabs
+                : { ...s.rightPanelLastTabs, [workspaceId]: active },
           // Collapsing always drops full-expand: a maximized panel that is
           // no longer on screen would leave the workspace column at zero
           // width with nothing beside it.
           rightPanelMaximized: false,
-        }));
+          };
+        });
       },
 
       toggleRightPanel: (workspaceId, tab) => {
@@ -525,6 +546,7 @@ export const useUIStore = create<UIStore>()(
       version: 1,
       partialize: (state) => ({
         rightPanelTabs: state.rightPanelTabs,
+        rightPanelLastTabs: state.rightPanelLastTabs,
         rightPanelPanes: state.rightPanelPanes,
         rightPanelDismissedPanes: state.rightPanelDismissedPanes,
         rightPanelWidth: state.rightPanelWidth,

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -26,9 +26,11 @@ export type RightPanelCorePane =
  * empty" needed a third value rather than a second boolean: every caller
  * already reads `!== null` as *is the panel on screen*, and they all stay
  * correct. It is deliberately **not** a registry pane — it never enters
- * `rightPanelPanes`, never grows a tab, and resolves to the first open pane
- * if there is one (see `right-panel.tsx`), so activating it is also the
- * honest "just open the panel to whatever it was showing" request.
+ * `rightPanelPanes`, never grows a tab, and resolves to the pane the panel
+ * was collapsed from (`rightPanelLastTabs`) when that pane is still open,
+ * else to the first open pane if there is one (see `right-panel.tsx`), so
+ * activating it is also the honest "just open the panel to whatever it was
+ * showing" request.
  */
 export const RIGHT_PANEL_EMPTY = "empty";
 
@@ -350,10 +352,10 @@ export const useUIStore = create<UIStore>()(
               active === null || active === RIGHT_PANEL_EMPTY
                 ? s.rightPanelLastTabs
                 : { ...s.rightPanelLastTabs, [workspaceId]: active },
-          // Collapsing always drops full-expand: a maximized panel that is
-          // no longer on screen would leave the workspace column at zero
-          // width with nothing beside it.
-          rightPanelMaximized: false,
+            // Collapsing always drops full-expand: a maximized panel that is
+            // no longer on screen would leave the workspace column at zero
+            // width with nothing beside it.
+            rightPanelMaximized: false,
           };
         });
       },


### PR DESCRIPTION
Collapsing the right panel and reopening it always landed on the first tab (Files) instead of the tab the workspace was on, because collapse overwrote the active tab with `null` and every reopen path opened on the picker sentinel, which resolves to the first pane in the deck.

The store now remembers the active pane per workspace on collapse (persisted), and the sentinel resolves to it if that pane is still open; otherwise it falls back to the picker as before. Tab switching, pane closing, and the agent-browser undock behaviour are unchanged. Two store tests cover restore and fallback.

No visual change beyond which tab is selected on reopen.

Claude Fable 5 via Claude Code