### PR TITLE
fix(agent-chat): preserve sessions when changing fast mode

### DIFF
--- a/src-tauri/src/agent_provider/acp/session.rs
+++ b/src-tauri/src/agent_provider/acp/session.rs
@@ -1427,6 +1427,13 @@ impl AcpSession {
         Ok(())
     }
 
+    /// Apply the Fast session option without replacing the ACP session.
+    /// Dialects that never advertise a Fast config option resolve to a
+    /// no-op inside [`Self::set_boolean_config`].
+    pub async fn set_fast_mode(&self, fast_mode: bool) -> Result<(), ProviderError> {
+        self.set_boolean_config(ConfigKind::Fast, fast_mode).await
+    }
+
     pub async fn set_permission_mode(&self, mode: String) -> Result<(), ProviderError> {
         if !matches!(mode.as_str(), "agent" | "ask" | "plan") {
             return Err(ProviderError::ValidationError {

--- a/src-tauri/src/agent_provider/codex/mod.rs
+++ b/src-tauri/src/agent_provider/codex/mod.rs
@@ -337,6 +337,20 @@ impl AgentProvider for CodexAgentProvider {
         Ok(())
     }
 
+    async fn set_fast_mode(
+        &self,
+        thread_id: ThreadId,
+        fast_mode: bool,
+    ) -> Result<(), ProviderError> {
+        let session = {
+            let sessions = self.sessions.read().await;
+            sessions.get(&thread_id).cloned()
+        };
+        let session = session.ok_or(ProviderError::SessionNotFound { thread_id })?;
+        session.set_fast_mode(fast_mode).await;
+        Ok(())
+    }
+
     async fn set_permission_mode(
         &self,
         _thread_id: ThreadId,

--- a/src-tauri/src/agent_provider/codex/protocol.rs
+++ b/src-tauri/src/agent_provider/codex/protocol.rs
@@ -248,9 +248,13 @@ pub struct TurnStartParams {
     /// Per-turn model override. Falls through to the session default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
-    /// Service tier override.
+    /// Per-turn service-tier override. Codex applies it to the turn this
+    /// request starts and leaves the thread's own tier untouched, so a user's
+    /// configured `service_tier` survives the composer's Fast/Standard toggle.
+    /// Never send `serviceTier` here: that one rewrites the thread's tier for
+    /// every later turn as well.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_tier: Option<String>,
+    pub service_tier_for_turn: Option<String>,
     /// Reasoning-effort hint.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<String>,
@@ -1403,6 +1407,23 @@ mod tests {
     }
 
     #[test]
+    fn turn_start_tier_uses_the_per_turn_field_only() {
+        let params = TurnStartParams {
+            thread_id: "t-codex".into(),
+            input: vec![],
+            model: None,
+            service_tier_for_turn: Some("default".into()),
+            effort: None,
+            collaboration_mode: None,
+        };
+        let value = serde_json::to_value(&params).unwrap();
+        assert_eq!(value["serviceTierForTurn"], "default");
+        // `serviceTier` would persist onto the thread and override whatever
+        // tier the user configured for every later turn.
+        assert!(value.get("serviceTier").is_none());
+    }
+
+    #[test]
     fn turn_input_text_serializes_with_type_tag() {
         let item = TurnInputItem::Text {
             text: "hello".into(),
@@ -1457,7 +1478,7 @@ mod tests {
                 },
             ],
             model: Some("gpt-5.4".into()),
-            service_tier: None,
+            service_tier_for_turn: None,
             effort: None,
             collaboration_mode: None,
         };
@@ -1485,7 +1506,7 @@ mod tests {
                 text_elements: vec![],
             }],
             model: None,
-            service_tier: None,
+            service_tier_for_turn: None,
             effort: None,
             collaboration_mode: None,
         };
@@ -1501,7 +1522,7 @@ mod tests {
             thread_id: "t-codex".into(),
             input: vec![],
             model: Some("gpt-5.6-sol".into()),
-            service_tier: None,
+            service_tier_for_turn: None,
             effort: Some("high".into()),
             collaboration_mode: Some(CollaborationMode {
                 mode: "default".into(),

--- a/src-tauri/src/agent_provider/codex/protocol.rs
+++ b/src-tauri/src/agent_provider/codex/protocol.rs
@@ -42,21 +42,22 @@ use crate::agent_provider::ApprovalDecision;
 /// `thread/resume` JSON-RPC call, triggering an automatic fallback to
 /// `thread/start`.
 ///
-/// Inferred list. The upstream reference that prompted this adapter
-/// mentions a `RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS` constant but the
-/// exact string set was not cited, so these are the reasonable
-/// candidates. Matching is case-insensitive against whatever error
-/// message the RPC call surfaces.
+/// Matching is case-insensitive against whatever error message the RPC call
+/// surfaces. `no rollout found` is pinned from a real desktop-restart failure;
+/// the remaining phrases cover older/provider-equivalent wording.
 ///
 /// An incomplete list is safe: a resume error that does not match falls
 /// through to a plain [`ProviderError::RpcError`](crate::agent_provider::ProviderError::RpcError)
 /// instead of being auto-recovered. The session ends up broken, but
 /// nothing misbehaves silently.
 ///
-// TODO: verify against real codex app-server error messages once the
-// adapter is exercised in real failure scenarios.
 pub const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS: &[&str] = &[
+    // Current app-server wording when the persisted rollout is absent. This
+    // is the real-world desktop-restart case that originally exposed the
+    // incomplete inferred list below.
+    "no rollout found",
     "thread not found",
+    "missing thread",
     "unknown thread",
     "no such thread",
     "thread does not exist",

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -125,6 +125,10 @@ pub(crate) struct CodexSessionState {
     /// — mirrors the reference's `collaborationMode.settings.reasoning_effort`
     /// session default.
     pub default_effort: Option<String>,
+    /// Service-speed tier applied to subsequent `turn/start` requests.
+    /// Codex accepts this per turn, so changing Fast mode does not require
+    /// rebuilding or resuming the provider thread.
+    pub fast_mode: bool,
     /// Follow-up turns queued while a turn was in flight, in FIFO
     /// dispatch order. Drained one-at-a-time as the session returns to
     /// idle (see [`CodexSession::drain_queue`]).
@@ -516,6 +520,7 @@ impl CodexSession {
             status: SessionStatus::Ready,
             model,
             default_effort: effort,
+            fast_mode,
             queued_turns: VecDeque::new(),
         });
         let session = Arc::new(Self {
@@ -833,12 +838,13 @@ impl CodexSession {
         model_override: Option<String>,
         effort_override: Option<String>,
     ) -> Result<TurnId, ProviderError> {
-        let (codex_thread_id, model_default, effort_default) = {
+        let (codex_thread_id, model_default, effort_default, fast_mode) = {
             let state = self.state.lock().await;
             (
                 state.codex_thread_id.clone(),
                 state.model.clone(),
                 state.default_effort.clone(),
+                state.fast_mode,
             )
         };
 
@@ -893,7 +899,11 @@ impl CodexSession {
             thread_id: codex_thread_id,
             input: input_items,
             model,
-            service_tier: None,
+            // `serviceTier` is a turn override that also becomes the thread's
+            // default for later turns. Send an explicit `default` when Fast
+            // is off; omission would inherit a thread that was previously
+            // launched in the Fast tier.
+            service_tier: Some(if fast_mode { "fast" } else { "default" }.into()),
             effort,
             collaboration_mode,
         };
@@ -1032,6 +1042,13 @@ impl CodexSession {
     pub async fn set_model(&self, model: String) {
         let mut state = self.state.lock().await;
         state.model = Some(model);
+    }
+
+    /// Update the service tier used by subsequent turns without replacing
+    /// the Codex app-server or its loaded thread.
+    pub async fn set_fast_mode(&self, fast_mode: bool) {
+        let mut state = self.state.lock().await;
+        state.fast_mode = fast_mode;
     }
 
     /// Gracefully shut the session down: close the JSON-RPC child
@@ -1552,7 +1569,11 @@ mod tests {
 
     #[test]
     fn recoverable_resume_error_matches_snippets() {
+        assert!(is_recoverable_resume_error(
+            "rpc error -32600: no rollout found for thread id 019db5ad"
+        ));
         assert!(is_recoverable_resume_error("rpc error: Thread not found (code 42)"));
+        assert!(is_recoverable_resume_error("missing thread"));
         assert!(is_recoverable_resume_error("unknown thread"));
         assert!(is_recoverable_resume_error("NO SUCH THREAD"));
         assert!(!is_recoverable_resume_error("network is unreachable"));

--- a/src-tauri/src/agent_provider/codex/session.rs
+++ b/src-tauri/src/agent_provider/codex/session.rs
@@ -899,11 +899,11 @@ impl CodexSession {
             thread_id: codex_thread_id,
             input: input_items,
             model,
-            // `serviceTier` is a turn override that also becomes the thread's
-            // default for later turns. Send an explicit `default` when Fast
-            // is off; omission would inherit a thread that was previously
-            // launched in the Fast tier.
-            service_tier: Some(if fast_mode { "fast" } else { "default" }.into()),
+            // `serviceTierForTurn` scopes the choice to this turn only, so the
+            // thread keeps whatever tier the user configured. Send an explicit
+            // `default` when Fast is off: omission would inherit the thread's
+            // tier and silently keep a previous Fast turn's speed.
+            service_tier_for_turn: Some(if fast_mode { "fast" } else { "default" }.into()),
             effort,
             collaboration_mode,
         };

--- a/src-tauri/src/agent_provider/cursor/mod.rs
+++ b/src-tauri/src/agent_provider/cursor/mod.rs
@@ -230,6 +230,17 @@ impl AgentProvider for CursorAgentProvider {
         self.session(&thread_id).await?.set_model(model).await
     }
 
+    async fn set_fast_mode(
+        &self,
+        thread_id: ThreadId,
+        fast_mode: bool,
+    ) -> Result<(), ProviderError> {
+        self.session(&thread_id)
+            .await?
+            .set_fast_mode(fast_mode)
+            .await
+    }
+
     async fn set_permission_mode(
         &self,
         thread_id: ThreadId,

--- a/src-tauri/src/agent_provider/provider.rs
+++ b/src-tauri/src/agent_provider/provider.rs
@@ -110,6 +110,19 @@ pub trait AgentProvider: Send + Sync {
     /// [`ProviderError::ValidationError`](super::errors::ProviderError::ValidationError).
     async fn set_model(&self, thread_id: ThreadId, model: String) -> Result<(), ProviderError>;
 
+    /// Swap the session's service-speed tier at runtime. Providers that
+    /// advertise Fast mode should override this and apply the choice to the
+    /// existing provider session rather than forcing a stop/resume cycle.
+    async fn set_fast_mode(
+        &self,
+        _thread_id: ThreadId,
+        _fast_mode: bool,
+    ) -> Result<(), ProviderError> {
+        Err(ProviderError::ValidationError {
+            message: "provider does not support mid-session Fast mode changes".into(),
+        })
+    }
+
     /// Swap the session's permission mode at runtime.
     async fn set_permission_mode(
         &self,

--- a/src-tauri/src/commands/agent_chat.rs
+++ b/src-tauri/src/commands/agent_chat.rs
@@ -3353,6 +3353,38 @@ pub async fn agent_chat_set_model<R: Runtime>(
     }
 }
 
+/// Change the provider's service-speed tier without replacing its live
+/// conversation. The choice is persisted first so an app restart or dead
+/// provider process resumes with the same tier; a missing live session is
+/// therefore already healed for the next auto-resume.
+#[tauri::command]
+pub async fn agent_chat_set_fast_mode<R: Runtime>(
+    app: AppHandle<R>,
+    provider: ProviderKind,
+    thread_id: ThreadId,
+    fast_mode: bool,
+) -> Result<(), String> {
+    let observability: State<'_, ObservabilityStore> = app.state();
+    feature_flag_on(&observability)?;
+    let registry: State<'_, ProviderRegistry> = app.state();
+    let impl_ = lookup_provider(&registry, provider).await?;
+    {
+        let db: State<'_, DatabaseStore> = app.state();
+        let config = AgentChatSessionConfig {
+            fast_mode: Some(fast_mode),
+            ..AgentChatSessionConfig::default()
+        };
+        if let Err(error) = db.update_agent_chat_session_config(&thread_id.0, &config) {
+            eprintln!("[codemux::agent_chat] failed to persist Fast mode config: {error}");
+        }
+    }
+    match impl_.set_fast_mode(thread_id, fast_mode).await {
+        Ok(()) => Ok(()),
+        Err(ProviderError::SessionNotFound { .. }) => Ok(()),
+        Err(err) => Err(provider_err(err)),
+    }
+}
+
 /// Change a session's permission mode (accept-edits, bypass, plan,
 /// etc.). The mode is passed through as a string; providers reject
 /// unknown values via `ProviderError::ValidationError`.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2129,6 +2129,7 @@ fn build_core_app<R: tauri::Runtime>(
             commands::agent_chat_turn_active,
             commands::agent_chat_respond_to_request,
             commands::agent_chat_set_model,
+            commands::agent_chat_set_fast_mode,
             commands::agent_chat_set_permission_mode,
             commands::list_chat_provider_capabilities,
             commands::agent_chat_provider_health,

--- a/src-tauri/tests/codex_adapter.rs
+++ b/src-tauri/tests/codex_adapter.rs
@@ -432,6 +432,51 @@ async fn send_turn_emits_structured_skill_item_on_the_wire() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fast_mode_changes_apply_to_turns_without_restarting_the_thread() {
+    async fn captured_tier(initial_fast: bool, next_fast: bool, thread: &str) -> String {
+        let capture_dir = tempfile::tempdir().unwrap();
+        let capture_path = capture_dir.path().join("turn.json");
+        let capture_path_string = capture_path.to_string_lossy().to_string();
+        let wrapper = wrapper_with_env(&[("FAKE_CODEX_CAPTURE_TURN", &capture_path_string)]);
+        let provider = provider_with_fixture_and_binary(wrapper.to_path_buf());
+        let mut input = start_input(thread);
+        input.fast_mode = initial_fast;
+        start_session_resilient(&provider, input).await.unwrap();
+
+        provider
+            .set_fast_mode(ThreadId(thread.into()), next_fast)
+            .await
+            .unwrap();
+        provider
+            .send_turn(SendTurnInput {
+                thread_id: ThreadId(thread.into()),
+                text: "continue".into(),
+                images: vec![],
+                model_override: None,
+                effort_override: None,
+                permission_mode_override: None,
+                client_nonce: None,
+                display_text: None,
+                skill_invocations: vec![],
+                turn_checkpoint: None,
+            })
+            .await
+            .unwrap();
+
+        let captured: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&capture_path).unwrap()).unwrap();
+        provider.stop_session(ThreadId(thread.into())).await.ok();
+        captured["serviceTier"].as_str().unwrap().to_string()
+    }
+
+    assert_eq!(captured_tier(false, true, "t-fast-on").await, "fast");
+    assert_eq!(
+        captured_tier(true, false, "t-fast-off").await,
+        "default"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rollback_conversation_uses_codex_thread_rollback_contract() {
     let capture_dir = tempfile::tempdir().unwrap();
     let capture_path = capture_dir.path().join("rollback.json");

--- a/src-tauri/tests/codex_adapter.rs
+++ b/src-tauri/tests/codex_adapter.rs
@@ -466,14 +466,21 @@ async fn fast_mode_changes_apply_to_turns_without_restarting_the_thread() {
         let captured: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&capture_path).unwrap()).unwrap();
         provider.stop_session(ThreadId(thread.into())).await.ok();
-        captured["serviceTier"].as_str().unwrap().to_string()
+        // The per-turn field is the only tier key allowed on `turn/start`.
+        // `serviceTier` would rewrite the thread's tier for every later turn
+        // and clobber a user's configured `service_tier`.
+        assert!(
+            captured.get("serviceTier").is_none(),
+            "turn/start must not send the persistent serviceTier: {captured}"
+        );
+        captured["serviceTierForTurn"]
+            .as_str()
+            .unwrap_or_else(|| panic!("turn/start must send serviceTierForTurn: {captured}"))
+            .to_string()
     }
 
     assert_eq!(captured_tier(false, true, "t-fast-on").await, "fast");
-    assert_eq!(
-        captured_tier(true, false, "t-fast-off").await,
-        "default"
-    );
+    assert_eq!(captured_tier(true, false, "t-fast-off").await, "default");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/tests/helpers/fake_codex_app_server/main.rs
+++ b/src-tauri/tests/helpers/fake_codex_app_server/main.rs
@@ -27,7 +27,7 @@
 //!
 //! * `FAKE_CODEX_SCRIPT` — path to a script JSON file.
 //! * `FAKE_CODEX_FAIL_RESUME=1` — make `thread/resume` fail with a
-//!   recoverable "thread not found" error.
+//!   recoverable real-world "no rollout found" error.
 //! * `FAKE_CODEX_THREAD_ID` — override the id returned from
 //!   `thread/start` (default `"c-1"`).
 //! * `FAKE_CODEX_EXIT_AFTER=<method>` — exit the fixture 0 after
@@ -270,7 +270,7 @@ fn main() {
                         write_line(&json!({
                             "jsonrpc":"2.0",
                             "id": id,
-                            "error": {"code":-32000,"message":"thread not found"},
+                            "error": {"code":-32600,"message":"no rollout found for thread id old-thread"},
                         }));
                     }
                 } else if let Some(id) = id {

--- a/src/components/chat/AgentChatPane.test.tsx
+++ b/src/components/chat/AgentChatPane.test.tsx
@@ -214,6 +214,7 @@ vi.mock("./Composer", () => ({
     onModelChange,
     onProviderModelChange,
     onContextWindowChange,
+    onFastModeChange,
     onPermissionModeChange,
     provider,
     providerCliInstalled,
@@ -236,6 +237,7 @@ vi.mock("./Composer", () => ({
       model: string,
     ) => void;
     onContextWindowChange: (contextWindow: string) => void;
+    onFastModeChange: (fastMode: boolean) => void;
     onPermissionModeChange: (mode: string) => void;
     provider: "claude" | "codex" | "cursor" | "grok" | "opencode";
     providerCliInstalled?: boolean | null;
@@ -304,6 +306,10 @@ vi.mock("./Composer", () => ({
       <button
         data-testid="context-window-change"
         onClick={() => onContextWindowChange("1m")}
+      />
+      <button
+        data-testid="fast-mode-change"
+        onClick={() => onFastModeChange(true)}
       />
       {/* Permission-mode picker selection. Per-turn providers have to
           push the choice onto the LIVE session; per-session ones
@@ -433,6 +439,7 @@ vi.mock("@/tauri/commands", () => ({
   agentChatSendTurn: vi.fn().mockResolvedValue(undefined),
   agentChatSendQueuedTurnNow: vi.fn().mockResolvedValue(undefined),
   agentChatSetModel: vi.fn().mockResolvedValue(undefined),
+  agentChatSetFastMode: vi.fn().mockResolvedValue(undefined),
   agentChatSetPermissionMode: vi.fn().mockResolvedValue(undefined),
   agentChatStartSession: vi.fn().mockResolvedValue("thread-new"),
   agentChatStopSession: vi.fn().mockResolvedValue(undefined),
@@ -668,6 +675,7 @@ import {
   agentChatListSessions,
   agentChatRespondToRequest,
   agentChatSendTurn,
+  agentChatSetFastMode,
   agentChatSetModel,
   agentChatSetPermissionMode,
   agentChatStartSession,
@@ -2069,7 +2077,10 @@ describe("AgentChatPane picker-config persistence (design G)", () => {
     vi.mocked(agentChatUpdateSessionConfig).mockClear();
     mockAppState.appState = HOME_APP_STATE.appState;
   });
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    useProviderCapabilities.setState({ codex: null, codexError: null });
+  });
 
   it("persists the model on a picker change (fire-and-forget)", async () => {
     const existingPane = { ...pane, thread_id: "thread-x" };
@@ -2099,6 +2110,65 @@ describe("AgentChatPane picker-config persistence (design G)", () => {
         context_window: "1m",
       }),
     );
+  });
+
+  it("applies Codex Fast mode live without stopping or restarting the session", async () => {
+    useProviderCapabilities.setState({
+      codex: {
+        models: [
+          {
+            id: "gpt-5.4",
+            label: "GPT-5.4",
+            description: null,
+            effort_levels: ["medium", "high"],
+            default_effort: "medium",
+            effort_descriptions: {},
+            prompt_injected_effort_levels: [],
+            context_window_options: [],
+            supports_adaptive_thinking: false,
+            supports_thinking_toggle: false,
+            supports_fast_mode: true,
+            supports_images: true,
+            sub_provider: null,
+            is_free: false,
+          },
+        ],
+        effort_granularity: "per_turn",
+        effort_label_map: {},
+        permission_modes: [],
+        default_permission_mode: "danger-full-access",
+        permission_granularity: "per_session",
+      },
+      codexError: null,
+    });
+    currentSliceOverrides = {
+      "thread-x": { model: "gpt-5.4", fastMode: false },
+    };
+    const codexPane = {
+      ...pane,
+      provider: "codex" as const,
+      thread_id: "thread-x",
+    };
+    const { container } = render(<AgentChatPane pane={codexPane} />);
+    vi.mocked(agentChatSetFastMode).mockClear();
+    vi.mocked(agentChatStopSession).mockClear();
+    vi.mocked(agentChatStartSession).mockClear();
+
+    const button = container.querySelector(
+      '[data-testid="fast-mode-change"]',
+    ) as HTMLButtonElement;
+    button.click();
+
+    await waitFor(() =>
+      expect(agentChatSetFastMode).toHaveBeenCalledWith(
+        "codex",
+        "thread-x",
+        true,
+      ),
+    );
+    expect(setFastModeMock).toHaveBeenCalledWith("thread-x", true);
+    expect(agentChatStopSession).not.toHaveBeenCalled();
+    expect(agentChatStartSession).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/chat/AgentChatPane.tsx
+++ b/src/components/chat/AgentChatPane.tsx
@@ -86,6 +86,7 @@ import {
   agentChatRevertTurnCheckpoint,
   agentChatRespondToRequest,
   agentChatSendTurn,
+  agentChatSetFastMode,
   agentChatSetModel,
   agentChatSetPermissionMode,
   agentChatStartSession,
@@ -2247,14 +2248,14 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
   );
 
   /**
-   * Shared silent-restart helper. Permission-mode, effort, and
-   * context-window all trigger the same flow on Claude: stop the
+   * Shared silent-restart helper for settings a provider genuinely binds at
+   * session creation. Permission-mode, effort, and context-window trigger
+   * this flow on Claude: stop the
    * current provider process, then rebuild it under the SAME durable
    * CodeMux thread id with the updated launch params. The resume cursor
    * carries provider-native state when available; the stable thread id
    * keeps the visible transcript authoritative even if native resume
-   * ultimately has to fall back. Codex-side callers only route through
-   * here for launch-scoped features such as Fast mode.
+   * ultimately has to fall back.
    *
    * Declared above the mode handlers so `handleModeRemove` can use
    * it for the silent-restart restore path (the SDK rejects live
@@ -2267,7 +2268,6 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       effort?: string | null;
       contextWindow?: string | null;
       model?: string | null;
-      fastMode?: boolean;
       /** Drop provider-native continuity. Required when Grok reports that
        * the chosen model belongs to an incompatible agent family. */
       freshSession?: boolean;
@@ -2309,10 +2309,7 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
           : currentSlice.contextWindow;
       const nextModel =
         updates.model !== undefined ? updates.model : currentSlice.model;
-      const nextFastMode =
-        updates.fastMode !== undefined
-          ? updates.fastMode
-          : currentSlice.fastMode;
+      const nextFastMode = currentSlice.fastMode;
       void (async () => {
         try {
           await agentChatStopSession(provider, threadId);
@@ -2764,36 +2761,36 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
         configPatch.fast_mode = plan.resetFastMode;
       }
       persistSessionConfig(configPatch);
-      if (plan.resetFastMode !== undefined) {
-        restartSessionWith({
-          model: next,
-          fastMode: plan.resetFastMode,
-          onFailure: rollback,
-        });
-      } else {
-        agentChatSetModel(provider, threadId, next).catch((err) => {
-          if (provider === "grok" && grokModelChangeRequiresRestart(err)) {
-            // This request may have failed after a newer picker choice was
-            // already accepted. Never rebuild the native session around the
-            // stale model in that case.
-            if (
-              useAgentChatStore.getState().threads[threadId]?.model !== next
-            ) {
-              return;
-            }
-            // Grok locks the underlying agent family after the first turn.
-            // Keep the durable Codemux transcript, but create a fresh native
-            // Grok session so the newly selected family can start cleanly.
-            restartSessionWith({
-              model: next,
-              freshSession: true,
-              onFailure: rollback,
-            });
+      agentChatSetModel(provider, threadId, next).catch((err) => {
+        if (provider === "grok" && grokModelChangeRequiresRestart(err)) {
+          // This request may have failed after a newer picker choice was
+          // already accepted. Never rebuild the native session around the
+          // stale model in that case.
+          if (useAgentChatStore.getState().threads[threadId]?.model !== next) {
             return;
           }
-          rollback();
-          toast.error(`Failed to set model: ${formatProviderError(err)}`);
-        });
+          // Grok locks the underlying agent family after the first turn.
+          // Keep the durable Codemux transcript, but create a fresh native
+          // Grok session so the newly selected family can start cleanly.
+          restartSessionWith({
+            model: next,
+            freshSession: true,
+            onFailure: rollback,
+          });
+          return;
+        }
+        rollback();
+        toast.error(`Failed to set model: ${formatProviderError(err)}`);
+      });
+      // A compat-driven Fast reset rides the live session too: both
+      // Fast-capable providers apply the tier without a relaunch, so the
+      // model swap above stays the only reason to touch the session.
+      if (plan.resetFastMode !== undefined) {
+        agentChatSetFastMode(provider, threadId, plan.resetFastMode).catch(
+          (err) => {
+            toast.error(`Failed to set service tier: ${err}`);
+          },
+        );
       }
     },
     [
@@ -2935,19 +2932,18 @@ export function AgentChatPane({ pane }: { pane: AgentChatPaneNode }) {
       const current = useAgentChatStore.getState().threads[threadId];
       if (!current || current.fastMode === next) return;
       setStoreFastMode(threadId, next);
-      persistSessionConfig({ fast_mode: next });
-      // Both providers bind speed to the session/thread launch. A silent
-      // restart keeps transcript + resume state while making the choice take
-      // effect before the next turn.
-      restartSessionWith({ fastMode: next });
+      // Codex carries the service tier on `turn/start`; Cursor exposes a live
+      // ACP Fast config option. Neither requires replacing the conversation.
+      agentChatSetFastMode(provider, threadId, next).catch((err) => {
+        toast.error(`Failed to set service tier: ${err}`);
+      });
     },
     [
       threadId,
+      provider,
       activeModel,
       grokConfigurationBusy,
       setStoreFastMode,
-      persistSessionConfig,
-      restartSessionWith,
     ],
   );
 

--- a/src/dev/tauri-mock.ts
+++ b/src/dev/tauri-mock.ts
@@ -3685,6 +3685,7 @@ const handlers: Record<string, Handler> = {
     return undefined;
   },
   agent_chat_set_model: () => undefined,
+  agent_chat_set_fast_mode: () => undefined,
   agent_chat_set_permission_mode: () => undefined,
   agent_chat_stop_session: () => undefined,
   agent_chat_rename_session: () => undefined,

--- a/src/tauri/commands.ts
+++ b/src/tauri/commands.ts
@@ -1734,6 +1734,12 @@ export const agentChatSetModel = (
   model: string | null,
 ) => invoke<void>("agent_chat_set_model", { provider, threadId, model });
 
+export const agentChatSetFastMode = (
+  provider: AgentChatProviderKind,
+  threadId: string,
+  fastMode: boolean,
+) => invoke<void>("agent_chat_set_fast_mode", { provider, threadId, fastMode });
+
 export const agentChatSetPermissionMode = (
   provider: AgentChatProviderKind,
   threadId: string,


### PR DESCRIPTION
Switching Fast mode stopped and resumed the active provider session. When Codex could no longer find the persisted rollout, that unnecessary restart surfaced a `no rollout found` error and could fall back to a fresh provider thread.

Apply Fast-mode changes live for Codex and Cursor, persist the selection for future resumes, and send Codex service-tier choices on each subsequent turn. Also recognize the real Codex stale-rollout error as recoverable and cover both behaviors with focused regression tests.

Tests:
- `npm run check`
- `npm run test -- src/components/chat/AgentChatPane.test.tsx`
- `cargo test -j 2 --manifest-path src-tauri/Cargo.toml --test codex_adapter fast_mode_changes_apply_to_turns_without_restarting_the_thread -- --test-threads=2`
- `cargo test -j 2 --manifest-path src-tauri/Cargo.toml --test codex_adapter thread_resume_with_recoverable_error_falls_back_to_start -- --test-threads=2`
- `cargo check -j 2 --manifest-path src-tauri/Cargo.toml`

Model: gpt-5.6-sol (high reasoning)
Harness: Codex in CodeMux