### PR TITLE
fix(cursor): don't deadlock the writer mutex when Stop races the prompt

### DIFF
--- a/src-tauri/src/agent_provider/cursor/session.rs
+++ b/src-tauri/src/agent_provider/cursor/session.rs
@@ -654,10 +654,11 @@ impl CursorSession {
     /// could win the stdin write race and reach the child before the
     /// prompt it was meant to cancel, leaving the child with nothing to
     /// cancel and the user's Stop silently dropped. `biased` polls the
-    /// prompt future first, so the request is written before the cancel
-    /// arm is ever reachable, and the transport's writer mutex is FIFO so
-    /// a contended write still keeps that order. `session/cancel` is a
-    /// notification with no reply, so repeating it is harmless.
+    /// prompt future first, so the request has already claimed the
+    /// transport's writer mutex before the cancel arm is ever reachable,
+    /// and that mutex is FIFO so the cancel queues behind the prompt and
+    /// still reaches the child second. `session/cancel` is a notification
+    /// with no reply, so repeating it is harmless.
     async fn send_prompt(
         &self,
         prompt: &[Value],
@@ -680,16 +681,35 @@ impl CursorSession {
                     if !self.state.lock().await.take_interrupt(generation) {
                         continue;
                     }
-                    if let Err(error) = self
-                        .child
-                        .notify(
-                            "session/cancel",
-                            json!({ "sessionId": self.provider_session_id.0 }),
-                        )
-                        .await
-                    {
-                        self.warn(format!("Could not cancel the Cursor turn: {error}"), None);
-                    }
+                    // Hand the cancel to a detached task instead of
+                    // awaiting it here. A child's stdin is a blocking-pool
+                    // wrapper on Windows, whose `flush` yields at least
+                    // once, so the pinned prompt future can be parked
+                    // *inside* `write_line` while still holding the
+                    // transport's writer mutex. Awaiting the cancel in this
+                    // branch body would then block on that same mutex —
+                    // and `select!` does not poll the prompt arm that owns
+                    // it while a branch body is awaiting, so the turn
+                    // deadlocks and the Stop is swallowed. Spawning keeps
+                    // the loop polling the prompt so its write can finish
+                    // and release the lock; the cancel queues behind it on
+                    // the FIFO mutex, preserving the order described above.
+                    let child = Arc::clone(&self.child);
+                    let session_id = self.provider_session_id.0.clone();
+                    let event_tx = self.event_tx.clone();
+                    let thread_id = self.thread_id.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = child
+                            .notify("session/cancel", json!({ "sessionId": session_id }))
+                            .await
+                        {
+                            let _ = event_tx.send(ProviderRuntimeEvent::RuntimeWarning {
+                                thread_id: Some(thread_id),
+                                message: format!("Could not cancel the Cursor turn: {error}"),
+                                original_payload: None,
+                            });
+                        }
+                    });
                 }
             }
         }


### PR DESCRIPTION
The Windows CI leg fails reliably on `cursor_stop_is_never_lost_whenever_it_lands`, hanging for the full 20s timeout. It is a real deadlock in the Cursor adapter's Stop path, not a flaky test.

## Problem

`send_prompt` pins the `session/prompt` request and races it against the interrupt notify in a `biased` `select!`. The cancel arm awaited `notify("session/cancel")`, which takes the transport's writer mutex — the same mutex the pinned prompt future holds across its `write_all`/`flush` pair in `JsonRpcChild::write_line`.

On Linux a pipe write and flush both complete inside the first poll, so the guard is released before the cancel arm is ever reachable. On Windows child stdin is a blocking-pool wrapper whose `flush` must yield at least once, so the prompt future parks *inside* `write_line` while still owning the guard. `select!` then runs the cancel arm, which blocks on that guard — while never polling the arm that owns it. Permanent deadlock: the prompt never flushes, the cancel is never written, the turn never completes, and the user's Stop is silently swallowed.

The function's own doc comment encoded the assumption that broke: "the request is written before the cancel arm is ever reachable". That only holds if the write completes in a single poll.

This is a latent pre-existing bug, not a recent regression — `cursor/session.rs` is unchanged since v0.20.3 and `json_rpc_child/mod.rs` since 2026-08-06. Windows timing only started landing in the window reliably.

## Fix

Spawn the cancel instead of awaiting it in the branch body, so the loop keeps polling the prompt and its write can drain.

Send order is unchanged: the biased poll has already claimed the writer mutex for the prompt before the cancel arm runs, and the mutex is FIFO, so the cancel still queues behind it and reaches the child second. That ordering guarantee is what the original race fix depended on, and it is preserved.

## Verification

- `cargo check` clean
- `cursor_adapter` integration tests 6/6 runs green locally
- 18 cursor unit tests green
- No API change; success path untouched

Windows CI on this branch is the real check — that is the leg that reproduces it.