### PR TITLE
fix(mcp): route shared-child tool calls to the calling session's workspace

### DIFF
--- a/scripts/e2e/mcp-workspace-routing-e2e.sh
+++ b/scripts/e2e/mcp-workspace-routing-e2e.sh
@@ -6,38 +6,58 @@
 # "codemux/workspace_id" on tools/call binds the agent browser session to the
 # intended workspace, overriding both the cwd fallback and the env var.
 #
-# Runs against a DEBUG build only: debug builds use codemux-dev.sock and
-# ~/.config/codemux-dev, so a production instance is never touched.
+# Isolation: the serve process and every CLI invocation below run with their
+# own XDG_CONFIG_HOME / XDG_DATA_HOME / XDG_RUNTIME_DIR under a throwaway
+# root (the app resolves its store through `dirs::config_dir()` /
+# `dirs::data_dir()` and its control socket through XDG_RUNTIME_DIR), so
+# neither the release store (~/.config/codemux) nor the dev store
+# (~/.config/codemux-dev, which `npm run tauri:dev` shares) is read or
+# written. Only a DEBUG build is accepted as a second guard: its socket and
+# store names differ from the release build's.
 #
 # Usage: scripts/e2e/mcp-workspace-routing-e2e.sh [path-to-debug-codemux]
 set -euo pipefail
 
+for tool in jq strings ss; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "FAIL: missing required tool: $tool" >&2; exit 1; }
+done
+
 BIN="${1:-src-tauri/target/debug/codemux}"
 BIN="$(readlink -f "$BIN" 2>/dev/null || echo "$BIN")"
-PORT="${E2E_SERVE_PORT:-4477}"
 ROOT="$(mktemp -d /tmp/codemux-mcp-routing-e2e.XXXXXX)"
 WS_A="$ROOT/ws-a"
 WS_B="$ROOT/ws-b"
 SERVE_PID=""
 SERVE_LOG="$ROOT/serve.log"
 
+# Every codemux invocation from here on (serve, `json`, the `mcp` child)
+# sees only the throwaway root.
+export XDG_CONFIG_HOME="$ROOT/config"
+export XDG_DATA_HOME="$ROOT/data"
+export XDG_STATE_HOME="$ROOT/state"
+export XDG_CACHE_HOME="$ROOT/cache"
+export XDG_RUNTIME_DIR="$ROOT/run"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME" "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
 fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "PASS: $*"; }
 
 cleanup() {
-  # Close any browser sessions we opened, then stop only the serve process
-  # we started ourselves.
-  for ws in "${WSID_A:-}" "${WSID_B:-}"; do
-    [ -n "$ws" ] && "$BIN" json browser_automation \
-      "{\"workspace_id\":\"$ws\",\"action\":{\"kind\":\"close\"}}" >/dev/null 2>&1 || true
-  done
+  # Close what we opened (browser sessions, then the workspaces themselves)
+  # while the serve is still answering, then stop only the serve process we
+  # started ourselves. Every step is best-effort so a dead serve can't wedge
+  # teardown.
   if [ -n "$SERVE_PID" ] && kill -0 "$SERVE_PID" 2>/dev/null; then
+    for ws in "${WSID_A:-}" "${WSID_B:-}"; do
+      [ -n "$ws" ] || continue
+      timeout 15 "$BIN" json browser_automation \
+        "{\"workspace_id\":\"$ws\",\"action\":{\"kind\":\"close\"}}" >/dev/null 2>&1 || true
+      timeout 15 "$BIN" json close_workspace "{\"workspace_id\":\"$ws\"}" >/dev/null 2>&1 || true
+    done
     kill "$SERVE_PID" 2>/dev/null || true
     for _ in $(seq 1 20); do kill -0 "$SERVE_PID" 2>/dev/null || break; sleep 0.25; done
     kill -9 "$SERVE_PID" 2>/dev/null || true
-    # The dev control socket belongs to the serve we just stopped; drop it
-    # so the next debug run doesn't see a stale file.
-    rm -f "${XDG_RUNTIME_DIR:-/tmp}/codemux-dev.sock"
   fi
   rm -rf "$ROOT"
 }
@@ -45,19 +65,24 @@ trap cleanup EXIT
 
 [ -x "$BIN" ] || fail "debug binary not found at $BIN (build with: cargo build --manifest-path src-tauri/Cargo.toml)"
 # Refuse anything that doesn't look like a debug build — a release binary
-# would target the user's live instance via codemux.sock.
+# uses different socket/store names, and the XDG isolation above is the only
+# thing standing between this test and a live instance.
 # (the socket name is assembled at runtime, so match the debug-only
 # "codemux-dev" basename constant rather than the joined filename; the
 # `|| true` absorbs strings' SIGPIPE when grep stops at the first match,
 # which pipefail would otherwise misread as "not found")
 DEBUG_MARKER=$(strings -a "$BIN" 2>/dev/null | grep -c -m1 'codemux-dev' || true)
 [ "$DEBUG_MARKER" = "1" ] \
-  || fail "$BIN does not look like a debug build; refusing to run against a live instance"
-# Refuse to run beside an existing debug backend (tauri:dev, another serve):
-# the readiness probe would latch onto IT and the test would pollute it.
-if "$BIN" json status '{}' >/dev/null 2>&1; then
-  fail "a debug backend is already answering on codemux-dev.sock — stop it first"
+  || fail "$BIN does not look like a debug build; refusing to run"
+
+# Pick a free loopback port for the web-remote listener the serve binds.
+PORT="${E2E_SERVE_PORT:-}"
+if [ -z "$PORT" ]; then
+  for candidate in $(seq 4477 4577); do
+    if ! ss -ltn 2>/dev/null | grep -q ":$candidate "; then PORT="$candidate"; break; fi
+  done
 fi
+[ -n "$PORT" ] || fail "no free port in 4477-4577"
 
 mkdir -p "$WS_A" "$WS_B"
 
@@ -72,7 +97,12 @@ for _ in $(seq 1 40); do
   sleep 0.5
 done
 "$BIN" json status '{}' >/dev/null 2>&1 || fail "control socket never came up"
-pass "headless debug backend up (pid $SERVE_PID)"
+pass "headless debug backend up (pid $SERVE_PID, port $PORT)"
+# Prove the isolation actually took: the store and socket must live under
+# our root, not the user's.
+[ -S "$XDG_RUNTIME_DIR/codemux-dev.sock" ] || fail "control socket not under $XDG_RUNTIME_DIR"
+[ -e "$XDG_CONFIG_HOME/codemux-dev/codemux.db" ] || fail "sqlite store not under $XDG_CONFIG_HOME"
+pass "store and socket isolated under $ROOT"
 
 # ── Two workspaces ─────────────────────────────────────────────────────────
 WSID_A=$("$BIN" json create_workspace "{\"path\":\"$WS_A\"}" | jq -re '.data.workspace_id // .workspace_id')
@@ -132,5 +162,18 @@ mcp_call "$WS_A" "$WSID_A" \
   "{\"name\":\"browser_navigate\",\"arguments\":{\"url\":\"http://127.0.0.1:9/nope\"},\"_meta\":{\"codemux/workspace_id\":\"$WSID_B\"}}" >/dev/null
 [ "$(session_ws_of "$WSID_B")" = "$WSID_B" ] || fail "case 2: _meta workspace id did not override env+cwd (session for B missing)"
 pass "case 2: _meta codemux/workspace_id routes the session to B over env+cwd"
+
+# Case 3 — a stale/unknown _meta id must not reach the browser layer (it
+# would mint a phantom `ws-<id>` session); the control layer drops it and
+# falls through to the cwd hint (ws-a). The handler logs the id it settled
+# on, so the serve log is the witness.
+mcp_call "$WS_A" "" \
+  '{"name":"browser_navigate","arguments":{"url":"http://127.0.0.1:9/nope"},"_meta":{"codemux/workspace_id":"ws-does-not-exist"}}' >/dev/null
+grep -q 'workspace_id=ws-does-not-exist' "$SERVE_LOG" \
+  && fail "case 3: unknown _meta id was forwarded to the browser handler"
+[ "$(grep -c "workspace_id=$WSID_A cwd_resolved=true" "$SERVE_LOG")" -ge 2 ] \
+  || fail "case 3: unknown _meta id did not fall through to the cwd hint"
+[ -z "$(session_ws_of "ws-does-not-exist")" ] || fail "case 3: phantom session recorded"
+pass "case 3: unknown _meta workspace id is dropped in favour of the cwd hint"
 
 echo "ALL PASS"

--- a/scripts/e2e/mcp-workspace-routing-e2e.sh
+++ b/scripts/e2e/mcp-workspace-routing-e2e.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# E2E: MCP tools/call workspace routing → agent browser session binding.
+#
+# Reproduces the shared `codemux mcp` child scenario (no CODEMUX_WORKSPACE_ID
+# env, cwd pointing at the wrong place) and asserts that a `_meta`
+# "codemux/workspace_id" on tools/call binds the agent browser session to the
+# intended workspace, overriding both the cwd fallback and the env var.
+#
+# Runs against a DEBUG build only: debug builds use codemux-dev.sock and
+# ~/.config/codemux-dev, so a production instance is never touched.
+#
+# Usage: scripts/e2e/mcp-workspace-routing-e2e.sh [path-to-debug-codemux]
+set -euo pipefail
+
+BIN="${1:-src-tauri/target/debug/codemux}"
+BIN="$(readlink -f "$BIN" 2>/dev/null || echo "$BIN")"
+PORT="${E2E_SERVE_PORT:-4477}"
+ROOT="$(mktemp -d /tmp/codemux-mcp-routing-e2e.XXXXXX)"
+WS_A="$ROOT/ws-a"
+WS_B="$ROOT/ws-b"
+SERVE_PID=""
+SERVE_LOG="$ROOT/serve.log"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+cleanup() {
+  # Close any browser sessions we opened, then stop only the serve process
+  # we started ourselves.
+  for ws in "${WSID_A:-}" "${WSID_B:-}"; do
+    [ -n "$ws" ] && "$BIN" json browser_automation \
+      "{\"workspace_id\":\"$ws\",\"action\":{\"kind\":\"close\"}}" >/dev/null 2>&1 || true
+  done
+  if [ -n "$SERVE_PID" ] && kill -0 "$SERVE_PID" 2>/dev/null; then
+    kill "$SERVE_PID" 2>/dev/null || true
+    for _ in $(seq 1 20); do kill -0 "$SERVE_PID" 2>/dev/null || break; sleep 0.25; done
+    kill -9 "$SERVE_PID" 2>/dev/null || true
+    # The dev control socket belongs to the serve we just stopped; drop it
+    # so the next debug run doesn't see a stale file.
+    rm -f "${XDG_RUNTIME_DIR:-/tmp}/codemux-dev.sock"
+  fi
+  rm -rf "$ROOT"
+}
+trap cleanup EXIT
+
+[ -x "$BIN" ] || fail "debug binary not found at $BIN (build with: cargo build --manifest-path src-tauri/Cargo.toml)"
+# Refuse anything that doesn't look like a debug build — a release binary
+# would target the user's live instance via codemux.sock.
+# (the socket name is assembled at runtime, so match the debug-only
+# "codemux-dev" basename constant rather than the joined filename; the
+# `|| true` absorbs strings' SIGPIPE when grep stops at the first match,
+# which pipefail would otherwise misread as "not found")
+DEBUG_MARKER=$(strings -a "$BIN" 2>/dev/null | grep -c -m1 'codemux-dev' || true)
+[ "$DEBUG_MARKER" = "1" ] \
+  || fail "$BIN does not look like a debug build; refusing to run against a live instance"
+# Refuse to run beside an existing debug backend (tauri:dev, another serve):
+# the readiness probe would latch onto IT and the test would pollute it.
+if "$BIN" json status '{}' >/dev/null 2>&1; then
+  fail "a debug backend is already answering on codemux-dev.sock — stop it first"
+fi
+
+mkdir -p "$WS_A" "$WS_B"
+
+# ── Boot an isolated headless backend ──────────────────────────────────────
+# The pty-daemon would outlive the serve process; this test never opens a
+# terminal, so suppress it entirely.
+CODEMUX_DISABLE_PTY_DAEMON=1 "$BIN" serve --scope loopback --port "$PORT" >"$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+for _ in $(seq 1 40); do
+  if "$BIN" json status '{}' >/dev/null 2>&1; then break; fi
+  kill -0 "$SERVE_PID" 2>/dev/null || { cat "$SERVE_LOG" >&2; fail "serve exited early"; }
+  sleep 0.5
+done
+"$BIN" json status '{}' >/dev/null 2>&1 || fail "control socket never came up"
+pass "headless debug backend up (pid $SERVE_PID)"
+
+# ── Two workspaces ─────────────────────────────────────────────────────────
+WSID_A=$("$BIN" json create_workspace "{\"path\":\"$WS_A\"}" | jq -re '.data.workspace_id // .workspace_id')
+WSID_B=$("$BIN" json create_workspace "{\"path\":\"$WS_B\"}" | jq -re '.data.workspace_id // .workspace_id')
+[ -n "$WSID_A" ] && [ -n "$WSID_B" ] || fail "workspace creation failed"
+pass "workspaces created: A=$WSID_A ($WS_A), B=$WSID_B ($WS_B)"
+
+# ── Drive a `codemux mcp` child exactly like the shared registry child ─────
+# cwd = ws-a dir, env WSID unset (case 1) or pointing at ws-a (case 2), so
+# every legacy signal says "workspace A". The _meta must win and route to B.
+mcp_call() { # $1=cwd $2=env_wsid("" for unset) $3=params_json
+  # Drive the child over a fifo so stdin can be closed the moment the
+  # tools/call response lands, instead of holding it open on a timer.
+  local cwd="$1" env_wsid="$2" params="$3"
+  local fifo="$ROOT/mcp-in.$RANDOM" out="$ROOT/mcp-out.$RANDOM" pid
+  mkfifo "$fifo"
+  (
+    cd "$cwd"
+    if [ -n "$env_wsid" ]; then
+      CODEMUX_WORKSPACE_ID="$env_wsid" timeout 90 "$BIN" mcp <"$fifo" >"$out" 2>/dev/null &
+    else
+      env -u CODEMUX_WORKSPACE_ID timeout 90 "$BIN" mcp <"$fifo" >"$out" 2>/dev/null &
+    fi
+    echo $! >"$out.pid"
+  )
+  exec 3>"$fifo" # rendezvous with the child's stdin open
+  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"e2e","version":"0"}}}' >&3
+  printf '%s\n' '{"jsonrpc":"2.0","method":"notifications/initialized"}' >&3
+  printf '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":%s}\n' "$params" >&3
+  for _ in $(seq 1 160); do
+    grep -q '"id":2' "$out" 2>/dev/null && break
+    sleep 0.5
+  done
+  exec 3>&- # EOF -> child shuts down
+  pid=$(cat "$out.pid")
+  for _ in $(seq 1 20); do kill -0 "$pid" 2>/dev/null || break; sleep 0.25; done
+  kill "$pid" 2>/dev/null || true
+  rm -f "$fifo" "$out.pid"
+  grep -m1 '"id":2' "$out" || fail "no tools/call response from codemux mcp child"
+}
+
+session_ws_of() { # $1=workspace_id → prints matching session workspace_id or empty
+  "$BIN" json get_app_state '{}' \
+    | jq -r --arg ws "$1" '(.data // .) | .agent_browser_sessions[]? | select(.workspace_id==$ws) | .workspace_id' \
+    | head -1
+}
+
+# Case 1 — regression baseline: no env, no _meta, cwd=ws-a → cwd fallback → A.
+mcp_call "$WS_A" "" \
+  '{"name":"browser_navigate","arguments":{"url":"http://127.0.0.1:9/nope"}}' >/dev/null
+[ "$(session_ws_of "$WSID_A")" = "$WSID_A" ] || fail "case 1: cwd fallback did not bind to workspace A"
+[ -z "$(session_ws_of "$WSID_B")" ] || fail "case 1: unexpected session for workspace B"
+pass "case 1: cwd fallback still binds to A (baseline)"
+
+# Case 2 — the fix: env AND cwd both say A, _meta says B → must bind to B.
+mcp_call "$WS_A" "$WSID_A" \
+  "{\"name\":\"browser_navigate\",\"arguments\":{\"url\":\"http://127.0.0.1:9/nope\"},\"_meta\":{\"codemux/workspace_id\":\"$WSID_B\"}}" >/dev/null
+[ "$(session_ws_of "$WSID_B")" = "$WSID_B" ] || fail "case 2: _meta workspace id did not override env+cwd (session for B missing)"
+pass "case 2: _meta codemux/workspace_id routes the session to B over env+cwd"
+
+echo "ALL PASS"

--- a/src-tauri/examples/opencode_chat_smoke.rs
+++ b/src-tauri/examples/opencode_chat_smoke.rs
@@ -69,6 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             additional_directories: vec![],
             recorded_usage_baseline: None,
             env: None,
+            workspace_id: None,
             extra: serde_json::Value::Null,
         })
         .await?;

--- a/src-tauri/src/agent_provider/claude/session.rs
+++ b/src-tauri/src/agent_provider/claude/session.rs
@@ -186,6 +186,12 @@ pub(crate) struct ClaudeSession {
     /// `handle_mcp_tool_call` to route `mcp-tool-call` requests from
     /// the sidecar to the right MCP child.
     mcp_registry: Option<crate::mcp::registry::McpRegistry>,
+    /// Owning workspace of the chat pane this session runs in, from
+    /// `StartSessionInput.workspace_id`. Attached per-call to MCP
+    /// dispatches so workspace-scoped built-in tools bind to THIS
+    /// session's workspace — the registry's shared MCP child cannot
+    /// learn the caller from its env.
+    workspace_id: Option<String>,
 }
 
 impl ClaudeSession {
@@ -354,6 +360,7 @@ impl ClaudeSession {
             intentionally_closed: Arc::new(RwLock::new(false)),
             dead: Arc::new(AtomicBool::new(false)),
             mcp_registry: spawn.mcp_registry.clone(),
+            workspace_id: input.workspace_id.clone(),
         });
 
         // Announce the session up front.
@@ -1374,7 +1381,10 @@ async fn handle_mcp_tool_call(
         return;
     };
 
-    match registry.dispatch_tool_call(&prefixed_name, arguments).await {
+    match registry
+        .dispatch_tool_call(&prefixed_name, arguments, session.workspace_id.as_deref())
+        .await
+    {
         Ok(result) => {
             // The MCP child returns the full `tools/call` result —
             // including `content` and optional `isError`. Forward it

--- a/src-tauri/src/agent_provider/codex/mod.rs
+++ b/src-tauri/src/agent_provider/codex/mod.rs
@@ -213,6 +213,7 @@ impl AgentProvider for CodexAgentProvider {
             input.fast_mode,
             input.resume_cursor.clone(),
             input.env,
+            input.workspace_id,
             self.spawn_config(),
             self.event_tx.clone(),
             input.recorded_usage_baseline,

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -226,6 +226,12 @@ pub(crate) struct CodexSession {
     /// Handed to the notification task's demux so a resumed thread does
     /// not re-record its history. Zero for a fresh thread.
     recorded_usage_baseline: UsageBaseline,
+    /// Owning workspace of the chat pane this session runs in, from
+    /// `StartSessionInput.workspace_id`. Attached per-call to dynamic
+    /// tool dispatches so workspace-scoped built-in tools bind to THIS
+    /// session's workspace — the registry's shared MCP child cannot
+    /// learn the caller from its env.
+    workspace_id: Option<String>,
 }
 
 impl CodexSession {
@@ -245,6 +251,9 @@ impl CodexSession {
         fast_mode: bool,
         resume_cursor: Option<Value>,
         caller_env: Option<HashMap<String, String>>,
+        // Owning workspace of the calling chat pane; stored on the
+        // session and tagged onto MCP dispatches (see the field doc).
+        workspace_id: Option<String>,
         spawn: CodexSpawnConfig,
         event_tx: broadcast::Sender<ProviderRuntimeEvent>,
         // Usage already in the ledger for this thread. Seeded into the
@@ -520,6 +529,7 @@ impl CodexSession {
             tasks: Mutex::new(Vec::new()),
             dead: Arc::new(AtomicBool::new(false)),
             recorded_usage_baseline: recorded_usage_baseline.unwrap_or_default(),
+            workspace_id,
         });
 
         // Emit SessionConfigured up front so subscribers see the thread
@@ -1274,7 +1284,12 @@ fn spawn_incoming_requests_task(
                     let Some(req) = maybe_req else { break; };
                     let msg = ServerRequestMessage::from_raw(&req.method, req.params.clone());
                     if let ServerRequestMessage::ToolCall(params) = msg {
-                        let result = handle_dynamic_tool_call(mcp_registry.as_ref(), params).await;
+                        let result = handle_dynamic_tool_call(
+                            mcp_registry.as_ref(),
+                            session.workspace_id.as_deref(),
+                            params,
+                        )
+                        .await;
                         if let Err(error) = child.respond(req.id, Ok(result)).await {
                             let _ = event_tx.send(ProviderRuntimeEvent::RuntimeWarning {
                                 thread_id: Some(session.thread_id.clone()),
@@ -1299,11 +1314,15 @@ fn spawn_incoming_requests_task(
 
 /// Execute a Codex dynamic-tool request through the process-wide registry and
 /// translate the MCP content envelope into Codex's input-content shape.
-async fn handle_dynamic_tool_call(registry: Option<&McpRegistry>, raw: Value) -> Value {
+async fn handle_dynamic_tool_call(
+    registry: Option<&McpRegistry>,
+    workspace_id: Option<&str>,
+    raw: Value,
+) -> Value {
     let parsed = serde_json::from_value::<DynamicToolCallParams>(raw);
     let (success, result) = match (registry, parsed) {
         (Some(registry), Ok(call)) => match registry
-            .dispatch_tool_call(&registry_tool_name(&call.tool), call.arguments)
+            .dispatch_tool_call(&registry_tool_name(&call.tool), call.arguments, workspace_id)
             .await
         {
             Ok(result) => {
@@ -1666,6 +1685,7 @@ mod tests {
     #[tokio::test]
     async fn dynamic_tool_call_without_registry_returns_failed_response() {
         let response = handle_dynamic_tool_call(
+            None,
             None,
             json!({
                 "threadId": "thread",

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -1683,6 +1683,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dynamic_tool_call_tags_builtin_dispatch_with_session_workspace() {
+        // The session's workspace id must reach the built-in server as
+        // `_meta[WORKSPACE_META_KEY]` on the outbound `tools/call`; the mock
+        // only answers a request that carries it.
+        let (_server, registry, call) =
+            crate::mcp::registry::test_support::codemux_remote_server("ws-42").await;
+        let response = handle_dynamic_tool_call(
+            Some(&registry),
+            Some("ws-42"),
+            json!({
+                "threadId": "thread",
+                "turnId": "turn",
+                "callId": "call",
+                "namespace": null,
+                "tool": "codemux_mcp__codemux-remote__echo",
+                "arguments": {"text": "hi"}
+            }),
+        )
+        .await;
+        assert_eq!(response["success"], true, "{response}");
+        assert_eq!(response["contentItems"][0]["text"], "routed");
+        call.assert_async().await;
+    }
+
+    #[tokio::test]
     async fn dynamic_tool_call_without_registry_returns_failed_response() {
         let response = handle_dynamic_tool_call(
             None,

--- a/src-tauri/src/agent_provider/types.rs
+++ b/src-tauri/src/agent_provider/types.rs
@@ -144,14 +144,16 @@ pub struct StartSessionInput {
     /// Environment variables to overlay onto the spawned child, or inherit
     /// the runtime's env when `None`.
     pub env: Option<std::collections::HashMap<String, String>>,
-    /// Id of the workspace that owns this session's chat pane, resolved by
-    /// the command layer (see `workspace_env_overlay` in
-    /// `commands/agent_chat.rs`). Adapters attach it to MCP tool dispatches
-    /// so workspace-scoped built-in tools (browser routing, git cwd) act on
-    /// the session's OWN workspace — the registry's shared MCP child cannot
-    /// learn it from env. `None` for orphaned panes and provider sessions
-    /// with no owning workspace.
-    #[serde(default)]
+    /// Id of the workspace that owns this session's chat pane. Filled by
+    /// the command layer from the pane binding (see `pane_workspace_context`
+    /// in `commands/agent_chat.rs`) and never taken from the IPC caller —
+    /// a frontend value could otherwise point a pane's tool calls at a
+    /// workspace it does not live in. Adapters attach it to MCP tool
+    /// dispatches so workspace-scoped built-in tools (browser routing, git
+    /// cwd) act on the session's OWN workspace — the registry's shared MCP
+    /// child cannot learn it from env. `None` for orphaned panes and
+    /// provider sessions with no owning workspace.
+    #[serde(skip_deserializing)]
     pub workspace_id: Option<String>,
     /// Free-form provider-specific extras. Adapters parse what they
     /// understand and ignore the rest. First-class fields above win over

--- a/src-tauri/src/agent_provider/types.rs
+++ b/src-tauri/src/agent_provider/types.rs
@@ -144,6 +144,15 @@ pub struct StartSessionInput {
     /// Environment variables to overlay onto the spawned child, or inherit
     /// the runtime's env when `None`.
     pub env: Option<std::collections::HashMap<String, String>>,
+    /// Id of the workspace that owns this session's chat pane, resolved by
+    /// the command layer (see `workspace_env_overlay` in
+    /// `commands/agent_chat.rs`). Adapters attach it to MCP tool dispatches
+    /// so workspace-scoped built-in tools (browser routing, git cwd) act on
+    /// the session's OWN workspace — the registry's shared MCP child cannot
+    /// learn it from env. `None` for orphaned panes and provider sessions
+    /// with no owning workspace.
+    #[serde(default)]
+    pub workspace_id: Option<String>,
     /// Free-form provider-specific extras. Adapters parse what they
     /// understand and ignore the rest. First-class fields above win over
     /// keys here when both are present.

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -693,6 +693,16 @@ pub async fn agent_chat_start_session<R: Runtime>(
             .as_ref()
             .and_then(|id| snapshot.workspaces.iter().find(|w| &w.workspace_id.0 == id));
         input.env = workspace_env_overlay(ws, &pane_id, input.env.take());
+        // First-class copy of the owning workspace id, sourced from the same
+        // snapshot as the env's CODEMUX_WORKSPACE_ID so the two can't
+        // disagree. Adapters attach it per-call to MCP dispatches, where the
+        // shared MCP child's env cannot identify the calling session. A
+        // caller-supplied value wins, mirroring the env overlay's
+        // insert-if-absent semantics.
+        input.workspace_id = input
+            .workspace_id
+            .take()
+            .or_else(|| ws.map(|w| w.workspace_id.0.clone()));
     }
     let session = impl_.start_session(input).await.map_err(provider_err)?;
     let state: State<'_, AppStateStore> = app.state();
@@ -1705,7 +1715,11 @@ pub async fn ensure_live_session<R: Runtime>(
     // browser / CLI subprocesses route to its OWN workspace, exactly
     // like `agent_chat_start_session`. Resolve the pane from the thread;
     // an orphaned thread (no pane) injects nothing.
-    let env = {
+    // Also capture the owning workspace id itself: the rebuilt session
+    // attaches it per-call to MCP dispatches, same as a fresh start (see
+    // `agent_chat_start_session`). Sourced from the same snapshot as the
+    // env overlay so the two can't disagree.
+    let (env, workspace_id) = {
         let state: State<'_, AppStateStore> = app.state();
         match state.agent_chat_pane_id_for_thread(&thread_id.0) {
             Some(pane_id) => {
@@ -1714,9 +1728,12 @@ pub async fn ensure_live_session<R: Runtime>(
                 let ws = workspace_id
                     .as_ref()
                     .and_then(|id| snapshot.workspaces.iter().find(|w| &w.workspace_id.0 == id));
-                workspace_env_overlay(ws, &pane_id, None)
+                (
+                    workspace_env_overlay(ws, &pane_id, None),
+                    ws.map(|w| w.workspace_id.0.clone()),
+                )
             }
-            None => None,
+            None => (None, None),
         }
     };
 
@@ -1784,6 +1801,7 @@ pub async fn ensure_live_session<R: Runtime>(
         fast_mode: record.fast_mode,
         additional_directories: vec![],
         env: env.clone(),
+        workspace_id: workspace_id.clone(),
         extra: serde_json::Value::Null,
         recorded_usage_baseline: None,
     };

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -513,6 +513,32 @@ fn workspace_env_overlay(
     Some(env)
 }
 
+/// Everything a chat session inherits from the pane it runs in: the env
+/// overlay (`CODEMUX_WORKSPACE_ID`, `CODEMUX_PANE_ID`, …) for the agent's
+/// own subprocesses, and the owning workspace id itself, which adapters tag
+/// onto MCP dispatches because the registry's shared `codemux mcp` child
+/// cannot learn the caller from env. Both come from ONE snapshot so they
+/// can't disagree, and the id is derived from the pane binding only — never
+/// from the IPC caller. An orphaned pane (no workspace) yields `existing`
+/// untouched and `None`. Shared by `agent_chat_start_session` and the
+/// `ensure_live_session` rebuild so the two session-minting paths stay in
+/// lockstep.
+pub fn pane_workspace_context(
+    state: &AppStateStore,
+    pane_id: &str,
+    existing: Option<HashMap<String, String>>,
+) -> (Option<HashMap<String, String>>, Option<String>) {
+    let workspace_id = state.workspace_id_for_pane(pane_id);
+    let snapshot = state.snapshot();
+    let ws = workspace_id
+        .as_ref()
+        .and_then(|id| snapshot.workspaces.iter().find(|w| &w.workspace_id.0 == id));
+    (
+        workspace_env_overlay(ws, pane_id, existing),
+        ws.map(|w| w.workspace_id.0.clone()),
+    )
+}
+
 /// Start a new provider session for the given pane.
 ///
 /// The returned [`ThreadId`] is the identifier the provider itself
@@ -682,27 +708,15 @@ pub async fn agent_chat_start_session<R: Runtime>(
     }
     // Overlay the chat pane's workspace env onto `input.env` BEFORE the
     // provider consumes it, so the agent's browser/CLI subprocesses route to
-    // the agent's own workspace instead of the user's active one. Resolve the
-    // owning workspace from the pane; an orphaned pane (no workspace) injects
-    // nothing, matching the terminal path's behavior.
+    // the agent's own workspace instead of the user's active one, and stamp
+    // the owning workspace id for the adapter's MCP dispatches. Both derive
+    // from the pane binding (`pane_workspace_context`); an orphaned pane (no
+    // workspace) injects nothing, matching the terminal path's behavior.
     {
         let state: State<'_, AppStateStore> = app.state();
-        let workspace_id = state.workspace_id_for_pane(&pane_id);
-        let snapshot = state.snapshot();
-        let ws = workspace_id
-            .as_ref()
-            .and_then(|id| snapshot.workspaces.iter().find(|w| &w.workspace_id.0 == id));
-        input.env = workspace_env_overlay(ws, &pane_id, input.env.take());
-        // First-class copy of the owning workspace id, sourced from the same
-        // snapshot as the env's CODEMUX_WORKSPACE_ID so the two can't
-        // disagree. Adapters attach it per-call to MCP dispatches, where the
-        // shared MCP child's env cannot identify the calling session. A
-        // caller-supplied value wins, mirroring the env overlay's
-        // insert-if-absent semantics.
-        input.workspace_id = input
-            .workspace_id
-            .take()
-            .or_else(|| ws.map(|w| w.workspace_id.0.clone()));
+        let (env, workspace_id) = pane_workspace_context(&state, &pane_id, input.env.take());
+        input.env = env;
+        input.workspace_id = workspace_id;
     }
     let session = impl_.start_session(input).await.map_err(provider_err)?;
     let state: State<'_, AppStateStore> = app.state();
@@ -1711,28 +1725,15 @@ pub async fn ensure_live_session<R: Runtime>(
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
-    // Rebuild the workspace env overlay so the resumed agent's
-    // browser / CLI subprocesses route to its OWN workspace, exactly
-    // like `agent_chat_start_session`. Resolve the pane from the thread;
-    // an orphaned thread (no pane) injects nothing.
-    // Also capture the owning workspace id itself: the rebuilt session
-    // attaches it per-call to MCP dispatches, same as a fresh start (see
-    // `agent_chat_start_session`). Sourced from the same snapshot as the
-    // env overlay so the two can't disagree.
+    // Rebuild the workspace env overlay and owning workspace id so the
+    // resumed agent's browser / CLI subprocesses and MCP dispatches route
+    // to its OWN workspace, exactly like `agent_chat_start_session`
+    // (`pane_workspace_context`). Resolve the pane from the thread; an
+    // orphaned thread (no pane) injects nothing.
     let (env, workspace_id) = {
         let state: State<'_, AppStateStore> = app.state();
         match state.agent_chat_pane_id_for_thread(&thread_id.0) {
-            Some(pane_id) => {
-                let workspace_id = state.workspace_id_for_pane(&pane_id);
-                let snapshot = state.snapshot();
-                let ws = workspace_id
-                    .as_ref()
-                    .and_then(|id| snapshot.workspaces.iter().find(|w| &w.workspace_id.0 == id));
-                (
-                    workspace_env_overlay(ws, &pane_id, None),
-                    ws.map(|w| w.workspace_id.0.clone()),
-                )
-            }
+            Some(pane_id) => pane_workspace_context(&state, &pane_id, None),
             None => (None, None),
         }
     };

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1131,34 +1131,19 @@ async fn dispatch_request<R: Runtime>(app: &AppHandle<R>, request: ControlReques
             let state: State<'_, AppStateStore> = app.state();
             let agent_browser: State<'_, crate::agent_browser::AgentBrowserManager> = app.state();
             let observability: State<'_, crate::observability::ObservabilityStore> = app.state();
-            let mut workspace_id = request.params
+            let requested_workspace_id = request.params
                 .get("workspace_id")
                 .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string();
-
-            // Layer B fallback: when the caller sent no `workspace_id` (its
-            // `CODEMUX_WORKSPACE_ID` env was never injected — the agent-chat
-            // sidecar's Bash subprocesses, OpenCode's shared server, etc.)
-            // but did include a `cwd` hint, resolve the owning workspace by
-            // path so the pane lands in the *agent's* workspace instead of
-            // the "Legacy global path" below, which targets whatever
-            // workspace the user is currently viewing.
-            let mut cwd_resolved = false;
-            if workspace_id.is_empty() {
-                let cwd = request.params
-                    .get("cwd")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default();
-                if !cwd.is_empty() {
-                    if let Some(resolved) =
-                        resolve_workspace_id_by_cwd(&state.snapshot().workspaces, cwd)
-                    {
-                        workspace_id = resolved;
-                        cwd_resolved = true;
-                    }
-                }
-            }
+                .unwrap_or_default();
+            let cwd_hint = request.params
+                .get("cwd")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let (workspace_id, cwd_resolved) = resolve_browser_workspace_id(
+                &state.snapshot().workspaces,
+                requested_workspace_id,
+                cwd_hint,
+            );
 
             let action_kind = request.params.get("action")
                 .and_then(|v| v.get("kind"))
@@ -1803,6 +1788,33 @@ fn should_create_legacy_browser_pane(
     browser_sessions_empty
 }
 
+/// Pick the workspace a `browser_automation` call acts on. Returns
+/// `(workspace_id, cwd_resolved)`; an empty id means "legacy global path"
+/// (whatever workspace the user is viewing).
+///
+/// A caller-supplied id only counts when it names a workspace in the
+/// snapshot. The shared `codemux mcp` child forwards whatever `_meta` tag
+/// or env var it was handed, so an id from a session whose workspace has
+/// since closed would otherwise reach `resolve_agent_browser_session` and
+/// mint a phantom `ws-<id>` session that no pane can show. An unknown or
+/// empty id falls through to the Layer B `cwd` hint: when the caller's
+/// `CODEMUX_WORKSPACE_ID` env was never injected (the agent-chat sidecar's
+/// Bash subprocesses, OpenCode's shared server, etc.) the owning workspace
+/// is resolved by path so the pane lands in the *agent's* workspace.
+fn resolve_browser_workspace_id(
+    workspaces: &[crate::state::WorkspaceSnapshot],
+    requested: &str,
+    cwd: &str,
+) -> (String, bool) {
+    if !requested.is_empty() && workspaces.iter().any(|ws| ws.workspace_id.0 == requested) {
+        return (requested.to_string(), false);
+    }
+    match resolve_workspace_id_by_cwd(workspaces, cwd) {
+        Some(resolved) => (resolved, true),
+        None => (String::new(), false),
+    }
+}
+
 /// Resolve which workspace owns a given `cwd`, for browser routing when the
 /// caller sent an empty `workspace_id` (agent-chat Bash subprocesses,
 /// OpenCode's shared server, or any MCP/CLI caller whose
@@ -2070,6 +2082,54 @@ mod tests {
             last_active_at: None,
             last_visited_at: None,
         }
+    }
+
+    // ─── resolve_browser_workspace_id (id validation + cwd fallback) ────
+
+    #[test]
+    fn browser_workspace_known_id_wins_over_cwd() {
+        let workspaces = vec![ws("ws-a", "/home/user/proj-a", None), ws("ws-b", "/home/user/proj-b", None)];
+        assert_eq!(
+            resolve_browser_workspace_id(&workspaces, "ws-b", "/home/user/proj-a"),
+            ("ws-b".to_string(), false)
+        );
+    }
+
+    #[test]
+    fn browser_workspace_unknown_id_falls_back_to_cwd() {
+        // A stale `_meta` / env id (workspace closed, app restarted) must
+        // not mint a phantom `ws-<id>` session; the cwd hint takes over.
+        let workspaces = vec![ws("ws-a", "/home/user/proj-a", None)];
+        assert_eq!(
+            resolve_browser_workspace_id(&workspaces, "ws-zombie", "/home/user/proj-a/src"),
+            ("ws-a".to_string(), true)
+        );
+    }
+
+    #[test]
+    fn browser_workspace_unknown_id_without_cwd_is_legacy_global() {
+        let workspaces = vec![ws("ws-a", "/home/user/proj-a", None)];
+        assert_eq!(
+            resolve_browser_workspace_id(&workspaces, "ws-zombie", ""),
+            (String::new(), false)
+        );
+        assert_eq!(
+            resolve_browser_workspace_id(&workspaces, "ws-zombie", "/elsewhere"),
+            (String::new(), false)
+        );
+    }
+
+    #[test]
+    fn browser_workspace_empty_id_uses_cwd_then_legacy() {
+        let workspaces = vec![ws("ws-a", "/home/user/proj-a", None)];
+        assert_eq!(
+            resolve_browser_workspace_id(&workspaces, "", "/home/user/proj-a"),
+            ("ws-a".to_string(), true)
+        );
+        assert_eq!(
+            resolve_browser_workspace_id(&workspaces, "", ""),
+            (String::new(), false)
+        );
     }
 
     #[test]

--- a/src-tauri/src/mcp/gateway.rs
+++ b/src-tauri/src/mcp/gateway.rs
@@ -26,11 +26,20 @@ use super::McpConfigSource;
 /// ever attaches, the gateway will need per-consumer identity (a token or path
 /// per consumer) instead of this fixed list.
 ///
-/// Per-CALL identity can already travel in-band: a `tools/call` request may
-/// carry `_meta["codemux/workspace_id"]`, which the gateway forwards to the
-/// registry so workspace-scoped built-in tools bind to the caller's
-/// workspace. OpenCode does not send it today, so its calls keep the legacy
-/// env/cwd fallback until per-consumer identity lands.
+/// Per-CALL identity can travel in-band: a `tools/call` request may carry
+/// `_meta[WORKSPACE_META_KEY]`, which the gateway forwards to the registry
+/// so workspace-scoped built-in tools bind to the caller's workspace.
+///
+/// OpenCode remains on the legacy cwd fallback. Codemux runs ONE
+/// `opencode serve` process for every chat session and registers this
+/// gateway once, by name, on that shared instance (`attach_mcp_gateway`);
+/// OpenCode's MCP registrations are instance-global and its client sends no
+/// per-session `_meta`, so there is no channel through which an OpenCode
+/// tool call can identify its session or workspace. Fixing that means
+/// moving the OpenCode adapter to per-directory instances, which is a
+/// separate change. Until then OpenCode's browser/git/conversation tools
+/// bind to whatever `resolve_workspace_id_by_cwd` finds for the process
+/// cwd — see the note in `opencode/server.rs`.
 const GATEWAY_NATIVE_SOURCES: [McpConfigSource; 2] =
     [McpConfigSource::OpenCodeUser, McpConfigSource::OpenCodeProject];
 
@@ -200,10 +209,11 @@ async fn handle_post(
                 .unwrap_or_else(|| json!({}));
             // Forward the caller's workspace identity when the request
             // carries it, so built-in workspace-scoped tools route to the
-            // calling session's workspace. Absent for OpenCode today.
+            // calling session's workspace. Absent for OpenCode (see the
+            // module note on `GATEWAY_NATIVE_SOURCES`).
             let workspace_id = params
                 .get("_meta")
-                .and_then(|meta| meta.get("codemux/workspace_id"))
+                .and_then(|meta| meta.get(super::WORKSPACE_META_KEY))
                 .and_then(Value::as_str)
                 .filter(|id| !id.is_empty());
             match state

--- a/src-tauri/src/mcp/gateway.rs
+++ b/src-tauri/src/mcp/gateway.rs
@@ -25,6 +25,12 @@ use super::McpConfigSource;
 /// config, so serving them back would double every tool. If another provider
 /// ever attaches, the gateway will need per-consumer identity (a token or path
 /// per consumer) instead of this fixed list.
+///
+/// Per-CALL identity can already travel in-band: a `tools/call` request may
+/// carry `_meta["codemux/workspace_id"]`, which the gateway forwards to the
+/// registry so workspace-scoped built-in tools bind to the caller's
+/// workspace. OpenCode does not send it today, so its calls keep the legacy
+/// env/cwd fallback until per-consumer identity lands.
 const GATEWAY_NATIVE_SOURCES: [McpConfigSource; 2] =
     [McpConfigSource::OpenCodeUser, McpConfigSource::OpenCodeProject];
 
@@ -192,7 +198,19 @@ async fn handle_post(
                 .get("arguments")
                 .cloned()
                 .unwrap_or_else(|| json!({}));
-            match state.registry.dispatch_tool_call(name, arguments).await {
+            // Forward the caller's workspace identity when the request
+            // carries it, so built-in workspace-scoped tools route to the
+            // calling session's workspace. Absent for OpenCode today.
+            let workspace_id = params
+                .get("_meta")
+                .and_then(|meta| meta.get("codemux/workspace_id"))
+                .and_then(Value::as_str)
+                .filter(|id| !id.is_empty());
+            match state
+                .registry
+                .dispatch_tool_call(name, arguments, workspace_id)
+                .await
+            {
                 Ok(result) => rpc_result(id, result).into_response(),
                 Err(message) => rpc_result(
                     id,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -18,6 +18,14 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
+/// `_meta` key under which a `tools/call` carries the calling session's
+/// workspace id to the built-in `codemux mcp` server. Every agent-chat
+/// session shares ONE spawned child, so the child's env cannot identify
+/// the caller; the registry tags each dispatch with this key instead and
+/// the server prefers it over `CODEMUX_WORKSPACE_ID` (see
+/// `mcp_server::resolve_workspace_id`).
+pub const WORKSPACE_META_KEY: &str = "codemux/workspace_id";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum McpConfigSource {

--- a/src-tauri/src/mcp/registry.rs
+++ b/src-tauri/src/mcp/registry.rs
@@ -507,15 +507,26 @@ impl McpRegistry {
     /// `tools/call` response with `content: [...]` and optional
     /// `isError`). Errors come through as `Err(String)` so the caller
     /// can wrap them in a synthetic `isError: true` result for the SDK.
+    ///
+    /// `workspace_id` is the calling session's owning workspace. All
+    /// provider sessions share ONE spawned `codemux mcp` child, so the
+    /// child's env cannot identify the caller — the id travels per-call
+    /// in the request's `_meta` instead (see [`tool_call_params`]) so
+    /// workspace-scoped tools (browser routing, git cwd) bind to the
+    /// session's own workspace rather than whichever one the app
+    /// process happens to sit in. `None` keeps the child's env/cwd
+    /// fallback behavior.
     pub async fn dispatch_tool_call(
         &self,
         prefixed_name: &str,
         arguments: serde_json::Value,
+        workspace_id: Option<&str>,
     ) -> Result<serde_json::Value, String> {
-        let (raw_name, child, remote) = {
+        let (raw_name, is_codemux_self, child, remote) = {
             let inner = self.inner.lock().await;
             let mut found: Option<(
                 String,
+                bool,
                 Option<std::sync::Arc<crate::json_rpc_child::JsonRpcChild>>,
                 Option<std::sync::Arc<super::http_client::HttpMcpClient>>,
             )> = None;
@@ -536,7 +547,14 @@ impl McpRegistry {
                                 handle.config.name
                             ));
                         }
-                        found = Some((tool.name.clone(), child, remote));
+                        // Only the built-in server understands the
+                        // `_meta` workspace tag; the Codemux source is
+                        // its marker (see `codemux_self_config`).
+                        let is_self = handle
+                            .config
+                            .sources
+                            .contains(&super::McpConfigSource::Codemux);
+                        found = Some((tool.name.clone(), is_self, child, remote));
                         break;
                     }
                 }
@@ -550,10 +568,7 @@ impl McpRegistry {
             }
         };
 
-        let params = serde_json::json!({
-            "name": raw_name,
-            "arguments": arguments,
-        });
+        let params = tool_call_params(&raw_name, arguments, is_codemux_self, workspace_id);
         if let Some(child) = child {
             child
                 .request("tools/call", params)
@@ -602,6 +617,30 @@ impl McpRegistry {
             let _ = t.await;
         }
     }
+}
+
+/// Build the `tools/call` params for a registry dispatch. The caller's
+/// workspace id rides in `_meta` (MCP's per-request metadata channel)
+/// under a namespaced key, and ONLY for the built-in codemux server —
+/// third-party servers must keep receiving the exact `{name, arguments}`
+/// shape they got before, so a stray `_meta` cannot confuse a strict
+/// implementation.
+fn tool_call_params(
+    raw_name: &str,
+    arguments: serde_json::Value,
+    is_codemux_self: bool,
+    workspace_id: Option<&str>,
+) -> serde_json::Value {
+    let mut params = serde_json::json!({
+        "name": raw_name,
+        "arguments": arguments,
+    });
+    if is_codemux_self {
+        if let Some(id) = workspace_id {
+            params["_meta"] = serde_json::json!({ "codemux/workspace_id": id });
+        }
+    }
+    params
 }
 
 /// Emit a status-changed event so the frontend updates without
@@ -898,11 +937,42 @@ mod tests {
         assert_eq!(user_tools, 4, "all user MCP tools must be registered");
     }
 
+    #[test]
+    fn tool_call_params_tags_codemux_self_with_workspace_meta() {
+        let params = tool_call_params(
+            "browser_navigate",
+            serde_json::json!({"url": "http://localhost:1420"}),
+            true,
+            Some("ws-42"),
+        );
+        assert_eq!(params["name"], "browser_navigate");
+        assert_eq!(params["arguments"]["url"], "http://localhost:1420");
+        assert_eq!(params["_meta"]["codemux/workspace_id"], "ws-42");
+    }
+
+    #[test]
+    fn tool_call_params_omits_meta_without_workspace() {
+        let params = tool_call_params("browser_navigate", serde_json::json!({}), true, None);
+        assert!(params.get("_meta").is_none());
+    }
+
+    #[test]
+    fn tool_call_params_never_tags_third_party_servers() {
+        // A third-party server must see the exact pre-existing shape even
+        // when the caller supplied a workspace id.
+        let params = tool_call_params("create_issue", serde_json::json!({}), false, Some("ws-42"));
+        assert!(params.get("_meta").is_none());
+        assert_eq!(
+            params,
+            serde_json::json!({ "name": "create_issue", "arguments": {} })
+        );
+    }
+
     #[tokio::test]
     async fn dispatch_tool_call_unknown_tool_errors() {
         let reg = McpRegistry::new();
         let err = reg
-            .dispatch_tool_call("mcp__nope__x", serde_json::json!({}))
+            .dispatch_tool_call("mcp__nope__x", serde_json::json!({}), None)
             .await
             .unwrap_err();
         assert!(err.contains("unknown MCP tool"));
@@ -926,7 +996,7 @@ mod tests {
             inner.handles.insert("github".into(), h);
         }
         let err = reg
-            .dispatch_tool_call("mcp__github__create_issue", serde_json::json!({}))
+            .dispatch_tool_call("mcp__github__create_issue", serde_json::json!({}), None)
             .await
             .unwrap_err();
         assert!(err.contains("not running"));
@@ -1023,6 +1093,7 @@ mod tests {
             .dispatch_tool_call(
                 "mcp__remote__echo",
                 serde_json::json!({"text": "hi"}),
+                None,
             )
             .await
             .unwrap();
@@ -1057,6 +1128,7 @@ mod tests {
             .dispatch_tool_call(
                 &tool.prefixed_name,
                 serde_json::json!({"query": "default browser"}),
+                None,
             )
             .await
             .expect("real MCP tool call should succeed");

--- a/src-tauri/src/mcp/registry.rs
+++ b/src-tauri/src/mcp/registry.rs
@@ -637,7 +637,7 @@ fn tool_call_params(
     });
     if is_codemux_self {
         if let Some(id) = workspace_id {
-            params["_meta"] = serde_json::json!({ "codemux/workspace_id": id });
+            params["_meta"] = serde_json::json!({ super::WORKSPACE_META_KEY: id });
         }
     }
     params
@@ -717,10 +717,117 @@ fn discover_configs(project_root: Option<&std::path::Path>) -> Vec<McpServerConf
     super::dedupe_servers(out)
 }
 
+/// Shared fixture for tests that need to observe the exact `tools/call`
+/// the registry sends to the built-in server: a mock HTTP MCP server
+/// registered under the `Codemux` source (the marker `dispatch_tool_call`
+/// keys the `_meta` workspace tag on), so the adapters' dispatch paths can
+/// assert on the outbound wire shape without spawning a real child.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use crate::mcp::{McpConfigSource, McpServerConfig, McpTransport};
+    use mockito::Matcher;
+
+    /// One mock `codemux-remote` server exposing a single `echo` tool. The
+    /// returned `Mock` is the `tools/call` expectation: it only matches a
+    /// request whose params carry `_meta[WORKSPACE_META_KEY] == workspace_id`,
+    /// so `assert_async` proves the tag reached the wire.
+    pub(crate) async fn codemux_remote_server(
+        workspace_id: &str,
+    ) -> (mockito::ServerGuard, McpRegistry, mockito::Mock) {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/mcp")
+            .match_body(Matcher::PartialJson(serde_json::json!({ "method": "initialize" })))
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "protocolVersion": "2025-06-18",
+                        "capabilities": {},
+                        "serverInfo": {"name": "codemux", "version": "1"}
+                    }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        server
+            .mock("POST", "/mcp")
+            .match_body(Matcher::PartialJson(
+                serde_json::json!({ "method": "notifications/initialized" }),
+            ))
+            .with_status(202)
+            .create_async()
+            .await;
+        server
+            .mock("POST", "/mcp")
+            .match_body(Matcher::PartialJson(serde_json::json!({ "method": "tools/list" })))
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "result": {"tools": [{
+                        "name": "echo",
+                        "description": "Echo",
+                        "inputSchema": {"type": "object"}
+                    }]}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+        let call = server
+            .mock("POST", "/mcp")
+            .match_body(Matcher::PartialJson(serde_json::json!({
+                "method": "tools/call",
+                "params": {
+                    "name": "echo",
+                    "_meta": { crate::mcp::WORKSPACE_META_KEY: workspace_id }
+                }
+            })))
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "result": {"content": [{"type": "text", "text": "routed"}]}
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let registry = McpRegistry::new();
+        let config = McpServerConfig {
+            id: "codemux-remote".into(),
+            name: "codemux-remote".into(),
+            sources: vec![McpConfigSource::Codemux],
+            command: format!("{}/mcp", server.url()),
+            args: Vec::new(),
+            env: HashMap::new(),
+            disabled: false,
+            transport: McpTransport::Http,
+            raw: serde_json::json!({}),
+        };
+        let row = registry
+            .ensure_started(None::<&tauri::AppHandle<tauri::Wry>>, config)
+            .await;
+        assert!(
+            matches!(row.status, McpServerStatus::Running { tool_count: 1 }),
+            "{row:?}"
+        );
+        (server, registry, call)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mcp::{McpConfigSource, McpServerConfig, McpTransport};
+    use crate::mcp::{McpConfigSource, McpServerConfig, McpTransport, WORKSPACE_META_KEY};
     use std::collections::HashMap;
 
     fn make_config(id: &str, name: &str, command: &str) -> McpServerConfig {
@@ -947,7 +1054,7 @@ mod tests {
         );
         assert_eq!(params["name"], "browser_navigate");
         assert_eq!(params["arguments"]["url"], "http://localhost:1420");
-        assert_eq!(params["_meta"]["codemux/workspace_id"], "ws-42");
+        assert_eq!(params["_meta"][WORKSPACE_META_KEY], "ws-42");
     }
 
     #[test]
@@ -966,6 +1073,26 @@ mod tests {
             params,
             serde_json::json!({ "name": "create_issue", "arguments": {} })
         );
+    }
+
+    #[tokio::test]
+    async fn dispatch_tool_call_sends_workspace_meta_to_builtin_server() {
+        // The wire check for the whole chain: a dispatch with a workspace id
+        // against the built-in server must produce an outbound `tools/call`
+        // whose params carry `_meta[WORKSPACE_META_KEY]` — the mock only
+        // answers a request that has it.
+        let (_server, reg, call) =
+            super::test_support::codemux_remote_server("ws-42").await;
+        let result = reg
+            .dispatch_tool_call(
+                "mcp__codemux-remote__echo",
+                serde_json::json!({"text": "hi"}),
+                Some("ws-42"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result["content"][0]["text"], "routed");
+        call.assert_async().await;
     }
 
     #[tokio::test]

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -934,13 +934,15 @@ fn pane_split_direction(tool: &str) -> &'static str {
 /// wins over the process env: every agent-chat session shares ONE
 /// `codemux mcp` child (spawned with no workspace env), so the registry
 /// tags each call with the calling session's workspace in
-/// `_meta["codemux/workspace_id"]`. The env var still covers children the
+/// `_meta[WORKSPACE_META_KEY]`. The env var still covers children the
 /// workspace lifecycle spawns per-workspace via `.mcp.json` (which never
 /// send `_meta`). `env_fallback` is passed in so tests stay hermetic.
+/// The id is forwarded as-is; the control layer drops one that names no
+/// live workspace (`resolve_browser_workspace_id`).
 fn resolve_workspace_id(params: &Value, env_fallback: Option<String>) -> String {
     params
         .get("_meta")
-        .and_then(|meta| meta.get("codemux/workspace_id"))
+        .and_then(|meta| meta.get(crate::mcp::WORKSPACE_META_KEY))
         .and_then(Value::as_str)
         .filter(|id| !id.is_empty())
         .map(str::to_owned)
@@ -2085,7 +2087,7 @@ mod tests {
         let params = json!({
             "name": "browser_navigate",
             "arguments": {},
-            "_meta": { "codemux/workspace_id": "ws-from-meta" }
+            "_meta": { crate::mcp::WORKSPACE_META_KEY: "ws-from-meta" }
         });
         assert_eq!(
             resolve_workspace_id(&params, Some("ws-from-env".into())),
@@ -2105,12 +2107,12 @@ mod tests {
 
     #[test]
     fn workspace_id_ignores_empty_or_non_string_meta() {
-        let empty = json!({ "name": "t", "_meta": { "codemux/workspace_id": "" } });
+        let empty = json!({ "name": "t", "_meta": { crate::mcp::WORKSPACE_META_KEY: "" } });
         assert_eq!(
             resolve_workspace_id(&empty, Some("ws-from-env".into())),
             "ws-from-env"
         );
-        let wrong_type = json!({ "name": "t", "_meta": { "codemux/workspace_id": 7 } });
+        let wrong_type = json!({ "name": "t", "_meta": { crate::mcp::WORKSPACE_META_KEY: 7 } });
         assert_eq!(
             resolve_workspace_id(&wrong_type, Some("ws-from-env".into())),
             "ws-from-env"

--- a/src-tauri/src/mcp_server.rs
+++ b/src-tauri/src/mcp_server.rs
@@ -930,6 +930,24 @@ fn pane_split_direction(tool: &str) -> &'static str {
     }
 }
 
+/// Resolve the workspace id a tool call should act on. Per-call `_meta`
+/// wins over the process env: every agent-chat session shares ONE
+/// `codemux mcp` child (spawned with no workspace env), so the registry
+/// tags each call with the calling session's workspace in
+/// `_meta["codemux/workspace_id"]`. The env var still covers children the
+/// workspace lifecycle spawns per-workspace via `.mcp.json` (which never
+/// send `_meta`). `env_fallback` is passed in so tests stay hermetic.
+fn resolve_workspace_id(params: &Value, env_fallback: Option<String>) -> String {
+    params
+        .get("_meta")
+        .and_then(|meta| meta.get("codemux/workspace_id"))
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+        .or(env_fallback)
+        .unwrap_or_default()
+}
+
 async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
     let tool_name = match params.get("name").and_then(Value::as_str) {
         Some(name) => name.to_string(),
@@ -937,8 +955,10 @@ async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
     };
     let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
 
-    // Workspace ID for workspace-scoped browser routing.
-    let workspace_id = std::env::var("CODEMUX_WORKSPACE_ID").unwrap_or_default();
+    // Workspace ID for workspace-scoped routing (browser session binding,
+    // git cwd). Caller-tagged `_meta` first, env second.
+    let workspace_id =
+        resolve_workspace_id(&params, std::env::var("CODEMUX_WORKSPACE_ID").ok());
     // Best-effort cwd so the control layer can resolve the owning workspace
     // by path when this MCP server's `CODEMUX_WORKSPACE_ID` env is missing
     // (covers MCP callers whose env wasn't injected). Empty string on error;
@@ -1285,23 +1305,23 @@ async fn handle_tool_call(id: Value, params: Value) -> JsonRpcResponse {
         }
 
         // -- Git tools (shell out) --
-        "git_status" => run_git(&["status", "--porcelain"]).await,
+        "git_status" => run_git(&["status", "--porcelain"], &workspace_id).await,
         "git_diff" => {
             let file = arguments.get("file").and_then(Value::as_str);
             match file {
-                Some(f) => run_git(&["diff", f]).await,
-                None => run_git(&["diff"]).await,
+                Some(f) => run_git(&["diff", f], &workspace_id).await,
+                None => run_git(&["diff"], &workspace_id).await,
             }
         }
         "git_stage" => {
             let file = arguments.get("file").and_then(Value::as_str).unwrap_or(".");
-            run_git(&["add", file]).await
+            run_git(&["add", file], &workspace_id).await
         }
         "git_commit" => {
             let message = arguments.get("message").and_then(Value::as_str).unwrap_or_default();
-            run_git(&["commit", "-m", message]).await
+            run_git(&["commit", "-m", message], &workspace_id).await
         }
-        "git_push" => run_git(&["push"]).await,
+        "git_push" => run_git(&["push"], &workspace_id).await,
 
         // -- Terminal / workspace / status / ports (Phase 1) --
         "terminal_write" => {
@@ -1583,9 +1603,14 @@ async fn call_socket(command: &str, params: Value) -> Result<Value, String> {
 // Git helper (shell out in workspace cwd)
 // ---------------------------------------------------------------------------
 
-async fn get_workspace_cwd() -> Result<String, String> {
-    // Try CODEMUX_WORKSPACE_ID env var first to get workspace path via app state.
-    if let Ok(workspace_id) = std::env::var("CODEMUX_WORKSPACE_ID") {
+/// `workspace_id` is the already-resolved id from `handle_tool_call`
+/// (per-call `_meta` first, env fallback second — see
+/// `resolve_workspace_id`), so git tools route to the same workspace the
+/// browser tools bind to. Empty means "no workspace known" and falls
+/// through to the process cwd.
+async fn get_workspace_cwd(workspace_id: &str) -> Result<String, String> {
+    // Map the workspace id to its path via app state.
+    if !workspace_id.is_empty() {
         let response = call_socket("get_app_state", json!({})).await?;
         if let Some(workspaces) = response.get("workspaces").and_then(Value::as_array) {
             for ws in workspaces {
@@ -1593,7 +1618,7 @@ async fn get_workspace_cwd() -> Result<String, String> {
                 let wid_str = wid
                     .and_then(Value::as_str)
                     .or_else(|| wid.and_then(|v| v.as_object()).and_then(|o| o.get("0")).and_then(Value::as_str));
-                if wid_str == Some(&workspace_id) {
+                if wid_str == Some(workspace_id) {
                     if let Some(cwd) = ws.get("cwd").and_then(Value::as_str) {
                         return Ok(cwd.to_string());
                     }
@@ -1607,8 +1632,8 @@ async fn get_workspace_cwd() -> Result<String, String> {
         .map_err(|e| format!("Cannot determine workspace directory: {e}"))
 }
 
-async fn run_git(args: &[&str]) -> Result<Value, String> {
-    let cwd = get_workspace_cwd().await?;
+async fn run_git(args: &[&str], workspace_id: &str) -> Result<Value, String> {
+    let cwd = get_workspace_cwd(workspace_id).await?;
     let output = tokio::process::Command::new("git")
         .args(args)
         .current_dir(&cwd)
@@ -2049,6 +2074,47 @@ mod tests {
         let resp = JsonRpcResponse::error(json!(3), -32601, "Not found");
         let serialized = serde_json::to_string(&resp).unwrap();
         assert!(!serialized.contains("\"data\""), "data field should be omitted when None");
+    }
+
+    // -----------------------------------------------------------------------
+    // Workspace-id resolution
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn workspace_id_prefers_call_meta_over_env_fallback() {
+        let params = json!({
+            "name": "browser_navigate",
+            "arguments": {},
+            "_meta": { "codemux/workspace_id": "ws-from-meta" }
+        });
+        assert_eq!(
+            resolve_workspace_id(&params, Some("ws-from-env".into())),
+            "ws-from-meta"
+        );
+    }
+
+    #[test]
+    fn workspace_id_falls_back_to_env_without_meta() {
+        let params = json!({ "name": "browser_navigate", "arguments": {} });
+        assert_eq!(
+            resolve_workspace_id(&params, Some("ws-from-env".into())),
+            "ws-from-env"
+        );
+        assert_eq!(resolve_workspace_id(&params, None), "");
+    }
+
+    #[test]
+    fn workspace_id_ignores_empty_or_non_string_meta() {
+        let empty = json!({ "name": "t", "_meta": { "codemux/workspace_id": "" } });
+        assert_eq!(
+            resolve_workspace_id(&empty, Some("ws-from-env".into())),
+            "ws-from-env"
+        );
+        let wrong_type = json!({ "name": "t", "_meta": { "codemux/workspace_id": 7 } });
+        assert_eq!(
+            resolve_workspace_id(&wrong_type, Some("ws-from-env".into())),
+            "ws-from-env"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src-tauri/tests/agent_chat_commands.rs
+++ b/src-tauri/tests/agent_chat_commands.rs
@@ -71,6 +71,7 @@ fn start_input(thread_id: &str) -> StartSessionInput {
         additional_directories: vec![],
         recorded_usage_baseline: None,
         env: None,
+        workspace_id: None,
         extra: serde_json::Value::Null,
     }
 }
@@ -1137,6 +1138,7 @@ mod auto_resume {
                 additional_directories: vec![],
                 recorded_usage_baseline: None,
                 env: None,
+                workspace_id: None,
                 extra: Value::Null,
             })
             .await

--- a/src-tauri/tests/agent_chat_commands.rs
+++ b/src-tauri/tests/agent_chat_commands.rs
@@ -1809,3 +1809,122 @@ async fn deleting_a_session_removes_all_hidden_checkpoint_refs() {
         assert!(!status.success(), "checkpoint ref leaked: {ref_name}");
     }
 }
+
+// ── Workspace identity handed to the provider ─────────────────────────
+//
+// Both session-minting paths must hand the adapter the workspace that
+// OWNS the chat pane — never one an IPC caller supplied — so the
+// adapter's MCP dispatches route to the pane's workspace. The fresh-start
+// command itself can't be driven here: `agent_chat_start_session` primes
+// the MCP registry, which spawns the built-in `<current_exe> mcp` child
+// (this test binary) plus the user's real MCP configs. Its derivation is
+// the shared `pane_workspace_context` helper, asserted directly; the
+// rebuild path is driven end-to-end through `ensure_live_session` with
+// the mock provider capturing the `StartSessionInput`.
+
+mod workspace_identity {
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use codemux_lib::agent_provider::{ProviderKind, StartSessionInput, ThreadId};
+    use codemux_lib::commands::agent_chat::{
+        ensure_live_session, pane_workspace_context, ProviderRegistry,
+    };
+    use codemux_lib::database::DatabaseStore;
+    use codemux_lib::state::AppStateStore;
+    use tauri::Manager;
+
+    use crate::mock_agent_provider::MockAgentProvider;
+
+    #[test]
+    fn fresh_start_context_derives_workspace_id_from_pane_binding() {
+        let state = AppStateStore::default();
+        let ws = state.create_workspace_at_path(PathBuf::from("/tmp/codemux-ws-identity"));
+        let pane = state
+            .create_agent_chat_pane(&ws.0, None, None, None)
+            .expect("create_agent_chat_pane");
+
+        let caller_env = HashMap::from([("KEEP_ME".to_string(), "1".to_string())]);
+        let (env, workspace_id) = pane_workspace_context(&state, &pane.0, Some(caller_env));
+
+        assert_eq!(
+            workspace_id.as_deref(),
+            Some(ws.0.as_str()),
+            "the owning workspace comes from the pane binding"
+        );
+        let env = env.expect("env overlay present for a bound pane");
+        assert_eq!(
+            env.get("CODEMUX_WORKSPACE_ID"),
+            Some(&ws.0),
+            "env and first-class id come from the same snapshot"
+        );
+        assert_eq!(env.get("KEEP_ME").map(String::as_str), Some("1"));
+
+        // An orphaned pane injects nothing and names no workspace.
+        assert_eq!(pane_workspace_context(&state, "pane-orphan", None), (None, None));
+    }
+
+    #[test]
+    fn ipc_input_cannot_carry_a_workspace_id() {
+        // The IPC shape never sets `workspace_id`; a caller that tries must
+        // be ignored so a pane cannot point its tool calls at a workspace it
+        // does not live in.
+        let input: StartSessionInput = serde_json::from_value(serde_json::json!({
+            "thread_id": "thread-ipc",
+            "cwd": "/tmp/codemux-test",
+            "fast_mode": false,
+            "additional_directories": [],
+            "workspace_id": "ws-somebody-elses"
+        }))
+        .expect("StartSessionInput deserializes");
+        assert_eq!(input.workspace_id, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rebuild_hands_provider_the_pane_workspace_id() {
+        let app = tauri::test::mock_app();
+        app.manage(DatabaseStore::new_in_memory());
+        app.manage(AppStateStore::default());
+        app.manage(ProviderRegistry::new());
+        let handle = app.handle().clone();
+
+        let mock = Arc::new(MockAgentProvider::new(ProviderKind::Codex));
+        {
+            let registry: tauri::State<'_, ProviderRegistry> = handle.state();
+            registry.set_codex(mock.clone() as _).await;
+        }
+
+        // A chat pane bound to the thread inside a workspace, plus the
+        // persisted row the rebuild reads.
+        let thread = ThreadId("thread-rebuild-identity".into());
+        let state: tauri::State<'_, AppStateStore> = handle.state();
+        let ws = state.create_workspace_at_path(PathBuf::from("/tmp/codemux-ws-rebuild"));
+        super::bind_chat_pane(&state, &ws.0, &thread.0);
+        {
+            let db: tauri::State<'_, DatabaseStore> = handle.state();
+            db.upsert_agent_chat_session(&thread.0, &ws.0, Some("/tmp/codemux-ws-rebuild"), "codex")
+                .unwrap();
+        }
+
+        ensure_live_session(&handle, ProviderKind::Codex, &thread)
+            .await
+            .expect("rebuild should succeed");
+
+        let inputs = mock.start_inputs();
+        assert_eq!(inputs.len(), 1, "exactly one start_session was sent");
+        assert_eq!(
+            inputs[0].workspace_id.as_deref(),
+            Some(ws.0.as_str()),
+            "the rebuilt session carries the pane's owning workspace"
+        );
+        assert_eq!(
+            inputs[0]
+                .env
+                .as_ref()
+                .and_then(|env| env.get("CODEMUX_WORKSPACE_ID")),
+            Some(&ws.0),
+            "env overlay agrees with the first-class id"
+        );
+    }
+}

--- a/src-tauri/tests/claude_adapter.rs
+++ b/src-tauri/tests/claude_adapter.rs
@@ -117,6 +117,7 @@ fn start_input(thread_id: &str) -> StartSessionInput {
         additional_directories: vec![],
         recorded_usage_baseline: None,
         env: None,
+        workspace_id: None,
         extra: serde_json::Value::Null,
     }
 }

--- a/src-tauri/tests/codex_adapter.rs
+++ b/src-tauri/tests/codex_adapter.rs
@@ -127,6 +127,7 @@ fn start_input(thread_id: &str) -> StartSessionInput {
         additional_directories: vec![],
         recorded_usage_baseline: None,
         env: None,
+        workspace_id: None,
         extra: serde_json::Value::Null,
     }
 }

--- a/src-tauri/tests/cursor_adapter.rs
+++ b/src-tauri/tests/cursor_adapter.rs
@@ -30,6 +30,7 @@ fn start_input(
         fast_mode,
         additional_directories: vec![],
         env: None,
+        workspace_id: None,
         extra: serde_json::Value::Null,
         recorded_usage_baseline: None,
     }
@@ -55,6 +56,7 @@ fn fixture_start_input(thread_id: &str) -> StartSessionInput {
         fast_mode: false,
         additional_directories: vec![],
         env: None,
+        workspace_id: None,
         extra: serde_json::Value::Null,
         recorded_usage_baseline: None,
     }

--- a/src-tauri/tests/helpers/mock_agent_provider.rs
+++ b/src-tauri/tests/helpers/mock_agent_provider.rs
@@ -66,6 +66,10 @@ pub struct MockAgentProvider {
     /// `start_session` inserts, `stop_session` removes.
     live: Arc<Mutex<HashSet<ThreadId>>>,
     rollback_error: Arc<Mutex<Option<String>>>,
+    /// Every `StartSessionInput` received, in order, so tests can assert
+    /// on what the command layer actually handed the provider (workspace
+    /// id, env overlay, resume cursor) rather than only that it was called.
+    start_inputs: Arc<Mutex<Vec<StartSessionInput>>>,
 }
 
 impl MockAgentProvider {
@@ -77,7 +81,14 @@ impl MockAgentProvider {
             event_tx,
             live: Arc::new(Mutex::new(HashSet::new())),
             rollback_error: Arc::new(Mutex::new(None)),
+            start_inputs: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    /// Snapshot of every `start_session` input received so far.
+    #[allow(dead_code)]
+    pub fn start_inputs(&self) -> Vec<StartSessionInput> {
+        self.start_inputs.lock().unwrap().clone()
     }
 
     pub fn fail_next_rollback(&self, message: impl Into<String>) {
@@ -114,6 +125,7 @@ impl AgentProvider for MockAgentProvider {
         input: StartSessionInput,
     ) -> Result<ProviderSession, ProviderError> {
         self.calls.push(MockCall::StartSession(input.thread_id.clone()));
+        self.start_inputs.lock().unwrap().push(input.clone());
         self.live.lock().unwrap().insert(input.thread_id.clone());
         Ok(ProviderSession {
             thread_id: input.thread_id.clone(),


### PR DESCRIPTION
## Problem

Agent-chat MCP tool calls from every provider converge on a single shared `codemux mcp` child whose env cannot identify the caller. It guessed the owning workspace from its own process cwd, so `browser_automation` bound the agent browser session to whichever workspace matched (typically a Home workspace at `$HOME`). The background-browser indicator and the "Opened the browser" chat chip then rendered in the wrong workspace — to the user it looked like the indicator was gone entirely. Git and conversation tools routed through the same child had the identical defect.

## Fix

Thread the workspace id per call instead of per process:

- `StartSessionInput.workspace_id` — Claude/Codex sessions carry their owning workspace, sourced from the same snapshot as the env overlay's `CODEMUX_WORKSPACE_ID` so the two can't disagree (both fresh starts and `ensure_live_session` rebuilds).
- `McpRegistry::dispatch_tool_call` gained `workspace_id: Option<&str>` and attaches it as `_meta: {"codemux/workspace_id": …}` — only when the target is the built-in server; third-party MCP servers receive the byte-identical previous shape.
- The `codemux mcp` child prefers the `_meta` id over its env for browser, git, and conversation tools; env and cwd fallbacks are unchanged for per-workspace children spawned via `.mcp.json`.
- The HTTP MCP gateway forwards an incoming `_meta` workspace id when present (no behavior change for its current consumer).

## Scope

OpenCode is not covered by this change and stays on the existing cwd fallback. Codemux drives every OpenCode chat through one shared `opencode serve` instance and registers the MCP gateway once by name on it; OpenCode's MCP registrations are instance-global and its client sends no per-session `_meta`, so there is currently no channel through which an OpenCode tool call can identify its session or workspace. Per-session routing for OpenCode requires moving the adapter to per-directory instances and is tracked as a separate change.

## Verification

- New e2e: `scripts/e2e/mcp-workspace-routing-e2e.sh` boots an isolated headless debug backend (`codemux-dev.sock`, own config dir), creates two workspaces, and drives a real `codemux mcp` child where env and cwd both point at workspace A while `_meta` says B — asserts the session binds to B, and that the cwd-fallback baseline still binds A. Runs in ~5s with clean teardown; refuses release binaries and already-running dev instances.
- Unit tests: `_meta` tagging matrix in `registry.rs`, hermetic workspace-id resolver tests in `mcp_server.rs`.
- A `_meta` id that no longer matches an open workspace is treated as absent (cwd hint, then legacy) instead of binding a phantom browser session; the IPC input can no longer override the pane's owning workspace.
- Adapter-level coverage: the mock provider records `StartSessionInput.workspace_id` for fresh starts and `ensure_live_session` rebuilds, and registry/codex tests assert `_meta` on the outbound `tools/call`.
- The e2e runs under its own XDG root (config, data, state, cache, runtime) and closes the workspaces it creates, so the real dev store is never touched.
- `cargo check` clean; mcp + agent_provider lib tests (129 + 580) and the claude/codex/cursor/agent-chat integration suites all pass.

Built with Claude Fable 5 on Claude Code.