### PR TITLE
feat: group the Subagents pane by spawn wave with result-first rows

### DIFF
--- a/src/components/layout/right-panel/subagents-pane.test.tsx
+++ b/src/components/layout/right-panel/subagents-pane.test.tsx
@@ -18,23 +18,73 @@ function subagent(overrides: Partial<SubagentView>): SubagentView {
   };
 }
 
+function prompt(id: string, seq: number, text: string): ChatViewItem {
+  return { kind: "user_message", id, seq, text };
+}
+
+function run(id: string, seq: number, subagents: SubagentView[]): ChatViewItem {
+  return { kind: "subagent_run", id, seq, turn_id: `turn-${id}`, subagents };
+}
+
+/** One wave: the shape every pre-wave test used. */
 function messages(subagents: SubagentView[]): ChatViewItem[] {
   return [
-    {
-      kind: "subagent_run",
-      id: "run-1",
-      seq: 0,
-      turn_id: "turn-1",
-      subagents,
-    },
+    prompt("u-1", 0, "Implement clipboard-paste fallback"),
+    run("run-1", 1, subagents),
+  ];
+}
+
+/** Two waves — the design fixture: an older implement wave, then a newer
+ *  analysis wave with one failure. */
+function twoWaves(): ChatViewItem[] {
+  return [
+    prompt("u-1", 0, "Implement + verify\nsecond line is not the title"),
+    run("run-1", 1, [
+      subagent({
+        id: "impl",
+        name: "Subagent",
+        model: "haiku",
+        status: "completed",
+        resultText: "Patched session.ts, all 14 tests green",
+        durationMs: 371_000,
+        totalTokens: 400_000,
+      }),
+      subagent({
+        id: "verify",
+        name: "Subagent",
+        model: "haiku",
+        status: "stopped",
+        resultText: "Stopped — superseded by wave 2 findings",
+        durationMs: 67_000,
+        totalTokens: 240_000,
+      }),
+    ]),
+    prompt("u-2", 2, "Issue analysis"),
+    run("run-2", 3, [
+      subagent({
+        id: "explore-1",
+        model: "opus",
+        status: "completed",
+        resultText:
+          "Root cause: applyRuntimeInfo never re-registers the tile delegate\nmore detail",
+        durationMs: 207_000,
+      }),
+      subagent({
+        id: "explore-2",
+        model: "opus",
+        status: "failed",
+        resultText: "Failed — sandbox denied network access during fetch",
+        durationMs: 185_000,
+      }),
+    ]),
   ];
 }
 
 beforeEach(() => useUIStore.setState({ subagentEnterRequest: null }));
 afterEach(cleanup);
 
-describe("SubagentsPane — focused watch surface", () => {
-  it("shows aggregate progress, live cards, and compact finished rows", () => {
+describe("SubagentsPane — grouped waves with result-first rows", () => {
+  it("shows aggregate progress and titles the wave with its prompt", () => {
     render(
       <SubagentsPane
         threadId="thread-1"
@@ -43,24 +93,31 @@ describe("SubagentsPane — focused watch surface", () => {
             id: "live",
             name: "Pricing audit",
             model: "anthropic/claude-opus-4-8",
-            toolUseCount: 12,
+            activity: "reading pricing.ts…",
           }),
           subagent({
             id: "done",
             name: "Verification pass",
             model: "openai/gpt-5.4",
             status: "completed",
-            activity: "All checks pass",
+            resultText: "All checks pass\nDetails follow",
             durationMs: 16_000,
-            toolUseCount: 4,
           }),
         ])}
       />,
     );
 
     expect(screen.getByText("1 / 2")).toBeInTheDocument();
-    expect(screen.getByLabelText("1 live subagents")).toBeInTheDocument();
-    expect(screen.getByText("Finished · 1")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "1",
+    );
+    const wave = screen.getByRole("region", {
+      name: "Implement clipboard-paste fallback",
+    });
+    expect(wave).toHaveAttribute("data-wave-status", "running");
+    expect(screen.getByText("2 agents · 1 running")).toBeInTheDocument();
+    // Both rows: name, model capsule, and the excerpt line.
     expect(screen.getByText("Pricing audit")).toBeInTheDocument();
     expect(screen.getByText("Verification pass")).toBeInTheDocument();
     expect(
@@ -69,10 +126,79 @@ describe("SubagentsPane — focused watch surface", () => {
     expect(screen.getByTitle("Model: openai/gpt-5.4")).toHaveTextContent(
       "openai/gpt-5.4",
     );
-    expect(screen.getByRole("progressbar")).toHaveAttribute(
-      "aria-valuenow",
-      "1",
+    expect(screen.getByText("reading pricing.ts…")).toBeInTheDocument();
+    expect(screen.getByText("All checks pass")).toBeInTheDocument();
+  });
+
+  it("falls back to 'Ran N subagents' when no prompt precedes the wave", () => {
+    render(
+      <SubagentsPane
+        threadId="thread-1"
+        messages={[
+          run("run-1", 0, [
+            subagent({ id: "a", status: "completed" }),
+            subagent({ id: "b", name: "Verify", status: "completed" }),
+          ]),
+        ]}
+      />,
     );
+    expect(
+      screen.getByRole("region", { name: "Ran 2 subagents" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the latest wave open, folds older ones, and toggles on click", () => {
+    render(<SubagentsPane threadId="thread-1" messages={twoWaves()} />);
+
+    const older = screen.getByRole("button", { name: /^Implement \+ verify/ });
+    const newer = screen.getByRole("button", { name: /^Issue analysis/ });
+    expect(older).toHaveAttribute("aria-expanded", "false");
+    expect(newer).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.queryByText("Patched session.ts, all 14 tests green"),
+    ).toBeNull();
+    expect(
+      screen.getByText(
+        "Root cause: applyRuntimeInfo never re-registers the tile delegate",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(older);
+    expect(older).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByText("Patched session.ts, all 14 tests green"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(newer);
+    expect(newer).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByText(
+        "Root cause: applyRuntimeInfo never re-registers the tile delegate",
+      ),
+    ).toBeNull();
+  });
+
+  it("surfaces a failure on the wave header and numbers repeated names", () => {
+    render(<SubagentsPane threadId="thread-1" messages={twoWaves()} />);
+
+    const failedWave = screen.getByRole("region", { name: "Issue analysis" });
+    expect(failedWave).toHaveAttribute("data-wave-status", "failed");
+    expect(screen.getByText("2 agents · 1 failed")).toBeInTheDocument();
+    // Folded wave still reports its rollup, including tokens and a halt.
+    const olderWave = screen.getByRole("region", {
+      name: "Implement + verify",
+    });
+    expect(olderWave).toHaveAttribute("data-wave-status", "stopped");
+    expect(
+      screen.getByText("2 agents · 1 stopped · Σ 640K tok"),
+    ).toBeInTheDocument();
+    // Two "Explore" rows → "Explore 1" / "Explore 2".
+    expect(
+      screen.getByRole("button", { name: "Open Explore 1 thread" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open Explore 2 thread" }),
+    ).toBeInTheDocument();
   });
 
   it("omits the model capsule when the provider has not reported one", () => {
@@ -86,14 +212,16 @@ describe("SubagentsPane — focused watch surface", () => {
     expect(container.querySelector("[data-subagent-model]")).toBeNull();
   });
 
-  it("opens a live subagent thread from the panel", () => {
+  it("opens a subagent thread from its row", () => {
     render(
       <SubagentsPane
         threadId="thread-1"
         messages={messages([subagent({ id: "sub-42" })])}
       />,
     );
-    fireEvent.click(screen.getByText("Open thread"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Explore thread" }),
+    );
     expect(useUIStore.getState().subagentEnterRequest).toMatchObject({
       threadId: "thread-1",
       subagentId: "sub-42",

--- a/src/components/layout/right-panel/subagents-pane.test.tsx
+++ b/src/components/layout/right-panel/subagents-pane.test.tsx
@@ -1,6 +1,13 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 
 import type { ChatViewItem, SubagentView } from "@/lib/agent-chat/types";
 import { useUIStore } from "@/stores/ui-store";
@@ -81,7 +88,10 @@ function twoWaves(): ChatViewItem[] {
 }
 
 beforeEach(() => useUIStore.setState({ subagentEnterRequest: null }));
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe("SubagentsPane — grouped waves with result-first rows", () => {
   it("shows aggregate progress and titles the wave with its prompt", () => {
@@ -210,6 +220,33 @@ describe("SubagentsPane — grouped waves with result-first rows", () => {
     );
 
     expect(container.querySelector("[data-subagent-model]")).toBeNull();
+  });
+
+  it("keeps the header timer live while a sibling has failed", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(100_000));
+    render(
+      <SubagentsPane
+        threadId="thread-1"
+        messages={messages([
+          subagent({ id: "a", status: "failed", durationMs: 5_000 }),
+          subagent({ id: "b", status: "running", startedAt: 90_000 }),
+        ])}
+      />,
+    );
+
+    const wave = screen.getByRole("region", {
+      name: "Implement clipboard-paste fallback",
+    });
+    // The failure still wins the header glyph...
+    expect(wave).toHaveAttribute("data-wave-status", "failed");
+    // ...but the elapsed label follows the agent that is still running.
+    const header = within(wave).getByRole("button", { expanded: true });
+    const elapsed = within(header).getByText("0m 10s");
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(elapsed).toHaveTextContent("0m 13s");
   });
 
   it("opens a subagent thread from its row", () => {

--- a/src/components/layout/right-panel/subagents-pane.tsx
+++ b/src/components/layout/right-panel/subagents-pane.tsx
@@ -145,7 +145,9 @@ function WaveGroup({
   const status = subagentWaveStatus(wave.subagents);
   const title = subagentWaveTitle(wave);
   const ordinals = subagentOrdinals(wave.subagents);
-  const running = status === "running";
+  // Not `status === "running"`: that rollup ranks a failure above a live
+  // agent, which would freeze the timer while a sibling is still going.
+  const running = wave.subagents.some(isRunning);
   return (
     <section
       data-wave-status={status}

--- a/src/components/layout/right-panel/subagents-pane.tsx
+++ b/src/components/layout/right-panel/subagents-pane.tsx
@@ -1,23 +1,40 @@
 /**
  * The Subagents pane is Turn 2's watch surface. The transcript keeps only a
  * 32px work-log row; live detail, progress, and thread drill-in live here.
+ *
+ * Rows group by spawn wave (one `subagent_run` card each). A wave folds to
+ * a single header — prompt, rollup, longest duration — so tens of finished
+ * agents become a few groups. The latest wave and any wave still running
+ * stay open; older ones fold. Each child row is two lines: name / model /
+ * duration, then the first line of the agent's report, so a finished row
+ * reads as a receipt rather than a tombstone.
  */
 import { Ban, Check, ChevronRight, X } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { TickingText } from "@/components/chat/TickingText";
+import { formatCompactTokens } from "@/components/chat/WorkflowRunCard";
 import { AgentOrb } from "@/components/ui/agent-orb";
 import { subagentOrbActivity } from "@/lib/agent-chat/orb-activity";
 import {
   formatElapsed,
   isRunning,
+  statusTone,
   subagentActivityLine,
   subagentElapsedMs,
   subagentGroupRollup,
-  subagentRunItems,
+  subagentOrdinals,
   subagentToolCount,
+  subagentWaveStatus,
+  subagentWaveTitle,
+  subagentWaves,
+  type SubagentWave,
 } from "@/lib/agent-chat/subagents";
-import type { ChatViewItem, SubagentView } from "@/lib/agent-chat/types";
+import type {
+  ChatViewItem,
+  SubagentView,
+  SubagentViewStatus,
+} from "@/lib/agent-chat/types";
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/stores/ui-store";
 
@@ -29,20 +46,21 @@ export function SubagentsPane({
   messages: ChatViewItem[];
 }) {
   const requestEnterSubagent = useUIStore((s) => s.requestEnterSubagent);
-  const runs = useMemo(() => subagentRunItems(messages), [messages]);
-  const subagents = useMemo(() => {
-    const byId = new Map<string, SubagentView>();
-    for (const run of runs) {
-      for (const subagent of run.subagents) byId.set(subagent.id, subagent);
-    }
-    return [...byId.values()];
-  }, [runs]);
+  const waves = useMemo(() => subagentWaves(messages), [messages]);
+  const subagents = useMemo(
+    () => waves.flatMap((wave) => wave.subagents),
+    [waves],
+  );
+  // Explicit user folds/unfolds, keyed by wave id. Anything not in here
+  // follows the default: open while running or when it is the latest wave.
+  const [folds, setFolds] = useState<Record<string, boolean>>({});
+
   const active = subagents.filter(isRunning);
-  const finished = subagents.filter((subagent) => !isRunning(subagent));
+  const finished = subagents.length - active.length;
   const progress =
     subagents.length === 0
       ? 0
-      : Math.round((finished.length / subagents.length) * 100);
+      : Math.round((finished / subagents.length) * 100);
 
   if (subagents.length === 0) {
     return (
@@ -57,6 +75,7 @@ export function SubagentsPane({
   const openThread = (subagentId: string) => {
     if (threadId) requestEnterSubagent(threadId, subagentId);
   };
+  const latestWaveId = waves[waves.length - 1]?.id;
 
   return (
     <div
@@ -65,7 +84,7 @@ export function SubagentsPane({
     >
       <div className="flex h-5 items-center gap-2.5">
         <span className="shrink-0 font-mono text-[10px] text-foreground/80">
-          {finished.length} / {subagents.length}
+          {finished} / {subagents.length}
         </span>
         <span className="h-[3px] min-w-0 flex-1 overflow-hidden rounded-full bg-foreground/[0.07]">
           <span
@@ -84,129 +103,198 @@ export function SubagentsPane({
         role="progressbar"
         aria-valuemin={0}
         aria-valuemax={subagents.length}
-        aria-valuenow={finished.length}
+        aria-valuenow={finished}
         aria-label="Subagent progress"
       />
 
-      {active.length > 0 && (
-        <section
-          className="mt-3"
-          aria-label={`${active.length} live subagents`}
-        >
-          <div className="space-y-1.5">
-            {active.map((subagent) => (
-              <LiveSubagentCard
-                key={subagent.id}
-                subagent={subagent}
-                onOpen={() => openThread(subagent.id)}
-                canOpen={threadId != null}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      {finished.length > 0 && (
-        <section className="mt-4" aria-labelledby="finished-subagents-heading">
-          <h3
-            id="finished-subagents-heading"
-            className="mb-1 font-mono text-[9px] font-medium uppercase tracking-[0.12em] text-muted-foreground/65"
-          >
-            Finished · {finished.length}
-          </h3>
-          <div>
-            {finished.map((subagent) => (
-              <FinishedSubagentRow
-                key={subagent.id}
-                subagent={subagent}
-                onOpen={() => openThread(subagent.id)}
-                canOpen={threadId != null}
-              />
-            ))}
-          </div>
-        </section>
-      )}
+      <div className="mt-3 flex flex-col gap-1.5">
+        {waves.map((wave) => {
+          const running = wave.subagents.some(isRunning);
+          const open = folds[wave.id] ?? (running || wave.id === latestWaveId);
+          return (
+            <WaveGroup
+              key={wave.id}
+              wave={wave}
+              open={open}
+              onToggle={() =>
+                setFolds((prev) => ({ ...prev, [wave.id]: !open }))
+              }
+              onOpen={openThread}
+              canOpen={threadId != null}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 }
 
-function LiveSubagentCard({
-  subagent,
+function WaveGroup({
+  wave,
+  open,
+  onToggle,
   onOpen,
   canOpen,
 }: {
-  subagent: SubagentView;
-  onOpen: () => void;
+  wave: SubagentWave;
+  open: boolean;
+  onToggle: () => void;
+  onOpen: (subagentId: string) => void;
   canOpen: boolean;
 }) {
-  const activity = subagentActivityLine(subagent);
+  const status = subagentWaveStatus(wave.subagents);
+  const title = subagentWaveTitle(wave);
+  const ordinals = subagentOrdinals(wave.subagents);
+  const running = status === "running";
   return (
-    <div className="rounded-lg bg-foreground/[0.045] px-2.5 py-2.5">
-      <div className="flex min-w-0 items-center gap-2">
-        <AgentOrb size={20} {...subagentOrbActivity(subagent)} aria-hidden />
-        <span className="min-w-0 flex-1 truncate text-[11px] font-semibold text-foreground/90">
-          {subagent.name ?? subagent.agentType ?? "Subagent"}
+    <section
+      data-wave-status={status}
+      aria-label={title}
+      className="overflow-hidden rounded-[10px] bg-foreground/[0.03]"
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex h-[38px] w-full items-center gap-2 px-2.5 text-left hover:bg-foreground/[0.03]"
+      >
+        <WaveGlyph status={status} />
+        <span className="flex min-w-0 flex-1 flex-col gap-px">
+          <span className="truncate text-[11.5px] font-semibold text-foreground">
+            {title}
+          </span>
+          <span className="truncate font-mono text-[9px] text-muted-foreground">
+            {waveMeta(wave.subagents)}
+          </span>
         </span>
-        <SubagentModelBadge model={subagent.model} />
-      </div>
-      <div className="mt-1.5 truncate pl-7 font-mono text-[10px] text-muted-foreground">
-        {activity}
-      </div>
-      <div className="mt-2 ml-7 flex items-center gap-2">
-        <button
-          type="button"
-          disabled={!canOpen}
-          onClick={onOpen}
-          className="flex items-center gap-0.5 text-[10px] font-medium text-foreground/75 hover:text-foreground disabled:cursor-default"
-        >
-          Open thread
-          <ChevronRight className="size-3" aria-hidden />
-        </button>
-        <span className="ml-auto shrink-0 font-mono text-[9px] text-muted-foreground">
-          {toolCountLabel(subagent)}
-        </span>
-      </div>
-    </div>
+        <TickingText
+          active={running}
+          className="shrink-0 font-mono text-[9.5px] tabular-nums text-muted-foreground"
+          compute={(now) => elapsedLabel(wave.subagents, now)}
+        />
+        <ChevronRight
+          className={cn(
+            "size-[11px] shrink-0 text-muted-foreground transition-transform duration-150",
+            open && "rotate-90",
+          )}
+          aria-hidden
+        />
+      </button>
+      {open && (
+        <div className="border-t border-border/60 px-1 pt-1 pb-1">
+          {wave.subagents.map((subagent) => (
+            <WaveRow
+              key={subagent.id}
+              subagent={subagent}
+              ordinal={ordinals.get(subagent.id) ?? null}
+              onOpen={() => onOpen(subagent.id)}
+              canOpen={canOpen}
+            />
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 
-function FinishedSubagentRow({
+function WaveRow({
   subagent,
+  ordinal,
   onOpen,
   canOpen,
 }: {
   subagent: SubagentView;
+  ordinal: number | null;
   onOpen: () => void;
   canOpen: boolean;
 }) {
+  const name = subagent.name ?? subagent.agentType ?? "Subagent";
+  const label = ordinal == null ? name : `${name} ${ordinal}`;
+  const running = isRunning(subagent);
+  const excerpt = subagentActivityLine(subagent);
   return (
     <button
       type="button"
       disabled={!canOpen}
       onClick={onOpen}
-      className="group -mx-1.5 flex h-[26px] w-[calc(100%+0.75rem)] min-w-0 items-center gap-2 rounded-md px-1.5 text-left hover:bg-foreground/[0.04] disabled:cursor-default"
-      aria-label={`Open ${subagent.name ?? subagent.agentType ?? "subagent"} thread`}
+      aria-label={`Open ${label} thread`}
+      className="group flex w-full flex-col gap-0.5 rounded-[7px] px-1.5 pt-1.5 pb-[7px] text-left hover:bg-foreground/[0.04] disabled:cursor-default"
     >
-      <FinishedGlyph subagent={subagent} />
-      <span className="min-w-0 flex-1 truncate font-mono text-[10px] text-foreground/75">
-        {subagent.name ?? subagent.agentType ?? "Subagent"}
+      <span className="grid w-full grid-cols-[20px_minmax(0,1fr)_auto_auto_10px] items-center gap-1.5">
+        <RowGlyph subagent={subagent} />
+        <span className="min-w-0 truncate font-mono text-[10.5px] text-foreground/80">
+          {name}
+          {ordinal != null && (
+            <span className="text-muted-foreground/70"> {ordinal}</span>
+          )}
+        </span>
+        <SubagentModelBadge model={subagent.model} />
+        <TickingText
+          active={running}
+          className="min-w-[38px] shrink-0 text-right font-mono text-[9.5px] tabular-nums text-muted-foreground"
+          compute={(now) => rowTimeLabel(subagent, now)}
+        />
+        <ChevronRight
+          className="size-[9px] justify-self-end text-muted-foreground/50 group-hover:text-muted-foreground"
+          aria-hidden
+        />
       </span>
-      <SubagentModelBadge model={subagent.model} compact />
-      <TickingText
-        active={false}
-        className="shrink-0 font-mono text-[9px] text-muted-foreground/80"
-        compute={(now) => finishedTimeLabel(subagent, now)}
-      />
-      <ChevronRight
-        className="size-3 shrink-0 text-muted-foreground/50 group-hover:text-muted-foreground"
-        aria-hidden
-      />
+      <span
+        data-subagent-excerpt
+        title={excerpt}
+        className="w-full truncate pr-4 pl-[26px] font-mono text-[9.5px] leading-[1.45] text-muted-foreground"
+      >
+        {excerpt}
+      </span>
     </button>
   );
 }
 
-function FinishedGlyph({ subagent }: { subagent: SubagentView }) {
-  const props = { className: "size-3 shrink-0", "aria-hidden": true } as const;
+function WaveGlyph({ status }: { status: SubagentViewStatus }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      className={cn(
+        "flex size-[17px] shrink-0 items-center justify-center rounded-full",
+        tone.chipBg,
+      )}
+      aria-hidden
+    >
+      {status === "running" ? (
+        <span className="size-1.5 animate-pulse rounded-full bg-current" />
+      ) : status === "failed" ? (
+        <svg
+          width="9"
+          height="9"
+          viewBox="0 0 12 12"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        >
+          <path d="M6 3.2v3.3M6 8.6v.2" />
+        </svg>
+      ) : status === "completed" ? (
+        <Check className="size-[9px]" strokeWidth={2.4} />
+      ) : (
+        <Ban className="size-[9px]" strokeWidth={2.2} />
+      )}
+    </span>
+  );
+}
+
+function RowGlyph({ subagent }: { subagent: SubagentView }) {
+  if (isRunning(subagent)) {
+    return (
+      <span className="flex justify-center">
+        <AgentOrb size={20} {...subagentOrbActivity(subagent)} aria-hidden />
+      </span>
+    );
+  }
+  const props = {
+    className: "size-2.5 shrink-0 justify-self-center",
+    "aria-hidden": true,
+  } as const;
   if (subagent.status === "failed") {
     return (
       <X {...props} className={cn(props.className, "text-status-attention")} />
@@ -231,13 +319,7 @@ function FinishedGlyph({ subagent }: { subagent: SubagentView }) {
  * reported instead of guessing at a vendor-specific display name. Long ids
  * truncate in the row; the native title keeps the full value one hover away.
  */
-function SubagentModelBadge({
-  model,
-  compact = false,
-}: {
-  model?: string;
-  compact?: boolean;
-}) {
+function SubagentModelBadge({ model }: { model?: string }) {
   const value = model?.trim();
   if (!value) return null;
 
@@ -245,12 +327,7 @@ function SubagentModelBadge({
     <span
       data-subagent-model={value}
       title={`Model: ${value}`}
-      className={cn(
-        "inline-flex min-w-0 shrink-0 items-center gap-1 overflow-hidden rounded-[5px] border border-foreground/[0.08] bg-background/55 font-mono text-muted-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.025)]",
-        compact
-          ? "h-[17px] max-w-[38%] px-1.5 text-[8px]"
-          : "h-[18px] max-w-[48%] px-1.5 text-[9px]",
-      )}
+      className="inline-flex h-[17px] max-w-[96px] min-w-0 shrink-0 items-center gap-1 overflow-hidden rounded-[5px] border border-foreground/[0.08] bg-background/55 px-1.5 font-mono text-[8px] text-muted-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.025)]"
     >
       <span
         className="size-1 shrink-0 rounded-full bg-accent-ember/75"
@@ -261,19 +338,37 @@ function SubagentModelBadge({
   );
 }
 
+function plural(count: number, word: string): string {
+  return `${count} ${word}${count === 1 ? "" : "s"}`;
+}
+
+/** "4 agents · 1 failed · Σ 1.1m tok" — prints only what the app knows. */
+function waveMeta(subagents: readonly SubagentView[]): string {
+  // Token aggregation is clock-independent; zero avoids consulting a
+  // clock during render while still sharing the canonical rollup helper.
+  const rollup = subagentGroupRollup(subagents, 0);
+  const parts = [plural(subagents.length, "agent")];
+  const failed = subagents.filter((s) => s.status === "failed").length;
+  const halted = subagents.filter(
+    (s) => s.status === "stopped" || s.status === "interrupted",
+  ).length;
+  if (rollup.activeCount > 0) parts.push(`${rollup.activeCount} running`);
+  if (failed > 0) parts.push(`${failed} failed`);
+  if (halted > 0) parts.push(`${halted} stopped`);
+  if (rollup.totalTokens != null) {
+    parts.push(`Σ ${formatCompactTokens(rollup.totalTokens)} tok`);
+  }
+  return parts.join(" · ");
+}
+
 function elapsedLabel(subagents: readonly SubagentView[], now: number): string {
   const elapsed = subagentGroupRollup(subagents, now).elapsedMs;
   return elapsed == null ? "" : formatElapsed(elapsed);
 }
 
-function finishedTimeLabel(subagent: SubagentView, now: number): string {
+function rowTimeLabel(subagent: SubagentView, now: number): string {
   const elapsed = subagentElapsedMs(subagent, now);
   if (elapsed != null) return formatElapsed(elapsed);
-  const tools = subagentToolCount(subagent);
-  return `${tools} ${tools === 1 ? "tool" : "tools"}`;
-}
-
-function toolCountLabel(subagent: SubagentView): string {
   const tools = subagentToolCount(subagent);
   return `${tools} ${tools === 1 ? "tool" : "tools"}`;
 }

--- a/src/lib/agent-chat/subagents.test.ts
+++ b/src/lib/agent-chat/subagents.test.ts
@@ -750,6 +750,32 @@ describe("subagentWaves — spawn-wave grouping for the pane", () => {
     expect(waves[0].subagents[0].status).toBe("completed");
   });
 
+  it("ignores a queued follow-up parked past the card it precedes in the array", () => {
+    // The reducer appends a queued bubble at the array tail with a
+    // far-future seq, then appends the card the CURRENT turn spawns after
+    // it. Walking the array would title the wave with the queued text.
+    const waves = subagentWaves([
+      user("u1", 0, "Fix the flaky test"),
+      {
+        kind: "user_message",
+        id: "q1",
+        seq: 1_000_000_001,
+        text: "Also update the docs",
+        queued: { queuedId: "queued-1" },
+      },
+      card("c1", 1, [sub("a")]),
+    ]);
+    expect(waves.map((w) => w.prompt)).toEqual(["Fix the flaky test"]);
+  });
+
+  it("walks the transcript in seq order, not array order", () => {
+    const waves = subagentWaves([
+      card("c1", 1, [sub("a")]),
+      user("u1", 0, "Fix the flaky test"),
+    ]);
+    expect(waves.map((w) => w.prompt)).toEqual(["Fix the flaky test"]);
+  });
+
   it("rolls the wave status up with failure surfacing first", () => {
     expect(subagentWaveStatus([sub("a"), sub("b")])).toBe("completed");
     expect(

--- a/src/lib/agent-chat/subagents.test.ts
+++ b/src/lib/agent-chat/subagents.test.ts
@@ -23,7 +23,11 @@ import {
   subagentMetaLine,
   subagentOrdinal,
   subagentStatusLabel,
+  subagentOrdinals,
   subagentToolCount,
+  subagentWaveStatus,
+  subagentWaveTitle,
+  subagentWaves,
   toneIndexForId,
 } from "./subagents";
 import type {
@@ -85,7 +89,10 @@ describe("mergeStatus", () => {
     // hand-built payloads can omit it (Rust serde-defaults to `pending`).
     // An `undefined` leaking through used to crash `statusTone` at render.
     expect(
-      mergeStatus("running", undefined as unknown as SubagentSnapshot["status"]),
+      mergeStatus(
+        "running",
+        undefined as unknown as SubagentSnapshot["status"],
+      ),
     ).toBe("running");
     expect(
       mergeStatus("completed", "bogus" as SubagentSnapshot["status"]),
@@ -121,13 +128,18 @@ describe("mergeSnapshot revive / statusAssumed (issue #153)", () => {
     // A later snapshot that simply omits the flag must not promote the row
     // back to "real subagent" (same additive-merge rule as every field).
     expect(
-      mergeSnapshot(merged, { subagent_id: "bg", status: "running" } as SubagentSnapshot)
-        .backgroundTask,
+      mergeSnapshot(merged, {
+        subagent_id: "bg",
+        status: "running",
+      } as SubagentSnapshot).backgroundTask,
     ).toBe(true);
     // A row that was never flagged stays shape-identical (no stray key).
     expect(
       "backgroundTask" in
-        mergeSnapshot(view(), { subagent_id: "s1", status: "running" } as SubagentSnapshot),
+        mergeSnapshot(view(), {
+          subagent_id: "s1",
+          status: "running",
+        } as SubagentSnapshot),
     ).toBe(false);
   });
 
@@ -182,7 +194,13 @@ describe("mergeSnapshot revive / statusAssumed (issue #153)", () => {
 
 describe("settleSubagentsForToolResult / interruptRunningSubagents", () => {
   function card(subs: SubagentView[]): SubagentRunItem {
-    return { kind: "subagent_run", id: "run-1", seq: 0, turn_id: "t", subagents: subs };
+    return {
+      kind: "subagent_run",
+      id: "run-1",
+      seq: 0,
+      turn_id: "t",
+      subagents: subs,
+    };
   }
   function workflowWith(agents: SubagentView[]): WorkflowRunItem {
     return {
@@ -220,11 +238,15 @@ describe("settleSubagentsForToolResult / interruptRunningSubagents", () => {
     expect(c1.subagents[2].status).toBe("running"); // untouched
 
     const byParent = settleSubagentsForToolResult(messages, "tool-b", false);
-    expect((byParent[0] as SubagentRunItem).subagents[1].status).toBe("completed");
+    expect((byParent[0] as SubagentRunItem).subagents[1].status).toBe(
+      "completed",
+    );
   });
 
   it("uses failed when the tool_result is an error", () => {
-    const messages: ChatViewItem[] = [card([view({ id: "tool-a", status: "running" })])];
+    const messages: ChatViewItem[] = [
+      card([view({ id: "tool-a", status: "running" })]),
+    ];
     const out = settleSubagentsForToolResult(messages, "tool-a", true);
     expect((out[0] as SubagentRunItem).subagents[0].status).toBe("failed");
   });
@@ -233,9 +255,13 @@ describe("settleSubagentsForToolResult / interruptRunningSubagents", () => {
     const done = view({ id: "tool-a", status: "completed" });
     const messages: ChatViewItem[] = [card([done])];
     // Already terminal → untouched, same ref.
-    expect(settleSubagentsForToolResult(messages, "tool-a", false)).toBe(messages);
+    expect(settleSubagentsForToolResult(messages, "tool-a", false)).toBe(
+      messages,
+    );
     // No id/parent match → same ref.
-    expect(settleSubagentsForToolResult(messages, "nope", false)).toBe(messages);
+    expect(settleSubagentsForToolResult(messages, "nope", false)).toBe(
+      messages,
+    );
   });
 
   it("settles running agents inside workflow phases too", () => {
@@ -250,18 +276,25 @@ describe("settleSubagentsForToolResult / interruptRunningSubagents", () => {
 
   it("interruptRunningSubagents flips running/pending to interrupted across cards and phases", () => {
     const messages: ChatViewItem[] = [
-      card([view({ id: "a", status: "running" }), view({ id: "b", status: "completed" })]),
+      card([
+        view({ id: "a", status: "running" }),
+        view({ id: "b", status: "completed" }),
+      ]),
       workflowWith([view({ id: "c", status: "pending" })]),
     ];
     const out = interruptRunningSubagents(messages);
     expect((out[0] as SubagentRunItem).subagents[0].status).toBe("interrupted");
     expect((out[0] as SubagentRunItem).subagents[0].statusAssumed).toBe(true);
     expect((out[0] as SubagentRunItem).subagents[1].status).toBe("completed"); // untouched
-    expect((out[1] as WorkflowRunItem).phases[0].agents[0].status).toBe("interrupted");
+    expect((out[1] as WorkflowRunItem).phases[0].agents[0].status).toBe(
+      "interrupted",
+    );
   });
 
   it("interruptRunningSubagents returns the SAME ref when nothing is running", () => {
-    const messages: ChatViewItem[] = [card([view({ id: "a", status: "completed" })])];
+    const messages: ChatViewItem[] = [
+      card([view({ id: "a", status: "completed" })]),
+    ];
     expect(interruptRunningSubagents(messages)).toBe(messages);
   });
 });
@@ -321,15 +354,32 @@ describe("mergeSnapshot", () => {
 
 describe("derived meta / activity fallbacks", () => {
   it("tool-count falls back to counting child tool calls", () => {
-    const v = view({ items: [toolCall(), toolCall(), { kind: "assistant_message", id: "a", seq: 1, turn_id: null, text: "x", streaming: false }] });
+    const v = view({
+      items: [
+        toolCall(),
+        toolCall(),
+        {
+          kind: "assistant_message",
+          id: "a",
+          seq: 1,
+          turn_id: null,
+          text: "x",
+          streaming: false,
+        },
+      ],
+    });
     expect(subagentToolCount(v)).toBe(2);
     // Provider usage wins when present.
-    expect(subagentToolCount(view({ toolUseCount: 9, items: [toolCall()] }))).toBe(9);
+    expect(
+      subagentToolCount(view({ toolUseCount: 9, items: [toolCall()] })),
+    ).toBe(9);
   });
 
   it("elapsed falls back to now - startedAt when no duration", () => {
     expect(subagentElapsedMs(view({ startedAt: 1000 }), 3000)).toBe(2000);
-    expect(subagentElapsedMs(view({ durationMs: 52000, startedAt: 1000 }), 9e9)).toBe(52000);
+    expect(
+      subagentElapsedMs(view({ durationMs: 52000, startedAt: 1000 }), 9e9),
+    ).toBe(52000);
     expect(subagentElapsedMs(view({}), 5000)).toBeNull();
   });
 
@@ -345,14 +395,18 @@ describe("derived meta / activity fallbacks", () => {
     );
     const withTool = view({
       activity: undefined,
-      items: [toolCall({ tool_name: "Bash", input: { command: "npm run verify" } })],
+      items: [
+        toolCall({ tool_name: "Bash", input: { command: "npm run verify" } }),
+      ],
     });
     expect(subagentActivityLine(withTool)).toBe("run npm run verify");
   });
 
   it("done rows show the result first line, else 'Done'", () => {
     expect(
-      subagentActivityLine(view({ status: "completed", resultText: "Line 1\nLine 2" })),
+      subagentActivityLine(
+        view({ status: "completed", resultText: "Line 1\nLine 2" }),
+      ),
     ).toBe("Line 1");
     expect(subagentActivityLine(view({ status: "completed" }))).toBe("Done");
     expect(subagentActivityLine(view({ status: "failed" }))).toBe("Failed");
@@ -374,16 +428,31 @@ describe("describeToolCall / peek", () => {
 
   it("running tools read as running in the peek", () => {
     const d = describeToolCall(
-      toolCall({ tool_name: "Bash", status: "running", input: { command: "npm run verify" } }),
+      toolCall({
+        tool_name: "Bash",
+        status: "running",
+        input: { command: "npm run verify" },
+      }),
     );
-    expect(d).toEqual({ verb: "run", target: "npm run verify", meta: "running" });
+    expect(d).toEqual({
+      verb: "run",
+      target: "npm run verify",
+      meta: "running",
+    });
   });
 
   it("recentToolCalls returns up to N newest, in order", () => {
     const v = view({
       items: [
         toolCall({ id: "t1" }),
-        { kind: "assistant_message", id: "a", seq: 1, turn_id: null, text: "x", streaming: false },
+        {
+          kind: "assistant_message",
+          id: "a",
+          seq: 1,
+          turn_id: null,
+          text: "x",
+          streaming: false,
+        },
         toolCall({ id: "t2" }),
         toolCall({ id: "t3" }),
         toolCall({ id: "t4" }),
@@ -482,17 +551,16 @@ describe("whole-thread lookups", () => {
 
     // Mid-run both read as live.
     expect(countRunningSubagents(withBg, true)).toBe(2);
-    expect(runningSubagentEntries(withBg, true).map((e) => e.subagent.id)).toEqual([
-      "bg",
-      "real",
-    ]);
+    expect(
+      runningSubagentEntries(withBg, true).map((e) => e.subagent.id),
+    ).toEqual(["bg", "real"]);
 
     // Run over: the never-terminating background job stops counting, so
     // the docked bar can't spin forever after the turn settled.
     expect(countRunningSubagents(withBg, false)).toBe(1);
-    expect(runningSubagentEntries(withBg, false).map((e) => e.subagent.id)).toEqual([
-      "real",
-    ]);
+    expect(
+      runningSubagentEntries(withBg, false).map((e) => e.subagent.id),
+    ).toEqual(["real"]);
   });
 
   it("labels each running subagent with its originating card once several cards exist", () => {
@@ -534,7 +602,12 @@ describe("subagentGroupRollup", () => {
           totalTokens: 20_000,
           toolUseCount: 6,
         }),
-        view({ id: "b", status: "running", totalTokens: 18_800, toolUseCount: 3 }),
+        view({
+          id: "b",
+          status: "running",
+          totalTokens: 18_800,
+          toolUseCount: 3,
+        }),
       ],
       0,
     );
@@ -588,7 +661,9 @@ describe("subagentLatestOutput", () => {
     expect(
       subagentLatestOutput(
         view({
-          items: [toolCall({ tool_name: "Bash", input: { command: "cargo test" } })],
+          items: [
+            toolCall({ tool_name: "Bash", input: { command: "cargo test" } }),
+          ],
         }),
       ),
     ).toBe("run cargo test · ok");
@@ -596,5 +671,116 @@ describe("subagentLatestOutput", () => {
 
   it("returns null when there is nothing real to show", () => {
     expect(subagentLatestOutput(view({}))).toBeNull();
+  });
+});
+
+describe("subagentWaves — spawn-wave grouping for the pane", () => {
+  const sub = (id: string, over: Partial<SubagentView> = {}): SubagentView => ({
+    id,
+    name: "Explore",
+    status: "completed",
+    items: [],
+    toneIndex: 0,
+    ...over,
+  });
+  const user = (id: string, seq: number, text: string): ChatViewItem => ({
+    kind: "user_message",
+    id,
+    seq,
+    text,
+  });
+  const card = (
+    id: string,
+    seq: number,
+    subagents: SubagentView[],
+  ): ChatViewItem => ({
+    kind: "subagent_run",
+    id,
+    seq,
+    turn_id: null,
+    subagents,
+  });
+
+  it("titles each wave with the first line of the nearest preceding prompt", () => {
+    const waves = subagentWaves([
+      user("u1", 0, "  Implement + verify\nwith detail"),
+      card("c1", 1, [sub("a")]),
+      user("u2", 2, "Issue analysis"),
+      {
+        kind: "assistant_message",
+        id: "m",
+        seq: 3,
+        turn_id: null,
+        text: "ok",
+      } as ChatViewItem,
+      card("c2", 4, [sub("b"), sub("c")]),
+    ]);
+    expect(waves.map((w) => [w.id, w.prompt, w.subagents.length])).toEqual([
+      ["c1", "Implement + verify", 1],
+      ["c2", "Issue analysis", 2],
+    ]);
+    expect(waves.map(subagentWaveTitle)).toEqual([
+      "Implement + verify",
+      "Issue analysis",
+    ]);
+  });
+
+  it("falls back to 'Ran N subagents' without a prompt, and skips empty cards", () => {
+    const waves = subagentWaves([
+      card("empty", 0, []),
+      card("c1", 1, [sub("a")]),
+      user("blank", 2, "   \n  "),
+      card("c2", 3, [sub("b"), sub("c")]),
+    ]);
+    expect(waves.map(subagentWaveTitle)).toEqual([
+      "Ran 1 subagent",
+      "Ran 2 subagents",
+    ]);
+  });
+
+  it("keeps a re-reported id in its first wave with the latest view", () => {
+    const waves = subagentWaves([
+      card("c1", 0, [sub("a", { status: "running" })]),
+      card("c2", 1, [sub("a", { status: "completed" }), sub("b")]),
+    ]);
+    expect(waves.map((w) => w.subagents.map((s) => s.id))).toEqual([
+      ["a"],
+      ["b"],
+    ]);
+    expect(waves[0].subagents[0].status).toBe("completed");
+  });
+
+  it("rolls the wave status up with failure surfacing first", () => {
+    expect(subagentWaveStatus([sub("a"), sub("b")])).toBe("completed");
+    expect(
+      subagentWaveStatus([sub("a"), sub("b", { status: "stopped" })]),
+    ).toBe("stopped");
+    expect(
+      subagentWaveStatus([
+        sub("a", { status: "interrupted" }),
+        sub("b", { status: "pending" }),
+      ]),
+    ).toBe("running");
+    expect(
+      subagentWaveStatus([
+        sub("a", { status: "running" }),
+        sub("b", { status: "failed" }),
+      ]),
+    ).toBe("failed");
+  });
+
+  it("numbers only repeated names within a wave", () => {
+    const ordinals = subagentOrdinals([
+      sub("a"),
+      sub("b", { name: "Verify" }),
+      sub("c"),
+      sub("d", { name: undefined, agentType: "general-purpose" }),
+    ]);
+    expect([...ordinals.entries()]).toEqual([
+      ["a", 1],
+      ["b", null],
+      ["c", 2],
+      ["d", null],
+    ]);
   });
 });

--- a/src/lib/agent-chat/subagents.ts
+++ b/src/lib/agent-chat/subagents.ts
@@ -670,19 +670,26 @@ export interface SubagentWave {
 /**
  * Group a transcript's subagents by spawn wave, in transcript order.
  *
- * A wave's prompt is the nearest preceding `user_message` — user
- * messages carry no `turn_id`, but the transcript is sequenced, so the
- * last prompt before a card is the turn that spawned it. A subagent id
- * reported by more than one card stays in the wave that first saw it and
- * takes the latest view, mirroring the reducer's non-regressing merge.
- * Empty cards are skipped.
+ * A wave's prompt is the nearest preceding `user_message` in seq order —
+ * user messages carry no `turn_id`, but the transcript is sequenced, so
+ * the last prompt before a card is the turn that spawned it. The store's
+ * array is not seq-ordered (a queued follow-up parks at the tail with a
+ * far-future seq, and the card the current turn spawns lands after it),
+ * so this walks a seq-sorted copy with the transcript's comparator and
+ * skips bubbles still queued: they have not spawned anything yet. A
+ * subagent id reported by more than one card stays in the wave that
+ * first saw it and takes the latest view, mirroring the reducer's
+ * non-regressing merge. Empty cards are skipped.
  */
 export function subagentWaves(messages: ChatViewItem[]): SubagentWave[] {
   const waves: SubagentWave[] = [];
   const home = new Map<string, SubagentView[]>();
   let prompt: string | null = null;
-  for (const item of messages) {
+  const ordered = messages.slice();
+  ordered.sort((a, b) => a.seq - b.seq || a.id.localeCompare(b.id));
+  for (const item of ordered) {
     if (item.kind === "user_message") {
+      if (item.queued) continue;
       const line = firstLine(item.text);
       prompt = line.length > 0 ? line : null;
       continue;

--- a/src/lib/agent-chat/subagents.ts
+++ b/src/lib/agent-chat/subagents.ts
@@ -649,3 +649,119 @@ export function interruptRunningSubagents(
       : sub,
   );
 }
+
+// ── Spawn waves (the Subagents pane's grouping) ──
+
+/**
+ * One spawn wave: a `subagent_run` card together with the turn that
+ * spawned it. The pane folds each wave to a single header row so tens of
+ * finished agents read as a handful of groups instead of a growing list.
+ */
+export interface SubagentWave {
+  /** The card id — stable React key and fold-state key. */
+  id: string;
+  /** First line of the user prompt that spawned the wave, or null when
+   *  no user message precedes the card (a workflow-only or partially
+   *  hydrated transcript). See {@link subagentWaveTitle} for the fallback. */
+  prompt: string | null;
+  subagents: SubagentView[];
+}
+
+/**
+ * Group a transcript's subagents by spawn wave, in transcript order.
+ *
+ * A wave's prompt is the nearest preceding `user_message` — user
+ * messages carry no `turn_id`, but the transcript is sequenced, so the
+ * last prompt before a card is the turn that spawned it. A subagent id
+ * reported by more than one card stays in the wave that first saw it and
+ * takes the latest view, mirroring the reducer's non-regressing merge.
+ * Empty cards are skipped.
+ */
+export function subagentWaves(messages: ChatViewItem[]): SubagentWave[] {
+  const waves: SubagentWave[] = [];
+  const home = new Map<string, SubagentView[]>();
+  let prompt: string | null = null;
+  for (const item of messages) {
+    if (item.kind === "user_message") {
+      const line = firstLine(item.text);
+      prompt = line.length > 0 ? line : null;
+      continue;
+    }
+    if (item.kind !== "subagent_run") continue;
+    const subagents: SubagentView[] = [];
+    for (const subagent of item.subagents) {
+      const existing = home.get(subagent.id);
+      if (existing) {
+        const idx = existing.findIndex((s) => s.id === subagent.id);
+        if (idx >= 0) existing[idx] = subagent;
+        continue;
+      }
+      subagents.push(subagent);
+      home.set(subagent.id, subagents);
+    }
+    if (subagents.length > 0) waves.push({ id: item.id, prompt, subagents });
+  }
+  return waves;
+}
+
+/** Wave header title: the spawning prompt, else "Ran N subagents". */
+export function subagentWaveTitle(wave: SubagentWave): string {
+  if (wave.prompt) return wave.prompt;
+  const n = wave.subagents.length;
+  return `Ran ${n} subagent${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * Whole-wave status for the header glyph. Precedence: a failure surfaces
+ * even when the wave is folded (failed > running > halted > completed),
+ * so a red header is never hidden behind a green one.
+ */
+export function subagentWaveStatus(
+  subagents: readonly SubagentView[],
+): SubagentViewStatus {
+  let status: SubagentViewStatus = "completed";
+  let rank = 0;
+  for (const subagent of subagents) {
+    const r =
+      subagent.status === "failed"
+        ? 3
+        : isRunning(subagent)
+          ? 2
+          : subagent.status === "stopped" || subagent.status === "interrupted"
+            ? 1
+            : 0;
+    if (r > rank) {
+      rank = r;
+      status = isRunning(subagent) ? "running" : subagent.status;
+    }
+  }
+  return status;
+}
+
+/**
+ * Ordinals for repeated names inside one wave ("Explore 1", "Explore 2").
+ * Unique names get null so a lone "Verify" is not suffixed with a
+ * pointless "1".
+ */
+export function subagentOrdinals(
+  subagents: readonly SubagentView[],
+): Map<string, number | null> {
+  const label = (s: SubagentView) => s.name ?? s.agentType ?? "Subagent";
+  const counts = new Map<string, number>();
+  for (const s of subagents) {
+    counts.set(label(s), (counts.get(label(s)) ?? 0) + 1);
+  }
+  const seen = new Map<string, number>();
+  const out = new Map<string, number | null>();
+  for (const s of subagents) {
+    const name = label(s);
+    if ((counts.get(name) ?? 0) < 2) {
+      out.set(s.id, null);
+      continue;
+    }
+    const next = (seen.get(name) ?? 0) + 1;
+    seen.set(name, next);
+    out.set(s.id, next);
+  }
+  return out;
+}


### PR DESCRIPTION
The Subagents pane listed every finished agent as one flat row, so the list grew linearly with each spawn and each row was a tombstone — name, a ragged model badge, a duration, and nothing about what the agent actually reported.

Rows now group by spawn wave (one `subagent_run` card each). A wave folds to a single header carrying the prompt that spawned it, a rollup line (agents · running · failed · stopped · Σ tokens — only what the app actually knows), and its longest duration. The latest wave and any wave still running stay open; older waves fold, and a failed wave keeps its red header even when folded. Each row is two lines: name (with an ordinal when a name repeats inside the wave), model, duration, then the first line of the agent's report or its live activity line. Clicking a row drills into the subagent thread. Wave titles come from the nearest preceding user message, falling back to "Ran N subagents".

The grouping lives in four pure helpers in `lib/agent-chat/subagents.ts` (`subagentWaves`, `subagentWaveTitle`, `subagentWaveStatus`, `subagentOrdinals`) with unit tests; the pane tests cover fold defaults, toggling, failure surfacing, ordinals, the model capsule, and drill-in.

Verified in the dev mock by streaming a second wave live (`__codemuxChatMock.streamSubagents`), watching it settle, unfolding the older wave, and drilling into a row.

### Before

![before](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/implement-canvas-6-design/before.png)

### After — one wave

![after, one wave](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/implement-canvas-6-design/after-one-wave.png)

### After — second wave streaming (older wave folded)

![after, two waves live](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/implement-canvas-6-design/after-two-waves-live.png)

### After — both waves settled

![after, two waves settled](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/implement-canvas-6-design/after-two-waves-settled.png)

### After — older wave unfolded, row drilled into the subagent thread

![after, unfolded and drilled in](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/implement-canvas-6-design/after-unfolded-drilldown.png)

Model: Claude Fable 5 · Harness: Claude Code (Codemux).
