### PR TITLE
feat(right-panel): drag-to-reorder, wheel scroll and icon-only overflow for pane tabs

### DIFF
--- a/src/components/layout/right-panel.tsx
+++ b/src/components/layout/right-panel.tsx
@@ -62,7 +62,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { OrchestrationPanel } from "@/components/workflow/orchestration-panel";
 import { useWorkspaceWorkflow } from "@/components/workflow/use-workspace-workflow";
-import { ChangesPanel, type ChangesSectionFilter } from "@/components/workspace/changes-panel";
+import {
+  ChangesPanel,
+  type ChangesSectionFilter,
+} from "@/components/workspace/changes-panel";
 import { FileTreePanel } from "@/components/workspace/file-tree-panel";
 import { ReviewPanel } from "@/components/workspace/review-panel";
 import { useActiveChatTasks } from "@/hooks/use-active-chat-tasks";
@@ -70,10 +73,7 @@ import { useTitlebarOverlay } from "@/hooks/use-gui-chrome";
 import { useResolvedKeybinds } from "@/hooks/use-resolved-keybinds";
 import { isMarkdownFile } from "@/components/editor/EditorPane";
 import type { ChatViewItem } from "@/lib/agent-chat/types";
-import {
-  isImageExtension,
-  isVideoExtension,
-} from "@/lib/editor-languages";
+import { isImageExtension, isVideoExtension } from "@/lib/editor-languages";
 import { maxRightPanelWidth } from "@/lib/right-panel-width";
 import { cn } from "@/lib/utils";
 import { useAgentChatStore } from "@/stores/agent-chat-store";
@@ -162,18 +162,21 @@ function ReviewTabBadge({
   workspaceId: string;
   prNumber: number | null;
 }) {
-  const checksData = useQuery<CheckInfo[]>({
-    queryKey: ["pr", "checks", workspaceId, prNumber] as const,
-    enabled: false,
-  }).data ?? [];
-  const reviewsData = useQuery<ReviewComment[]>({
-    queryKey: ["pr", "reviews", workspaceId, prNumber] as const,
-    enabled: false,
-  }).data ?? [];
-  const inlineData = useQuery<InlineReviewComment[]>({
-    queryKey: ["pr", "inline", workspaceId, prNumber] as const,
-    enabled: false,
-  }).data ?? [];
+  const checksData =
+    useQuery<CheckInfo[]>({
+      queryKey: ["pr", "checks", workspaceId, prNumber] as const,
+      enabled: false,
+    }).data ?? [];
+  const reviewsData =
+    useQuery<ReviewComment[]>({
+      queryKey: ["pr", "reviews", workspaceId, prNumber] as const,
+      enabled: false,
+    }).data ?? [];
+  const inlineData =
+    useQuery<InlineReviewComment[]>({
+      queryKey: ["pr", "inline", workspaceId, prNumber] as const,
+      enabled: false,
+    }).data ?? [];
 
   const commentCount =
     reviewsData.length + inlineData.filter((c) => !c.in_reply_to_id).length;
@@ -182,7 +185,9 @@ function ReviewTabBadge({
   return (
     <>
       {commentCount > 0 && (
-        <span className="font-mono text-[9.5px] tabular-nums">{commentCount}</span>
+        <span className="font-mono text-[9.5px] tabular-nums">
+          {commentCount}
+        </span>
       )}
       {status === "pending" && (
         <Loader2 className="size-3 animate-spin text-status-working" />
@@ -213,7 +218,10 @@ const CHANGES_FILTER_LABEL: Record<ChangesSectionFilter, string> = {
 // #127: memo is effective because setAppState performs structural sharing — the
 // `workspace` snapshot keeps a stable ref across backend ticks that don't change
 // it, and `activeTab` is a primitive, so shallow compare skips re-renders.
-export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Props) {
+export const RightPanel = memo(function RightPanel({
+  workspace,
+  activeTab,
+}: Props) {
   const workspaceId = workspace.workspace_id;
   const cwd = workspace.worktree_path ?? workspace.cwd;
 
@@ -221,12 +229,15 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
   const collapseRightPanel = useUIStore((s) => s.collapseRightPanel);
   const addRightPanelPane = useUIStore((s) => s.addRightPanelPane);
   const closeRightPanelPane = useUIStore((s) => s.closeRightPanelPane);
+  const reorderRightPanelPanes = useUIStore((s) => s.reorderRightPanelPanes);
   const setShowFileSearch = useUIStore((s) => s.setShowFileSearch);
   const setRightPanelWidth = useUIStore((s) => s.setRightPanelWidth);
   const rightPanelWidth = useUIStore((s) => s.rightPanelWidth);
   const rightPanelRowWidth = useUIStore((s) => s.rightPanelRowWidth);
   const storedPanes = useUIStore((s) => s.rightPanelPanes[workspaceId]);
-  const storedDismissed = useUIStore((s) => s.rightPanelDismissedPanes[workspaceId]);
+  const storedDismissed = useUIStore(
+    (s) => s.rightPanelDismissedPanes[workspaceId],
+  );
   const showHidden = useSyncedSettingsStore(selectShowHiddenFiles);
   const updateSetting = useSyncedSettingsStore((s) => s.updateSetting);
   const { getKeysForAction } = useResolvedKeybinds();
@@ -249,9 +260,13 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
     streaming: tasksThreadStreaming = false,
   } = useActiveChatTasks(workspace);
   const tasksSnapshot =
-    activeChatTasks && activeChatTasks.tasks.length > 0 ? activeChatTasks : null;
+    activeChatTasks && activeChatTasks.tasks.length > 0
+      ? activeChatTasks
+      : null;
   const messages = useAgentChatStore((s) =>
-    threadId ? (s.threads[threadId]?.messages ?? EMPTY_MESSAGES) : EMPTY_MESSAGES,
+    threadId
+      ? (s.threads[threadId]?.messages ?? EMPTY_MESSAGES)
+      : EMPTY_MESSAGES,
   );
   const contextUsage = useAgentChatStore((s) =>
     threadId ? (s.threads[threadId]?.contextUsage ?? null) : null,
@@ -265,7 +280,8 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
     workspaceWorkflow.run.status !== "pending_approval"
       ? workspaceWorkflow.run
       : null;
-  const workflowThreadId = workflowRun != null ? workspaceWorkflow.threadId : null;
+  const workflowThreadId =
+    workflowRun != null ? workspaceWorkflow.threadId : null;
 
   const subagentSummary = useMemo(() => {
     let groups = 0;
@@ -274,7 +290,8 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
       if (item.kind !== "subagent_run") continue;
       groups += 1;
       for (const view of item.subagents) {
-        if (view.status === "running" || view.status === "pending") running += 1;
+        if (view.status === "running" || view.status === "pending")
+          running += 1;
       }
     }
     return { groups, running };
@@ -382,7 +399,9 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
         // hosting it: surfaced to the backend, invisible to the user. So
         // re-check the deck now and hand the session back if it moved on.
         const ui = useUIStore.getState();
-        const stillOpen = ui.getRightPanelPanes(workspaceId).includes("browser");
+        const stillOpen = ui
+          .getRightPanelPanes(workspaceId)
+          .includes("browser");
         const panelUp = ui.getRightPanelTab(workspaceId) !== null;
         if (stillOpen && panelUp) return;
         // Mirror the intent that raced us: closing the tab is an explicit
@@ -402,7 +421,8 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
 
   // ── Per-pane view state ──
   const [docViews, setDocViews] = useState<Record<string, DocViewState>>({});
-  const [changesFilter, setChangesFilter] = useState<ChangesSectionFilter>("all");
+  const [changesFilter, setChangesFilter] =
+    useState<ChangesSectionFilter>("all");
   const [treeRefreshKey, setTreeRefreshKey] = useState(0);
   const [changesRefreshKey, setChangesRefreshKey] = useState(0);
   const [copiedDoc, setCopiedDoc] = useState(false);
@@ -502,7 +522,13 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
         remaining[Math.min(index, remaining.length - 1)] ?? RIGHT_PANEL_EMPTY,
       );
     },
-    [closeRightPanelPane, setRightPanelTab, workspaceId, activePane, visiblePanes],
+    [
+      closeRightPanelPane,
+      setRightPanelTab,
+      workspaceId,
+      activePane,
+      visiblePanes,
+    ],
   );
 
   const handleOpenTerminal = useCallback(() => {
@@ -525,7 +551,9 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
   // has been measured the toggle still works — it just falls back to the
   // stored width so the first click can't snap the panel to a bogus size.
   const panelMaxWidth =
-    rightPanelRowWidth > 0 ? maxRightPanelWidth(rightPanelRowWidth) : rightPanelWidth;
+    rightPanelRowWidth > 0
+      ? maxRightPanelWidth(rightPanelRowWidth)
+      : rightPanelWidth;
   const expanded = rightPanelWidth >= panelMaxWidth;
   const handleToggleExpand = useCallback(() => {
     const next = expanded ? PANEL_DEFAULT_WIDTH : Math.round(panelMaxWidth);
@@ -543,8 +571,10 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
   const handleCopyDoc = useCallback(() => {
     if (!activeDocPath) return;
     const content =
-      useEditorStore.getState().getTab(docEditorTabId(workspaceId, activeDocPath))
-        ?.baselineContent ?? "";
+      useEditorStore
+        .getState()
+        .getTab(docEditorTabId(workspaceId, activeDocPath))?.baselineContent ??
+      "";
     void navigator.clipboard
       ?.writeText(content)
       .then(() => {
@@ -573,7 +603,8 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
     switch (id) {
       case "changes":
         tab.testId = "changes-tab";
-        if (workspace.git_changed_files > 0) tab.badge = workspace.git_changed_files;
+        if (workspace.git_changed_files > 0)
+          tab.badge = workspace.git_changed_files;
         break;
       case "review":
         tab.testId = "review-tab";
@@ -589,7 +620,8 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
       case "tasks": {
         tab.testId = "tasks-tab";
         const done =
-          tasksSnapshot?.tasks.filter((t) => t.status === "completed").length ?? 0;
+          tasksSnapshot?.tasks.filter((t) => t.status === "completed").length ??
+          0;
         tab.badge = `${done}/${tasksSnapshot?.tasks.length ?? 0}`;
         tab.accentBadgeWhenActive = true;
         break;
@@ -752,7 +784,9 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
         actions = (
           <>
             <PaneActionButton
-              label={diffTab?.layout === "unified" ? "Split view" : "Unified view"}
+              label={
+                diffTab?.layout === "unified" ? "Split view" : "Unified view"
+              }
               icon={diffTab?.layout === "unified" ? Columns2 : AlignJustify}
               onClick={() =>
                 diffSetLayout(
@@ -780,7 +814,9 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
         ) : null;
         break;
       case "tasks":
-        actions = tasksSnapshot ? <TasksPaneActions snapshot={tasksSnapshot} /> : null;
+        actions = tasksSnapshot ? (
+          <TasksPaneActions snapshot={tasksSnapshot} />
+        ) : null;
         break;
     }
   }
@@ -805,7 +841,9 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
     },
     review: { prNumber: workspace.pr_number, state: workspace.pr_state },
     diff: {
-      filePath: diffTab?.filePath ? relativeToRoot(diffTab.filePath, cwd) : null,
+      filePath: diffTab?.filePath
+        ? relativeToRoot(diffTab.filePath, cwd)
+        : null,
     },
     browser: browserOpen
       ? {
@@ -824,6 +862,7 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
         activeTab={activePane}
         onSelect={(id) => setRightPanelTab(workspaceId, id)}
         onClose={handleClose}
+        onReorder={(ids) => reorderRightPanelPanes(workspaceId, ids)}
         actions={actions}
         surfaces={surfaces}
         onOpenFile={handleOpenFile}
@@ -887,7 +926,9 @@ export const RightPanel = memo(function RightPanel({ workspace, activeTab }: Pro
       <PaneStatusFoot
         status={statusLine}
         tokens={
-          contextUsage?.total_processed_tokens ?? contextUsage?.used_tokens ?? null
+          contextUsage?.total_processed_tokens ??
+          contextUsage?.used_tokens ??
+          null
         }
       />
     </div>

--- a/src/components/layout/right-panel/pane-tab-strip.test.tsx
+++ b/src/components/layout/right-panel/pane-tab-strip.test.tsx
@@ -268,4 +268,41 @@ describe("PaneTabStrip — overflow", () => {
       restore();
     }
   });
+
+  it("keeps the compact strip's scroll offset when another tab is activated", () => {
+    const restore = stubScrollerOverflow(800, 400);
+    try {
+      const { rerender } = renderStrip();
+      const scroller = screen.getByTestId("right-panel-tabs-scroll");
+      expect(scroller).toHaveAttribute("data-compact", "true");
+      // The user has panned to the right…
+      Object.defineProperty(scroller, "scrollLeft", {
+        value: 300,
+        writable: true,
+        configurable: true,
+      });
+      // …and activating a tab re-measures the strip (full layout, then
+      // compact again). That bounce must not throw the offset away.
+      rerender(
+        <PaneTabStrip
+          tabs={TABS}
+          activeTab="changes"
+          onSelect={() => {}}
+          onClose={() => {}}
+          onReorder={() => {}}
+          surfaces={[]}
+          onOpenFile={() => {}}
+          openFileKeys=""
+          inTitlebar
+          onToggleExpand={() => {}}
+          expanded={false}
+          onCollapsePanel={() => {}}
+        />,
+      );
+      expect(scroller).toHaveAttribute("data-compact", "true");
+      expect(scroller.scrollLeft).toBe(300);
+    } finally {
+      restore();
+    }
+  });
 });

--- a/src/components/layout/right-panel/pane-tab-strip.test.tsx
+++ b/src/components/layout/right-panel/pane-tab-strip.test.tsx
@@ -1,0 +1,271 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { FileText, FolderTree, GitBranch } from "lucide-react";
+
+import { PaneTabStrip, type DeckTab } from "./pane-tab-strip";
+
+const TABS: DeckTab[] = [
+  { id: "files", label: "Files", icon: FolderTree, testId: "files-tab" },
+  {
+    id: "changes",
+    label: "Changes",
+    icon: GitBranch,
+    testId: "changes-tab",
+    badge: 4,
+  },
+  {
+    id: "doc:/p/README.md",
+    label: "README.md",
+    icon: FileText,
+    testId: "doc-tab",
+  },
+];
+
+function renderStrip(
+  overrides: Partial<React.ComponentProps<typeof PaneTabStrip>> = {},
+) {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  const onReorder = vi.fn();
+  const utils = render(
+    <PaneTabStrip
+      tabs={TABS}
+      activeTab="files"
+      onSelect={onSelect}
+      onClose={onClose}
+      onReorder={onReorder}
+      surfaces={[]}
+      onOpenFile={() => {}}
+      openFileKeys=""
+      inTitlebar
+      onToggleExpand={() => {}}
+      expanded={false}
+      onCollapsePanel={() => {}}
+      {...overrides}
+    />,
+  );
+  const chip = (id: string) =>
+    utils.container.querySelector(
+      `[data-tab-id="${CSS.escape(id)}"]`,
+    ) as HTMLElement;
+  // Lay the three chips out left-to-right in 100px slots so the drop index
+  // has something to measure against.
+  TABS.forEach((tab, i) => stubRect(chip(tab.id), i * 100, 100));
+  return { ...utils, onSelect, onClose, onReorder, chip };
+}
+
+function stubRect(el: HTMLElement, left: number, width: number) {
+  Object.defineProperty(el, "getBoundingClientRect", {
+    value: () =>
+      ({
+        left,
+        right: left + width,
+        width,
+        top: 0,
+        bottom: 26,
+        height: 26,
+        x: left,
+        y: 0,
+        toJSON() {},
+      }) as DOMRect,
+    configurable: true,
+  });
+}
+
+/** jsdom has no layout; make the strip report an overflowing one. */
+function stubScrollerOverflow(scrollWidth: number, clientWidth: number) {
+  const isScroller = (el: HTMLElement) =>
+    el.dataset?.testid === "right-panel-tabs-scroll";
+  const proto = HTMLElement.prototype;
+  const original = {
+    scrollWidth: Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "scrollWidth",
+    )!,
+    clientWidth: Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "clientWidth",
+    )!,
+  };
+  Object.defineProperty(proto, "scrollWidth", {
+    configurable: true,
+    get() {
+      return isScroller(this) ? scrollWidth : 0;
+    },
+  });
+  Object.defineProperty(proto, "clientWidth", {
+    configurable: true,
+    get() {
+      return isScroller(this) ? clientWidth : 0;
+    },
+  });
+  return () => {
+    delete (proto as unknown as Record<string, unknown>).scrollWidth;
+    delete (proto as unknown as Record<string, unknown>).clientWidth;
+    Object.defineProperty(
+      Element.prototype,
+      "scrollWidth",
+      original.scrollWidth,
+    );
+    Object.defineProperty(
+      Element.prototype,
+      "clientWidth",
+      original.clientWidth,
+    );
+  };
+}
+
+afterEach(cleanup);
+
+describe("PaneTabStrip — drag-to-reorder", () => {
+  it("selects on a plain click and never reorders", () => {
+    const { chip, onSelect, onReorder } = renderStrip();
+    fireEvent.pointerDown(chip("changes"), {
+      pointerId: 1,
+      button: 0,
+      clientX: 150,
+      clientY: 14,
+    });
+    fireEvent.pointerUp(document, {
+      pointerId: 1,
+      button: 0,
+      clientX: 150,
+      clientY: 14,
+    });
+    fireEvent.click(screen.getByText("Changes"));
+    expect(onSelect).toHaveBeenCalledWith("changes");
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("reports the new order once the drag threshold is crossed and dropped", () => {
+    const { chip, onReorder } = renderStrip();
+    fireEvent.pointerDown(chip("files"), {
+      pointerId: 1,
+      button: 0,
+      clientX: 50,
+      clientY: 14,
+    });
+    // Past the 5px threshold and past the last chip's midpoint (250), so
+    // the tab lands at the end of the strip.
+    fireEvent.pointerMove(document, {
+      pointerId: 1,
+      clientX: 260,
+      clientY: 14,
+    });
+    expect(screen.getByTestId("tab-drop-indicator")).toBeInTheDocument();
+    fireEvent.pointerUp(document, { pointerId: 1, clientX: 260, clientY: 14 });
+    expect(onReorder).toHaveBeenCalledWith([
+      "changes",
+      "doc:/p/README.md",
+      "files",
+    ]);
+  });
+
+  it("swallows the click a real drag leaves behind", () => {
+    const { chip, onSelect } = renderStrip();
+    fireEvent.pointerDown(chip("changes"), {
+      pointerId: 1,
+      button: 0,
+      clientX: 150,
+      clientY: 14,
+    });
+    fireEvent.pointerMove(document, {
+      pointerId: 1,
+      clientX: 260,
+      clientY: 14,
+    });
+    fireEvent.pointerUp(document, { pointerId: 1, clientX: 260, clientY: 14 });
+    fireEvent.click(screen.getByText("Changes"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("never starts a drag from the close button, which still closes", () => {
+    const { onClose, onReorder } = renderStrip();
+    const close = screen.getByLabelText("Close Files");
+    fireEvent.pointerDown(close, {
+      pointerId: 1,
+      button: 0,
+      clientX: 90,
+      clientY: 14,
+    });
+    fireEvent.pointerMove(document, {
+      pointerId: 1,
+      clientX: 260,
+      clientY: 14,
+    });
+    fireEvent.pointerUp(document, { pointerId: 1, clientX: 260, clientY: 14 });
+    fireEvent.click(close);
+    expect(onReorder).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledWith("files");
+  });
+
+  it("closes on middle-click", () => {
+    const { chip, onClose } = renderStrip();
+    chip("changes").dispatchEvent(
+      new MouseEvent("auxclick", {
+        button: 1,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(onClose).toHaveBeenCalledWith("changes");
+  });
+});
+
+describe("PaneTabStrip — overflow", () => {
+  it("pans with a vertical wheel once the tabs overflow", () => {
+    renderStrip();
+    const scroller = screen.getByTestId("right-panel-tabs-scroll");
+    Object.defineProperty(scroller, "scrollWidth", {
+      value: 800,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "clientWidth", {
+      value: 400,
+      configurable: true,
+    });
+    Object.defineProperty(scroller, "scrollLeft", {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+    fireEvent.wheel(scroller, { deltaY: 120 });
+    expect(scroller.scrollLeft).toBe(120);
+  });
+
+  it("keeps every label while the row fits", () => {
+    renderStrip();
+    expect(screen.getByText("Files")).toBeInTheDocument();
+    expect(screen.getByText("Changes")).toBeInTheDocument();
+    expect(screen.getByText("README.md")).toBeInTheDocument();
+    expect(screen.getByTestId("right-panel-tabs-scroll")).not.toHaveAttribute(
+      "data-compact",
+    );
+  });
+
+  it("collapses inactive tabs to icon + badge once the full row overflows", () => {
+    const restore = stubScrollerOverflow(800, 400);
+    try {
+      renderStrip();
+      const scroller = screen.getByTestId("right-panel-tabs-scroll");
+      expect(scroller).toHaveAttribute("data-compact", "true");
+      // The active tab keeps its label and its close button…
+      expect(screen.getByText("Files")).toBeInTheDocument();
+      expect(screen.getByLabelText("Close Files")).toBeInTheDocument();
+      // …the others drop to icon + badge, with the name on the button and
+      // no overlaid close affordance to mis-hit.
+      expect(screen.queryByText("Changes")).toBeNull();
+      expect(screen.getByLabelText("Changes")).toBeInTheDocument();
+      expect(screen.getByText("4")).toBeInTheDocument();
+      expect(screen.queryByLabelText("Close Changes")).toBeNull();
+      // Content is clipped on the right, so that edge fades.
+      expect(scroller.style.maskImage).toMatch(/transparent\)$/);
+      expect(scroller.style.maskImage).toMatch(
+        /^linear-gradient\(to right, black,/,
+      );
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/components/layout/right-panel/pane-tab-strip.tsx
+++ b/src/components/layout/right-panel/pane-tab-strip.tsx
@@ -24,8 +24,27 @@
  * Live activity is carried by the badge itself (a mono count, accent-tinted
  * while its pane is active) — nothing in the strip blinks; app-wide
  * "working" is an orb.
+ *
+ * **Overflow.** The deck grows: every file opened from the tree is another
+ * tab, and a busy thread adds tasks, orchestration and subagents on top of
+ * the three defaults. Rather than ellipsize every inactive label down to
+ * an identical unreadable stub the moment the row gets tight, the strip
+ * switches modes: once the full-label row would overflow, inactive tabs
+ * collapse to icon + badge (the pinned-tab convention — the label lives in
+ * the tooltip) and the active tab alone keeps its label. Whatever still
+ * doesn't fit scrolls, with a soft fade on the clipped edge so the
+ * overflow is visible without a scrollbar, and a plain vertical wheel pans
+ * it. Tabs reorder by drag, same gesture as the titlebar tabs.
  */
-import { memo, useEffect, useRef, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import {
   ChevronsLeftRight,
   PanelRight,
@@ -45,10 +64,13 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useTabReorder, type PillReorderHandlers } from "@/lib/tab-reorder";
 import { topRightReserve } from "@/lib/titlebar-geometry";
 import { cn } from "@/lib/utils";
+import { useHorizontalWheelScroll } from "@/lib/wheel";
 import type { RightPanelTab } from "@/stores/ui-store";
 
+import { TabDropIndicator } from "../tab-drop-indicator";
 import { PaneActionButton } from "./pane-actions";
 import { PANE_REGISTRY, type PaneMeta } from "./pane-registry";
 import type { SurfaceAction } from "./surface-actions";
@@ -67,15 +89,23 @@ export interface DeckTab {
 function DeckTabChip({
   tab,
   active,
+  compact,
+  dragging,
   inTitlebar,
+  reorderProps,
   onSelect,
   onClose,
 }: {
   tab: DeckTab;
   active: boolean;
+  /** Icon-only: the strip has overflowed and this (inactive) tab gave up
+   *  its label. See the file header. */
+  compact: boolean;
+  dragging: boolean;
   /** Which surface the row is painted on, so the close affordance's mask
    *  can match it — see its `bg-*` below. */
   inTitlebar: boolean;
+  reorderProps: PillReorderHandlers;
   onSelect: () => void;
   onClose: () => void;
 }) {
@@ -90,82 +120,193 @@ function DeckTabChip({
     ref.current?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
   }, [active]);
 
+  const badge = tab.badge != null && (
+    <span
+      className={cn(
+        "font-mono text-[9.5px] tabular-nums",
+        active && tab.accentBadgeWhenActive
+          ? "text-accent-ember"
+          : "text-foreground/38",
+      )}
+    >
+      {tab.badge}
+    </span>
+  );
+
   return (
     <div
       ref={ref}
+      {...reorderProps}
       data-testid={tab.testId}
       data-state={active ? "active" : "inactive"}
+      data-compact={compact ? "true" : undefined}
+      // Middle-click closes, as in every browser and editor tab strip —
+      // and it is the only close gesture a compact tab has, since an X
+      // overlaid on a 28px chip would be the thing you hit when aiming for
+      // the tab.
+      onAuxClick={(event) => {
+        if (event.button !== 1) return;
+        event.preventDefault();
+        onClose();
+      }}
       className={cn(
         // No border, no shadow, no ring — the fill is the whole signal.
-        "group/tab relative flex h-[26px] items-center rounded-[7px]",
+        "group/tab relative flex h-[26px] shrink-0 items-center rounded-[7px]",
         "transition-colors duration-[120ms]",
-        // The panel starts near 320px and the pane actions now share this
-        // row, so a deck of four or five tabs has to give somewhere at its
-        // narrow end. The pane you're *looking at* keeps its whole label;
-        // the others ellipsize down to a stub, floored where the icon and
-        // badge still read. Past that the row scrolls, and the effect above
-        // keeps the active tab inside the scrolled window.
         active
-          ? "shrink-0 bg-foreground/7 font-semibold text-foreground"
-          : "min-w-[58px] font-medium text-foreground/42 hover:bg-foreground/5 hover:text-foreground/70",
+          ? "bg-foreground/7 font-semibold text-foreground"
+          : "font-medium text-foreground/42 hover:bg-foreground/5 hover:text-foreground/70",
+        dragging && "opacity-40",
       )}
     >
       <button
         type="button"
         onClick={onSelect}
         aria-pressed={active}
-        // Truncated labels stay readable on hover rather than earning a
-        // second row to spell themselves out in.
+        aria-label={compact ? tab.label : undefined}
+        // Compact tabs spell their name out on hover rather than earning a
+        // second row to do it in.
         title={tab.label}
         className={cn(
-          "flex h-full min-w-0 items-center gap-[7px] pl-[9px] text-[12px] whitespace-nowrap",
-          // Room for the close affordance only where it is actually shown;
-          // an always-reserved slot per tab costs a whole label at this
-          // width.
-          active ? "pr-[20px]" : "pr-[9px]",
-        )}
-      >
-        <Icon className="size-[13px] shrink-0" strokeWidth={1.6} />
-        <span className="truncate">{tab.label}</span>
-        {tab.badge != null && (
-          <span
-            className={cn(
-              "font-mono text-[9.5px] tabular-nums",
-              active && tab.accentBadgeWhenActive
-                ? "text-accent-ember"
-                : "text-foreground/38",
-            )}
-          >
-            {tab.badge}
-          </span>
-        )}
-      </button>
-      <button
-        type="button"
-        aria-label={`Close ${tab.label}`}
-        onClick={(event) => {
-          event.stopPropagation();
-          onClose();
-        }}
-        className={cn(
-          // Overlays the tab's right edge rather than taking a layout slot,
-          // so revealing it on hover doesn't shove the row around.
-          "absolute right-[3px] top-1/2 flex size-[15px] -translate-y-1/2 items-center justify-center rounded-[4px] transition-opacity",
-          "hover:bg-foreground/15 focus-visible:opacity-100",
-          active
-            ? "opacity-50 hover:opacity-100"
-            : // Opaque on purpose: it masks the truncated label it sits on
-              // top of, so it has to match whatever the row is painted on.
-              cn(
-                "opacity-0 group-hover/tab:opacity-70",
-                inTitlebar ? "bg-background" : "bg-card",
+          "flex h-full min-w-0 items-center whitespace-nowrap text-[12px]",
+          compact
+            ? "gap-[5px] px-[8px]"
+            : cn(
+                "gap-[7px] pl-[9px]",
+                // Room for the close affordance only where it is actually
+                // shown; an always-reserved slot per tab costs a whole
+                // label at this width.
+                active ? "pr-[20px]" : "pr-[9px]",
               ),
         )}
       >
-        <X className="size-[10px]" strokeWidth={1.8} />
+        <Icon className="size-[13px] shrink-0" strokeWidth={1.6} />
+        {!compact && <span className="truncate">{tab.label}</span>}
+        {badge}
       </button>
+      {!compact && (
+        <button
+          type="button"
+          data-no-drag
+          aria-label={`Close ${tab.label}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onClose();
+          }}
+          className={cn(
+            // Overlays the tab's right edge rather than taking a layout
+            // slot, so revealing it on hover doesn't shove the row around.
+            "absolute right-[3px] top-1/2 flex size-[15px] -translate-y-1/2 items-center justify-center rounded-[4px] transition-opacity",
+            "hover:bg-foreground/15 focus-visible:opacity-100",
+            active
+              ? "opacity-50 hover:opacity-100"
+              : // Opaque on purpose: it masks the label it sits on top of,
+                // so it has to match whatever the row is painted on.
+                cn(
+                  "opacity-0 group-hover/tab:opacity-70",
+                  inTitlebar ? "bg-background" : "bg-card",
+                ),
+          )}
+        >
+          <X className="size-[10px]" strokeWidth={1.8} />
+        </button>
+      )}
     </div>
   );
+}
+
+/** Width of the edge fade that marks clipped tabs. */
+const EDGE_FADE_PX = 16;
+/** The drag gap's `min-w-4`: the part of it that can never be lent back to
+ *  the tabs. */
+const DRAG_GAP_MIN_PX = 16;
+
+/**
+ * Decides between the full-label and the icon-only strip, and tracks which
+ * edges have tabs hidden behind them.
+ *
+ * The two layouts have different widths, so "does it overflow?" cannot be
+ * asked of the compact strip about the full one: the answer would flip
+ * every frame. Instead the full strip's width is measured once whenever it
+ * is laid out (`naturalWidth`), and the compact strip only lets go once
+ * the room available — its own width plus whatever the drag gap next to it
+ * could give back — covers that. Every change to the tab set (or to which
+ * tab is active, since only that one keeps its label) re-runs the full
+ * layout under `useLayoutEffect`, so the expanded frame is measured but
+ * never painted.
+ */
+function useDeckOverflow(
+  scrollerRef: React.RefObject<HTMLDivElement | null>,
+  gapRef: React.RefObject<HTMLDivElement | null>,
+  layoutKey: string,
+) {
+  const [compact, setCompact] = useState(false);
+  const [edges, setEdges] = useState({ start: false, end: false });
+  const naturalWidthRef = useRef(0);
+
+  const measureEdges = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const start = el.scrollLeft > 1;
+    const end = el.scrollWidth - el.clientWidth - el.scrollLeft > 1;
+    setEdges((prev) =>
+      prev.start === start && prev.end === end ? prev : { start, end },
+    );
+  }, [scrollerRef]);
+
+  // A new tab set is measured from the full layout.
+  useLayoutEffect(() => {
+    setCompact(false);
+  }, [layoutKey]);
+
+  useLayoutEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    if (!compact) {
+      naturalWidthRef.current = el.scrollWidth;
+      if (el.scrollWidth > el.clientWidth + 1) {
+        setCompact(true);
+        return;
+      }
+    }
+    measureEdges();
+  }, [compact, layoutKey, measureEdges, scrollerRef]);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const onResize = () => {
+      const gap = gapRef.current;
+      const available =
+        el.clientWidth + Math.max(0, (gap?.clientWidth ?? 0) - DRAG_GAP_MIN_PX);
+      if (compact && available >= naturalWidthRef.current) setCompact(false);
+      else if (!compact && el.scrollWidth > el.clientWidth + 1)
+        setCompact(true);
+      measureEdges();
+    };
+    el.addEventListener("scroll", measureEdges, { passive: true });
+    let observer: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(onResize);
+      observer.observe(el);
+      if (gapRef.current) observer.observe(gapRef.current);
+    }
+    return () => {
+      el.removeEventListener("scroll", measureEdges);
+      observer?.disconnect();
+    };
+  }, [compact, gapRef, measureEdges, scrollerRef]);
+
+  return { compact, edges };
+}
+
+function edgeMask(edges: { start: boolean; end: boolean }): string | undefined {
+  if (!edges.start && !edges.end) return undefined;
+  const from = edges.start ? `transparent, black ${EDGE_FADE_PX}px` : "black";
+  const to = edges.end
+    ? `black calc(100% - ${EDGE_FADE_PX}px), transparent`
+    : "black";
+  return `linear-gradient(to right, ${from}, ${to})`;
 }
 
 export interface PaneTabStripProps {
@@ -173,6 +314,8 @@ export interface PaneTabStripProps {
   activeTab: RightPanelTab | null;
   onSelect: (id: RightPanelTab) => void;
   onClose: (id: RightPanelTab) => void;
+  /** Drag-to-reorder landed: the strip's full new order. */
+  onReorder: (ids: RightPanelTab[]) => void;
   /**
    * The active pane's own controls, rendered in this row's right-hand slot
    * and swapped in place when the active tab changes. Built by
@@ -208,6 +351,7 @@ export const PaneTabStrip = memo(function PaneTabStrip({
   activeTab,
   onSelect,
   onClose,
+  onReorder,
   actions,
   surfaces,
   onOpenFile,
@@ -219,6 +363,45 @@ export const PaneTabStrip = memo(function PaneTabStrip({
   className,
 }: PaneTabStripProps) {
   const remoteClient = isRemoteClient();
+
+  const tabIds = tabs.map((tab) => tab.id);
+  const { containerRef, dragTabId, dropIndicatorLeft, getPillProps } =
+    useTabReorder<HTMLDivElement>(tabIds, onReorder as (ids: string[]) => void);
+
+  // A plain vertical wheel pans the strip once it overflows — `overflow-x:
+  // auto` only answers to native horizontal input on its own. See
+  // `@/lib/wheel`. The scroller is also the reorder hook's measurement
+  // container and the overflow hook's, so all three share one ref.
+  const attachWheelScroll = useHorizontalWheelScroll<HTMLDivElement>();
+  const setScrollerNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      containerRef.current = node;
+      attachWheelScroll(node);
+    },
+    [attachWheelScroll, containerRef],
+  );
+  const gapRef = useRef<HTMLDivElement>(null);
+  const { compact, edges } = useDeckOverflow(
+    containerRef,
+    gapRef,
+    `${tabIds.join("|")}#${activeTab ?? ""}`,
+  );
+  const mask = edgeMask(edges);
+
+  // The active chip scrolls itself into view, but that runs against the
+  // full-label layout the strip measures and discards (passive effects
+  // flush before the collapse re-render), which leaves the compact strip
+  // sitting on a stale offset with its first icon under the fade. Re-seat
+  // from zero once the layout has settled.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.scrollLeft = 0;
+    el.querySelector<HTMLElement>(
+      '[data-tab-id][data-state="active"]',
+    )?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+  }, [compact, containerRef]);
+
   return (
     <div
       data-testid="right-panel-tabs-header"
@@ -256,13 +439,25 @@ export const PaneTabStrip = memo(function PaneTabStrip({
           any panel width. */}
       {/* `no-scrollbar` is referenced elsewhere in the tree but never
           defined, so the hiding is spelled out here rather than trusted. */}
-      <div className="flex min-w-0 items-center gap-[2px] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div
+        ref={setScrollerNode}
+        data-testid="right-panel-tabs-scroll"
+        data-compact={compact ? "true" : undefined}
+        className="relative flex min-w-0 items-center gap-[2px] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={mask ? { maskImage: mask, WebkitMaskImage: mask } : undefined}
+      >
+        {dragTabId && dropIndicatorLeft !== null && (
+          <TabDropIndicator left={dropIndicatorLeft} />
+        )}
         {tabs.map((tab) => (
           <DeckTabChip
             key={tab.id}
             tab={tab}
             active={tab.id === activeTab}
+            compact={compact && tab.id !== activeTab}
+            dragging={dragTabId === tab.id}
             inTitlebar={inTitlebar}
+            reorderProps={getPillProps(tab.id)}
             onSelect={() => onSelect(tab.id)}
             onClose={() => onClose(tab.id)}
           />
@@ -324,6 +519,7 @@ export const PaneTabStrip = memo(function PaneTabStrip({
           only: `data-tauri-drag-region` does nothing in a browser, and the
           bare spacer has no children to shadow. */}
       <div
+        ref={gapRef}
         data-testid="right-panel-drag-gap"
         data-tauri-drag-region={inTitlebar && !remoteClient ? true : undefined}
         className="min-w-4 flex-1 self-stretch"

--- a/src/components/layout/right-panel/pane-tab-strip.tsx
+++ b/src/components/layout/right-panel/pane-tab-strip.tsx
@@ -143,7 +143,12 @@ function DeckTabChip({
       // Middle-click closes, as in every browser and editor tab strip —
       // and it is the only close gesture a compact tab has, since an X
       // overlaid on a 28px chip would be the thing you hit when aiming for
-      // the tab.
+      // the tab. The mousedown is cancelled too: on an overflowing strip
+      // a middle button-press would otherwise also engage the webview's
+      // autoscroll on its way to the close.
+      onMouseDown={(event) => {
+        if (event.button === 1) event.preventDefault();
+      }}
       onAuxClick={(event) => {
         if (event.button !== 1) return;
         event.preventDefault();
@@ -381,22 +386,29 @@ export const PaneTabStrip = memo(function PaneTabStrip({
     [attachWheelScroll, containerRef],
   );
   const gapRef = useRef<HTMLDivElement>(null);
-  const { compact, edges } = useDeckOverflow(
-    containerRef,
-    gapRef,
-    `${tabIds.join("|")}#${activeTab ?? ""}`,
-  );
+  const layoutKey = `${tabIds.join("|")}#${activeTab ?? ""}`;
+  // Where the strip was scrolled when its tab set (or active tab) last
+  // changed — read before the overflow hook below swaps in the full-label
+  // layout to measure it, so the offset is the one the user actually set.
+  const settledScrollLeftRef = useRef(0);
+  useLayoutEffect(() => {
+    settledScrollLeftRef.current = containerRef.current?.scrollLeft ?? 0;
+  }, [layoutKey, containerRef]);
+  const { compact, edges } = useDeckOverflow(containerRef, gapRef, layoutKey);
   const mask = edgeMask(edges);
 
   // The active chip scrolls itself into view, but that runs against the
   // full-label layout the strip measures and discards (passive effects
   // flush before the collapse re-render), which leaves the compact strip
-  // sitting on a stale offset with its first icon under the fade. Re-seat
-  // from zero once the layout has settled.
+  // sitting on a stale offset with its first icon under the fade. Once the
+  // layout has settled, put back the offset captured above — so a strip
+  // the user had panned stays where it was after activating a tab — and
+  // then nudge the active chip into view if it is still clipped. On the
+  // first collapse that offset is zero, so the strip re-seats from the start.
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    el.scrollLeft = 0;
+    el.scrollLeft = settledScrollLeftRef.current;
     el.querySelector<HTMLElement>(
       '[data-tab-id][data-state="active"]',
     )?.scrollIntoView?.({ block: "nearest", inline: "nearest" });

--- a/src/components/layout/tab-drop-indicator.tsx
+++ b/src/components/layout/tab-drop-indicator.tsx
@@ -1,0 +1,19 @@
+/**
+ * The drop cue for a tab strip mid-drag: a vertical mirror of the sidebar's
+ * leading-dot + thin neutral line. No accent color, so it reads as a UI
+ * cue rather than an alert. Positioned in the strip's content coordinate
+ * space (see `useTabReorder`'s `dropIndicatorLeft`), so the host strip must
+ * be `relative`.
+ */
+export function TabDropIndicator({ left }: { left: number }) {
+  return (
+    <div
+      className="pointer-events-none absolute inset-y-0.5 z-30 flex flex-col items-center"
+      style={{ left: left - 1, width: 2 }}
+      data-testid="tab-drop-indicator"
+    >
+      <div className="-mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/70" />
+      <div className="w-px flex-1 rounded-full bg-foreground/40" />
+    </div>
+  );
+}

--- a/src/components/layout/title-bar-tabs.tsx
+++ b/src/components/layout/title-bar-tabs.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   ChevronDown,
   FileCode,
@@ -27,6 +27,7 @@ import {
 } from "@/components/layout/titlebar-control-style";
 import { getHighestPriorityStatus } from "@/lib/pane-status";
 import { cn } from "@/lib/utils";
+import { useTabReorder, type PillReorderHandlers } from "@/lib/tab-reorder";
 import { useHorizontalWheelScroll } from "@/lib/wheel";
 import { useAppStore } from "@/stores/app-store";
 import { activateTab, closeTab, reorderTabs } from "@/tauri/commands";
@@ -38,6 +39,8 @@ import type {
   TabSnapshot,
   WorkspaceSnapshot,
 } from "@/tauri/types";
+
+import { TabDropIndicator } from "./tab-drop-indicator";
 
 type AgentChatPaneNode = Extract<PaneNodeSnapshot, { kind: "agent_chat" }>;
 
@@ -83,214 +86,6 @@ interface TitleBarTabsProps {
   workspace: WorkspaceSnapshot;
 }
 
-// Movement (px) before a pointerdown on a pill turns into a reorder drag
-// instead of resolving as a plain click. Small enough to feel immediate,
-// large enough that a normal click/tap never misfires as a drag.
-const DRAG_THRESHOLD = 5;
-
-interface PillReorderHandlers {
-  "data-tab-id": string;
-  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
-  onClickCapture: (e: React.MouseEvent<HTMLDivElement>) => void;
-}
-
-/**
- * Pointer-based drag-to-reorder for the titlebar tab strip. HTML5 DnD (what
- * the legacy `TabBar` uses) is avoided on purpose: the titlebar's center is
- * a live `data-tauri-drag-region`, and stacking native HTML5 drag — which
- * Tauri/WebKit's own drag-region handling already interposes on — on top of
- * that is exactly the "not clean" combination the GUI-chrome doc flagged as
- * a follow-up. Pointer events don't interact with the OS drag region at all
- * and give full control over when a "drag" actually starts.
- *
- * Listeners for pointermove/up/cancel are attached to `document` (not the
- * pill itself) for the lifetime of one pointer session, so fast pointer
- * movement that outruns the small pill's bounds — which would otherwise
- * stop delivering events to a per-element listener — still gets tracked.
- * `setPointerCapture` isn't used: capturing on the pointerdown target would
- * retarget the browser's synthesized `click` to that same target too,
- * which would break the inner activate/close buttons ever receiving a
- * plain click.
- */
-function useTabReorder(workspace: WorkspaceSnapshot) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [dragTabId, setDragTabId] = useState<string | null>(null);
-  const [dropIndex, setDropIndexState] = useState<number | null>(null);
-
-  // Refs mirror state the pointer listeners need to read/write without
-  // forcing a hook re-subscription (workspace) or a render on every write
-  // that doesn't need one.
-  const dropIndexRef = useRef<number | null>(null);
-  const workspaceRef = useRef(workspace);
-  workspaceRef.current = workspace;
-
-  const pendingTabIdRef = useRef<string | null>(null);
-  const pointerIdRef = useRef<number | null>(null);
-  const startPosRef = useRef({ x: 0, y: 0 });
-  const draggingRef = useRef(false);
-  const suppressClickRef = useRef(false);
-  const cleanupRef = useRef<(() => void) | null>(null);
-
-  const setDropIndex = useCallback((v: number | null) => {
-    dropIndexRef.current = v;
-    setDropIndexState(v);
-  }, []);
-
-  const computeDropIndex = useCallback(
-    (clientX: number) => {
-      const el = containerRef.current;
-      if (!el) return;
-      const tabEls = el.querySelectorAll<HTMLElement>("[data-tab-id]");
-      if (tabEls.length === 0) return;
-
-      let closestIdx = 0;
-      let closestDist = Infinity;
-      let insertBefore = true;
-      tabEls.forEach((tabEl, i) => {
-        const rect = tabEl.getBoundingClientRect();
-        const midX = rect.left + rect.width / 2;
-        const dist = Math.abs(clientX - midX);
-        if (dist < closestDist) {
-          closestDist = dist;
-          closestIdx = i;
-          insertBefore = clientX < midX;
-        }
-      });
-      setDropIndex(insertBefore ? closestIdx : closestIdx + 1);
-    },
-    [setDropIndex],
-  );
-
-  const endSession = useCallback(
-    (commit: boolean) => {
-      cleanupRef.current?.();
-      cleanupRef.current = null;
-
-      const tabId = pendingTabIdRef.current;
-      const wasDragging = draggingRef.current;
-      const finalDropIndex = dropIndexRef.current;
-
-      pendingTabIdRef.current = null;
-      pointerIdRef.current = null;
-      draggingRef.current = false;
-      setDragTabId(null);
-      setDropIndex(null);
-
-      if (commit && wasDragging && tabId != null && finalDropIndex != null) {
-        const ws = workspaceRef.current;
-        const currentIds = ws.tabs.map((t) => t.tab_id);
-        const dragIdx = currentIds.indexOf(tabId);
-        if (dragIdx >= 0) {
-          const newIds = [...currentIds];
-          newIds.splice(dragIdx, 1);
-          const insertAt =
-            finalDropIndex > dragIdx ? finalDropIndex - 1 : finalDropIndex;
-          newIds.splice(Math.min(insertAt, newIds.length), 0, tabId);
-          if (newIds.join(",") !== currentIds.join(",")) {
-            reorderTabs(ws.workspace_id, newIds).catch(console.error);
-          }
-        }
-      }
-    },
-    [setDropIndex],
-  );
-
-  const handlePointerDown = useCallback(
-    (tabId: string) => (e: React.PointerEvent<HTMLDivElement>) => {
-      // Only the primary button/contact starts a reorder session, never one
-      // already in flight, and never from a close/chevron control
-      // explicitly opted out via `data-no-drag` — those need their plain
-      // click behavior preserved untouched.
-      if (e.button !== 0) return;
-      if ((e.target as HTMLElement).closest("[data-no-drag]")) return;
-      if (pendingTabIdRef.current != null) return;
-
-      pendingTabIdRef.current = tabId;
-      pointerIdRef.current = e.pointerId;
-      startPosRef.current = { x: e.clientX, y: e.clientY };
-      draggingRef.current = false;
-
-      const handleMove = (ev: PointerEvent) => {
-        if (ev.pointerId !== pointerIdRef.current) return;
-        const dx = ev.clientX - startPosRef.current.x;
-        const dy = ev.clientY - startPosRef.current.y;
-        if (!draggingRef.current) {
-          if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
-          draggingRef.current = true;
-          setDragTabId(pendingTabIdRef.current);
-        }
-        ev.preventDefault();
-        computeDropIndex(ev.clientX);
-      };
-
-      const handleUp = (ev: PointerEvent) => {
-        if (ev.pointerId !== pointerIdRef.current) return;
-        if (draggingRef.current) suppressClickRef.current = true;
-        endSession(true);
-      };
-
-      const handleCancel = (ev: PointerEvent) => {
-        if (ev.pointerId !== pointerIdRef.current) return;
-        endSession(false);
-      };
-
-      document.addEventListener("pointermove", handleMove);
-      document.addEventListener("pointerup", handleUp);
-      document.addEventListener("pointercancel", handleCancel);
-      cleanupRef.current = () => {
-        document.removeEventListener("pointermove", handleMove);
-        document.removeEventListener("pointerup", handleUp);
-        document.removeEventListener("pointercancel", handleCancel);
-      };
-    },
-    [computeDropIndex, endSession],
-  );
-
-  // Belt-and-suspenders: drop any live document listeners if the strip
-  // unmounts mid-drag (e.g. workspace switch).
-  useEffect(() => () => cleanupRef.current?.(), []);
-
-  const getPillProps = useCallback(
-    (tabId: string): PillReorderHandlers => ({
-      "data-tab-id": tabId,
-      onPointerDown: handlePointerDown(tabId),
-      onClickCapture: (e: React.MouseEvent<HTMLDivElement>) => {
-        // Swallow the click synthesized after a real drag so it doesn't
-        // activate the tab (or, for the active chat tab, pop the history
-        // dropdown) as a side effect of the reorder gesture.
-        if (suppressClickRef.current) {
-          e.preventDefault();
-          e.stopPropagation();
-          suppressClickRef.current = false;
-        }
-      },
-    }),
-    [handlePointerDown],
-  );
-
-  // Drop-indicator screen position — a vertical mirror of TabBar's
-  // leading-dot + thin line. Converted into the strip's scrolled content
-  // coordinate space (`+ scrollLeft`) since the strip scrolls
-  // horizontally, unlike TabBar's non-scrolling list.
-  let dropIndicatorLeft: number | null = null;
-  if (dragTabId && dropIndex !== null && containerRef.current) {
-    const el = containerRef.current;
-    const tabEls = el.querySelectorAll<HTMLElement>("[data-tab-id]");
-    const listRect = el.getBoundingClientRect();
-    if (tabEls.length > 0) {
-      if (dropIndex >= tabEls.length) {
-        const lastRect = tabEls[tabEls.length - 1].getBoundingClientRect();
-        dropIndicatorLeft = lastRect.right - listRect.left + el.scrollLeft;
-      } else {
-        const targetRect = tabEls[dropIndex].getBoundingClientRect();
-        dropIndicatorLeft = targetRect.left - listRect.left + el.scrollLeft;
-      }
-    }
-  }
-
-  return { containerRef, dragTabId, dropIndicatorLeft, getPillProps };
-}
-
 /**
  * Workspace tabs merged into the title bar for GUI chrome. Each tab is a
  * compact pill; the active chat tab grows a chevron that opens the shared
@@ -298,7 +93,7 @@ function useTabReorder(workspace: WorkspaceSnapshot) {
  * inline pill here — it lives in the docked `SubagentActivityBar` above
  * the composer. Tabs stay backend-owned — activation/close/reorder go through
  * the existing commands. Reorder is a pointer-driven drag (see
- * `useTabReorder` below) rather than the legacy TabBar's HTML5 DnD.
+ * `@/lib/tab-reorder`) rather than the legacy TabBar's HTML5 DnD.
  */
 export function TitleBarTabs({ workspace }: TitleBarTabsProps) {
   const paneStatuses = useAppStore(
@@ -314,13 +109,25 @@ export function TitleBarTabs({ workspace }: TitleBarTabsProps) {
     );
     if (!surface) continue;
     const ids = collectPaneIds(surface.root);
-    const statuses: (PaneStatus | undefined)[] = ids.map((id) => paneStatuses[id]);
+    const statuses: (PaneStatus | undefined)[] = ids.map(
+      (id) => paneStatuses[id],
+    );
     const highest = getHighestPriorityStatus(statuses);
     if (highest) tabStatusMap.set(tab.tab_id, highest);
   }
 
+  // Tabs stay backend-owned, so a drop hands the new order to the reorder
+  // command rather than a store. Shared with the right panel's pane deck —
+  // see `@/lib/tab-reorder`.
+  const tabIds = workspace.tabs.map((t) => t.tab_id);
+  const commitReorder = useCallback(
+    (ids: string[]) => {
+      reorderTabs(workspace.workspace_id, ids).catch(console.error);
+    },
+    [workspace.workspace_id],
+  );
   const { containerRef, dragTabId, dropIndicatorLeft, getPillProps } =
-    useTabReorder(workspace);
+    useTabReorder<HTMLDivElement>(tabIds, commitReorder);
 
   // Let tabs scroll with a normal vertical mouse wheel once they overflow,
   // same fix as the preset bar: `overflow-x: auto` only responds to native
@@ -346,17 +153,8 @@ export function TitleBarTabs({ workspace }: TitleBarTabsProps) {
       style={{ scrollbarWidth: "none" }}
       data-testid="titlebar-tabs-scroll"
     >
-      {/* Drop indicator — vertical mirror of the sidebar's leading-dot +
-          thin neutral line. No accent color, so it reads as a UI cue
-          rather than an alert. */}
       {dragTabId && dropIndicatorLeft !== null && (
-        <div
-          className="absolute inset-y-0.5 z-30 flex flex-col items-center pointer-events-none"
-          style={{ left: dropIndicatorLeft - 1, width: 2 }}
-        >
-          <div className="-mt-0.5 h-1.5 w-1.5 shrink-0 rounded-full bg-foreground/70" />
-          <div className="w-px flex-1 rounded-full bg-foreground/40" />
-        </div>
+        <TabDropIndicator left={dropIndicatorLeft} />
       )}
       {workspace.tabs.map((tab) => {
         const surface = tab.surface_id

--- a/src/lib/tab-reorder.ts
+++ b/src/lib/tab-reorder.ts
@@ -1,0 +1,238 @@
+/**
+ * Pointer-based drag-to-reorder for a horizontal strip of tabs. Shared by
+ * the titlebar's workspace tabs and the right panel's pane deck, so the two
+ * strips have one drag feel: the same movement threshold before a press
+ * turns into a drag, the same drop-indicator geometry, the same
+ * click-suppression after a drop.
+ *
+ * HTML5 DnD is avoided on purpose: both strips sit in the window's titlebar
+ * band next to a live `data-tauri-drag-region`, and stacking native HTML5
+ * drag — which Tauri/WebKit's own drag-region handling already interposes
+ * on — on top of that is exactly the "not clean" combination the GUI-chrome
+ * doc flagged. Pointer events don't interact with the OS drag region at
+ * all and give full control over when a "drag" actually starts.
+ *
+ * Listeners for pointermove/up/cancel are attached to `document` (not the
+ * pill itself) for the lifetime of one pointer session, so fast pointer
+ * movement that outruns the small pill's bounds — which would otherwise
+ * stop delivering events to a per-element listener — still gets tracked.
+ * `setPointerCapture` isn't used: capturing on the pointerdown target would
+ * retarget the browser's synthesized `click` to that same target too,
+ * which would break the inner activate/close buttons ever receiving a
+ * plain click.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import type React from "react";
+
+/** Movement (px) before a pointerdown on a pill turns into a reorder drag
+ *  instead of resolving as a plain click. Small enough to feel immediate,
+ *  large enough that a normal click/tap never misfires as a drag. */
+export const DRAG_THRESHOLD = 5;
+
+export interface PillReorderHandlers {
+  "data-tab-id": string;
+  onPointerDown: (e: React.PointerEvent<HTMLElement>) => void;
+  onClickCapture: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+export interface TabReorder<T extends HTMLElement> {
+  /** Place on the scrolling strip element — the drop index is measured
+   *  against its `[data-tab-id]` descendants. */
+  containerRef: React.MutableRefObject<T | null>;
+  /** Id of the tab being dragged, once the threshold is crossed. */
+  dragTabId: string | null;
+  /** Drop-indicator x in the strip's *content* coordinate space (already
+   *  offset by `scrollLeft`), or null while nothing is being dragged. */
+  dropIndicatorLeft: number | null;
+  /** Spread onto each tab's outer element. Controls inside a tab that must
+   *  keep a plain click (close buttons, chevrons) opt out with
+   *  `data-no-drag`. */
+  getPillProps: (tabId: string) => PillReorderHandlers;
+}
+
+/**
+ * @param ids The strip's current order. Read at drop time, so the caller
+ *   never has to worry about the list changing mid-drag.
+ * @param onReorder Called with the full new order once a drag actually
+ *   moved a tab; never called for a no-op drop or a plain click.
+ */
+export function useTabReorder<T extends HTMLElement = HTMLDivElement>(
+  ids: readonly string[],
+  onReorder: (ids: string[]) => void,
+): TabReorder<T> {
+  const containerRef = useRef<T | null>(null);
+  const [dragTabId, setDragTabId] = useState<string | null>(null);
+  const [dropIndex, setDropIndexState] = useState<number | null>(null);
+
+  // Refs mirror state the pointer listeners need to read/write without
+  // forcing a hook re-subscription or a render on every write that
+  // doesn't need one.
+  const dropIndexRef = useRef<number | null>(null);
+  const idsRef = useRef(ids);
+  idsRef.current = ids;
+  const onReorderRef = useRef(onReorder);
+  onReorderRef.current = onReorder;
+
+  const pendingTabIdRef = useRef<string | null>(null);
+  const pointerIdRef = useRef<number | null>(null);
+  const startPosRef = useRef({ x: 0, y: 0 });
+  const draggingRef = useRef(false);
+  const suppressClickRef = useRef(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const setDropIndex = useCallback((v: number | null) => {
+    dropIndexRef.current = v;
+    setDropIndexState(v);
+  }, []);
+
+  const computeDropIndex = useCallback(
+    (clientX: number) => {
+      const el = containerRef.current;
+      if (!el) return;
+      const tabEls = el.querySelectorAll<HTMLElement>("[data-tab-id]");
+      if (tabEls.length === 0) return;
+
+      let closestIdx = 0;
+      let closestDist = Infinity;
+      let insertBefore = true;
+      tabEls.forEach((tabEl, i) => {
+        const rect = tabEl.getBoundingClientRect();
+        const midX = rect.left + rect.width / 2;
+        const dist = Math.abs(clientX - midX);
+        if (dist < closestDist) {
+          closestDist = dist;
+          closestIdx = i;
+          insertBefore = clientX < midX;
+        }
+      });
+      setDropIndex(insertBefore ? closestIdx : closestIdx + 1);
+    },
+    [setDropIndex],
+  );
+
+  const endSession = useCallback(
+    (commit: boolean) => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+
+      const tabId = pendingTabIdRef.current;
+      const wasDragging = draggingRef.current;
+      const finalDropIndex = dropIndexRef.current;
+
+      pendingTabIdRef.current = null;
+      pointerIdRef.current = null;
+      draggingRef.current = false;
+      setDragTabId(null);
+      setDropIndex(null);
+
+      if (commit && wasDragging && tabId != null && finalDropIndex != null) {
+        const currentIds = idsRef.current;
+        const dragIdx = currentIds.indexOf(tabId);
+        if (dragIdx >= 0) {
+          const newIds = [...currentIds];
+          newIds.splice(dragIdx, 1);
+          const insertAt =
+            finalDropIndex > dragIdx ? finalDropIndex - 1 : finalDropIndex;
+          newIds.splice(Math.min(insertAt, newIds.length), 0, tabId);
+          if (newIds.join(",") !== currentIds.join(",")) {
+            onReorderRef.current(newIds);
+          }
+        }
+      }
+    },
+    [setDropIndex],
+  );
+
+  const handlePointerDown = useCallback(
+    (tabId: string) => (e: React.PointerEvent<HTMLElement>) => {
+      // Only the primary button/contact starts a reorder session, never one
+      // already in flight, and never from a close/chevron control
+      // explicitly opted out via `data-no-drag` — those need their plain
+      // click behavior preserved untouched.
+      if (e.button !== 0) return;
+      if ((e.target as HTMLElement).closest("[data-no-drag]")) return;
+      if (pendingTabIdRef.current != null) return;
+
+      pendingTabIdRef.current = tabId;
+      pointerIdRef.current = e.pointerId;
+      startPosRef.current = { x: e.clientX, y: e.clientY };
+      draggingRef.current = false;
+
+      const handleMove = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerIdRef.current) return;
+        const dx = ev.clientX - startPosRef.current.x;
+        const dy = ev.clientY - startPosRef.current.y;
+        if (!draggingRef.current) {
+          if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+          draggingRef.current = true;
+          setDragTabId(pendingTabIdRef.current);
+        }
+        ev.preventDefault();
+        computeDropIndex(ev.clientX);
+      };
+
+      const handleUp = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerIdRef.current) return;
+        if (draggingRef.current) suppressClickRef.current = true;
+        endSession(true);
+      };
+
+      const handleCancel = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerIdRef.current) return;
+        endSession(false);
+      };
+
+      document.addEventListener("pointermove", handleMove);
+      document.addEventListener("pointerup", handleUp);
+      document.addEventListener("pointercancel", handleCancel);
+      cleanupRef.current = () => {
+        document.removeEventListener("pointermove", handleMove);
+        document.removeEventListener("pointerup", handleUp);
+        document.removeEventListener("pointercancel", handleCancel);
+      };
+    },
+    [computeDropIndex, endSession],
+  );
+
+  // Belt-and-suspenders: drop any live document listeners if the strip
+  // unmounts mid-drag (e.g. workspace switch).
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const getPillProps = useCallback(
+    (tabId: string): PillReorderHandlers => ({
+      "data-tab-id": tabId,
+      onPointerDown: handlePointerDown(tabId),
+      onClickCapture: (e: React.MouseEvent<HTMLElement>) => {
+        // Swallow the click synthesized after a real drag so it doesn't
+        // activate the tab (or, for the active chat tab, pop the history
+        // dropdown) as a side effect of the reorder gesture.
+        if (suppressClickRef.current) {
+          e.preventDefault();
+          e.stopPropagation();
+          suppressClickRef.current = false;
+        }
+      },
+    }),
+    [handlePointerDown],
+  );
+
+  // Drop-indicator position, converted into the strip's scrolled content
+  // coordinate space (`+ scrollLeft`) since the strip scrolls horizontally.
+  let dropIndicatorLeft: number | null = null;
+  if (dragTabId && dropIndex !== null && containerRef.current) {
+    const el = containerRef.current;
+    const tabEls = el.querySelectorAll<HTMLElement>("[data-tab-id]");
+    const listRect = el.getBoundingClientRect();
+    if (tabEls.length > 0) {
+      if (dropIndex >= tabEls.length) {
+        const lastRect = tabEls[tabEls.length - 1].getBoundingClientRect();
+        dropIndicatorLeft = lastRect.right - listRect.left + el.scrollLeft;
+      } else {
+        const targetRect = tabEls[dropIndex].getBoundingClientRect();
+        dropIndicatorLeft = targetRect.left - listRect.left + el.scrollLeft;
+      }
+    }
+  }
+
+  return { containerRef, dragTabId, dropIndicatorLeft, getPillProps };
+}

--- a/src/stores/ui-store.test.ts
+++ b/src/stores/ui-store.test.ts
@@ -250,9 +250,7 @@ describe("ui-store — onboarding state", () => {
 
     it("still refuses a width below the panel minimum", () => {
       useUIStore.getState().setRightPanelWidth(10);
-      expect(useUIStore.getState().rightPanelWidth).toBe(
-        RIGHT_PANEL_MIN_WIDTH,
-      );
+      expect(useUIStore.getState().rightPanelWidth).toBe(RIGHT_PANEL_MIN_WIDTH);
     });
 
     it("does not persist the measured row width", () => {
@@ -359,7 +357,9 @@ describe("ui-store — the empty-panel sentinel", () => {
   });
 
   it("reopens on the pane the panel was collapsed from", () => {
-    useUIStore.setState({ rightPanelPanes: { "ws-1": ["files", "diff", "review"] } });
+    useUIStore.setState({
+      rightPanelPanes: { "ws-1": ["files", "diff", "review"] },
+    });
     useUIStore.getState().setRightPanelTab("ws-1", "review");
     useUIStore.getState().collapseRightPanel("ws-1");
 
@@ -392,6 +392,47 @@ describe("ui-store — the empty-panel sentinel", () => {
     expect(useUIStore.getState().getRightPanelTab("ws-1")).toBe(
       RIGHT_PANEL_EMPTY,
     );
+  });
+});
+
+describe("ui-store — reorderRightPanelPanes", () => {
+  it("applies the strip's new order", () => {
+    useUIStore.setState({
+      rightPanelPanes: { "ws-1": ["files", "changes", "review"] },
+    });
+    useUIStore
+      .getState()
+      .reorderRightPanelPanes("ws-1", ["review", "files", "changes"]);
+    expect(useUIStore.getState().getRightPanelPanes("ws-1")).toEqual([
+      "review",
+      "files",
+      "changes",
+    ]);
+  });
+
+  it("keeps panes the strip is not showing in their slots", () => {
+    // `tasks` is availability-gated: open in the deck, absent from the
+    // strip while the thread has no tasks. A drag among the visible tabs
+    // must not move it.
+    useUIStore.setState({
+      rightPanelPanes: { "ws-1": ["files", "tasks", "changes", "review"] },
+    });
+    useUIStore
+      .getState()
+      .reorderRightPanelPanes("ws-1", ["review", "changes", "files"]);
+    expect(useUIStore.getState().getRightPanelPanes("ws-1")).toEqual([
+      "review",
+      "tasks",
+      "changes",
+      "files",
+    ]);
+  });
+
+  it("is a no-op for an unchanged order", () => {
+    useUIStore.setState({ rightPanelPanes: { "ws-1": ["files", "changes"] } });
+    const before = useUIStore.getState().rightPanelPanes;
+    useUIStore.getState().reorderRightPanelPanes("ws-1", ["files", "changes"]);
+    expect(useUIStore.getState().rightPanelPanes).toBe(before);
   });
 });
 

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -37,17 +37,13 @@ export const RIGHT_PANEL_EMPTY = "empty";
 /** What the Theme Studio should open on — one of its two tabs, or an
  *  existing custom theme to reopen. */
 export type ThemeStudioRequest =
-  | { mode: "generate" }
-  | { mode: "import" }
-  | { editThemeId: string };
+  { mode: "generate" } | { mode: "import" } | { editThemeId: string };
 
 /** A pane id in the right-panel deck. `doc:<absolute path>` panes are
  *  opened per file, so the id carries its own payload — that keeps the
  *  open-pane list a plain, persistable string array. */
 export type RightPanelTab =
-  | RightPanelCorePane
-  | `doc:${string}`
-  | typeof RIGHT_PANEL_EMPTY;
+  RightPanelCorePane | `doc:${string}` | typeof RIGHT_PANEL_EMPTY;
 
 /** The deck a workspace starts with. Matches the three panes that were
  *  always-present tabs before the deck existed, so an upgrade is a no-op
@@ -201,11 +197,22 @@ interface UIStore {
    *  availability auto-open for tasks/orchestration/subagents. */
   addRightPanelPane: (workspaceId: string, pane: RightPanelTab) => void;
   closeRightPanelPane: (workspaceId: string, pane: RightPanelTab) => void;
+  /** Drag-to-reorder from the deck's tab strip. `order` is the strip's new
+   *  order — which may be only the *visible* subset of the open panes,
+   *  since availability-gated panes drop out of the strip while their
+   *  data is absent. Hidden panes keep their slots. */
+  reorderRightPanelPanes: (
+    workspaceId: string,
+    order: readonly RightPanelTab[],
+  ) => void;
   setRightPanelWidth: (width: number) => void;
   setRightPanelRowWidth: (width: number) => void;
   /** Toggle full-expand. No-op while the panel is collapsed. */
   toggleRightPanelMaximized: (workspaceId: string) => void;
-  setShowNewWorkspaceDialog: (show: boolean, projectDir?: string | null) => void;
+  setShowNewWorkspaceDialog: (
+    show: boolean,
+    projectDir?: string | null,
+  ) => void;
   setShowSettings: (show: boolean, section?: string | null) => void;
   /** Open Settings ▸ Presets and request creating a new preset. */
   requestNewPreset: () => void;
@@ -292,7 +299,8 @@ export const useUIStore = create<UIStore>()(
       expandProjectRequest: null,
       subagentEnterRequest: null,
 
-      getRightPanelTab: (workspaceId) => get().rightPanelTabs[workspaceId] ?? null,
+      getRightPanelTab: (workspaceId) =>
+        get().rightPanelTabs[workspaceId] ?? null,
 
       setRightPanelTab: (workspaceId, tab) => {
         // Collapsing is its own action (it has a backend consequence, see
@@ -303,7 +311,8 @@ export const useUIStore = create<UIStore>()(
           return;
         }
         set((s) => {
-          const list = s.rightPanelPanes[workspaceId] ?? DEFAULT_RIGHT_PANEL_PANES;
+          const list =
+            s.rightPanelPanes[workspaceId] ?? DEFAULT_RIGHT_PANEL_PANES;
           // The picker sentinel is "open to whatever it was showing": a
           // collapsed panel comes back on the pane it was collapsed from,
           // provided that pane is still in the deck. It is a view state,
@@ -311,10 +320,14 @@ export const useUIStore = create<UIStore>()(
           if (tab === RIGHT_PANEL_EMPTY) {
             const last = s.rightPanelLastTabs[workspaceId];
             const restored =
-              s.rightPanelTabs[workspaceId] == null && last && list.includes(last)
+              s.rightPanelTabs[workspaceId] == null &&
+              last &&
+              list.includes(last)
                 ? last
                 : tab;
-            return { rightPanelTabs: { ...s.rightPanelTabs, [workspaceId]: restored } };
+            return {
+              rightPanelTabs: { ...s.rightPanelTabs, [workspaceId]: restored },
+            };
           }
           const tabs = { ...s.rightPanelTabs, [workspaceId]: tab };
           const dismissed = s.rightPanelDismissedPanes[workspaceId] ?? [];
@@ -370,7 +383,8 @@ export const useUIStore = create<UIStore>()(
 
       addRightPanelPane: (workspaceId, pane) =>
         set((s) => {
-          const list = s.rightPanelPanes[workspaceId] ?? DEFAULT_RIGHT_PANEL_PANES;
+          const list =
+            s.rightPanelPanes[workspaceId] ?? DEFAULT_RIGHT_PANEL_PANES;
           if (list.includes(pane)) return s;
           return {
             rightPanelPanes: {
@@ -387,7 +401,8 @@ export const useUIStore = create<UIStore>()(
       // titlebar is still the way to collapse.
       closeRightPanelPane: (workspaceId, pane) =>
         set((s) => {
-          const list = s.rightPanelPanes[workspaceId] ?? DEFAULT_RIGHT_PANEL_PANES;
+          const list =
+            s.rightPanelPanes[workspaceId] ?? DEFAULT_RIGHT_PANEL_PANES;
           const index = list.indexOf(pane);
           if (index === -1) return s;
           const next = list.filter((p) => p !== pane);
@@ -405,9 +420,25 @@ export const useUIStore = create<UIStore>()(
               ...s.rightPanelTabs,
               [workspaceId]:
                 active === pane
-                  ? (next[Math.min(index, next.length - 1)] ?? RIGHT_PANEL_EMPTY)
+                  ? (next[Math.min(index, next.length - 1)] ??
+                    RIGHT_PANEL_EMPTY)
                   : active,
             },
+          };
+        }),
+
+      reorderRightPanelPanes: (workspaceId, order) =>
+        set((s) => {
+          const list =
+            s.rightPanelPanes[workspaceId] ?? DEFAULT_RIGHT_PANEL_PANES;
+          const shown = new Set(order.filter((id) => list.includes(id)));
+          const queue = [...shown];
+          // Walk the current list and refill only the slots the strip
+          // showed, in the strip's new order; unknown ids are dropped.
+          const next = list.map((id) => (shown.has(id) ? queue.shift()! : id));
+          if (next.every((id, i) => id === list[i])) return s;
+          return {
+            rightPanelPanes: { ...s.rightPanelPanes, [workspaceId]: next },
           };
         }),
 
@@ -440,9 +471,16 @@ export const useUIStore = create<UIStore>()(
         }),
 
       setShowNewWorkspaceDialog: (show, projectDir = null) =>
-        set({ showNewWorkspaceDialog: show, newWorkspaceProjectDir: show ? (projectDir ?? null) : null }),
+        set({
+          showNewWorkspaceDialog: show,
+          newWorkspaceProjectDir: show ? (projectDir ?? null) : null,
+        }),
 
-      setShowSettings: (show, section = null) => set({ showSettings: show, settingsSection: show ? (section ?? null) : null }),
+      setShowSettings: (show, section = null) =>
+        set({
+          showSettings: show,
+          settingsSection: show ? (section ?? null) : null,
+        }),
       requestNewPreset: () =>
         set({
           showSettings: true,
@@ -451,9 +489,13 @@ export const useUIStore = create<UIStore>()(
         }),
       clearPendingPresetCreate: () => set({ pendingPresetCreate: false }),
       setShowAutomations: (show) => set({ showAutomations: show }),
-      setShowWorkspacesOverview: (show) => set({ showWorkspacesOverview: show }),
+      setShowWorkspacesOverview: (show) =>
+        set({ showWorkspacesOverview: show }),
       setShowPullRequests: (show, select = null) =>
-        set({ showPullRequests: show, pendingPrSelection: show ? select : null }),
+        set({
+          showPullRequests: show,
+          pendingPrSelection: show ? select : null,
+        }),
       clearPendingPrSelection: () => set({ pendingPrSelection: null }),
       markPrBadgeSeen: (keys) =>
         set((state) => ({
@@ -463,7 +505,10 @@ export const useUIStore = create<UIStore>()(
         set({ renameWorkspaceId: workspaceId }),
       closeRenameWorkspace: () => set({ renameWorkspaceId: null }),
       setShowFileSearch: (show, target = "editor") =>
-        set({ showFileSearch: show, fileSearchTarget: show ? target : "editor" }),
+        set({
+          showFileSearch: show,
+          fileSearchTarget: show ? target : "editor",
+        }),
       setShowContentSearch: (show) => set({ showContentSearch: show }),
 
       addPendingWorkspace: (pw) =>
@@ -477,7 +522,9 @@ export const useUIStore = create<UIStore>()(
       failPendingWorkspace: (id, error) =>
         set((s) => ({
           pendingWorkspaces: s.pendingWorkspaces.map((pw) =>
-            pw.id === id ? { ...pw, status: "failed" as const, errorMessage: error } : pw,
+            pw.id === id
+              ? { ...pw, status: "failed" as const, errorMessage: error }
+              : pw,
           ),
         })),
 
@@ -485,11 +532,15 @@ export const useUIStore = create<UIStore>()(
 
       setLastModelSelection: (family, selection) =>
         set((s) => ({
-          lastModelSelections: { ...s.lastModelSelections, [family]: selection },
+          lastModelSelections: {
+            ...s.lastModelSelections,
+            [family]: selection,
+          },
         })),
 
       setShowCommandPalette: (show) => set({ showCommandPalette: show }),
-      toggleCommandPalette: () => set((s) => ({ showCommandPalette: !s.showCommandPalette })),
+      toggleCommandPalette: () =>
+        set((s) => ({ showCommandPalette: !s.showCommandPalette })),
 
       // Deliberately does NOT close Settings. Settings is a full-screen
       // destination, so this used to have to leave it for the palette to
@@ -517,7 +568,10 @@ export const useUIStore = create<UIStore>()(
         set((s) =>
           dir === null
             ? { onboardingProjectDir: null, hasSeenOnboarding: true }
-            : { onboardingProjectDir: dir, hasSeenOnboarding: s.hasSeenOnboarding },
+            : {
+                onboardingProjectDir: dir,
+                hasSeenOnboarding: s.hasSeenOnboarding,
+              },
         ),
 
       setSidebarToggleFn: (fn) => set({ sidebarToggleFn: fn }),
@@ -562,7 +616,9 @@ export const useUIStore = create<UIStore>()(
       // it silently fall back to the default.
       migrate: (persistedState, version) => {
         if (version >= 1) return persistedState;
-        const state = persistedState as { rightPanelTabs?: Record<string, string | null> };
+        const state = persistedState as {
+          rightPanelTabs?: Record<string, string | null>;
+        };
         if (state?.rightPanelTabs) {
           const migrated: Record<string, string | null> = {};
           for (const [wsId, tab] of Object.entries(state.rightPanelTabs)) {


### PR DESCRIPTION
## Problem

The right panel's tab strip had none of the affordances the titlebar tabs already had: tabs couldn't be dragged into a new order, a plain vertical wheel over the strip did nothing once it overflowed, and every inactive tab ellipsized to an identical 58px stub before the row even started scrolling. With a busy deck (core panes + a few open files) it read as `F… · Chan… · Revi… · Subage…`, with the rest hidden behind a hidden scrollbar and nothing to suggest they were there.

## Fix

- **Drag to reorder** — the titlebar's pointer-based reorder hook is extracted into a shared `useTabReorder` (`src/lib/tab-reorder.ts`) and a `TabDropIndicator`, so both strips get the identical gesture: 5px threshold, dimmed dragged chip, dot+line drop cue, trailing click swallowed. New `reorderRightPanelPanes` store action persists the order per workspace and keeps availability-gated panes (tasks/subagents while absent from the strip) in their slots. The titlebar strip's behaviour and tests are unchanged.
- **Vertical wheel pans the strip** — attaches the existing `useHorizontalWheelScroll` helper to the deck scroller.
- **Icon-only overflow** — once the full-label row would overflow, inactive tabs collapse to icon + badge (label in the tooltip) and only the active tab keeps its label and close button. Measured under `useLayoutEffect` with hysteresis, so the expanded frame is never painted and resizing can't flicker between modes. A 16px gradient fade marks whichever edge still has clipped tabs.
- **Middle-click closes** a tab — standard tab-strip convention, and the only close gesture a compact chip has (an overlaid X on a 28px chip would be what you hit when aiming for the tab).

Tests: 8 new strip tests (`pane-tab-strip.test.tsx`), 3 store tests; `npm run check` clean.

## Before / after

Nine panes open in the dev mock, Changes active, panel at 320 / 480 / 720px (before above after in each pair):

![widths](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/sidebar-tab-drag-reorder/compare-widths.png)

Drag in progress (drop cue between README.md and AGENTS.md) and the strip panned to its end with a plain vertical wheel:

![interactions](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/sidebar-tab-drag-reorder/compare-interactions.png)

Full window at 720px — before / after:

![before-720](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/sidebar-tab-drag-reorder/before-720.png)
![after-720](https://raw.githubusercontent.com/Zeus-Deus/codemux/pr-assets/pr/sidebar-tab-drag-reorder/after-720.png)

Known limit, unchanged by this PR: at 320px with the Changes pane active the tabs get ~50px of the row because the pane's own actions plus the fixed top-right cluster take the rest; collapsing pane actions into an overflow menu at narrow widths is a separate change.

Model: Claude Fable 5 · Harness: Claude Code
