### PR TITLE
fix(chat): stop showing a false "Run interrupted" during delegated work

### DIFF
--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -3222,15 +3222,46 @@ pub async fn agent_chat_stop_monitoring<R: Runtime>(
     Ok(())
 }
 
-/// Whether a live turn is currently in flight on a thread.
+/// Whether a live RUN is currently in flight on a thread.
 ///
 /// Cheap in-memory probe used by the frontend hydrate-on-remount path to
 /// tell "run still in flight" apart from "run died mid-turn": a healthy
 /// mid-flight run must not be labeled "Run interrupted" after a workspace
 /// switch remount. Deliberately does NOT auto-resume — this is a read-only
-/// check against the provider's live session registry, and a thread with no
-/// live session (e.g. after a restart) is correctly `false`. The frontend
-/// treats any error as `false`, so gating/lookup failures degrade safely.
+/// check against process-local live state, and a thread with no live
+/// session (e.g. after a restart) is correctly `false`.
+///
+/// "Run", not "turn", and the distinction is the whole point. Two
+/// independent signals are ORed:
+///
+/// 1. The provider has an `active_turn` — a prompt is genuinely in flight.
+/// 2. The thread's parent turn settled but real delegated agent work is
+///    still holding the run open ([`SubagentTracker::delegated_work_holding_turn`]).
+///
+/// (2) exists because a provider can end a turn while work it delegated is
+/// still streaming. Signal (1) alone then reads `false` across the whole
+/// delegated phase of a healthy run, and hydrate paints a live thread as
+/// interrupted: "Run interrupted" divider, a Continue chip, and the still-
+/// running subagent card flipped to `interrupted` by the settle passes.
+/// The frontend reducer models the same yield as an `interim` turn
+/// boundary; this keeps the backend's answer consistent with it.
+///
+/// This is NOT Claude-specific, though Claude is where it always happens:
+///
+/// * **Claude** — by design. The SDK emits a `result` every time the model
+///   yields to wait on a `Task` it spawned, and `claude/session.rs` clears
+///   `active_turn` on *every* `result` with no subagent check.
+/// * **Codex** — structurally exposed. Its `turn/completed` handler
+///   (`codex/session.rs`) checks only thread + turn identity, never
+///   subagent liveness, so a turn ended without a blocking `wait` leaves
+///   collab-agent children streaming on a still-open pump.
+/// * **OpenCode** — guarded. `translate.rs` suppresses child-session idle
+///   so only the parent's idle ends the turn.
+/// * **Cursor** — immune. It has no delegation concept and emits no
+///   `SubagentUpdated`, so (2) is always `false` and this is a strict no-op.
+///
+/// The frontend treats an error as "no information" rather than "dead", so
+/// gating/lookup failures no longer downgrade a live thread.
 #[tauri::command]
 pub async fn agent_chat_turn_active<R: Runtime>(
     app: AppHandle<R>,
@@ -3241,7 +3272,11 @@ pub async fn agent_chat_turn_active<R: Runtime>(
     feature_flag_on(&observability)?;
     let registry: State<'_, ProviderRegistry> = app.state();
     let impl_ = lookup_provider(&registry, provider).await?;
-    Ok(impl_.turn_active(&thread_id).await)
+    if impl_.turn_active(&thread_id).await {
+        return Ok(true);
+    }
+    let tracker: State<'_, SubagentTracker> = app.state();
+    Ok(tracker.delegated_work_holding_turn(&thread_id.0))
 }
 
 /// Respond to a pending approval / tool / input request.
@@ -3644,12 +3679,29 @@ pub async fn agent_chat_stop_session<R: Runtime>(
 /// Skips the feature-flag gate intentionally: the gate guards new session
 /// creation, but already-running sessions must be reaped regardless of
 /// whether the flag has since been flipped off.
+///
+/// Also drops each thread's [`SubagentTracker`] entry, mirroring
+/// `agent_chat_close_pane`. Relying on the session's `Closed` event to do
+/// it is not enough on this path: `stop_session` can answer
+/// `SessionNotFound` (nothing to emit), and the broadcast bridge swallows
+/// `Lagged`, so the terminal event can simply never arrive. A surviving
+/// entry with `turn_settled` still set would keep answering
+/// [`SubagentTracker::delegated_work_holding_turn`] — which
+/// `agent_chat_turn_active` reads — so a reopened thread would hydrate as
+/// a phantom live run until the stall watchdog tombstoned it.
 pub fn shutdown_agent_chat_threads<R: Runtime>(
     app: &AppHandle<R>,
     threads: Vec<(ProviderKind, String)>,
 ) {
     if threads.is_empty() {
         return;
+    }
+    // Synchronous and before the spawn: the pane is already gone, so the
+    // tracking is dead the moment we are called, and this must not depend
+    // on the async cleanup task being scheduled.
+    let tracker: State<'_, SubagentTracker> = app.state();
+    for (_, thread_id) in &threads {
+        tracker.clear_thread(thread_id);
     }
     let app_handle = app.clone();
     tauri::async_runtime::spawn(async move {
@@ -5622,6 +5674,55 @@ impl SubagentTracker {
         if should_remove {
             threads.remove(thread_id);
         }
+    }
+
+    /// Whether real delegated agent work is still holding `thread_id`'s run
+    /// open after its parent turn settled.
+    ///
+    /// This is the "interim yield": a provider whose parent turn ended while
+    /// work it delegated keeps streaming. The provider-level `active_turn`
+    /// bit reads `false` for a run that is very much alive, which is why
+    /// `agent_chat_turn_active` ORs this in. See that command for the
+    /// per-provider breakdown; it is fed from the provider-agnostic
+    /// `forward_event` path, so it covers every provider that reports
+    /// subagents and is a strict no-op for one that does not.
+    ///
+    /// Deliberately reuses [`ThreadSubagentState::review_pending`], the same
+    /// derivation that owes the sidebar its `Review` dot, so the transcript
+    /// and the pane indicator can never disagree about whether a run is
+    /// still going.
+    ///
+    /// In-memory and process-local: after a restart the map is empty and a
+    /// genuinely dead run correctly reads `false`. That is exactly the trust
+    /// boundary hydrate needs — persisted history alone cannot distinguish
+    /// "yielded, subagents running" from "killed mid-run with `running`
+    /// snapshots on disk".
+    ///
+    /// # False-positive bound
+    ///
+    /// A subagent that never reports a terminal snapshot holds this `true`
+    /// while the thread stays quiet — and a `true` here is the expensive
+    /// direction, because hydrate turns it into `streaming` and suppresses
+    /// the Continue chip. Three things bound it:
+    ///
+    /// * The stall watchdog force-settles a silent owed-review after
+    ///   `STALL_THRESHOLD`, flipping `forced_settled` and making
+    ///   `review_pending` false from then on.
+    /// * `review_owed_since` only stays fresh while real run activity keeps
+    ///   arriving — and activity arriving IS the run being alive, so the
+    ///   unbounded case and the correct case are the same case.
+    /// * `begin_turn` / `reset` clear the entry on the next send, a
+    ///   `Running` snapshot, and session `Closed`/`Error`.
+    ///
+    /// Note that Codex and OpenCode report no `task_kind`, so every row they
+    /// emit classifies as `Unreported` and defaults to `TaskClass::Agent`
+    /// (see `classify_snapshot`) — they have no monitor/background escape
+    /// hatch, which makes a stuck row likelier for them than for Claude.
+    pub fn delegated_work_holding_turn(&self, thread_id: &str) -> bool {
+        let threads = self.threads.lock().expect("subagent tracker poisoned");
+        threads
+            .get(thread_id)
+            .is_some_and(ThreadSubagentState::review_pending)
     }
 
     /// Drop `thread_id`'s watch-loop tasks and report the status the pane
@@ -8755,6 +8856,132 @@ mod tests {
             "and the pane falls to the settled status when it ends"
         );
         assert_eq!(tracker.tracked_thread_count(), 0);
+    }
+
+    // `agent_chat_turn_active`'s second signal, exercised through the
+    // provider-agnostic event vocabulary it actually keys on. Claude hits
+    // this on every SDK `result` it emits to yield; Codex hits it whenever a
+    // turn ends without a blocking `wait` on a spawned collab agent. Without
+    // it the hydrate probe reads "dead" across the whole delegated phase of a
+    // healthy run and the transcript renders "Run interrupted".
+    #[test]
+    fn delegated_work_holds_the_turn_open_after_the_parent_settles() {
+        let tracker = SubagentTracker::default();
+        let now = SystemTime::now();
+
+        assert!(
+            !tracker.delegated_work_holding_turn("t"),
+            "an unknown thread holds nothing"
+        );
+
+        // Real agent work spawns mid-turn. The parent still owns the run,
+        // so `active_turn` covers it and this signal stays quiet.
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), now);
+        assert!(
+            !tracker.delegated_work_holding_turn("t"),
+            "mid-turn the parent's own active_turn is the live signal"
+        );
+
+        // The interim yield: Claude emits `result`, clearing `active_turn`,
+        // while the subagent keeps streaming.
+        tracker.decide("t", &turn_completed(), now);
+        assert!(
+            tracker.delegated_work_holding_turn("t"),
+            "the run is still alive — this is what stops the false Continue chip"
+        );
+
+        // The subagent finishes: the run is genuinely over.
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Completed), now);
+        assert!(
+            !tracker.delegated_work_holding_turn("t"),
+            "nothing is holding the run open once delegated work ends"
+        );
+    }
+
+    // The no-op guarantee for a provider with no delegation concept (Cursor
+    // emits zero `SubagentUpdated` events). `track` is the only writer to the
+    // task map and it lives in the `SubagentUpdated` arm, so such a thread
+    // can never grow an Agent entry and `agent_chat_turn_active` keeps its
+    // pre-existing behaviour bit for bit.
+    #[test]
+    fn a_provider_that_reports_no_subagents_never_holds_the_turn_open() {
+        let tracker = SubagentTracker::default();
+        let now = SystemTime::now();
+        // A whole turn's worth of non-subagent traffic, then a completion.
+        tracker.decide("t", &turn_completed(), now);
+        assert!(!tracker.delegated_work_holding_turn("t"));
+        // ...and the entry does not even survive: nothing was tracked.
+        assert_eq!(tracker.tracked_thread_count(), 0);
+    }
+
+    // Pane/tab/workspace teardown must drop the hold, not leave it to the
+    // session's `Closed` event: `stop_session` can answer `SessionNotFound`
+    // (nothing to emit) and the broadcast bridge swallows `Lagged`, so that
+    // event can simply never arrive. `shutdown_agent_chat_threads` and
+    // `agent_chat_close_pane` both route here.
+    #[test]
+    fn clearing_a_thread_releases_the_delegated_work_hold() {
+        let tracker = SubagentTracker::default();
+        let now = SystemTime::now();
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), now);
+        tracker.decide("t", &turn_completed(), now);
+        assert!(tracker.delegated_work_holding_turn("t"));
+
+        tracker.clear_thread("t");
+        assert!(
+            !tracker.delegated_work_holding_turn("t"),
+            "a torn-down thread must not hydrate as a phantom live run"
+        );
+        assert_eq!(tracker.tracked_thread_count(), 0);
+        // Idempotent: the two teardown paths can both fire for one pane.
+        tracker.clear_thread("t");
+        assert!(!tracker.delegated_work_holding_turn("t"));
+    }
+
+    // A new prompt is a turn boundary, so the previous turn's delegated hold
+    // must not leak into it and keep the composer pinned at streaming.
+    #[test]
+    fn beginning_a_new_turn_releases_the_delegated_work_hold() {
+        let tracker = SubagentTracker::default();
+        let now = SystemTime::now();
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), now);
+        tracker.decide("t", &turn_completed(), now);
+        assert!(tracker.delegated_work_holding_turn("t"));
+
+        tracker.begin_turn("t");
+        assert!(!tracker.delegated_work_holding_turn("t"));
+    }
+
+    // Watch loops deliberately do NOT hold a run open — they can outlive the
+    // turn indefinitely, so treating them as live would pin the composer at
+    // "streaming" forever (the issue-#153 shape).
+    #[test]
+    fn a_watch_loop_alone_does_not_hold_the_turn_open() {
+        let tracker = SubagentTracker::default();
+        let now = SystemTime::now();
+        tracker.decide("t", &monitor_event("m1", SubagentStatus::Running), now);
+        tracker.decide("t", &turn_completed(), now);
+        assert!(!tracker.delegated_work_holding_turn("t"));
+    }
+
+    // The watchdog's force-settle is the timeout on the whole mechanism: a
+    // subagent that never reports a terminal status must not pin the
+    // transcript at "streaming" indefinitely.
+    #[test]
+    fn a_force_settled_thread_stops_holding_the_turn_open() {
+        let tracker = SubagentTracker::default();
+        let now = SystemTime::now();
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), now);
+        tracker.decide("t", &turn_completed(), now);
+        assert!(tracker.delegated_work_holding_turn("t"));
+
+        let overdue =
+            tracker.take_overdue_reviews(now + Duration::from_secs(3_600), Duration::ZERO);
+        assert!(overdue.iter().any(|id| id == "t"));
+        assert!(
+            !tracker.delegated_work_holding_turn("t"),
+            "the force-settle releases the frontend's streaming state too"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -3095,27 +3095,45 @@ fn first_line_title(text: &str) -> Option<String> {
 
 /// Interrupt the currently running turn on a thread.
 ///
-/// A `SessionNotFound` is swallowed into `Ok`: there is nothing to
-/// interrupt on a dead session (e.g. after a restart, before any turn
-/// has re-hydrated it), so a stale stop-click must not surface an error.
+/// Returns whether the interrupt actually reached a **live session**.
+/// `SessionNotFound` / `SessionClosed` is reported as `Ok(false)` rather than
+/// an error: there is nothing to interrupt on a dead session (e.g. after a
+/// restart, before any turn has re-hydrated it), so a stale stop-click must
+/// not surface an error — but the caller still has to tell that case apart
+/// from a delivered interrupt, because a dead session emits no settlement
+/// event and the pane would otherwise sit at `streaming` forever.
 /// Interrupt deliberately does NOT auto-resume — restarting a session
 /// just to immediately interrupt it would be pointless.
+///
+/// Either way the thread's delegated-work hold is released (see
+/// [`SubagentTracker::settle_interrupted_turn`]): the interrupt cancels the
+/// parent turn and the tasks it spawned, and an aborted task never reports a
+/// terminal snapshot of its own. Without this, `agent_chat_turn_active` keeps
+/// answering "live" for a run the user just stopped and the next hydrate
+/// re-animates it. A *rejected* interrupt is deliberately left alone — the
+/// turn may well still be running, and claiming otherwise is the expensive
+/// direction.
 #[tauri::command]
 pub async fn agent_chat_interrupt_turn<R: Runtime>(
     app: AppHandle<R>,
     provider: ProviderKind,
     thread_id: ThreadId,
     turn_id: Option<TurnId>,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let observability: State<'_, ObservabilityStore> = app.state();
     feature_flag_on(&observability)?;
     let registry: State<'_, ProviderRegistry> = app.state();
     let impl_ = lookup_provider(&registry, provider).await?;
-    match impl_.interrupt_turn(thread_id, turn_id).await {
-        Ok(()) => Ok(()),
-        Err(ProviderError::SessionNotFound { .. }) => Ok(()),
-        Err(err) => Err(provider_err(err)),
-    }
+    let reached = match impl_.interrupt_turn(thread_id.clone(), turn_id).await {
+        Ok(()) => true,
+        Err(ProviderError::SessionNotFound { .. }) | Err(ProviderError::SessionClosed { .. }) => {
+            false
+        }
+        Err(err) => return Err(provider_err(err)),
+    };
+    let tracker: State<'_, SubagentTracker> = app.state();
+    tracker.settle_interrupted_turn(&thread_id.0);
+    Ok(reached)
 }
 
 /// Stop the background watch loops a pane is monitoring with.
@@ -5467,6 +5485,30 @@ impl ThreadSubagentState {
         self.stopped_monitors.clear();
     }
 
+    /// Release the delegated work an explicit interrupt just cancelled.
+    ///
+    /// Stop kills the parent turn and the tasks it spawned with it, but an
+    /// aborted task emits no terminal `SubagentUpdated`, so its entry would
+    /// stay in [`Self::tasks`] and keep [`Self::review_pending`] — and with
+    /// it [`SubagentTracker::delegated_work_holding_turn`] — true until the
+    /// next turn boundary, a session teardown, or the stall watchdog ten
+    /// minutes later. A hydrate anywhere in that window probes the stopped
+    /// run as live and re-animates it: spinner, armed Stop button, running
+    /// subagent cards.
+    ///
+    /// Unlike [`Self::begin_turn`] this is not a new turn, so `turn_settled`
+    /// is left exactly as the provider's own events set it — the point is
+    /// only that nothing is left holding the run open.
+    ///
+    /// Watch loops are deliberately retained: they are explicitly allowed to
+    /// outlive the parent turn (they never held it open in the first place)
+    /// and `agent_chat_stop_monitoring` is the verb that ends them. The Stop
+    /// blocklist is retained for the same reason.
+    fn interrupted(&mut self) {
+        self.tasks.retain(|_, class| *class == TaskClass::Monitor);
+        self.review_owed_since = None;
+    }
+
     /// Forget everything (session close / error or explicit pane teardown).
     fn reset(&mut self) {
         self.tasks.clear();
@@ -5676,6 +5718,27 @@ impl SubagentTracker {
         }
     }
 
+    /// Release `thread_id`'s delegated-work hold after an explicit interrupt,
+    /// keeping any confirmed watch loop. Idempotent, and a no-op for a thread
+    /// that is not tracked.
+    ///
+    /// Backs `agent_chat_interrupt_turn`. Nothing else on the Stop path
+    /// touches this tracker — `SessionStatus::Ready` is a no-op in
+    /// [`map_event_to_pane_status`] (and has to stay one: Claude emits it on
+    /// every interim yield too, which is exactly the live case this whole
+    /// mechanism exists to protect) — so without this call a stopped run
+    /// keeps probing as live.
+    pub fn settle_interrupted_turn(&self, thread_id: &str) {
+        let mut threads = self.threads.lock().expect("subagent tracker poisoned");
+        let Some(state) = threads.get_mut(thread_id) else {
+            return;
+        };
+        state.interrupted();
+        if state.is_clear() {
+            threads.remove(thread_id);
+        }
+    }
+
     /// Whether real delegated agent work is still holding `thread_id`'s run
     /// open after its parent turn settled.
     ///
@@ -5713,6 +5776,9 @@ impl SubagentTracker {
     ///   unbounded case and the correct case are the same case.
     /// * `begin_turn` / `reset` clear the entry on the next send, a
     ///   `Running` snapshot, and session `Closed`/`Error`.
+    /// * [`Self::settle_interrupted_turn`] releases it the moment the user
+    ///   presses Stop — the one case where the run is genuinely dead with no
+    ///   terminal snapshot ever coming.
     ///
     /// Note that Codex and OpenCode report no `task_kind`, so every row they
     /// emit classifies as `Unreported` and defaults to `TaskClass::Agent`
@@ -8950,6 +9016,66 @@ mod tests {
 
         tracker.begin_turn("t");
         assert!(!tracker.delegated_work_holding_turn("t"));
+    }
+
+    // Stop is a hard terminal signal for delegated work, and nothing else on
+    // the interrupt path says so: `SessionStatus::Ready` is a no-op in the
+    // decision table and an aborted task emits no terminal snapshot. Without
+    // the explicit release the stopped run keeps probing live until the
+    // watchdog fires ten minutes later, and every hydrate in that window
+    // re-animates it (spinner, armed Stop, running subagent cards).
+    #[test]
+    fn an_interrupt_releases_the_delegated_work_hold() {
+        let tracker = SubagentTracker::default();
+        let now = SystemTime::now();
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), now);
+        tracker.decide("t", &turn_completed(), now);
+        assert!(
+            tracker.delegated_work_holding_turn("t"),
+            "precondition: the interim yield holds the run open"
+        );
+
+        tracker.settle_interrupted_turn("t");
+        assert!(
+            !tracker.delegated_work_holding_turn("t"),
+            "a stopped run must probe as dead, or hydrate re-animates it"
+        );
+        assert_eq!(tracker.tracked_thread_count(), 0);
+        // Idempotent, and harmless on a thread that was never tracked.
+        tracker.settle_interrupted_turn("t");
+        tracker.settle_interrupted_turn("unknown");
+        assert!(!tracker.delegated_work_holding_turn("t"));
+    }
+
+    // The other half of the same invariant: the release is scoped to the
+    // interrupt. A NORMAL turn that yields on delegated work must still hold
+    // the run open — that is the false "Run interrupted" this whole mechanism
+    // exists to prevent — and a watch loop must survive Stop, because
+    // `agent_chat_stop_monitoring` is the verb that ends those.
+    #[test]
+    fn an_interrupt_keeps_watch_loops_and_does_not_settle_a_later_turn() {
+        let tracker = SubagentTracker::default();
+        let now = SystemTime::now();
+        tracker.decide("t", &monitor_event("m1", SubagentStatus::Running), now);
+        tracker.decide("t", &subagent_event("s1", SubagentStatus::Running), now);
+        tracker.decide("t", &turn_completed(), now);
+
+        tracker.settle_interrupted_turn("t");
+        assert!(!tracker.delegated_work_holding_turn("t"));
+        assert_eq!(
+            tracker.stop_monitoring("t"),
+            Some(PaneStatus::Review),
+            "the watch loop is still tracked and still the monitoring bar's to stop"
+        );
+
+        // A fresh turn with fresh delegated work holds the run open again.
+        tracker.begin_turn("t");
+        tracker.decide("t", &subagent_event("s2", SubagentStatus::Running), now);
+        tracker.decide("t", &turn_completed(), now);
+        assert!(
+            tracker.delegated_work_holding_turn("t"),
+            "the interrupt must not settle anything beyond the run it stopped"
+        );
     }
 
     // Watch loops deliberately do NOT hold a run open — they can outlive the

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -565,6 +565,18 @@ fn run_git_with_index(
     Ok(String::from_utf8_lossy(&output.stdout).trim_end().to_string())
 }
 
+/// Stamp `dest` with `src`'s modification time. Returns whether it worked.
+fn copy_mtime(src: &Path, dest: &Path) -> bool {
+    let Ok(mtime) = std::fs::metadata(src).and_then(|m| m.modified()) else {
+        return false;
+    };
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(dest)
+        .and_then(|f| f.set_modified(mtime))
+        .is_ok()
+}
+
 /// Snapshot the full working-tree state (staged + unstaged + untracked,
 /// `.gitignore` respected) into a commit anchored at `full_ref`,
 /// without touching the user's index, worktree, or stash list.
@@ -630,6 +642,21 @@ pub fn git_checkpoint_create(
         if real_index.exists() {
             std::fs::copy(&real_index, &tmp_index)
                 .map_err(|e| format!("Failed to copy index for checkpoint: {e}"))?;
+            // Carry the real index's mtime onto the copy. Git only trusts a
+            // cached stat when the entry is older than the index that
+            // recorded it; an entry at or after the index mtime is "racily
+            // clean" and gets rehashed. `fs::copy` stamps the copy with
+            // *now*, which silently promotes every racily-clean entry to
+            // trusted — so a file rewritten in the same second as the real
+            // index write, at the same size, would stat as unchanged and the
+            // checkpoint would snapshot its stale content. A revert would
+            // then restore the wrong bytes.
+            if !copy_mtime(&real_index, &tmp_index) {
+                // Can't reproduce the mtime, so the stat cache can't be
+                // trusted: start from a cache-less index and rehash instead.
+                let _ = std::fs::remove_file(&tmp_index);
+                run_git_with_index(repo, &tmp_index, &["read-tree", "HEAD"])?;
+            }
         } else {
             run_git_with_index(repo, &tmp_index, &["read-tree", "HEAD"])?;
         }
@@ -6158,6 +6185,52 @@ C  source.txt -> copy.txt";
         // assert against whatever the repo actually reports.
         let current_branch = run_git(&repo, &["branch", "--show-current"]).unwrap();
         assert_eq!(cp.branch.as_deref(), Some(current_branch.as_str()), "branch recorded");
+    }
+
+    /// Block until just past the next wall-clock second, so what follows
+    /// cannot share a one-second stat timestamp with what came before.
+    fn sleep_past_second_boundary() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch");
+        std::thread::sleep(
+            std::time::Duration::from_nanos(1_000_000_000 - u64::from(now.subsec_nanos()))
+                + std::time::Duration::from_millis(20),
+        );
+    }
+
+    // Git index entries carry second-granularity timestamps, so a file
+    // rewritten to the same size within the same second as the index that
+    // recorded it stats as unchanged. Git covers that with the "racily
+    // clean" rule — an entry at or after the index's own mtime is rehashed
+    // — which only works while the index keeps the mtime it was written
+    // with. Seeding the checkpoint's private index by copying the real one
+    // used to stamp it with *now*, defeating the rule and snapshotting
+    // stale content that a later revert would restore over the user's work.
+    #[test]
+    fn checkpoint_captures_a_same_second_same_size_rewrite() {
+        let (_dir, repo) = setup_test_repo();
+        git_config(&repo);
+
+        // Commit and rewrite inside one second, same byte count.
+        sleep_past_second_boundary();
+        std::fs::write(repo.join("code.txt"), "v1").unwrap();
+        run_git(&repo, &["add", "."]).unwrap();
+        run_git(&repo, &["commit", "-m", "base"]).unwrap();
+        std::fs::write(repo.join("code.txt"), "v2").unwrap();
+        // Take the checkpoint in a later second, where a freshly stamped
+        // copy of the index would look newer than the rewrite.
+        sleep_past_second_boundary();
+
+        let cp = git_checkpoint_create(&repo, "refs/codemux/checkpoints/racy", "msg")
+            .unwrap()
+            .expect("checkpoint should be created");
+        let content = run_git(
+            &repo,
+            &["show", &format!("{}:code.txt", cp.snapshot_commit)],
+        )
+        .unwrap();
+        assert_eq!(content, "v2", "checkpoint must capture the rewritten bytes");
     }
 
     #[test]

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -80,6 +80,9 @@ const registerMountedThreadMock = vi.fn(() => unregisterMountedThreadMock);
 // Hoisted so the deferred-worktree submit tests can assert the
 // optimistic user bubble was appended to the NEW worktree's thread.
 const appendUserMessageMock = vi.fn();
+/** Stable across `getState()` calls so a test can assert what the pane
+ *  imperatively folded into the slice (e.g. Stop's local settle). */
+const applyEventMock = vi.fn();
 
 vi.mock("./ChatHomeLanding", () => ({
   ChatHomeLanding: ({ composer }: { composer: React.ReactNode }) => (
@@ -631,7 +634,7 @@ vi.mock("@/stores/agent-chat-store", () => {
     {
       getState: () => ({
         threads: buildThreads(),
-        applyEvent: vi.fn(),
+        applyEvent: applyEventMock,
         // Session bring-up seeds the agent-chat slice through these
         // after start_session resolves.
         ensureThread: vi.fn(),
@@ -2773,6 +2776,45 @@ describe("AgentChatPane Stop preserves its durable thread", () => {
     fireEvent.click(getByTestId("context-window-change"));
     await waitFor(() =>
       expect(agentChatStopSession).toHaveBeenCalledWith("claude", "thread-x"),
+    );
+  });
+
+  // Stop has to be an escape hatch even when the provider cannot be
+  // reached. Without a local settle the pane is trapped: the interrupt
+  // fails, no provider settlement event ever arrives, `streaming` stays
+  // true — which hides the Continue chip and re-renders the Stop button
+  // that just failed. This matters most for a run the liveness probe is
+  // holding open on a subagent that never reported a terminal snapshot.
+  it("settles the thread locally when the interrupt fails", async () => {
+    applyEventMock.mockClear();
+    vi.mocked(agentChatInterruptTurn)
+      .mockClear()
+      .mockRejectedValue(new Error("session not found"));
+
+    const { getByTestId } = render(<AgentChatPane pane={pane} />);
+    fireEvent.click(getByTestId("composer-stop"));
+
+    await waitFor(() => expect(agentChatInterruptTurn).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(applyEventMock).toHaveBeenCalledWith("thread-x", {
+        type: "session_state_changed",
+        thread_id: "thread-x",
+        status: { status: "ready" },
+      }),
+    );
+  });
+
+  it("leaves settling to the provider when the interrupt succeeds", async () => {
+    applyEventMock.mockClear();
+    vi.mocked(agentChatInterruptTurn).mockClear().mockResolvedValue(undefined);
+
+    const { getByTestId } = render(<AgentChatPane pane={pane} />);
+    fireEvent.click(getByTestId("composer-stop"));
+
+    await waitFor(() => expect(agentChatInterruptTurn).toHaveBeenCalled());
+    expect(applyEventMock).not.toHaveBeenCalledWith(
+      "thread-x",
+      expect.objectContaining({ type: "session_state_changed" }),
     );
   });
 });

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -2697,7 +2697,7 @@ describe("AgentChatPane Stop preserves its durable thread", () => {
       "thread-x": { streaming: true },
     };
     workspaceIdForPaneOverride = "ws-home";
-    vi.mocked(agentChatInterruptTurn).mockClear().mockResolvedValue(undefined);
+    vi.mocked(agentChatInterruptTurn).mockClear().mockResolvedValue(true);
     vi.mocked(agentChatStartSession).mockClear();
     vi.mocked(agentChatStopSession).mockClear().mockResolvedValue(undefined);
   });
@@ -2738,8 +2738,8 @@ describe("AgentChatPane Stop preserves its durable thread", () => {
     let releaseInterrupt!: () => void;
     vi.mocked(agentChatInterruptTurn).mockImplementationOnce(
       () =>
-        new Promise<void>((resolve) => {
-          releaseInterrupt = () => resolve();
+        new Promise<boolean>((resolve) => {
+          releaseInterrupt = () => resolve(true);
         }),
     );
     const { getByTestId } = render(<AgentChatPane pane={pane} />);
@@ -2779,17 +2779,17 @@ describe("AgentChatPane Stop preserves its durable thread", () => {
     );
   });
 
-  // Stop has to be an escape hatch even when the provider cannot be
-  // reached. Without a local settle the pane is trapped: the interrupt
-  // fails, no provider settlement event ever arrives, `streaming` stays
-  // true — which hides the Continue chip and re-renders the Stop button
-  // that just failed. This matters most for a run the liveness probe is
-  // holding open on a subagent that never reported a terminal snapshot.
-  it("settles the thread locally when the interrupt fails", async () => {
+  // Stop has to be an escape hatch when there was no live session to stop.
+  // The command reports that as `false` — NOT a rejection: a dead session
+  // is swallowed into `Ok` so a stale Stop click cannot toast. Without a
+  // local settle the pane is trapped: no provider settlement event is
+  // coming, `streaming` stays true, which hides the Continue chip and
+  // re-renders a Stop button that can never do anything. This matters most
+  // for a run the liveness probe is holding open on a subagent that never
+  // reported a terminal snapshot.
+  it("settles the thread locally when the interrupt reaches no live session", async () => {
     applyEventMock.mockClear();
-    vi.mocked(agentChatInterruptTurn)
-      .mockClear()
-      .mockRejectedValue(new Error("session not found"));
+    vi.mocked(agentChatInterruptTurn).mockClear().mockResolvedValue(false);
 
     const { getByTestId } = render(<AgentChatPane pane={pane} />);
     fireEvent.click(getByTestId("composer-stop"));
@@ -2804,9 +2804,36 @@ describe("AgentChatPane Stop preserves its durable thread", () => {
     );
   });
 
+  // The other direction, and the one the escape hatch must NOT take. A
+  // rejection is a transport/gating failure — a busy sidecar answering
+  // `interrupt RPC failed`, a registry miss — and the turn may still be
+  // streaming. Settling on it clears `streaming` for the rest of the turn
+  // (only a fresh `running` re-arms it), so text keeps arriving into a
+  // transcript with no spinner and no Stop button.
+  it("does not settle the thread when the interrupt rejects", async () => {
+    applyEventMock.mockClear();
+    vi.mocked(agentChatInterruptTurn)
+      .mockClear()
+      .mockRejectedValue(new Error("rpc error: interrupt RPC failed"));
+
+    const { getByTestId } = render(<AgentChatPane pane={pane} />);
+    fireEvent.click(getByTestId("composer-stop"));
+
+    await waitFor(() => expect(agentChatInterruptTurn).toHaveBeenCalled());
+    // Flush the rejection's catch/finally so "never settled" is a real
+    // observation rather than an assertion that simply ran too early.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(applyEventMock).not.toHaveBeenCalledWith(
+      "thread-x",
+      expect.objectContaining({ type: "session_state_changed" }),
+    );
+  });
+
   it("leaves settling to the provider when the interrupt succeeds", async () => {
     applyEventMock.mockClear();
-    vi.mocked(agentChatInterruptTurn).mockClear().mockResolvedValue(undefined);
+    vi.mocked(agentChatInterruptTurn).mockClear().mockResolvedValue(true);
 
     const { getByTestId } = render(<AgentChatPane pane={pane} />);
     fireEvent.click(getByTestId("composer-stop"));

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -92,6 +92,7 @@ import {
   agentChatStartSession,
   agentChatStopMonitoring,
   agentChatStopSession,
+  agentChatTurnActive,
   agentChatUpdateSessionConfig,
   getGithubIssueByPath,
   getGithubPrByPath,
@@ -735,8 +736,18 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       const promise = (async () => {
         flushAgentChatEvents(payload.thread_id);
         const rows = await agentChatListMessagesAfter(payload.thread_id, null);
+        // A revert is normally driven from this pane while nothing is
+        // streaming, but the trigger is a backend event that another window
+        // (or a remote client) can raise mid-run. Hardcoding `runLive: false`
+        // told the cold replay "this run is dead", which paints a live thread
+        // with the Run-interrupted divider and settles its in-flight subagent
+        // cards. Ask instead.
+        const runLive = await agentChatTurnActive(
+          provider,
+          payload.thread_id,
+        ).catch(() => false);
         useAgentChatStore.getState().hydrateThread(payload.thread_id, rows, {
-          runLive: false,
+          runLive,
           provider,
         });
         setSendAnchor(null);
@@ -2136,6 +2147,22 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         await agentChatInterruptTurn(provider, threadId, null);
       } catch (err) {
         toast.error(`Failed to stop turn: ${err}`);
+        // The interrupt never reached a provider (no live session, a
+        // registry miss), so NO settlement event is coming — and without
+        // one the pane is trapped: `streaming` stays true, which hides the
+        // Continue chip and keeps re-rendering the Stop button that just
+        // failed. Stop has to be an escape hatch even when the provider
+        // cannot be reached.
+        //
+        // `ready` is exactly the event a provider sends when it stops
+        // during a background wait: the reducer clears `streaming` and
+        // folds an interim turn boundary, so a run that had yielded on
+        // delegated work settles the same way it would have live.
+        useAgentChatStore.getState().applyEvent(threadId, {
+          type: "session_state_changed",
+          thread_id: threadId,
+          status: { status: "ready" },
+        });
       } finally {
         restartInFlightRef.current = false;
         setRestarting(false);

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -30,7 +30,10 @@ import {
   discardStagedImage,
 } from "@/lib/agent-chat/image-staging";
 import { activeAttachments } from "@/lib/agent-chat/attachment-tokens";
-import { hydrateThreadByCursor } from "@/lib/agent-chat/cursor-hydrate";
+import {
+  hydrateThreadByCursor,
+  resolveThreadRunLive,
+} from "@/lib/agent-chat/cursor-hydrate";
 import {
   enqueueAgentChatEvent,
   flushAgentChatEvents,
@@ -92,7 +95,6 @@ import {
   agentChatStartSession,
   agentChatStopMonitoring,
   agentChatStopSession,
-  agentChatTurnActive,
   agentChatUpdateSessionConfig,
   getGithubIssueByPath,
   getGithubPrByPath,
@@ -741,11 +743,9 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         // (or a remote client) can raise mid-run. Hardcoding `runLive: false`
         // told the cold replay "this run is dead", which paints a live thread
         // with the Run-interrupted divider and settles its in-flight subagent
-        // cards. Ask instead.
-        const runLive = await agentChatTurnActive(
-          provider,
-          payload.thread_id,
-        ).catch(() => false);
+        // cards. Ask instead — through the same helper hydrate uses, so a
+        // rejected probe means "no information" here too rather than "dead".
+        const runLive = await resolveThreadRunLive(provider, payload.thread_id);
         useAgentChatStore.getState().hydrateThread(payload.thread_id, rows, {
           runLive,
           provider,
@@ -2144,25 +2144,38 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
     setRestarting(true);
     void (async () => {
       try {
-        await agentChatInterruptTurn(provider, threadId, null);
-      } catch (err) {
-        toast.error(`Failed to stop turn: ${err}`);
-        // The interrupt never reached a provider (no live session, a
-        // registry miss), so NO settlement event is coming — and without
-        // one the pane is trapped: `streaming` stays true, which hides the
-        // Continue chip and keeps re-rendering the Stop button that just
-        // failed. Stop has to be an escape hatch even when the provider
-        // cannot be reached.
+        const reachedLiveSession = await agentChatInterruptTurn(
+          provider,
+          threadId,
+          null,
+        );
+        // The interrupt found no live session to stop, so NO settlement
+        // event is coming — and without one the pane is trapped:
+        // `streaming` stays true, which hides the Continue chip and keeps
+        // re-rendering a Stop button that can never do anything. Stop has
+        // to be an escape hatch there.
         //
         // `ready` is exactly the event a provider sends when it stops
         // during a background wait: the reducer clears `streaming` and
         // folds an interim turn boundary, so a run that had yielded on
         // delegated work settles the same way it would have live.
-        useAgentChatStore.getState().applyEvent(threadId, {
-          type: "session_state_changed",
-          thread_id: threadId,
-          status: { status: "ready" },
-        });
+        if (!reachedLiveSession) {
+          useAgentChatStore.getState().applyEvent(threadId, {
+            type: "session_state_changed",
+            thread_id: threadId,
+            status: { status: "ready" },
+          });
+        }
+      } catch (err) {
+        // Deliberately NO local settle here. A rejection is a transport or
+        // gating failure — a busy sidecar answering `interrupt RPC failed`,
+        // a registry miss — and none of those prove the turn stopped; the
+        // provider may still be streaming into this transcript. Settling on
+        // one clears `streaming` for good (only a fresh `running` re-arms
+        // it), leaving text arriving under no spinner and no Stop button.
+        // "Nothing was running" is reported as `false` above instead, which
+        // is the only answer that means it.
+        toast.error(`Failed to stop turn: ${err}`);
       } finally {
         restartInFlightRef.current = false;
         setRestarting(false);

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -3662,6 +3662,11 @@ const handlers: Record<string, Handler> = {
   // (whose terminal event simply hasn't persisted yet) apart from a
   // genuinely-interrupted one. The mock tracks in-flight turns in
   // `chatActiveTurns`, so mirror that directly.
+  //
+  // The real command also ORs in "the parent turn settled but delegated
+  // agents are still working" (see `agent_chat_turn_active`). The mock has
+  // no subagent tracker, so it models only the first signal — a mock
+  // scenario that yields mid-delegation would read as not-live here.
   agent_chat_turn_active: (a) => {
     const { threadId } = a as { threadId: string };
     return chatActiveTurns.has(threadId);

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -3630,7 +3630,14 @@ const handlers: Record<string, Handler> = {
     drainChatQueue(threadId);
     return undefined;
   },
-  agent_chat_interrupt_turn: () => undefined,
+  // Returns whether the interrupt reached a LIVE turn, matching the real
+  // command: `true` emits the provider's own `ready` settlement (which
+  // `interruptMockChatTurn` does), `false` tells the pane nothing was
+  // running so it has to settle itself.
+  agent_chat_interrupt_turn: (a) => {
+    const { threadId } = a as { threadId: string };
+    return interruptMockChatTurn(threadId);
+  },
   // The docked MonitoringBar's Stop. Mirrors the real backend closely
   // enough to be demoable: clear the pane's `monitoring` status + its
   // manual-monitor reason, then re-emit so the bar unmounts and the

--- a/src/hooks/use-agent-chat-session-actions.ts
+++ b/src/hooks/use-agent-chat-session-actions.ts
@@ -106,6 +106,14 @@ export function useAgentChatSessionActions(
           // here on sorts above the resumed history's head.
           const rows = await agentChatListMessagesAfter(record.thread_id, null);
           if (rows.length > 0) {
+            // `runLive` is omitted DELIBERATELY, unlike the remount and
+            // revert paths which now probe for it. `newLocalThreadId` is
+            // minted one line above and has no provider session yet, so the
+            // only honest answer is "not live" — and `runLive: true` would
+            // additionally set `streaming`, arming a Stop button for a run
+            // this pane does not own. If the resumed history ends mid-turn
+            // the Continue chip is then the correct affordance: continuing
+            // is exactly what the user is here to do.
             useAgentChatStore
               .getState()
               .hydrateThread(newLocalThreadId, rows, {

--- a/src/lib/agent-chat/cursor-hydrate.test.ts
+++ b/src/lib/agent-chat/cursor-hydrate.test.ts
@@ -759,6 +759,55 @@ describe("cursor hydrate — the turn-active probe", () => {
     expect(slice.interrupted).toBe(true);
   });
 
+  it("bounds the no-information fallback so a permanently broken probe settles", async () => {
+    // The fallback is a fixpoint if it is unbounded: hydrate writes
+    // `streaming: runLive`, so a streaming slice re-derives `true` from
+    // itself on every hydrate and can never settle while the probe keeps
+    // rejecting — which it does for as long as the flag stays off or the
+    // provider stays out of the registry. Own thread id: the fallback
+    // counter is per-thread, and this drives several hydrates over one.
+    const THREAD_2 = "thread-probe-fixpoint";
+    const store = useAgentChatStore.getState();
+    store.ensureThread(THREAD_2);
+    store.applyEvent(THREAD_2, {
+      type: "user_message",
+      thread_id: THREAD_2,
+      text: "go",
+    } as ProviderRuntimeEvent);
+    store.applyEvent(THREAD_2, {
+      type: "session_state_changed",
+      thread_id: THREAD_2,
+      status: { status: "running" },
+    } as ProviderRuntimeEvent);
+
+    const hydrateOnce = async (cursor: number) => {
+      useAgentChatStore.setState((state) => ({
+        threads: {
+          ...state.threads,
+          [THREAD_2]: { ...state.threads[THREAD_2], lastPersistedEventId: cursor },
+        },
+      }));
+      await hydrateThreadByCursor(THREAD_2, PROVIDER, () => false, {
+        listAfter: async (_t, afterId) =>
+          afterId === null ? [] : [row(cursor + 1, assistantEvent("tick"))],
+        headId: async () => cursor + 1,
+        turnActive: async () => {
+          throw new Error("provider_not_configured: Claude");
+        },
+      });
+      return useAgentChatStore.getState().threads[THREAD_2];
+    };
+
+    // The first few unanswered probes still defer to the slice — that is
+    // the startup window the "no information" rule exists for.
+    expect((await hydrateOnce(10)).streaming).toBe(true);
+    expect((await hydrateOnce(11)).streaming).toBe(true);
+    expect((await hydrateOnce(12)).streaming).toBe(true);
+    // Past the bound, "no information" settles instead of carrying a
+    // stuck spinner (and a suppressed Continue chip) for the session.
+    expect((await hydrateOnce(13)).streaming).toBe(false);
+  });
+
   it("a probe reporting a delegated-work hold keeps the run live", async () => {
     // The backend fix: `agent_chat_turn_active` now ORs in "the parent turn
     // settled but delegated agents are still working", so the probe answers

--- a/src/lib/agent-chat/cursor-hydrate.test.ts
+++ b/src/lib/agent-chat/cursor-hydrate.test.ts
@@ -683,3 +683,95 @@ describe("cursor hydrate — read-after-attach", () => {
     expect(transcript()).toEqual(["seed", "row-11"]);
   });
 });
+
+/**
+ * The liveness probe's failure mode.
+ *
+ * `agent_chat_turn_active` rejects for reasons unrelated to liveness — the
+ * feature flag being off, a `provider_not_configured` registry miss during
+ * startup. The old `.catch(() => false)` turned every one of those into
+ * "the run is dead", which is the single answer that flips a healthy
+ * transcript to "Run interrupted" with a Continue chip.
+ */
+describe("cursor hydrate — the turn-active probe", () => {
+  beforeEach(() => {
+    useAgentChatStore.setState({ threads: {} });
+  });
+
+  /** A warm slice mid-run: streaming, with its last turn settled by an
+   *  interim `turn_completed` (the provider yielded on delegated work). */
+  function seedStreamingSlice(cursor: number) {
+    const store = useAgentChatStore.getState();
+    store.ensureThread(THREAD);
+    store.applyEvent(THREAD, {
+      type: "user_message",
+      thread_id: THREAD,
+      text: "go",
+    } as ProviderRuntimeEvent);
+    store.applyEvent(THREAD, {
+      type: "session_state_changed",
+      thread_id: THREAD,
+      status: { status: "running" },
+    } as ProviderRuntimeEvent);
+    useAgentChatStore.setState((state) => ({
+      threads: {
+        ...state.threads,
+        [THREAD]: { ...state.threads[THREAD], lastPersistedEventId: cursor },
+      },
+    }));
+    expect(useAgentChatStore.getState().threads[THREAD].streaming).toBe(true);
+  }
+
+  it("a rejected probe does not mark a live thread interrupted", async () => {
+    seedStreamingSlice(10);
+    await hydrateThreadByCursor(THREAD, PROVIDER, () => false, {
+      listAfter: async (_t, afterId) =>
+        afterId === null ? [] : [row(11, assistantEvent("still working"))],
+      headId: async () => 11,
+      turnActive: async () => {
+        throw new Error("provider_not_configured: Claude");
+      },
+    });
+    const slice = useAgentChatStore.getState().threads[THREAD];
+    expect(slice.interrupted).toBe(false);
+    expect(slice.streaming).toBe(true);
+  });
+
+  it("a definite false still settles a thread that is not streaming", async () => {
+    // The probe answering "dead" is honoured — only an UNANSWERED probe
+    // falls back to the slice. Otherwise a genuinely dead run could never
+    // earn its divider.
+    seedStreamingSlice(10);
+    useAgentChatStore.setState((state) => ({
+      threads: {
+        ...state.threads,
+        [THREAD]: { ...state.threads[THREAD], streaming: false },
+      },
+    }));
+    await hydrateThreadByCursor(THREAD, PROVIDER, () => false, {
+      listAfter: async (_t, afterId) =>
+        afterId === null ? [] : [row(11, assistantEvent("last words"))],
+      headId: async () => 11,
+      turnActive: async () => false,
+    });
+    const slice = useAgentChatStore.getState().threads[THREAD];
+    expect(slice.streaming).toBe(false);
+    expect(slice.interrupted).toBe(true);
+  });
+
+  it("a probe reporting a delegated-work hold keeps the run live", async () => {
+    // The backend fix: `agent_chat_turn_active` now ORs in "the parent turn
+    // settled but delegated agents are still working", so the probe answers
+    // true across the whole delegated phase.
+    seedStreamingSlice(10);
+    await hydrateThreadByCursor(THREAD, PROVIDER, () => false, {
+      listAfter: async (_t, afterId) =>
+        afterId === null ? [] : [row(11, assistantEvent("subagent output"))],
+      headId: async () => 11,
+      turnActive: async () => true,
+    });
+    const slice = useAgentChatStore.getState().threads[THREAD];
+    expect(slice.interrupted).toBe(false);
+    expect(slice.streaming).toBe(true);
+  });
+});

--- a/src/lib/agent-chat/cursor-hydrate.ts
+++ b/src/lib/agent-chat/cursor-hydrate.ts
@@ -122,17 +122,62 @@ async function probeRunLive(
 }
 
 /**
+ * How many CONSECUTIVE unanswered probes a thread may carry its own
+ * `streaming` forward through before the fallback gives up and settles.
+ *
+ * The fallback is a fixpoint without a bound: hydrate writes `streaming:
+ * runLive`, so a slice that is already streaming re-derives `true` from
+ * itself on every hydrate and can never settle while the probe keeps
+ * rejecting — which it does for as long as the feature flag stays off or
+ * the provider stays out of the registry. Three is chosen to cover the
+ * startup window the probe's rejection modes actually live in (a couple of
+ * remounts while the registry fills) without letting a permanently broken
+ * probe pin a pane at "streaming" for the rest of the session.
+ */
+const MAX_UNANSWERED_PROBE_FALLBACKS = 3;
+
+/** Consecutive unanswered probes per thread. Cleared by any definite
+ *  answer, so a single transient rejection costs nothing. */
+const unansweredProbes = new Map<string, number>();
+
+/**
  * Resolve the probe's answer against the slice's own run state.
  *
  * Only an unanswered probe defers to the slice; a definite `false` is still
  * honoured, because that is how a genuinely-dead run earns its divider.
+ *
+ * The deferral is bounded — see {@link MAX_UNANSWERED_PROBE_FALLBACKS}.
+ * Past the bound "no information" resolves to `false`, which is the
+ * recoverable direction: the divider is wrong until the next real event,
+ * whereas a stuck `streaming` hides the Continue chip indefinitely.
  */
 function resolveRunLive(
   probed: boolean | null,
   threadId: string,
 ): boolean {
-  if (probed !== null) return probed;
+  if (probed !== null) {
+    unansweredProbes.delete(threadId);
+    return probed;
+  }
+  const seen = (unansweredProbes.get(threadId) ?? 0) + 1;
+  unansweredProbes.set(threadId, seen);
+  if (seen > MAX_UNANSWERED_PROBE_FALLBACKS) return false;
   return useAgentChatStore.getState().threads[threadId]?.streaming ?? false;
+}
+
+/**
+ * Probe a thread's run liveness with the same "a rejection is no
+ * information, not death" semantics hydrate uses.
+ *
+ * Exported for the turn-revert path, which rebuilds the transcript through
+ * the same replay and so must not read a gating failure as a dead run.
+ */
+export async function resolveThreadRunLive(
+  provider: AgentChatProviderKind,
+  threadId: string,
+  deps: CursorHydrateDeps = defaultDeps,
+): Promise<boolean> {
+  return resolveRunLive(await probeRunLive(deps, provider, threadId), threadId);
 }
 
 /**
@@ -246,10 +291,7 @@ async function hydratePass(
       // reducer moments later, which settles the thread. Both orderings
       // self-heal the same way; this one is kept only because it takes the
       // liveness reading as late as possible.
-      const runLive = resolveRunLive(
-        await probeRunLive(deps, provider, threadId),
-        threadId,
-      );
+      const runLive = await resolveThreadRunLive(provider, threadId, deps);
       if (isCancelled()) return false;
       useAgentChatStore
         .getState()
@@ -273,10 +315,7 @@ async function hydratePass(
       retry = allowRetry;
       return retry;
     }
-    const runLive = resolveRunLive(
-      await probeRunLive(deps, provider, threadId),
-      threadId,
-    );
+    const runLive = await resolveThreadRunLive(provider, threadId, deps);
     if (isCancelled()) return false;
     useAgentChatStore
       .getState()

--- a/src/lib/agent-chat/cursor-hydrate.ts
+++ b/src/lib/agent-chat/cursor-hydrate.ts
@@ -98,6 +98,44 @@ const defaultDeps: CursorHydrateDeps = {
 };
 
 /**
+ * Probe the backend for "is this thread's run still in flight", returning
+ * `null` — NOT `false` — when the question could not be answered.
+ *
+ * `agent_chat_turn_active` rejects for reasons that have nothing to do with
+ * liveness: the agent-chat feature flag being off, and a
+ * `provider_not_configured` registry miss that is reachable during startup.
+ * Collapsing those into `false` told hydrate "the run is dead", which is the
+ * one answer that flips a healthy transcript to "Run interrupted". `null`
+ * lets the caller fall back to what the slice already knows instead.
+ */
+async function probeRunLive(
+  deps: CursorHydrateDeps,
+  provider: AgentChatProviderKind,
+  threadId: string,
+): Promise<boolean | null> {
+  try {
+    return await deps.turnActive(provider, threadId);
+  } catch (err) {
+    console.warn("[agent-chat] turn-active probe failed:", err);
+    return null;
+  }
+}
+
+/**
+ * Resolve the probe's answer against the slice's own run state.
+ *
+ * Only an unanswered probe defers to the slice; a definite `false` is still
+ * honoured, because that is how a genuinely-dead run earns its divider.
+ */
+function resolveRunLive(
+  probed: boolean | null,
+  threadId: string,
+): boolean {
+  if (probed !== null) return probed;
+  return useAgentChatStore.getState().threads[threadId]?.streaming ?? false;
+}
+
+/**
  * Backoff for the one retry a cold read of zero rows over a NON-EMPTY
  * transcript earns. Long enough for a session collapse / thread re-home to
  * commit its row moves, short enough that the user does not notice.
@@ -194,15 +232,24 @@ async function hydratePass(
       warm && cursor !== 0 && (headId === null || headId < cursor);
     if (warm && !cursorAhead && rows.length <= MAX_WARM_TAIL_ROWS) {
       if (rows.length === 0) return false; // Warm and unchanged — zero work.
-      // Ask the backend whether this thread's turn is still in flight.
-      // Ordering matters: rows are fetched FIRST, liveness SECOND — if
-      // the turn settles between the two calls the `turn_completed` row
-      // is already in `rows`, so `runLive` can only ever be a
-      // conservative false, never a stale "alive". A live turn means the
+      // Ask the backend whether this thread's RUN is still in flight —
+      // which includes a parent turn that yielded while delegated agents
+      // keep working (see `agent_chat_turn_active`). A live run means the
       // tail's missing terminal event is expected, not an interrupt.
-      const runLive = await deps
-        .turnActive(provider, threadId)
-        .catch(() => false);
+      //
+      // Rows are fetched FIRST, liveness SECOND. That ordering is NOT
+      // free of races in either direction: a turn that settles inside the
+      // probe's IPC window persists its `turn_completed` after the row
+      // read, so the tail looks unsettled AND the probe says false. What
+      // makes it safe is the held-event buffer, not the ordering — that
+      // `turn_completed` is sitting in the hold and is released into the
+      // reducer moments later, which settles the thread. Both orderings
+      // self-heal the same way; this one is kept only because it takes the
+      // liveness reading as late as possible.
+      const runLive = resolveRunLive(
+        await probeRunLive(deps, provider, threadId),
+        threadId,
+      );
       if (isCancelled()) return false;
       useAgentChatStore
         .getState()
@@ -226,7 +273,10 @@ async function hydratePass(
       retry = allowRetry;
       return retry;
     }
-    const runLive = await deps.turnActive(provider, threadId).catch(() => false);
+    const runLive = resolveRunLive(
+      await probeRunLive(deps, provider, threadId),
+      threadId,
+    );
     if (isCancelled()) return false;
     useAgentChatStore
       .getState()

--- a/src/lib/agent-chat/hydrate.test.ts
+++ b/src/lib/agent-chat/hydrate.test.ts
@@ -882,6 +882,136 @@ describe("replayPayloads runLive (workspace-switch remount of a live run)", () =
   });
 });
 
+describe("interim yield — a remount while delegated agents keep working", () => {
+  // The regression this suite exists for: Claude Code emits an SDK `result`
+  // (persisted as `turn_completed`) every time the model yields to wait on a
+  // `Task` it spawned, then resumes the SAME session when the subagent
+  // reports back. The reducer models that as an `interim` boundary and keeps
+  // the turn live. Hydrate has to agree, or switching tabs mid-delegation
+  // paints a perfectly healthy run as interrupted.
+  const subagent = (status: string, activity?: string): ProviderRuntimeEvent =>
+    ({
+      type: "subagent_updated",
+      thread_id: "t",
+      subagent: {
+        subagent_id: "sub-1",
+        name: "Explore",
+        status,
+        ...(activity ? { activity } : {}),
+      },
+    }) as ProviderRuntimeEvent;
+
+  const resultEvent: ProviderRuntimeEvent = {
+    type: "turn_completed",
+    thread_id: "t",
+    turn_id: "turn-1",
+    status: { kind: "success" },
+  } as ProviderRuntimeEvent;
+
+  /** A warm slice parked in an interim hold, exactly as the live stream
+   *  leaves it just before the pane unmounts. */
+  function interimHoldSlice(): ChatThreadState {
+    let state = createEmptyThreadState();
+    state = applyEvent(state, {
+      type: "user_message",
+      thread_id: "t",
+      text: "go",
+    } as ProviderRuntimeEvent);
+    state = applyEvent(state, subagent("running"));
+    state = applyEvent(state, resultEvent);
+    return state;
+  }
+
+  it("parks in an interim hold: streaming, settled, not interrupted", () => {
+    const slice = interimHoldSlice();
+    expect(slice.streaming).toBe(true);
+    expect(slice.interrupted).toBe(false);
+    // The turn IS settled — a real `turn_completed` row was persisted.
+    // This is precisely what `streaming` stopped being a proxy for.
+    expect(slice.turnUnsettled).toBe(false);
+    const trailing = slice.messages[slice.messages.length - 1];
+    expect(trailing.kind).toBe("turn_ended");
+    expect(trailing.kind === "turn_ended" && trailing.interim).toBe(true);
+  });
+
+  it("does NOT flip to interrupted when the tail is delegated-agent output", () => {
+    const slice = interimHoldSlice();
+    // Tab switch. The backend keeps persisting subagent rows; on remount the
+    // warm tail is those rows, and `agent_chat_turn_active` now reports the
+    // run live because delegated work is holding it open.
+    const merged = applyReplayTail(
+      slice,
+      parseReplayPayloads([event(subagent("running", "reading files"))]),
+      {
+        runLive: true,
+        previousUnsettled: slice.turnUnsettled,
+        provider: "claude",
+      },
+    );
+
+    expect(merged.interrupted).toBe(false);
+    expect(merged.streaming).toBe(true);
+    // No Continue chip, no Run-interrupted divider.
+    expect(merged.interrupted && !merged.streaming).toBe(false);
+    // ...and the live subagent card was NOT settled behind the run's back.
+    expect(runningSubagentEntries(merged.messages)).toHaveLength(1);
+  });
+
+  it("seeds the tail scan from turnUnsettled, not from streaming", () => {
+    const slice = interimHoldSlice();
+    // The old seed. Kept as an explicit regression assertion: were the store
+    // to go back to `slice.interrupted || slice.streaming`, this is the value
+    // it would pass, and the scan would wrongly report an unsettled tail.
+    const oldSeed = slice.interrupted || slice.streaming;
+    expect(oldSeed).toBe(true);
+    expect(slice.turnUnsettled).toBe(false);
+
+    const tail = parseReplayPayloads([event(subagent("running", "still going"))]);
+    expect(lastTurnUnsettled(tail, oldSeed)).toBe(true); // the bug
+    expect(lastTurnUnsettled(tail, slice.turnUnsettled)).toBe(false); // the fix
+  });
+
+  it("still reports interrupted when the run really did die mid-turn", () => {
+    // Guard against over-correcting: a tail with no completion after a user
+    // turn, and a probe that says dead, must STILL raise the divider.
+    let slice = createEmptyThreadState();
+    slice = applyEvent(slice, {
+      type: "user_message",
+      thread_id: "t",
+      text: "go",
+    } as ProviderRuntimeEvent);
+    expect(slice.turnUnsettled).toBe(true);
+
+    const merged = applyReplayTail(slice, parseReplayPayloads([]), {
+      runLive: false,
+      previousUnsettled: slice.turnUnsettled,
+      provider: "claude",
+    });
+    expect(merged.interrupted).toBe(true);
+    expect(merged.streaming).toBe(false);
+  });
+
+  it("keeps turnUnsettled independent of the runLive override", () => {
+    // `turnUnsettled` describes the HISTORY, so a live probe must not edit
+    // it — otherwise the next tail merge seeds from a liveness verdict and
+    // stops matching a full-history scan.
+    let slice = createEmptyThreadState();
+    slice = applyEvent(slice, {
+      type: "user_message",
+      thread_id: "t",
+      text: "go",
+    } as ProviderRuntimeEvent);
+
+    const merged = applyReplayTail(slice, parseReplayPayloads([]), {
+      runLive: true,
+      previousUnsettled: slice.turnUnsettled,
+      provider: "claude",
+    });
+    expect(merged.interrupted).toBe(false); // suppressed by runLive
+    expect(merged.turnUnsettled).toBe(true); // but the history is unchanged
+  });
+});
+
 describe("applyReplayTail — a live run's streaming reasoning", () => {
   const thinking = (text: string): ProviderRuntimeEvent => ({
     type: "content_delta",

--- a/src/lib/agent-chat/hydrate.test.ts
+++ b/src/lib/agent-chat/hydrate.test.ts
@@ -991,6 +991,89 @@ describe("interim yield — a remount while delegated agents keep working", () =
     expect(merged.streaming).toBe(false);
   });
 
+  it("marks a dispatched queued turn unsettled, live and on replay alike", () => {
+    // A queued follow-up never goes through `appendUserMessageLocal`, the
+    // only other writer of `turnUnsettled`: its bubble is reconciled by
+    // `turn_queued` and promoted by `queued_turn_dispatched` (or, for a pane
+    // that missed the live event, by the persisted `user_message` envelope
+    // written at dispatch and matched on the nonce). Leaving the flag false
+    // there made the live slice disagree with a scan of the very same
+    // persisted rows — and because the dispatch row advances the store's
+    // cursor it never returns in a tail, so the wrong value seeds
+    // `previousUnsettled` for the whole of turn B.
+    const nonce = "nonce-b";
+    let slice = createEmptyThreadState();
+    slice = applyEvent(slice, {
+      type: "user_message",
+      thread_id: "t",
+      text: "A",
+    } as ProviderRuntimeEvent);
+    slice = applyEvent(slice, {
+      type: "turn_queued",
+      thread_id: "t",
+      queued_id: "q-1",
+      text: "B",
+      client_nonce: nonce,
+    } as ProviderRuntimeEvent);
+    slice = applyEvent(slice, resultEvent);
+    expect(slice.turnUnsettled).toBe(false); // turn A is genuinely settled
+    slice = applyEvent(slice, {
+      type: "queued_turn_dispatched",
+      thread_id: "t",
+      queued_id: "q-1",
+      turn_id: "turn-2",
+    } as ProviderRuntimeEvent);
+
+    // The same history, as the backend persisted it: B's envelope is
+    // written at dispatch and nothing has completed it yet.
+    const persisted = parseReplayPayloads([
+      user("A"),
+      event(resultEvent),
+      JSON.stringify({
+        type: "user_message",
+        thread_id: "t",
+        text: "B",
+        client_nonce: nonce,
+      }),
+    ]);
+
+    expect(lastTurnUnsettled(persisted, false)).toBe(true);
+    expect(slice.turnUnsettled).toBe(true);
+
+    // The consequence the seed drives: a warm merge over turn B keeps the
+    // divider and the Continue chip when the run really did die.
+    const merged = applyReplayTail(slice, parseReplayPayloads([]), {
+      runLive: false,
+      previousUnsettled: slice.turnUnsettled,
+      provider: "claude",
+    });
+    expect(merged.interrupted).toBe(true);
+
+    // And the durable envelope path (a pane that missed the live
+    // `queued_turn_dispatched`) reaches the same place.
+    let missed = createEmptyThreadState();
+    missed = applyEvent(missed, {
+      type: "user_message",
+      thread_id: "t",
+      text: "A",
+    } as ProviderRuntimeEvent);
+    missed = applyEvent(missed, {
+      type: "turn_queued",
+      thread_id: "t",
+      queued_id: "q-1",
+      text: "B",
+      client_nonce: nonce,
+    } as ProviderRuntimeEvent);
+    missed = applyEvent(missed, resultEvent);
+    missed = applyEvent(missed, {
+      type: "user_message",
+      thread_id: "t",
+      text: "B",
+      client_nonce: nonce,
+    } as ProviderRuntimeEvent);
+    expect(missed.turnUnsettled).toBe(true);
+  });
+
   it("keeps turnUnsettled independent of the runLive override", () => {
     // `turnUnsettled` describes the HISTORY, so a live probe must not edit
     // it — otherwise the next tail merge seeds from a liveness verdict and

--- a/src/lib/agent-chat/hydrate.ts
+++ b/src/lib/agent-chat/hydrate.ts
@@ -141,11 +141,10 @@ export function replayTimed(
  * workflow stop, the unsettled-tail flag) is a property of the whole
  * history, not of the tail.
  *
- * `previousUnsettled` summarizes the prefix for the unsettled-tail scan:
- * a warm slice that is streaming or already flagged interrupted ends on
- * an unsettled user turn. Any `user_message` / `turn_completed` in the
- * tail overrides it, which makes the merged answer identical to scanning
- * the concatenated history.
+ * `previousUnsettled` summarizes the prefix for the unsettled-tail scan —
+ * the caller passes the slice's tracked `turnUnsettled`. Any `user_message`
+ * / `turn_completed` in the tail overrides it, which makes the merged
+ * answer identical to scanning the concatenated history.
  *
  * When the run is live the settle passes are skipped entirely: their job
  * is to reconcile a transcript that ends mid-run, and a confirmed
@@ -357,6 +356,8 @@ function finalizeReplay(
     );
   }
 
+  const turnUnsettled = lastTurnUnsettled(parsed, previousUnsettled);
+
   return {
     ...state,
     messages,
@@ -375,9 +376,13 @@ function finalizeReplay(
     // `runLive` overrides both signals: a confirmed in-flight turn means
     // the run is alive, so neither the unsettled-tail heuristic nor a
     // stale replay-observed `child_exited` should surface the divider.
-    interrupted: runLive
-      ? false
-      : state.interrupted || lastTurnUnsettled(parsed, previousUnsettled),
+    interrupted: runLive ? false : state.interrupted || turnUnsettled,
+    // Recorded raw — WITHOUT the `runLive` override — because this is the
+    // seed the next cursor-tail merge scans from, and it has to describe the
+    // history, not the current liveness verdict. Folding `runLive` in here
+    // would make a tail read taken while a turn happened to be live disagree
+    // with a full-history scan of the same rows.
+    turnUnsettled,
     // Transient — never persisted, so a hydrated thread always starts clear.
     stalled: null,
   };

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -1094,6 +1094,12 @@ function appendUserMessageLocal(
   return {
     ...next,
     interrupted: false,
+    // A user turn with no completion after it is the definition of an
+    // unsettled tail. Set optimistically for the same reason the bubble is:
+    // a remount before the turn's first output must not read the thread as
+    // settled. The persisted `user_message` row folds through here too and
+    // is deduped by nonce, so live and replay agree.
+    turnUnsettled: true,
     messages: [...next.messages, item],
   };
 }
@@ -1584,6 +1590,10 @@ function applyEventInner(
           ...seqBumped,
           streaming: false,
           interrupted,
+          // A terminal event settles the tail even when it failed — the run
+          // recorded an ending, which is all `lastTurnUnsettled` asks. The
+          // `interrupted` flag above carries the "it died" meaning.
+          turnUnsettled: false,
           messages: [
             ...seqBumped.messages,
             {
@@ -1624,6 +1634,10 @@ function applyEventInner(
         ...seqBumped,
         streaming: interim,
         interrupted: false,
+        // Settled even when the boundary is `interim`: a `turn_completed`
+        // row IS persisted, so a later hydrate scanning history finds it and
+        // must reach the same answer this live fold does.
+        turnUnsettled: false,
         messages: [
           ...seqBumped.messages,
           {

--- a/src/lib/agent-chat/reducer.ts
+++ b/src/lib/agent-chat/reducer.ts
@@ -1199,6 +1199,18 @@ function promoteQueuedUserMessage(
     // A dispatched follow-up means a live turn is starting — clear any
     // interrupted flag so the Continue chip / divider drop.
     interrupted: false,
+    // ...and it is an unsettled tail until that turn completes, exactly
+    // like a directly-sent one. `appendUserMessageLocal` sets this for the
+    // ordinary path but a queued turn never goes through it: its persisted
+    // `user_message` envelope (written at dispatch, carrying the nonce)
+    // reconciles here instead, as does the live `queued_turn_dispatched`.
+    // Leaving it false made the live slice disagree with a scan of the same
+    // persisted rows — and since the dispatch row advances the store cursor
+    // it never comes back in a tail, so that wrong value seeds
+    // `previousUnsettled` for the whole turn and a warm merge over a
+    // genuinely unsettled queued turn shows neither divider nor Continue
+    // chip.
+    turnUnsettled: true,
     messages: replaceItem(next.messages, index, promoted),
   };
 }

--- a/src/lib/agent-chat/types.ts
+++ b/src/lib/agent-chat/types.ts
@@ -423,6 +423,21 @@ export interface ChatThreadState {
    *  Drives the "Run interrupted" divider and the composer's Continue
    *  chip. */
   interrupted: boolean;
+  /** Whether the thread's history ends on an unsettled user turn: a
+   *  `user_message` with no later `turn_completed`.
+   *
+   *  Maintained live by the reducer and recomputed by every hydrate, so a
+   *  warm cursor-tail merge can seed `lastTurnUnsettled` with the answer
+   *  for the prefix it is NOT re-scanning and get the same result as
+   *  scanning the whole concatenated history.
+   *
+   *  Deliberately NOT derived from `streaming`. Those two came apart when
+   *  the interim-turn hold landed: a provider that yields to wait on a
+   *  delegated agent emits a real `turn_completed` (so the last turn IS
+   *  settled) while the thread stays `streaming` because the run is still
+   *  alive. Using `streaming` as the proxy made every remount during a
+   *  delegated phase report a false "Run interrupted". */
+  turnUnsettled: boolean;
   /** Latest context-window occupancy reported by the provider, or
    *  `null` before the first usage report lands (which is also the
    *  signal to hide the composer's meter entirely). Latest snapshot
@@ -442,6 +457,7 @@ export function emptyThreadState(): ChatThreadState {
     nextSeq: 0,
     stalled: null,
     interrupted: false,
+    turnUnsettled: false,
     contextUsage: null,
   };
 }

--- a/src/stores/agent-chat-store.test.ts
+++ b/src/stores/agent-chat-store.test.ts
@@ -192,6 +192,113 @@ describe("agent-chat-store", () => {
     });
   });
 
+  // End-to-end over the store action, which is where the `previousUnsettled`
+  // seed actually lives. Nothing here was covered before: this file had zero
+  // assertions on `interrupted`.
+  describe("applyPayloadsTail — interrupted across a remount", () => {
+    function rows(startId: number, ...payloads: string[]) {
+      return payloads.map((payload, index) => ({
+        id: startId + index,
+        payload,
+      }));
+    }
+    const subagentRow = (status: string) =>
+      JSON.stringify({
+        type: "subagent_updated",
+        thread_id: "t",
+        subagent: { subagent_id: "sub-1", name: "Explore", status },
+      });
+
+    /** Drive a thread into an interim hold through the live event path,
+     *  then park a cursor on it — a pane that watched a delegated `Task`
+     *  start and is about to be unmounted by a tab switch. */
+    function seedInterimHold() {
+      const store = useAgentChatStore.getState();
+      store.ensureThread("t");
+      store.applyEvent("t", {
+        type: "user_message",
+        thread_id: "t",
+        text: "go",
+      } as never);
+      store.applyEvent("t", JSON.parse(subagentRow("running")));
+      store.applyEvent("t", {
+        type: "turn_completed",
+        thread_id: "t",
+        turn_id: "turn-1",
+        status: { kind: "success" },
+      } as never);
+      useAgentChatStore.setState((state) => ({
+        threads: {
+          ...state.threads,
+          t: { ...state.threads.t, lastPersistedEventId: 10 },
+        },
+      }));
+      return useAgentChatStore.getState().threads["t"];
+    }
+
+    it("keeps a delegated-work hold live instead of showing Continue", () => {
+      const before = seedInterimHold();
+      expect(before.streaming).toBe(true);
+      expect(before.turnUnsettled).toBe(false);
+
+      // Remount: the tail is the subagent rows persisted while unmounted,
+      // and the backend reports the run live because delegated work holds it.
+      useAgentChatStore
+        .getState()
+        .applyPayloadsTail("t", rows(11, subagentRow("running")), {
+          runLive: true,
+          provider: "claude",
+        });
+
+      const after = useAgentChatStore.getState().threads["t"];
+      expect(after.interrupted).toBe(false);
+      expect(after.streaming).toBe(true);
+      expect(after.interrupted && !after.streaming).toBe(false);
+    });
+
+    it("does not resurrect an unsettled tail from the streaming flag alone", () => {
+      // The narrow regression: even if the probe comes back false (a stale
+      // read, a slow tracker), the tail scan must not INVENT an unsettled
+      // turn — history genuinely ended on a `turn_completed`.
+      seedInterimHold();
+      useAgentChatStore
+        .getState()
+        .applyPayloadsTail("t", rows(11, subagentRow("running")), {
+          runLive: false,
+          provider: "claude",
+        });
+      expect(useAgentChatStore.getState().threads["t"].interrupted).toBe(false);
+    });
+
+    it("still raises the divider for a turn that never settled", () => {
+      const store = useAgentChatStore.getState();
+      store.ensureThread("t");
+      store.applyEvent("t", {
+        type: "user_message",
+        thread_id: "t",
+        text: "go",
+      } as never);
+      useAgentChatStore.setState((state) => ({
+        threads: {
+          ...state.threads,
+          t: { ...state.threads.t, lastPersistedEventId: 10 },
+        },
+      }));
+      expect(useAgentChatStore.getState().threads["t"].turnUnsettled).toBe(true);
+
+      useAgentChatStore
+        .getState()
+        .applyPayloadsTail("t", rows(11, subagentRow("running")), {
+          runLive: false,
+          provider: "claude",
+        });
+
+      const after = useAgentChatStore.getState().threads["t"];
+      expect(after.interrupted).toBe(true);
+      expect(after.streaming).toBe(false);
+    });
+  });
+
   describe("hydrateThread", () => {
     /** Wrap raw payloads as cursor rows (ids ascending from 1), the shape
      *  `agent_chat_list_messages_after` returns. */

--- a/src/stores/agent-chat-store.ts
+++ b/src/stores/agent-chat-store.ts
@@ -730,10 +730,13 @@ export const useAgentChatStore = create<AgentChatStore>((set) => ({
         const timed = parseTimedReplayPayloads(fresh);
         const merged = applyTimedReplayTail(slice, timed, {
             ...opts,
-            // Summarizes the prefix for the unsettled-tail scan: a slice
-            // that is streaming or already flagged interrupted ends on an
-            // unsettled user turn.
-            previousUnsettled: slice.interrupted || slice.streaming,
+            // Summarizes the prefix for the unsettled-tail scan. This is the
+            // tracked answer for the rows already folded, NOT a guess derived
+            // from `streaming`: a provider that yields to wait on a delegated
+            // agent stays `streaming` with its last turn genuinely settled,
+            // and seeding `true` there made every remount mid-delegation
+            // render a false "Run interrupted" divider + Continue chip.
+            previousUnsettled: slice.turnUnsettled,
         });
         return {
           ...slice,

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1630,12 +1630,20 @@ export const readLocalChatImage = async (
  *  Returns immediately; safe to fire-and-forget. */
 export const primeChatMcp = () => invoke<void>("agent_chat_prime_mcp");
 
+/** Interrupt the thread's running turn.
+ *
+ *  Resolves to whether the interrupt actually reached a LIVE session.
+ *  `false` — a dead or already-closed session — is a success, not an error
+ *  (a stale Stop click must not toast), but it is the caller's cue that no
+ *  settlement event is coming and the pane has to settle itself. A
+ *  REJECTION is the opposite signal: the turn may well still be running,
+ *  so the caller must not settle on it. */
 export const agentChatInterruptTurn = (
   provider: AgentChatProviderKind,
   threadId: string,
   turnId: string | null = null,
 ) =>
-  invoke<void>("agent_chat_interrupt_turn", {
+  invoke<boolean>("agent_chat_interrupt_turn", {
     provider,
     threadId,
     turnId,


### PR DESCRIPTION
## Problem

A provider can end a turn while work it delegated keeps streaming. Claude emits an SDK `result` every time the model yields to wait on a `Task` it spawned, and `claude/session.rs` clears `active_turn` on *every* `result` with no subagent check. Codex has the same shape — its `turn/completed` handler checks only thread and turn identity, never subagent liveness.

So `agent_chat_turn_active` reported "dead" across the entire delegated phase of a perfectly healthy run. Remounting a pane — switching tabs tears down the inactive pane tree — then hydrated the thread as interrupted: a "Run interrupted" divider, a Continue chip, and the still-running subagent card flipped to `interrupted` by hydrate's settle passes. It cleared itself only when the parent resumed and emitted text, which is why it looked random.

Reproduced deterministically before fixing:

```
before remount:  streaming: true,  interrupted: false,  trailing turn_ended interim: true
after  remount:  streaming: false, interrupted: true    → Continue chip
                 subagent status: 'interrupted'
```

Root cause is a feature that landed without updating its consumer. `runLive` (from the liveness probe) became hydrate's sole model of run liveness first; the **interim turn hold** landed afterwards and lives entirely in `reducer.ts`. `grep -c interim` over `hydrate.ts`, `cursor-hydrate.ts` and `agent-chat-store.ts` returns zero.

## Fix

Widen the probe to answer *"is this run live"* rather than *"is a turn live"*, by ORing in the subagent tracker's existing `review_pending` derivation — the same bit that owes the sidebar its Review dot, so the transcript and the pane indicator can never disagree. It is fed from the provider-agnostic `forward_event` path, and it is bounded by the stall watchdog's `forced_settled`.

Three supporting fixes, each with a test that fails without it:

- **Track `turnUnsettled` on the slice** instead of seeding the tail scan from `slice.interrupted || slice.streaming`. Those two came apart when the interim hold landed: an interim yield is streaming with its last turn genuinely settled. The old seed also *under*-reported, because it depended on a `SessionStateChanged{Running}` event that is never persisted and so could not survive a remount.
- **A rejected liveness probe now means "no information", not "dead".** The command rejects when the feature flag is off or the provider registry misses, both reachable at startup, and `.catch(() => false)` turned those into a false Continue chip.
- **Stop is an escape hatch.** On interrupt failure the pane settles locally. Without a settlement event it was trapped with `streaming` stuck on — which hid the Continue chip *and* re-rendered the Stop button that had just failed.

Also: pass a real `runLive` on the turn-revert path instead of hardcoding `false`, and clear the subagent tracker in `shutdown_agent_chat_threads` so a workspace/tab close cannot leave a phantom hold when `stop_session` answers `SessionNotFound` or the broadcast bridge drops the terminal event.

## Provider coverage

| Provider | Can end a turn with delegated work live? | Effect of this PR |
|---|---|---|
| Claude | Yes, by design | Fixed |
| Codex | Yes, unguarded | Fixed |
| OpenCode | No — guards child-session idle | No change |
| Cursor | No delegation concept, emits no `SubagentUpdated` | Provable no-op |

`state.track(...)` is the only writer to the tracker's task map and it lives in the `SubagentUpdated` arm, so a provider that reports no subagents keeps its previous behaviour bit for bit. There is a test pinning that.

Documented alongside the code: Codex and OpenCode report no `task_kind`, so every row they emit defaults to `TaskClass::Agent` with no monitor/background escape hatch, which makes a stuck row likelier for them. A false positive here is the expensive direction, so the bound is spelled out in the doc comment — and the Stop escape hatch above is what makes the worst case recoverable in one click.

## Tests

- **Frontend: 5097 passing / 330 files** (+22). First-ever `interrupted` coverage in `agent-chat-store.test.ts` and `cursor-hydrate.test.ts`, both of which previously had zero — and where all twelve `turnActive` stubs returned `false`, so the warm-tail→interrupted outcome was never asserted end to end.
- **Rust: full suite, zero failures** (+6 tracker tests: interim hold, watch-loops-don't-hold, force-settle releases, teardown clears, new turn clears, no-subagent no-op).
- `tsc --noEmit` clean; no new clippy warnings (125 → 125); no new rustfmt drift.

Each of the three supporting fixes was verified by reverting it and confirming the new test fails.

## Screenshots

None. The bug is a state-machine fault with no visual redesign, and it cannot be staged in the dev mock: the mock has no subagent tracker, so it cannot produce the interim yield that triggers it. The behavioural change is covered by the store- and hydrate-level assertions above.

## Not verified

Not exercised against a live Claude run with a real delegated `Task` — worth one manual pass before merge.

---

Written by Claude Opus 4.5 in Claude Code.
