### PR TITLE
fix(review): make the description fold a real control

### DIFF
--- a/src/components/workspace/review/review-description.tsx
+++ b/src/components/workspace/review/review-description.tsx
@@ -73,6 +73,11 @@ export function ReviewDescription({
   }, [draftKey, foldable]);
 
   const editing = draft !== undefined;
+  // Fold state is remembered per PR, but whether a description is long
+  // enough to fold is a property of the text in front of us right now.
+  // Only clip when both agree, so clipped content always has a control
+  // beside it to open it back up.
+  const isFolded = folded && foldable;
 
   const startEdit = () => {
     const initial = getDescriptionDraft(draftKey) ?? text;
@@ -134,12 +139,12 @@ export function ReviewDescription({
           <button
             type="button"
             onClick={toggleFold}
-            aria-expanded={!folded}
-            aria-label={folded ? "Unfold description" : "Fold description"}
+            aria-expanded={!isFolded}
+            aria-label={isFolded ? "Unfold description" : "Fold description"}
             className="text-muted-foreground transition-colors hover:text-foreground"
           >
             <ChevronDown
-              className={cn("size-3 transition-transform", folded && "-rotate-90")}
+              className={cn("size-3 transition-transform", isFolded && "-rotate-90")}
             />
           </button>
         )}
@@ -189,9 +194,9 @@ export function ReviewDescription({
         </div>
       ) : text ? (
         <div className="flex flex-col items-start">
-          <div className={cn("w-full", folded && "relative max-h-40 overflow-hidden")}>
+          <div className={cn("w-full", isFolded && "relative max-h-40 overflow-hidden")}>
             <MarkdownRendered content={text} inline />
-            {folded && (
+            {isFolded && (
               // Scrim only — the last visible line fades out instead of
               // being sliced through. The control below is the control.
               <div
@@ -204,7 +209,7 @@ export function ReviewDescription({
             <button
               type="button"
               onClick={toggleFold}
-              aria-expanded={!folded}
+              aria-expanded={!isFolded}
               className={cn(
                 btnCardXs,
                 "mt-1.5 text-muted-foreground hover:text-foreground",
@@ -212,9 +217,9 @@ export function ReviewDescription({
               data-testid="description-fold"
             >
               <ChevronDown
-                className={cn("size-3 transition-transform", !folded && "rotate-180")}
+                className={cn("size-3 transition-transform", !isFolded && "rotate-180")}
               />
-              {folded ? `Show all ${lineCount} lines` : "Show less"}
+              {isFolded ? `Show all ${lineCount} lines` : "Show less"}
             </button>
           )}
         </div>

--- a/src/components/workspace/review/review-description.tsx
+++ b/src/components/workspace/review/review-description.tsx
@@ -4,7 +4,14 @@ import { cn } from "@/lib/utils";
 import { toast } from "@/lib/toast";
 import { MarkdownRendered } from "@/components/editor/MarkdownRendered";
 import { updatePullRequest } from "@/tauri/commands";
-import { btnCard, btnEmberSolid, tzBody, tzEyebrow, tzMeta } from "./review-ui";
+import {
+  btnCard,
+  btnCardXs,
+  btnEmberSolid,
+  tzBody,
+  tzEyebrow,
+  tzMeta,
+} from "./review-ui";
 import {
   clearDescriptionDraft,
   getDescriptionDraft,
@@ -181,18 +188,33 @@ export function ReviewDescription({
           </div>
         </div>
       ) : text ? (
-        <div className={cn(folded && "relative max-h-40 overflow-hidden")}>
-          <MarkdownRendered content={text} inline />
-          {folded && (
+        <div className="flex flex-col items-start">
+          <div className={cn("w-full", folded && "relative max-h-40 overflow-hidden")}>
+            <MarkdownRendered content={text} inline />
+            {folded && (
+              // Scrim only — the last visible line fades out instead of
+              // being sliced through. The control below is the control.
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-background via-background/80 to-transparent"
+              />
+            )}
+          </div>
+          {foldable && (
             <button
               type="button"
               onClick={toggleFold}
+              aria-expanded={!folded}
               className={cn(
-                "absolute inset-x-0 bottom-0 flex h-10 items-end justify-center bg-gradient-to-t from-background to-transparent text-muted-foreground hover:text-foreground",
-                tzMeta,
+                btnCardXs,
+                "mt-1.5 text-muted-foreground hover:text-foreground",
               )}
+              data-testid="description-fold"
             >
-              Show all {lineCount} lines
+              <ChevronDown
+                className={cn("size-3 transition-transform", !folded && "rotate-180")}
+              />
+              {folded ? `Show all ${lineCount} lines` : "Show less"}
             </button>
           )}
         </div>

--- a/src/components/workspace/review/review-detail.test.tsx
+++ b/src/components/workspace/review/review-detail.test.tsx
@@ -554,6 +554,41 @@ describe("description editing", () => {
   });
 });
 
+// ── Description fold ──
+
+describe("description fold", () => {
+  const LONG = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join("\n");
+
+  /** The clip is the thing that hides text; the control is the way back. */
+  const clipped = () =>
+    screen.getByTestId("review-description").querySelector(".max-h-40.overflow-hidden");
+
+  it("never clips a description without offering a way to open it", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderDetail({ pr: makePr({ body: LONG }) });
+    await flush();
+
+    expect(clipped()).not.toBeNull();
+    expect(screen.getByTestId("description-fold")).toBeInTheDocument();
+
+    // Open and re-fold, so "folded" is what this PR remembers.
+    await user.click(screen.getByTestId("description-fold"));
+    expect(clipped()).toBeNull();
+    await user.click(screen.getByTestId("description-fold"));
+    expect(clipped()).not.toBeNull();
+
+    // The body is edited down to a few lines. The remembered fold no
+    // longer applies: nothing may stay clipped with no control beside it.
+    rerender({
+      pr: makePr({ body: "Short enough to read in one go." }),
+    });
+    await flush();
+
+    expect(screen.queryByTestId("description-fold")).not.toBeInTheDocument();
+    expect(clipped()).toBeNull();
+  });
+});
+
 // ── Reviewers line ──
 
 describe("reviewers line", () => {


### PR DESCRIPTION
## Problem

In the pull request panel, the "Show all N lines" affordance for a folded description *was* the gradient — a full-width transparent button whose label landed centered in the middle of the pane, on the same line as the half-clipped last row of text. It read as stray copy rather than something pressable, and its position was an accident of the overlay's geometry rather than a decision.

## Fix

Split the two jobs the overlay was doing.

- The gradient is now a `pointer-events-none` scrim — taller, three-stop — so the last visible line dissolves instead of being sliced through.
- The control is a chip below it in normal flow, reusing the review surface's existing `btnCardXs` geometry, left-aligned to the description's own text edge, with a chevron that tracks state.
- It also renders when expanded, as "Show less", so a long description can be collapsed from where you finished reading rather than only from the eyebrow chevron above it.

The chip carries `data-testid="description-fold"` and `aria-expanded`.

## Before / after

Same PR (#482 in the dev mock, 48-line body), same frame, same viewport.

![before: the label floats untethered in the middle of the pane, colliding with the clipped last line](https://raw.githubusercontent.com/Zeus-Deus/codemux/98342cfe/pr/description-fold-control/before.png)

![after: a card chip with a chevron sits below the faded text, aligned to its left edge](https://raw.githubusercontent.com/Zeus-Deus/codemux/98342cfe/pr/description-fold-control/after.png)

## Verification

- `npm run check`
- `npm run test -- src/components/workspace/review/review-detail.test.tsx` (40 passed)
- Walked both states in the dev mock: fold, expand, collapse from the bottom chip.
